### PR TITLE
CAS-1079: added convenient setters for setting timing properties in seconds

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicy.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Provides the Ticket Granting Ticket expiration policy.  Ticket Granting Tickets
  * can be used any number of times, have a fixed lifetime, and an idle timeout.
@@ -39,6 +41,20 @@ public final class TicketGrantingTicketExpirationPolicy implements ExpirationPol
 
     public void setTimeToKillInMilliSeconds(final long timeToKillInMilliSeconds) {
         this.timeToKillInMilliSeconds = timeToKillInMilliSeconds;
+    }
+
+    /** Convenient virtual property setter to set time in seconds */
+    public void setMaxTimeToLiveInSeconds(final long maxTimeToLiveInSeconds){
+        if(this.maxTimeToLiveInMilliSeconds == 0L) {
+            this.maxTimeToLiveInMilliSeconds = TimeUnit.SECONDS.toMillis(maxTimeToLiveInSeconds);
+        }
+    }
+
+    /** Convenient virtual property setter to set time in seconds */
+    public void setTimeToKillInSeconds(final long timeToKillInSeconds) {
+        if(this.timeToKillInMilliSeconds == 0L) {
+            this.timeToKillInMilliSeconds = TimeUnit.SECONDS.toMillis(timeToKillInSeconds);
+        }
     }
 
     public void afterPropertiesSet() throws Exception {

--- a/cas-server-core/src/test/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicyTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/ticket/support/TicketGrantingTicketExpirationPolicyTests.java
@@ -17,20 +17,23 @@ import org.jasig.cas.ticket.TicketGrantingTicketImpl;
  */
 public class TicketGrantingTicketExpirationPolicyTests extends TestCase {
 
-    private static final long HARD_TIMEOUT = 10000; // 10s
+    private static final long HARD_TIMEOUT = 10000L; // 10s
 
-    private static final long SLIDING_TIMEOUT = 2000; // 2s
+    private static final long SLIDING_TIMEOUT = 2000L; // 2s
+
+    private static final long HARD_TIMEOUT_SECONDS = 10L;
+
+    private static final long SLIDING_TIMEOUT_SECONDS = 2L;
 
     private TicketGrantingTicketExpirationPolicy expirationPolicy;
 
     private TicketGrantingTicket ticketGrantingTicket;
 
     protected void setUp() throws Exception {
-        expirationPolicy = new TicketGrantingTicketExpirationPolicy();
-        expirationPolicy.setMaxTimeToLiveInMilliSeconds(HARD_TIMEOUT);
-        expirationPolicy.setTimeToKillInMilliSeconds(SLIDING_TIMEOUT);
-        ticketGrantingTicket = new TicketGrantingTicketImpl("test", TestUtils.getAuthentication(), expirationPolicy);
-        super.setUp();
+        this.expirationPolicy = new TicketGrantingTicketExpirationPolicy();
+        this.expirationPolicy.setMaxTimeToLiveInSeconds(HARD_TIMEOUT_SECONDS);
+        this.expirationPolicy.setTimeToKillInSeconds(SLIDING_TIMEOUT_SECONDS);
+        this.ticketGrantingTicket = new TicketGrantingTicketImpl("test", TestUtils.getAuthentication(), this.expirationPolicy);
     }
 
     public void testTgtIsExpiredByHardTimeOut() throws InterruptedException {


### PR DESCRIPTION
Preserves the ability to also set time in milis
