### PR TITLE
fix for CAS-1177 issue

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/SpnegoCredentialsAction.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/web/flow/SpnegoCredentialsAction.java
@@ -132,8 +132,7 @@ public final class SpnegoCredentialsAction extends
         this.messageBeginPrefix = constructMessagePrefix();
     }
 
-    public void setSend401OnAuthenticationFailure(boolean send401OnAuthenticationFailure) {
-
+    public void setSend401OnAuthenticationFailure(final boolean send401OnAuthenticationFailure) {
         this.send401OnAuthenticationFailure = send401OnAuthenticationFailure;
     }
 


### PR DESCRIPTION
With backward compatibility. Added a new property "send401OnAuthenticationFailure" that can be set to false to avoid sendlng an interactive view to the user with a 401 status code if SPNEGO authentication fails.
