### PR TITLE
CAS-1084 implement a default properties file

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/default.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/default.properties
@@ -1,0 +1,19 @@
+#this properties file establishes default property values for CAS.
+#if you are looking to override any property values, override the values in cas.properties
+
+
+server.prefix=http://localhost:8080/cas
+
+cas.securityContext.serviceProperties.service=${server.prefix}/services/j_acegi_cas_security_check
+# Names of roles allowed to access the CAS service manager
+cas.securityContext.serviceProperties.adminRoles=ROLE_ADMIN
+cas.securityContext.casProcessingFilterEntryPoint.loginUrl=${server.prefix}/login
+cas.securityContext.ticketValidator.casServerUrlPrefix=${server.prefix}
+
+
+cas.themeResolver.defaultThemeName=cas-theme-default
+cas.viewResolver.basename=default_views
+
+host.name=cas
+
+database.hibernate.dialect=org.hibernate.dialect.HSQLDialect

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/propertyFileConfigurer.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/propertyFileConfigurer.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 	<description>
 		This file lets CAS know where you've stored the cas.properties file which details some of the configuration options
@@ -10,6 +9,12 @@
 		can be moved between tiers without modification.
 	</description>
        
-	<bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
-		p:location="/WEB-INF/cas.properties" />
+	<bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="locations">
+			<list>
+				<value>/WEB-INF/default.properties</value>
+				<value>/WEB-INF/cas.properties</value>
+			</list>
+		</property>
+	</bean>
 </beans>


### PR DESCRIPTION
default.properties is loaded before cas.properties to allow default settings to be set for stock CAS
and not cause issues for deployers when they override cas.properties in their own maven overlay
