### PR TITLE
LdapUtils does not correctly encode values for the DN

### DIFF
--- a/cas-server-core/pom.xml
+++ b/cas-server-core/pom.xml
@@ -116,6 +116,11 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.ldap</groupId>
+            <artifactId>spring-ldap-core</artifactId>
+        </dependency>
+
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>

--- a/cas-server-core/src/main/java/org/jasig/cas/util/LdapUtils.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/util/LdapUtils.java
@@ -14,6 +14,7 @@ import javax.naming.directory.DirContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ldap.core.LdapEncoder;
 
 /**
  * Utilities related to LDAP functions.
@@ -44,7 +45,7 @@ public final class LdapUtils {
         final String[] userDomain;
         String newFilter = filter;
 
-        properties.put("%u", userName.replace("\\", "\\\\"));
+        properties.put("%u", userName);
 
         userDomain = userName.split("@");
 
@@ -62,7 +63,7 @@ public final class LdapUtils {
         }
 
         for (final String key : properties.keySet()) {
-            final String value = properties.get(key);
+            final String value = LdapEncoder.nameEncode(properties.get(key));
             newFilter = newFilter.replaceAll(key, Matcher.quoteReplacement(value));
         }
 

--- a/cas-server-core/src/test/java/org/jasig/cas/util/LdapUtilsTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/util/LdapUtilsTests.java
@@ -1,0 +1,16 @@
+package org.jasig.cas.util;
+
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author Daniel Frett
+ * @since 3.4.11
+ * 
+ */
+public class LdapUtilsTests extends TestCase {
+    public void testEncoding() {
+        final String filter = "cn=%u";
+        assertEquals("cn=test\\+user@example.com", LdapUtils.getFilterWithValues(filter, "test+user@example.com"));
+    }
+}


### PR DESCRIPTION
values containing a + are not correctly encoded in the generated Ldap DN.

test+user@example.com should be encoded as test\+user@example.com  but the existing code encoded it as test+user@example.com

I updated LdapUtils to utilize the spring ldap framework for encoding the values, which added that dependency to the cas-server-core project. LdapUtils isn't actually used by anything in core, so it could be moved to the cas-server-support-ldap project specifically to solve this problem, but that has potential to break other users' code that utilizes LdapUtils, but doesn't depend on the cas-server-support-ldap project.
