### PR TITLE
CAS-1141 : Improve OAuth module

### DIFF
--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConfiguration.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConfiguration.java
@@ -39,7 +39,7 @@ public final class OAuthConfiguration {
     private String loginUrl;
     
     public List<OAuthProvider> getProviders() {
-        return providers;
+        return this.providers;
     }
     
     public void setProviders(final List<OAuthProvider> providers) {
@@ -47,7 +47,7 @@ public final class OAuthConfiguration {
     }
     
     public String getLoginUrl() {
-        return loginUrl;
+        return this.loginUrl;
     }
     
     public void setLoginUrl(final String loginUrl) {

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthUtils.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthUtils.java
@@ -128,11 +128,9 @@ public final class OAuthUtils {
      * @return the provider for the given type or null if no provider was found
      */
     public static OAuthProvider getProviderByType(final List<OAuthProvider> providers, final String type) {
-        if (providers != null && type != null) {
-            for (final OAuthProvider provider : providers) {
-                if (provider != null && type.equals(provider.getType())) {
-                    return provider;
-                }
+        for (final OAuthProvider provider : providers) {
+            if (provider != null && type.equals(provider.getType())) {
+                return provider;
             }
         }
         return null;

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/authentication/handler/support/OAuthAuthenticationHandler.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/authentication/handler/support/OAuthAuthenticationHandler.java
@@ -59,7 +59,7 @@ public final class OAuthAuthenticationHandler extends AbstractPreAndPostProcessi
         logger.debug("providerType : {}", providerType);
         
         // get provider
-        final OAuthProvider provider = OAuthUtils.getProviderByType(configuration.getProviders(), providerType);
+        final OAuthProvider provider = OAuthUtils.getProviderByType(this.configuration.getProviders(), providerType);
         logger.debug("provider : {}", provider);
         
         // get user profile

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth10LoginController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth10LoginController.java
@@ -49,7 +49,7 @@ public final class OAuth10LoginController extends AbstractController {
         // get provider type
         final String providerType = request.getParameter(OAuthConstants.OAUTH_PROVIDER);
         // get provider
-        final OAuthProvider provider = OAuthUtils.getProviderByType(configuration.getProviders(), providerType);
+        final OAuthProvider provider = OAuthUtils.getProviderByType(this.configuration.getProviders(), providerType);
         
         // authorization url
         final String authorizationUrl = provider.getAuthorizationUrl(new HttpUserSession(request));

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/flow/OAuthAction.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/flow/OAuthAction.java
@@ -77,7 +77,8 @@ public final class OAuthAction extends AbstractAction {
         // it's an authentication
         if (StringUtils.isNotBlank(providerType)) {
             // get provider
-            final OAuthProvider provider = OAuthUtils.getProviderByType(configuration.getProviders(), providerType);
+            final OAuthProvider provider = OAuthUtils
+                .getProviderByType(this.configuration.getProviders(), providerType);
             logger.debug("provider : {}", provider);
             
             // get credential
@@ -116,12 +117,12 @@ public final class OAuthAction extends AbstractAction {
             saveRequestParameter(request, session, OAuthConstants.METHOD);
             
             // for all providers, generate authorization urls
-            for (final OAuthProvider provider : configuration.getProviders()) {
+            for (final OAuthProvider provider : this.configuration.getProviders()) {
                 final String key = provider.getType() + "Url";
                 String authorizationUrl = null;
                 // for OAuth 1.0 protocol, delay request_token request by pointing to an intermediate url
                 if (provider instanceof BaseOAuth10Provider) {
-                    authorizationUrl = OAuthUtils.addParameter(request.getContextPath() + oauth10loginUrl,
+                    authorizationUrl = OAuthUtils.addParameter(request.getContextPath() + this.oauth10loginUrl,
                                                                OAuthConstants.OAUTH_PROVIDER, provider.getType());
                 } else {
                     authorizationUrl = provider.getAuthorizationUrl(new HttpUserSession(session));


### PR DESCRIPTION
Define the CAS server login url in the configuration bean (with providers) instead of defining the login url in each provider as a callback url (which is changed by code after).
