### PR TITLE
CAS-1153 : Optimization : delete web sessions on redirect

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -134,9 +134,9 @@
       <webflow:always-redirect-on-pause value="false"/>
       <webflow:redirect-in-same-state value="false" />
     </webflow:flow-execution-attributes>
-    <webflow:flow-execution-listeners>
+    <!-- webflow:flow-execution-listeners>
       <webflow:listener ref="terminateWebSessionListener" />
-    </webflow:flow-execution-listeners>
+    </webflow:flow-execution-listeners-->
   </webflow:flow-executor>
 
   <webflow:flow-registry id="flowRegistry" flow-builder-services="builder">
@@ -146,7 +146,8 @@
   <webflow:flow-builder-services id="builder" view-factory-creator="viewFactoryCreator"
                                  expression-parser="expressionParser"/>
 
-  <bean id="terminateWebSessionListener" class="org.jasig.cas.web.flow.TerminateWebSessionListener" />
+  <!-- disable until we move out services management webapp in 3.6.0
+  <bean id="terminateWebSessionListener" class="org.jasig.cas.web.flow.TerminateWebSessionListener" /-->
 
   <bean id="expressionParser" class="org.springframework.webflow.expression.WebFlowOgnlExpressionParser"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/classes/messages_fr.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/classes/messages_fr.properties
@@ -108,6 +108,9 @@ management.services.manage.label.serviceUrl=URL du service
 management.services.manage.label.enabled=Activé
 management.services.manage.label.allowedToProxy=Peut faire du proxy
 management.services.manage.label.ssoParticipant=SSO
+management.services.manage.label.usernameAttribute=Nom d'utilisateur
+management.services.manage.label.anonymous=Anonyme
+management.services.manage.label.attributes=Attributs
 
 management.services.manage.action.edit=éditer
 management.services.manage.action.delete=supprimer


### PR DESCRIPTION
As this optimization as a side-effect on the services management webapp which doesn't work properly any more, I propose to disable this feature unless I move out this webapp outside CAS server for version 3.6.0.

When testing, I found out some missing french properties : I added them to this commit.
