### PR TITLE
The CasDefaultFlowUrlHandler caused troubles 

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -105,8 +105,7 @@
 
 
   <bean class="org.springframework.webflow.mvc.servlet.FlowHandlerAdapter"
-        p:flowExecutor-ref="flowExecutor"
-        p:flowUrlHandler-ref="flowUrlHandler"/>
+        p:flowExecutor-ref="flowExecutor"/>
 
   <bean id="flowUrlHandler" class="org.jasig.cas.web.flow.CasDefaultFlowUrlHandler"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -676,7 +676,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
   <properties>
     <issues.projectKey>CAS</issues.projectKey>
     <scm.path>/cas3</scm.path>
-    <spring.webflow.version>2.3.0.RELEASE</spring.webflow.version>
+    <spring.webflow.version>2.3.1.RELEASE</spring.webflow.version>
     <spring.version>3.1.1.RELEASE</spring.version>
     <spring.ldap.version>1.3.1.RELEASE</spring.ldap.version>
     <spring.security.version>3.1.0.RELEASE</spring.security.version>


### PR DESCRIPTION
...with the 2.3.x SWF machinery to retrieve 'flowExecutionId'. Removed it from FlowHandlerAdapter to rely on the default SWF url flow handler. That fixes the problem
