### PR TITLE
ClearPass - Added clearPass filter and servlet mappings to the web.xml file. 

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -53,6 +53,15 @@
     <filter-name>springSecurityFilterChain</filter-name>
     <url-pattern>/services/*</url-pattern>
   </filter-mapping>
+ 
+  <filter>
+  	<filter-name>clearPassFilterChainProxy</filter-name>
+  	<filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>clearPassFilterChainProxy</filter-name>
+    <url-pattern>/clearPass</url-pattern>
+  </filter-mapping>
 
   <filter>
     <filter-name>characterEncodingFilter</filter-name>
@@ -146,6 +155,11 @@
   <servlet-mapping>
     <servlet-name>cas</servlet-name>
     <url-pattern>/CentralAuthenticationService</url-pattern>
+  </servlet-mapping>
+  
+  <servlet-mapping>
+    <servlet-name>cas</servlet-name>
+    <url-pattern>/clearPass</url-pattern>
   </servlet-mapping>
 
   <servlet-mapping>


### PR DESCRIPTION
These elements are required for the clearpass-configuration.xml file to take effect. The filter entry matches the pattern defined for the spring security config and the servlet mapping delegates requests to the spring handler mapping. All defined inside the same "clearpass-configuration.xml" file. 

clearpass-configuration.xml is by default inside the unused-spring directory. The above changes will have no effect on clearpass being disabled by default. 
