### PR TITLE
CAS:1202: Allow the maven build to report back missing language keys...

### DIFF
--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -207,7 +207,7 @@
 	            <goals>
 	                <goal>check</goal>
 	            </goals>
-	            <phase>process-sources</phase>
+	            <phase>process-resources</phase>
 	        </execution>
 	    </executions>
 	    <configuration>
@@ -216,5 +216,34 @@
 	    </configuration>
 	  </plugin>
     </plugins>
+    <pluginManagement>
+    	<plugins>
+    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+    		<plugin>
+    			<groupId>org.eclipse.m2e</groupId>
+    			<artifactId>lifecycle-mapping</artifactId>
+    			<version>1.0.0</version>
+    			<configuration>
+    				<lifecycleMappingMetadata>
+    					<pluginExecutions>
+    						<pluginExecution>
+    							<pluginExecutionFilter>
+    								<groupId>org.jasig.maven</groupId>
+    								<artifactId>maven-translate-plugin</artifactId>
+    								<versionRange>[0.0.1,)</versionRange>
+    								<goals>
+    									<goal>check</goal>
+    								</goals>
+    							</pluginExecutionFilter>
+    							<action>
+    								<ignore></ignore>
+    							</action>
+    						</pluginExecution>
+    					</pluginExecutions>
+    				</lifecycleMappingMetadata>
+    			</configuration>
+    		</plugin>
+    	</plugins>
+    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
Many language keys are missing from non-English bundles. The first attempt to address this issue to update all missing properties is to take advantage of the maven-translate plugin to report back all missing keys from bundles as part of the build process

JIRA: https://issues.jasig.org/browse/CAS-1202
