### PR TITLE
CAS-1154: Updated missing maven plugin versions in the pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.12.1</version>
+        <version>2.12</version>
         <configuration>
           <includes>
             <include>**/*Tests.java</include>


### PR DESCRIPTION
Build is KO : https://developer.jasig.org/bamboo/browse/CAS3-TIB-JOB1-322/log

Bad version of the surefire plugin : http://stackoverflow.com/questions/11793200/maven-failsafe-plugin-fails-with-unable-to-locate-surefire-booter
