### PR TITLE
CAS-1144 Clean-up inspektr configuration

### DIFF
--- a/cas-server-core/src/test/resources/inspektrThrottledSubmissionContext.xml
+++ b/cas-server-core/src/test/resources/inspektrThrottledSubmissionContext.xml
@@ -81,12 +81,6 @@
         <entry key="VALIDATE_SERVICE_TICKET_RESOURCE_RESOLVER">
           <ref local="ticketResourceResolver" />
         </entry>
-        <entry key="DELETE_SERVICE_ACTION_RESOLVER">
-          <ref local="returnValueResourceResolver" />
-        </entry>
-        <entry key="SAVE_SERVICE_RESOURCE_RESOLVER">
-          <ref local="returnValueResourceResolver" />
-        </entry>
         <entry key="DELETE_SERVICE_RESOURCE_RESOLVER">
           <ref local="deleteServiceResourceResolver" />
         </entry>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/auditTrailContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/auditTrailContext.xml
@@ -98,12 +98,6 @@
         <entry key="VALIDATE_SERVICE_TICKET_RESOURCE_RESOLVER">
           <ref local="ticketResourceResolver" />
         </entry>
-        <entry key="DELETE_SERVICE_ACTION_RESOLVER">
-          <ref local="returnValueResourceResolver" />
-        </entry>
-          <entry key="SAVE_SERVICE_RESOURCE_RESOLVER">
-          <ref local="returnValueResourceResolver" />
-        </entry>
         <entry key="DELETE_SERVICE_RESOURCE_RESOLVER">
             <ref local="deleteServiceResourceResolver" />
         </entry>


### PR DESCRIPTION
the SAVE_SERVICE_RESOURCE_RESOLVER resource resolver was specified twice, only one of them would actually apply because they are stored in a Map.
the DELETE_SERVICE_ACTION_RESOLVER key was specified as a resource resolver when it is only ever used as an action resolver.
