### PR TITLE
CAS-1180:Add support for logging when CAS tries to determine the user id. 

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -454,6 +454,9 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
             }
 
         }
+        
+        log.debug("Principal id to return for service [{}] is [{}]. The default principal id is [{}].", 
+                  new Object[] {registeredService.getName(), principal.getId(), principalId});
         return principalId;
     }
 


### PR DESCRIPTION
Facilitates troubleshooting and diagnostics in being able to monitor and verify CAS behavior through the logs, when it comes to determining the principal id to return to a given service.  

JIRA: https://issues.jasig.org/browse/CAS-1180
