### PR TITLE
CAS-1201: Ehcache-core dependency is missing from the clearPass pom

### DIFF
--- a/cas-server-extension-clearpass/pom.xml
+++ b/cas-server-extension-clearpass/pom.xml
@@ -82,6 +82,11 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
 		</dependency>
 		
 		<dependency>
+	      <groupId>net.sf.ehcache</groupId>
+	      <artifactId>ehcache-core</artifactId>
+	    </dependency>  
+    
+		<dependency>
 			<groupId>org.jasig.cas</groupId>
 			<artifactId>cas-server-integration-ehcache</artifactId>
 			<version>${project.version}</version>

--- a/cas-server-integration-ehcache/pom.xml
+++ b/cas-server-integration-ehcache/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
-      <version>2.6.0</version>
     </dependency>   
     <dependency>         
       <groupId>org.jasig.cas</groupId>         

--- a/pom.xml
+++ b/pom.xml
@@ -485,6 +485,12 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
         <artifactId>commons-lang</artifactId>
         <version>${commons.lang.version}</version>
       </dependency>
+      
+      <dependency>
+        <groupId>net.sf.ehcache</groupId>
+        <artifactId>ehcache-core</artifactId>
+        <version>${ehcache.version}</version>
+      </dependency>  
 
       <!-- Inspektr Dependencies -->
       <dependency>
@@ -892,5 +898,6 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
     <commons.io.version>2.0</commons.io.version>
     <mockito.version>1.9.0</mockito.version>
     <jdk.version>1.6</jdk.version>
+    <ehcache.version>2.6.0</ehcache.version>
   </properties>
 </project>


### PR DESCRIPTION
ehcache-core dependency is missing from the pom.xml file. The dependency currently needs to be externally defined when clearpass is added to an overlay pom

JIRA:
https://issues.jasig.org/browse/CAS-1201
