### PR TITLE
 - display 100 chars of serviceId in manage.jsp instead of 50

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/services/manage.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/services/manage.jsp
@@ -58,7 +58,7 @@
 		<c:forEach items="${services}" var="service" varStatus="status">
 		<tr id="row${status.index}"${param.id eq service.id ? ' class="added"' : ''}>
 			<td id="${service.id}" class="td1">${service.name}</td>
-			<td class="td2">${fn:length(service.serviceId) < 50 ? service.serviceId : fn:substring(service.serviceId, 0, 50)}</td>
+			<td class="td2">${fn:length(service.serviceId) < 100 ? service.serviceId : fn:substring(service.serviceId, 0, 100)}</td>
 			<td class="ac td3"><img src="../images/services/${service.enabled}.gif" alt="${service.enabled ? 'Enabled' : 'Disabled'}" /></td>
 			<td class="ac td4"><img src="../images/services/${service.allowedToProxy}.gif" alt="${service.allowedToProxy ? 'Allowed to Proxy' : 'Not Allowed to Proxy'}" /></td>
 			<td class="ac td5"><img src="../images/services/${service.ssoEnabled}.gif" alt="${service.ssoEnabled ? 'SSO Enabled' : 'SSO Disabled'}" /></td>


### PR DESCRIPTION
This optimizes display for longer service URLs registered in manage.jsp
