### PR TITLE
CAS-1178: Update the person directory dependency to the latest 1.5.1

### DIFF
--- a/cas-server-core/pom.xml
+++ b/cas-server-core/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jasig.service</groupId>
+            <groupId>org.jasig.service.persondir</groupId>
             <artifactId>person-directory-impl</artifactId>
             <scope>compile</scope>
         </dependency>
@@ -131,7 +131,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>${spring.security.version}</version>
             <scope>compile</scope>
         </dependency>
 
@@ -211,7 +210,6 @@
         <dependency>
             <groupId>commons-jexl</groupId>
             <artifactId>commons-jexl</artifactId>
-            <version>${commons.jexl.version}</version>
             <scope>runtime</scope>
             <type>jar</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
       </dependency>
 
       <dependency>
-        <groupId>org.jasig.service</groupId>
+        <groupId>org.jasig.service.persondir</groupId>
         <artifactId>person-directory-impl</artifactId>
         <version>${person.directory.version}</version>
         <exclusions>


### PR DESCRIPTION
Also, I removed a number of duplicate versions from the pom that are managed by the parents. 

Thanks to Eric Dalquist for releasing 1.5.1!
