### PR TITLE
Added support for maintaining URL anchors/fragments after security redirect

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
@@ -32,7 +32,7 @@
 </c:if>
 
   <div class="box fl-panel" id="login">
-			<form:form method="post" id="fm1" cssClass="fm-v clearfix" commandName="${commandName}" htmlEscape="true">
+			<form:form method="post" id="fm1" cssClass="fm-v clearfix" commandName="${commandName}" htmlEscape="true" onsubmit="return prepareSubmit(this);>
                   <form:errors path="*" id="msg" cssClass="errors" element="div" />
                 <!-- <spring:message code="screen.welcome.welcome" /> -->
                     <h2><spring:message code="screen.welcome.instructions" /></h2>

--- a/cas-server-webapp/src/main/webapp/js/cas.js
+++ b/cas-server-webapp/src/main/webapp/js/cas.js
@@ -58,6 +58,27 @@ function resetOldValue() {
     }
 }
 
+/**
+ * Prepares the login form for submission by appending any URI
+ * fragment (hash) to the form action in order to propagate it
+ * through the re-direct (i.e. store it client side).
+ * @param form The login form object.
+ * @returns true to allow the form to be submitted.
+ */
+function prepareSubmit(form) {
+	// Extract the fragment from the browser's current location.
+    var hash = decodeURIComponent(self.document.location.hash);
+
+	// The fragment value may not contain a leading # symbol
+    if (hash && hash.indexOf("#") === -1) {
+        hash = "#" + hash;
+    }
+	
+	// Append the fragment to the current action so that it persists to the redirected URL.
+    form.action = form.action + hash;
+    return true;
+}
+
 $(document).ready(function(){
     //focus username field
     $("input:visible:enabled:first").focus();


### PR DESCRIPTION
Anchors/fragments are lost across redirects, as the server-side handler of the form post ignores the client-side anchor, unless appended to the form POST url.  See https://jira.springsource.org/browse/SEC-1067 for more details.  This feature is needed if you want a CAS-authenticated application to be able to use anchors/fragments when bookmarking.  If the user has a bookmark with an anchor/fragment in it and is redirected to the login page when attempting to navigate to the link with the anchor, the anchor will be lost upon redirect without this patch.
