### PR TITLE
CAS-1019 stop vending proxy tix to outstanding PGTs of services disallowed from proxying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 *.ipr
 *.iml
 *.iws
+.idea/
+.DS_Store

--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -68,7 +68,7 @@ import java.util.Map;
  * <li> <code>serviceTicketExpirationPolicy</code> - The expiration policy for
  * ServiceTickets.</li>
  * </ul>
- * 
+ *
  * @author William G. Thompson, Jr.
  * @author Scott Battaglia
  * @author Dmitry Kopylenko
@@ -83,7 +83,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
     /** TicketRegistry for storing and retrieving tickets as needed. */
     @NotNull
     private TicketRegistry ticketRegistry;
-    
+
     /** New Ticket Registry for storing and retrieving services tickets. Can point to the same one as the ticketRegistry variable. */
     @NotNull
     private TicketRegistry serviceTicketRegistry;
@@ -125,7 +125,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
     /**
      * Implementation of destoryTicketGrantingTicket expires the ticket provided
      * and removes it from the TicketRegistry.
-     * 
+     *
      * @throws IllegalArgumentException if the TicketGrantingTicket ID is null.
      */
     @Audit(
@@ -194,6 +194,17 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
             && ticketGrantingTicket.getCountOfUses() > 0) {
             log.warn("ServiceManagement: Service Not Allowed to use SSO.  Service [" + service.getId() + "]");
             throw new UnauthorizedSsoServiceException();
+        }
+
+        //CAS-1019
+        final List<Authentication> authns = ticketGrantingTicket.getChainedAuthentications();
+        if(authns.size() > 1) {
+            if (!registeredService.isAllowedToProxy()) {
+                final String message = "ServiceManagement: Service Attempted to Proxy, but is not allowed.  Service: [" + service.getId() + "]" +
+                        "\nRegistered Service: [" + registeredService.toString() + "]";
+                log.warn(message);
+                throw new UnauthorizedProxyingException(message);
+            }
         }
 
         if (credentials != null) {
@@ -351,17 +362,17 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
             final String principalId = registeredService.isAnonymousAccess()
                 ? this.persistentIdGenerator.generate(principal, serviceTicket
                     .getService()) : principal.getId();
-                
+
             final Authentication authToUse;
-            
+
             if (!registeredService.isIgnoreAttributes()) {
                 final Map<String, Object> attributes = new HashMap<String, Object>();
-    
+
                 for (final String attribute : registeredService
                     .getAllowedAttributes()) {
                     final Object value = principal.getAttributes().get(
                         attribute);
-    
+
                     if (value != null) {
                         attributes.put(attribute, value);
                     }
@@ -379,7 +390,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
             } else {
                 authToUse = authentication;
             }
-            
+
 
             final List<Authentication> authentications = new ArrayList<Authentication>();
 
@@ -426,24 +437,24 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
 
     /**
      * Method to set the TicketRegistry.
-     * 
+     *
      * @param ticketRegistry the TicketRegistry to set.
      */
     public void setTicketRegistry(final TicketRegistry ticketRegistry) {
         this.ticketRegistry = ticketRegistry;
-        
+
         if (this.serviceTicketRegistry == null) {
             this.serviceTicketRegistry = ticketRegistry;
         }
     }
-    
+
     public void setServiceTicketRegistry(final TicketRegistry serviceTicketRegistry) {
         this.serviceTicketRegistry = serviceTicketRegistry;
     }
 
     /**
      * Method to inject the AuthenticationManager into the class.
-     * 
+     *
      * @param authenticationManager The authenticationManager to set.
      */
     public void setAuthenticationManager(
@@ -453,7 +464,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
 
     /**
      * Method to inject the TicketGrantingTicket Expiration Policy.
-     * 
+     *
      * @param ticketGrantingTicketExpirationPolicy The
      * ticketGrantingTicketExpirationPolicy to set.
      */
@@ -464,7 +475,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
 
     /**
      * Method to inject the Unique Ticket Id Generator into the class.
-     * 
+     *
      * @param uniqueTicketIdGenerator The uniqueTicketIdGenerator to use
      */
     public void setTicketGrantingTicketUniqueTicketIdGenerator(
@@ -474,7 +485,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
 
     /**
      * Method to inject the TicketGrantingTicket Expiration Policy.
-     * 
+     *
      * @param serviceTicketExpirationPolicy The serviceTicketExpirationPolicy to
      * set.
      */


### PR DESCRIPTION
Stops CAS from vending additional proxy tickets to services on the basis of their outstanding PGTs in the case where the registered service registration has been updated to disallow proxying.  

Prior to this change, disallowing a service from proxying prevents its acquisition of new PGTs but does not disable any PGT that may already be outstanding.
