### PR TITLE
CAS-1133

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationManagerImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationManagerImpl.java
@@ -84,6 +84,13 @@ public final class AuthenticationManagerImpl extends AbstractAuthenticationManag
         boolean authenticated = false;
         AuthenticationHandler authenticatedClass = null;
         String handlerName;
+        
+        /*
+         * Default AuthenticationException to throw, in case an error should occur.
+         * Will be reset to an instance of AuthenticationException thrown, if any, during the authentication attempt.
+         */
+        AuthenticationException unAuthSupportedHandlerException = BadCredentialsAuthenticationException.ERROR;
+        
         for (final AuthenticationHandler authenticationHandler : this.authenticationHandlers) {
             if (authenticationHandler.supports(credentials)) {
                 foundSupported = true;
@@ -97,15 +104,18 @@ public final class AuthenticationManagerImpl extends AbstractAuthenticationManag
                         authenticated = true;
                         break;
                     }
+                } catch (AuthenticationException e) {
+                    unAuthSupportedHandlerException = e;
+                    logAuthenticationHandlerError(handlerName, credentials, e);
                 } catch (Exception e) {
-                    log.error("{} threw error authenticating {}", new Object[] {handlerName, credentials, e});
+                    logAuthenticationHandlerError(handlerName, credentials, e);
                 }
             }
         }
 
         if (!authenticated) {
             if (foundSupported) {
-                throw BadCredentialsAuthenticationException.ERROR;
+                throw unAuthSupportedHandlerException;
             }
 
             throw UnsupportedCredentialsException.ERROR;
@@ -151,5 +161,17 @@ public final class AuthenticationManagerImpl extends AbstractAuthenticationManag
     public void setCredentialsToPrincipalResolvers(
         final List<CredentialsToPrincipalResolver> credentialsToPrincipalResolvers) {
         this.credentialsToPrincipalResolvers = credentialsToPrincipalResolvers;
+    }
+    
+    /**
+     * Logs the exception occurred as an error.
+     * 
+     * @param handlerName The class name of the authentication handler.
+     * @param credentials Client credentials subject to authentication. 
+     * @param e The exception that has occurred during authentication attempt.
+     */
+    private void logAuthenticationHandlerError(final String handlerName, final Credentials credentials, final Exception e) {
+        if (log.isErrorEnabled())
+            log.error("{} threw error authenticating {}", new Object[] {handlerName, credentials, e});
     }
 }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -121,17 +121,20 @@
 					| local authentication strategy.  You might accomplish this by coding a new such handler and declaring
 					| edu.someschool.its.cas.MySpecialHandler here, or you might use one of the handlers provided in the adaptors modules.
 					+-->
+					
+				 
 				<bean
 					class="org.jasig.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler" />
-					
+				
+				 	
 			  <!--
 		      | Sample LPPE-enabled Ldap authentication handler with errors codes defined as a regex pattern.
 		      | Each error type will redirect the user to a particular view state defined in the flow.
 		      | Unhandled error codes/types will prevent authentication.
 		      |
-		      | To disable LPPE error handling, simply reove the entire ldapErrorDefinitions block.
+		      | To disable LPPE error handling, simply remove the entire ldapErrorDefinitions block.
 		      -->
-		      <!--
+		      <!-- 
 		       <bean class="org.jasig.cas.adaptors.ldap.BindLdapAuthenticationHandler"
 		          p:filter="${ldap.authentication.filter}"
 		          p:searchBase="${ldap.authentication.basedn}"
@@ -167,12 +170,67 @@
 		            </list>
 		          </property>
 		       </bean>
-		       -->
+		        -->
 			</list>
 		</property>
 	</bean>
 
+	<!--
+    | Configuration beans that are required for LDAP authentication. 
+    | LDAP settings may be defined inside the 'cas.properties' file.
+    | In addition to the CAS LDAP module, Apache Common Pool may also be declared as a 
+    | dependency inside the pom.
+    | See here for additional information: https://wiki.jasig.org/display/CASUM/LDAP 
+    -->
+	<!--       
+	<bean id="contextSource" class="org.springframework.ldap.core.support.LdapContextSource">
+	    <property name="pooled" value="false"/>
+	    <property name="urls">
+	      <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
+	          <constructor-arg type="java.lang.String" value="${ldap.authentication.server.urls}"/>
+	      </bean>
+	  	</property>
+	    <property name="userDn" value="${ldap.authentication.manager.userdn}"/>
+	    <property name="password" value="${ldap.authentication.manager.password}"/>
+	
+	    <property name="baseEnvironmentProperties">
+	      <map>
+	        <entry key="com.sun.jndi.ldap.connect.timeout" value="${ldap.authentication.jndi.connect.timeout}" />
+	        <entry key="com.sun.jndi.ldap.read.timeout" value="${ldap.authentication.jndi.read.timeout}" />
+	        <entry key="java.naming.security.authentication" value="${ldap.authentication.jndi.security.level}" />
+	      </map>
+	    </property>
+	</bean>
 
+
+	<bean id="dirContextValidator"
+	  class="org.springframework.ldap.pool.validation.DefaultDirContextValidator"
+	  p:base=""
+	  p:filter="objectclass=*">
+	  <property name="searchControls">
+	    <bean class="javax.naming.directory.SearchControls"
+	      p:timeLimit="1000"
+	      p:countLimit="1"
+	      p:searchScope="0"
+	      p:returningAttributes="" />
+	  </property>
+	</bean>
+
+  	<bean id="pooledContextSource"
+	    class="org.springframework.ldap.pool.factory.PoolingContextSource"
+	    p:minIdle="${ldap.authentication.pool.minIdle}"
+	    p:maxIdle="${ldap.authentication.pool.maxIdle}"
+	    p:maxActive="${ldap.authentication.pool.maxSize}"
+	    p:maxWait="${ldap.authentication.pool.maxWait}"
+	    p:timeBetweenEvictionRunsMillis="${ldap.authentication.pool.evictionPeriod}"
+	    p:minEvictableIdleTimeMillis="${ldap.authentication.pool.idleTime}"
+	    p:testOnBorrow="${ldap.authentication.pool.testOnBorrow}"
+	    p:testWhileIdle="${ldap.authentication.pool.testWhileIdle}"
+	    p:dirContextValidator-ref="dirContextValidator"
+	    p:contextSource-ref="contextSource" />
+	
+	 -->
+	 
 	<!--
 	This bean defines the security roles for the Services Management application.  Simple deployments can use the in-memory version.
 	More robust deployments will want to use another option, such as the Jdbc version.


### PR DESCRIPTION
JIRA: https://issues.jasig.org/browse/CAS-1133

When an authentication exception occurs, such as one where the user's account is locked or its password has expired, the LPPE module does not return the error type back to the login flow. This causes the generic error message of "bad credentials" to be always displayed.

Also, added sample templates for the contextSource, dirContextValidator and pooledContextSource in the config, commented out. These beans are referenced by the sample BindLdapAuthHandler put into the config file for LPPE.
