### PR TITLE
Convert README to use markdown markup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-CENTRAL AUTHENTICATION SERVICE (CAS)
---------------------------------------------------------------------
-http://www.ja-sig.org/products/cas/
+# Central Authentication Service (CAS)
 
-1.  INTRODUCTION
+<http://www.ja-sig.org/products/cas/>
+
+## Introduction
 
 The Central Authentication Service (CAS) is the standard mechanism by which web
 applications should authenticate users. Any custom applications written benefit
@@ -14,23 +14,26 @@ in particular, providers of applications that grant access to anyone who
 possesses a NetID should understand that loose affiliates of an organization may
 be granted NetIDs.
 
-2.  RELEASE INFO
+## Release info
 
 CAS requires J2SE 1.5 and J2EE1.3.
 
-3. DISTRIBUTION JAR FILES
+## Distribution JAR files
 
 The "modules" directory contains distinct jars for each Maven module.  It also
 contains a war file that can be used for demo purposes.
 
-4.   DEPENDENCIES
+## Dependencies
 
-5. DEPLOYMENT
+## Deployment
 
-* Servlet Container that can handle JSP 2.0 (i.e. Tomcat 5.0.28)
+* Servlet Container that can handle JSP 2.0 (e.g., Tomcat 5.0.28)
 
-6. NOTE
-If building CAS from the source, running the test cases currently requires an active Internet connection.
-Please see: http://maven.apache.org/general.html#skip-test on how to disable the tests.
+## Note
 
+If building CAS from the source, running the test cases currently
+requires an active Internet connection.
 
+Please [see the maven docs][skip] on how to disable the tests.
+
+[skip]: http://maven.apache.org/general.html#skip-test


### PR DESCRIPTION
Using markdown allows GitHub to prettify the README. This is a formatting/extension-only change. Content remains the same.
