### PR TITLE
CAS-1184 : Generate source / javadoc for snapshot artefacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -806,6 +806,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
+            <version>2.2</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -818,6 +819,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.8</version>
             <configuration>
               <charset>UTF-8</charset>
               <encoding>UTF-8</encoding>


### PR DESCRIPTION
Add ci profile with maven-source-plugin and maven-javadoc-plugin.

Use :
  mvn clean install -Pci
instead of
  mvn clean install
to generate source and javadocs.
