### PR TITLE
CAS-1143 - Externalize the followServiceRedirects property

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -191,7 +191,8 @@
         p:centralAuthenticationService-ref="centralAuthenticationService"
         p:logoutView="casLogoutView"
         p:warnCookieGenerator-ref="warnCookieGenerator"
-        p:ticketGrantingTicketCookieGenerator-ref="ticketGrantingTicketCookieGenerator"/>
+        p:ticketGrantingTicketCookieGenerator-ref="ticketGrantingTicketCookieGenerator"
+        p:followServiceRedirects="${cas.logout.followServiceRedirects:false}"/>
 
   <bean id="healthCheckController" class="org.jasig.cas.web.HealthCheckController"
         p:healthCheckMonitor-ref="healthCheckMonitor"/>


### PR DESCRIPTION
... of the logout controller, with the default set to false as it was before. Moving the value configuration out of the file into a file like cas.properties allows for easier overlays.
