### PR TITLE
Rethrow AuthenticationException instead of BadCredentialsAuthenticationException.ERROR

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationManagerImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationManagerImpl.java
@@ -97,8 +97,9 @@ public final class AuthenticationManagerImpl extends AbstractAuthenticationManag
                         authenticated = true;
                         break;
                     }
-                } catch (Exception e) {
+                } catch (AuthenticationException e) {
                     log.error("{} threw error authenticating {}", new Object[] {handlerName, credentials, e});
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
If authenticationHandler.authenticate throws an AuthenticationException, rethrow that exception instead of a generic BadCredentialsAuthenticationException.ERROR, as it may contain extra information on why authentication failed (expired password, account locked,...).
