### PR TITLE
CAS-1145: Expose protocol level constants in CAS core

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationService.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationService.java
@@ -46,6 +46,15 @@ import org.jasig.cas.validation.Assertion;
  */
 public interface CentralAuthenticationService {
 
+    /** 
+     * The identifier of the application the client is trying to access. In almost all cases, 
+     * this will be the URL of the application. 
+     */
+    public static final String PROTOCOL_PARAMETER_SERVICE = "service";
+    
+    /** The identifier for the ticket issues by CAS */
+    public static final String PROTOCOL_PARAMETER_TICKET = "ticket";
+    
     /**
      * Create a TicketGrantingTicket based on opaque credentials supplied by the
      * caller.

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/SimpleWebApplicationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/SimpleWebApplicationServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.principal.Response.ResponseType;
 import org.jasig.cas.util.HttpClient;
 import org.springframework.util.StringUtils;
@@ -37,11 +38,7 @@ import org.springframework.util.StringUtils;
 public final class SimpleWebApplicationServiceImpl extends
     AbstractWebApplicationService {
 
-    private static final String CONST_PARAM_SERVICE = "service";
-
     private static final String CONST_PARAM_TARGET_SERVICE = "targetService";
-
-    private static final String CONST_PARAM_TICKET = "ticket";
 
     private static final String CONST_PARAM_METHOD = "method";
 
@@ -77,14 +74,14 @@ public final class SimpleWebApplicationServiceImpl extends
             .getParameter(CONST_PARAM_TARGET_SERVICE);
         final String method = request.getParameter(CONST_PARAM_METHOD);
         final String serviceToUse = StringUtils.hasText(targetService)
-            ? targetService : request.getParameter(CONST_PARAM_SERVICE);
+            ? targetService : request.getParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE);
 
         if (!StringUtils.hasText(serviceToUse)) {
             return null;
         }
 
         final String id = cleanupUrl(serviceToUse);
-        final String artifactId = request.getParameter(CONST_PARAM_TICKET);
+        final String artifactId = request.getParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET);
 
         return new SimpleWebApplicationServiceImpl(id, serviceToUse,
             artifactId, "POST".equals(method) ? ResponseType.POST
@@ -95,7 +92,7 @@ public final class SimpleWebApplicationServiceImpl extends
         final Map<String, String> parameters = new HashMap<String, String>();
 
         if (StringUtils.hasText(ticketId)) {
-            parameters.put(CONST_PARAM_TICKET, ticketId);
+            parameters.put(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, ticketId);
         }
 
         if (ResponseType.POST == this.responseType) {

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/Ticket.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/Ticket.java
@@ -45,7 +45,7 @@ public interface Ticket extends Serializable {
     boolean isExpired();
 
     /**
-     * Method to retrive the TicketGrantingTicket that granted this ticket.
+     * Method to retrieve the TicketGrantingTicket that granted this ticket.
      * 
      * @return the ticket or null if it has no parent
      */
@@ -59,8 +59,7 @@ public interface Ticket extends Serializable {
     long getCreationTime();
     
     /**
-     * Returns the number of times this ticket was used.
-     * @return
+     * @return the number of times this ticket was used.
      */
     int getCountOfUses();
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketValidationException.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/TicketValidationException.java
@@ -41,7 +41,7 @@ public class TicketValidationException extends TicketException {
      * Constructs a TicketValidationException with the default exception code
      * and the original exception that was thrown.
      * 
-     * @param throwable the chained exception
+     * @param service the service whose ticket validation has failed
      */
     public TicketValidationException(final Service service) {
         super(CODE);

--- a/cas-server-core/src/main/java/org/jasig/cas/validation/ImmutableAssertionImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/validation/ImmutableAssertionImpl.java
@@ -21,6 +21,7 @@ package org.jasig.cas.validation;
 import java.util.Collections;
 import java.util.List;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.principal.Service;
 import org.springframework.util.Assert;
@@ -94,6 +95,7 @@ public final class ImmutableAssertionImpl implements Assertion {
     }
 
     public String toString() {
-        return "[principals={" + this.principals.toString() + "} for service=" + this.service.toString() + "]";
+        return "[principals={" + this.principals.toString() + "} for " + CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE 
+                + "=" + this.service.toString() + "]";
     }
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/web/LogoutController.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/LogoutController.java
@@ -76,7 +76,7 @@ public final class LogoutController extends AbstractController {
         final HttpServletRequest request, final HttpServletResponse response)
         throws Exception {
         final String ticketGrantingTicketId = this.ticketGrantingTicketCookieGenerator.retrieveCookieValue(request);
-        final String service = request.getParameter("service");
+        final String service = request.getParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE);
 
         if (ticketGrantingTicketId != null) {
             this.centralAuthenticationService

--- a/cas-server-core/src/main/java/org/jasig/cas/web/ProxyController.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/ProxyController.java
@@ -55,9 +55,6 @@ public final class ProxyController extends AbstractController {
     /** View for if the creation of a "Proxy" Ticket Succeeds. */
     private static final String CONST_PROXY_SUCCESS = "casProxySuccessView";
 
-    /** Key to use in model for service tickets. */
-    private static final String MODEL_SERVICE_TICKET = "ticket";
-
     /** CORE to delegate all non-web tier functionality to. */
     @NotNull
     private CentralAuthenticationService centralAuthenticationService;
@@ -82,7 +79,7 @@ public final class ProxyController extends AbstractController {
         }
 
         try {
-            return new ModelAndView(CONST_PROXY_SUCCESS, MODEL_SERVICE_TICKET,
+            return new ModelAndView(CONST_PROXY_SUCCESS, CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET,
                 this.centralAuthenticationService.grantServiceTicket(ticket,
                     targetService));
         } catch (TicketException e) {

--- a/cas-server-core/src/main/java/org/jasig/cas/web/flow/InitialFlowSetupAction.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/flow/InitialFlowSetupAction.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.web.support.ArgumentExtractor;
 import org.jasig.cas.web.support.CookieRetrievingCookieGenerator;
@@ -89,7 +90,7 @@ public final class InitialFlowSetupAction extends AbstractAction {
             logger.debug("Placing service in FlowScope: " + service.getId());
         }
 
-        context.getFlowScope().put("service", service);
+        context.getFlowScope().put(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, service);
 
         return result("success");
     }

--- a/cas-server-core/src/test/java/org/jasig/cas/TestUtils.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/TestUtils.java
@@ -120,7 +120,7 @@ public final class TestUtils {
 
     public static Service getService(final String name) {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", name);
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, name);
         return SimpleWebApplicationServiceImpl.createServiceFrom(request);
     }
 

--- a/cas-server-core/src/test/java/org/jasig/cas/authentication/principal/ResponseTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/authentication/principal/ResponseTests.java
@@ -24,6 +24,8 @@ import junit.framework.TestCase;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jasig.cas.CentralAuthenticationService;
+
 /**
  * @author Scott Battaglia
  * @version $Revision$ $Date$
@@ -34,49 +36,51 @@ public class ResponseTests extends TestCase {
      public void testConstructionWithoutFragmentAndNoQueryString() {
         final String url = "http://localhost:8080/foo";
         final Map<String, String> attributes = new HashMap<String,String>();
-        attributes.put("ticket", "foobar");
+        attributes.put(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, "foobar");
         final Response response = Response.getRedirectResponse(url, attributes);
-        assertEquals(url + "?ticket=foobar", response.getUrl());
+        assertEquals(url + "?" + CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "=foobar", response.getUrl());
     }
 
     public void testConstructionWithoutFragmentButHasQueryString() {
         final String url = "http://localhost:8080/foo?test=boo";
         final Map<String, String> attributes = new HashMap<String,String>();
-        attributes.put("ticket", "foobar");
+        attributes.put(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, "foobar");
         final Response response = Response.getRedirectResponse(url, attributes);
-        assertEquals(url + "&ticket=foobar", response.getUrl());
+        assertEquals(url + "&" + CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "=foobar", response.getUrl());
     }
 
     public void testConstructionWithFragmentAndQueryString() {
         final String url = "http://localhost:8080/foo?test=boo#hello";
         final Map<String, String> attributes = new HashMap<String,String>();
-        attributes.put("ticket", "foobar");
+        attributes.put(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, "foobar");
         final Response response = Response.getRedirectResponse(url, attributes);
-        assertEquals("http://localhost:8080/foo?test=boo&ticket=foobar#hello", response.getUrl());
+        assertEquals("http://localhost:8080/foo?test=boo&" + CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "=foobar#hello", response.getUrl());
     }
 
     public void testConstructionWithFragmentAndNoQueryString() {
         final String url = "http://localhost:8080/foo#hello";
         final Map<String, String> attributes = new HashMap<String,String>();
-        attributes.put("ticket", "foobar");
+        attributes.put(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, "foobar");
         final Response response = Response.getRedirectResponse(url, attributes);
-        assertEquals("http://localhost:8080/foo?ticket=foobar#hello", response.getUrl());
+        assertEquals("http://localhost:8080/foo?" + CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "=foobar#hello", response.getUrl());
 
     }
 
     public void testUrlSanitization() {
         final String url = "https://www.example.com\r\nLocation: javascript:\r\n\r\n<script>alert(document.cookie)</script>";
         final Map<String, String> attributes = new HashMap<String,String>();
-        attributes.put("ticket", "ST-12345");
+        attributes.put(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, "ST-12345");
         final Response response = Response.getRedirectResponse(url, attributes);
-        assertEquals("https://www.example.com Location: javascript: <script>alert(document.cookie)</script>?ticket=ST-12345", response.getUrl());
+        assertEquals("https://www.example.com Location: javascript: <script>alert(document.cookie)</script>?" + 
+                CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "=ST-12345", response.getUrl());
     }
 
     public void testUrlWithUnicode() {
         final String url = "https://www.example.com/πολιτικῶν";
         final Map<String, String> attributes = new HashMap<String,String>();
-        attributes.put("ticket", "ST-12345");
+        attributes.put(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, "ST-12345");
         final Response response = Response.getRedirectResponse(url, attributes);
-        assertEquals("https://www.example.com/πολιτικῶν?ticket=ST-12345", response.getUrl());
+        assertEquals("https://www.example.com/πολιτικῶν?" + CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET
+                + "=ST-12345", response.getUrl());
     }
 }

--- a/cas-server-core/src/test/java/org/jasig/cas/authentication/principal/SimpleWebApplicationServiceImplTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/authentication/principal/SimpleWebApplicationServiceImplTests.java
@@ -20,6 +20,7 @@ package org.jasig.cas.authentication.principal;
 
 import junit.framework.TestCase;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.principal.Response.ResponseType;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -35,7 +36,7 @@ public class SimpleWebApplicationServiceImplTests extends TestCase {
 
     public void testResponse() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "service");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "service");
         final SimpleWebApplicationServiceImpl impl = SimpleWebApplicationServiceImpl.createServiceFrom(request);
         
         final Response response = impl.getResponse("ticketId");
@@ -45,7 +46,7 @@ public class SimpleWebApplicationServiceImplTests extends TestCase {
     
     public void testResponseForJsession() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "http://www.cnn.com/;jsession=test");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "http://www.cnn.com/;jsession=test");
         final WebApplicationService impl = SimpleWebApplicationServiceImpl.createServiceFrom(request);
         
         assertEquals("http://www.cnn.com/", impl.getId());
@@ -53,30 +54,30 @@ public class SimpleWebApplicationServiceImplTests extends TestCase {
     
     public void testResponseWithNoTicket() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "service");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "service");
         final WebApplicationService impl = SimpleWebApplicationServiceImpl.createServiceFrom(request);
         
         final Response response = impl.getResponse(null);
         assertNotNull(response);
         assertEquals(ResponseType.REDIRECT, response.getResponseType());
-        assertFalse(response.getUrl().contains("ticket="));
+        assertFalse(response.getUrl().contains(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "="));
     }
     
     public void testResponseWithNoTicketAndNoParameterInServiceURL() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "http://foo.com/");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "http://foo.com/");
         final WebApplicationService impl = SimpleWebApplicationServiceImpl.createServiceFrom(request);
         
         final Response response = impl.getResponse(null);
         assertNotNull(response);
         assertEquals(ResponseType.REDIRECT, response.getResponseType());
-        assertFalse(response.getUrl().contains("ticket="));
+        assertFalse(response.getUrl().contains(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "="));
         assertEquals("http://foo.com/",response.getUrl());
     }
     
     public void testResponseWithNoTicketAndOneParameterInServiceURL() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "http://foo.com/?param=test");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "http://foo.com/?param=test");
         final WebApplicationService impl = SimpleWebApplicationServiceImpl.createServiceFrom(request);
         
         final Response response = impl.getResponse(null);

--- a/cas-server-core/src/test/java/org/jasig/cas/services/web/ServiceThemeResolverTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/web/ServiceThemeResolverTests.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.services.DefaultServicesManagerImpl;
 import org.jasig.cas.services.InMemoryServiceRegistryDaoImpl;
 import org.jasig.cas.services.RegisteredServiceImpl;
@@ -67,7 +68,7 @@ public class ServiceThemeResolverTests extends TestCase {
         this.servicesManager.save(r);
         
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "myServiceId");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "myServiceId");
         request.addHeader("User-Agent", "Mozilla");
         System.out.println("1");
         assertEquals("myTheme", this.serviceThemeResolver.resolveThemeName(request));
@@ -75,7 +76,7 @@ public class ServiceThemeResolverTests extends TestCase {
     
     public void testGetDefaultService() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "myServiceId");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "myServiceId");
         request.addHeader("User-Agent", "Mozilla");
         assertEquals("test", this.serviceThemeResolver.resolveThemeName(request));
     }
@@ -83,7 +84,7 @@ public class ServiceThemeResolverTests extends TestCase {
     public void testGetDefaultServiceWithNoServicesManager() {
         this.serviceThemeResolver.setServicesManager(null);
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "myServiceId");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "myServiceId");
         request.addHeader("User-Agent", "Mozilla");
         assertEquals("test", this.serviceThemeResolver.resolveThemeName(request));
     }

--- a/cas-server-core/src/test/java/org/jasig/cas/web/LogoutControllerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/LogoutControllerTests.java
@@ -21,16 +21,15 @@ package org.jasig.cas.web;
 import javax.servlet.http.Cookie;
 
 import org.jasig.cas.AbstractCentralAuthenticationServiceTest;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.services.DefaultServicesManagerImpl;
 import org.jasig.cas.services.InMemoryServiceRegistryDaoImpl;
 import org.jasig.cas.services.RegisteredServiceImpl;
 import org.jasig.cas.web.support.CookieRetrievingCookieGenerator;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.servlet.view.RedirectView;
 import static org.junit.Assert.*;
 
@@ -84,7 +83,7 @@ public class LogoutControllerTests extends AbstractCentralAuthenticationServiceT
 
     @Test
     public void testLogoutForServiceWithFollowRedirectsAndMatchingService() throws Exception {
-        this.request.addParameter("service", "TestService");
+        this.request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "TestService");
         final RegisteredServiceImpl impl = new RegisteredServiceImpl();
         impl.setServiceId("TestService");
         impl.setName("TestService");
@@ -97,7 +96,7 @@ public class LogoutControllerTests extends AbstractCentralAuthenticationServiceT
 
     @Test
     public void logoutForServiceWithNoFollowRedirects() throws Exception {
-        this.request.addParameter("service", "TestService");
+        this.request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "TestService");
         this.logoutController.setFollowServiceRedirects(false);
         assertTrue(!(this.logoutController.handleRequestInternal(request,
             new MockHttpServletResponse()).getView() instanceof RedirectView));
@@ -105,7 +104,7 @@ public class LogoutControllerTests extends AbstractCentralAuthenticationServiceT
 
     @Test
     public void logoutForServiceWithFollowRedirectsNoAllowedService() throws Exception {
-        this.request.addParameter("service", "TestService");
+        this.request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "TestService");
         final RegisteredServiceImpl impl = new RegisteredServiceImpl();
         impl.setServiceId("http://FooBar");
         impl.setName("FooBar");

--- a/cas-server-core/src/test/java/org/jasig/cas/web/ProxyControllerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/ProxyControllerTests.java
@@ -21,6 +21,7 @@ package org.jasig.cas.web;
 import java.util.Map;
 
 import org.jasig.cas.AbstractCentralAuthenticationServiceTest;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.TestUtils;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.TicketGrantingTicketImpl;
@@ -85,7 +86,7 @@ public class ProxyControllerTests extends AbstractCentralAuthenticationServiceTe
 
         assertTrue(this.proxyController.handleRequestInternal(request,
             new MockHttpServletResponse()).getModel().containsKey(
-            "ticket"));
+            CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET));
     }
     
     @Test
@@ -98,6 +99,6 @@ public class ProxyControllerTests extends AbstractCentralAuthenticationServiceTe
       request.addParameter("targetService", "service");
   
       final Map<String, Object> map = this.proxyController.handleRequestInternal(request,  new MockHttpServletResponse()).getModel();
-      assertTrue(!map.containsKey("ticket"));
+      assertTrue(!map.containsKey(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET));
     }
 }

--- a/cas-server-core/src/test/java/org/jasig/cas/web/ServiceValidateControllerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/ServiceValidateControllerTests.java
@@ -21,6 +21,7 @@ package org.jasig.cas.web;
 import javax.servlet.http.HttpServletRequest;
 
 import org.jasig.cas.AbstractCentralAuthenticationServiceTest;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.TestUtils;
 import org.jasig.cas.mock.MockValidationSpecification;
 import org.jasig.cas.ticket.TicketException;
@@ -74,9 +75,9 @@ public class ServiceValidateControllerTests extends AbstractCentralAuthenticatio
             .grantServiceTicket(tId, TestUtils.getService());
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", TestUtils.getService()
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService()
             .getId());
-        request.addParameter("ticket", sId2);
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, sId2);
         request.addParameter("renew", "true");
 
         return request;
@@ -107,9 +108,9 @@ public class ServiceValidateControllerTests extends AbstractCentralAuthenticatio
             .grantServiceTicket(tId, TestUtils.getService());
 
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", TestUtils.getService()
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService()
             .getId());
-        request.addParameter("ticket", sId);
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, sId);
 
         assertEquals(CONST_SUCCESS_VIEW,
             this.serviceValidateController.handleRequestInternal(request,
@@ -153,9 +154,9 @@ public class ServiceValidateControllerTests extends AbstractCentralAuthenticatio
         getCentralAuthenticationService().destroyTicketGrantingTicket(tId);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", TestUtils.getService()
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService()
             .getId());
-        request.addParameter("ticket", sId);
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, sId);
 
         assertEquals(CONST_FAILURE_VIEW,
             this.serviceValidateController.handleRequestInternal(request,
@@ -172,9 +173,9 @@ public class ServiceValidateControllerTests extends AbstractCentralAuthenticatio
             .grantServiceTicket(tId, TestUtils.getService());
 
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", TestUtils.getService()
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService()
             .getId());
-        request.addParameter("ticket", sId);
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, sId);
         request
             .addParameter("pgtUrl", "https://www.acs.rutgers.edu");
 
@@ -193,9 +194,9 @@ public class ServiceValidateControllerTests extends AbstractCentralAuthenticatio
             .grantServiceTicket(tId, TestUtils.getService());
 
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", TestUtils.getService()
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService()
             .getId());
-        request.addParameter("ticket", sId);
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, sId);
         request.addParameter("pgtUrl", "http://www.acs.rutgers.edu");
 
         final ModelAndView modelAndView = this.serviceValidateController
@@ -215,9 +216,9 @@ public class ServiceValidateControllerTests extends AbstractCentralAuthenticatio
             .grantServiceTicket(tId, TestUtils.getService());
 
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", TestUtils.getService()
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService()
             .getId());
-        request.addParameter("ticket", sId);
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET, sId);
         request.addParameter("pgtUrl", "duh");
 
         final ModelAndView modelAndView = this.serviceValidateController

--- a/cas-server-core/src/test/java/org/jasig/cas/web/flow/AuthenticationViaFormActionTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/flow/AuthenticationViaFormActionTests.java
@@ -21,20 +21,19 @@ package org.jasig.cas.web.flow;
 import javax.servlet.http.HttpServletRequest;
 
 import org.jasig.cas.AbstractCentralAuthenticationServiceTest;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.TestUtils;
 import org.jasig.cas.authentication.principal.Credentials;
 import org.jasig.cas.authentication.principal.UsernamePasswordCredentials;
 import org.jasig.cas.web.bind.CredentialsBinder;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.validation.BindException;
 import org.springframework.web.util.CookieGenerator;
 import org.springframework.webflow.context.servlet.ServletExternalContext;
-import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
 
 /**
@@ -112,7 +111,7 @@ public class AuthenticationViaFormActionTests extends
         request.addParameter("username", "test");
         request.addParameter("password", "test");
         request.addParameter("warn", "true");
-        request.addParameter("service", "test");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
 
         context.setExternalContext(new ServletExternalContext(
             new MockServletContext(), request, response));
@@ -157,13 +156,13 @@ public class AuthenticationViaFormActionTests extends
 
         context.getFlowScope().put("ticketGrantingTicketId", ticketGrantingTicket);
         request.addParameter("renew", "true");
-        request.addParameter("service", "test");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
         request.addParameter("username", "test");
         request.addParameter("password", "test");
         
         context.setExternalContext(new ServletExternalContext(
             new MockServletContext(), request, new MockHttpServletResponse()));
-        context.getFlowScope().put("service", TestUtils.getService("test"));
+        context.getFlowScope().put(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService("test"));
     //    this.action.bind(context);
      //   assertEquals("warn", this.action.submit(context).getId());
     }
@@ -178,7 +177,7 @@ public class AuthenticationViaFormActionTests extends
 
         context.getFlowScope().put("ticketGrantingTicketId", ticketGrantingTicket);
         request.addParameter("renew", "true");
-        request.addParameter("service", "test");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
         request.addParameter("username", "test2");
         request.addParameter("password", "test2");
 
@@ -199,7 +198,7 @@ public class AuthenticationViaFormActionTests extends
 
         context.getFlowScope().put("ticketGrantingTicketId", ticketGrantingTicket);
         request.addParameter("renew", "true");
-        request.addParameter("service", "test");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
 
         context.setExternalContext(new ServletExternalContext(
             new MockServletContext(), request, new MockHttpServletResponse()));

--- a/cas-server-core/src/test/java/org/jasig/cas/web/flow/GenerateServiceTicketActionTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/flow/GenerateServiceTicketActionTests.java
@@ -21,6 +21,7 @@ package org.jasig.cas.web.flow;
 import javax.servlet.http.Cookie;
 
 import org.jasig.cas.AbstractCentralAuthenticationServiceTest;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.TestUtils;
 import org.jasig.cas.web.support.WebUtils;
 import org.junit.Before;
@@ -56,12 +57,12 @@ public final class GenerateServiceTicketActionTests extends AbstractCentralAuthe
     @Test
     public void testServiceTicketFromCookie() throws Exception {
         MockRequestContext context = new MockRequestContext();
-        context.getFlowScope().put("service", TestUtils.getService());
+        context.getFlowScope().put(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService());
         context.getFlowScope().put("ticketGrantingTicketId", this.ticketGrantingTicket);
         MockHttpServletRequest request = new MockHttpServletRequest();
         context.setExternalContext(new ServletExternalContext(
             new MockServletContext(), request, new MockHttpServletResponse()));
-        request.addParameter("service", "service");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "service");
         request.setCookies(new Cookie[] {new Cookie("TGT",
             this.ticketGrantingTicket)});
 
@@ -73,11 +74,11 @@ public final class GenerateServiceTicketActionTests extends AbstractCentralAuthe
     @Test
     public void testTicketGrantingTicketFromRequest() throws Exception {
         MockRequestContext context = new MockRequestContext();
-        context.getFlowScope().put("service", TestUtils.getService());
+        context.getFlowScope().put(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService());
         MockHttpServletRequest request = new MockHttpServletRequest();
         context.setExternalContext(new ServletExternalContext(
             new MockServletContext(), request, new MockHttpServletResponse()));
-        request.addParameter("service", "service");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "service");
         WebUtils.putTicketGrantingTicketInRequestScope(context,
             this.ticketGrantingTicket);
 
@@ -89,11 +90,11 @@ public final class GenerateServiceTicketActionTests extends AbstractCentralAuthe
     @Test
     public void testTicketGrantingTicketNoTgt() throws Exception {
         MockRequestContext context = new MockRequestContext();
-        context.getFlowScope().put("service", TestUtils.getService());
+        context.getFlowScope().put(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService());
         MockHttpServletRequest request = new MockHttpServletRequest();
         context.setExternalContext(new ServletExternalContext(
             new MockServletContext(), request, new MockHttpServletResponse()));
-        request.addParameter("service", "service");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "service");
         WebUtils.putTicketGrantingTicketInRequestScope(context, "bleh");
 
         assertEquals("error", this.action.execute(context).getId());
@@ -102,11 +103,11 @@ public final class GenerateServiceTicketActionTests extends AbstractCentralAuthe
     @Test
     public void testTicketGrantingTicketNotTgtButGateway() throws Exception {
         MockRequestContext context = new MockRequestContext();
-        context.getFlowScope().put("service", TestUtils.getService());
+        context.getFlowScope().put(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, TestUtils.getService());
         MockHttpServletRequest request = new MockHttpServletRequest();
         context.setExternalContext(new ServletExternalContext(
             new MockServletContext(), request, new MockHttpServletResponse()));
-        request.addParameter("service", "service");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "service");
         request.addParameter("gateway", "true");
         WebUtils.putTicketGrantingTicketInRequestScope(context, "bleh");
 

--- a/cas-server-core/src/test/java/org/jasig/cas/web/flow/InitialFlowSetupActionTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/flow/InitialFlowSetupActionTests.java
@@ -20,6 +20,7 @@ package org.jasig.cas.web.flow;
 
 import java.util.Arrays;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.web.support.ArgumentExtractor;
 import org.jasig.cas.web.support.CasArgumentExtractor;
 import org.jasig.cas.web.support.CookieRetrievingCookieGenerator;
@@ -107,7 +108,7 @@ public class InitialFlowSetupActionTests extends TestCase {
     public void testServiceFound() throws Exception {
         final MockRequestContext context = new MockRequestContext();
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "test");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
         context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
         
         final Event event = this.action.execute(context);

--- a/cas-server-core/src/test/java/org/jasig/cas/web/support/WebUtilTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/support/WebUtilTests.java
@@ -20,6 +20,7 @@ package org.jasig.cas.web.support;
 
 import java.util.Arrays;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.principal.Service;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -40,7 +41,7 @@ public class WebUtilTests extends TestCase {
         final ArgumentExtractor[] argumentExtractors = new ArgumentExtractor[] {
             openIdArgumentExtractor, casArgumentExtractor};
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "test");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
 
         final Service service = WebUtils.getService(Arrays
             .asList(argumentExtractors), request);
@@ -53,7 +54,7 @@ public class WebUtilTests extends TestCase {
         final ArgumentExtractor[] argumentExtractors = new ArgumentExtractor[] {
             openIdArgumentExtractor};
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "test");
+        request.setParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
 
         final Service service = WebUtils.getService(Arrays
             .asList(argumentExtractors), request);

--- a/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/integration/uportal/PasswordCachingCasAssertionSecurityContext.java
+++ b/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/integration/uportal/PasswordCachingCasAssertionSecurityContext.java
@@ -19,6 +19,7 @@
 
 package org.jasig.cas.extension.clearpass.integration.uportal;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.util.XmlUtils;
 import org.jasig.cas.client.validation.Assertion;
@@ -75,7 +76,8 @@ public class PasswordCachingCasAssertionSecurityContext extends CasAssertionSecu
     }
 
     protected final String retrievePasswordFromResponse(final String proxyTicket) {
-        final String url = this.clearPassUrl + (this.clearPassUrl.contains("?") ? "&" : "?") + "ticket=" + proxyTicket;
+        final String url = this.clearPassUrl + (this.clearPassUrl.contains("?") ? "&" : "?") +  
+                CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET + "=" + proxyTicket;
         final String response = retrieveResponseFromServer(url, "UTF-8");
         final String password = XmlUtils.getTextForElement(response, "credentials");
 

--- a/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -21,6 +21,7 @@ package org.jasig.cas.ticket.registry;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.ImmutableAuthentication;
 import org.jasig.cas.authentication.principal.Service;
@@ -75,7 +76,7 @@ public abstract class AbstractTicketRegistryTests  {
     
     public static Service getService() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", "test");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
         return SimpleWebApplicationServiceImpl.createServiceFrom(request);
     }
     

--- a/cas-server-integration-jboss/src/test/java/org/jasig/cas/ticket/registry/JBossCacheTicketRegistryTests.java
+++ b/cas-server-integration-jboss/src/test/java/org/jasig/cas/ticket/registry/JBossCacheTicketRegistryTests.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 
 import junit.framework.TestCase;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.ImmutableAuthentication;
 import org.jasig.cas.authentication.principal.SimplePrincipal;
@@ -207,7 +208,7 @@ public final class JBossCacheTicketRegistryTests extends TestCase {
     public void testGetTicketsFromRegistryEqualToTicketsAdded() {
         final Collection<Ticket> tickets = new ArrayList<Ticket>();
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", "test");
+        request.addParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, "test");
 
         for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
             final TicketGrantingTicket ticketGrantingTicket = new TicketGrantingTicketImpl(

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/OAuthConstants.java
@@ -38,15 +38,11 @@ public interface OAuthConstants {
     
     public final static String CODE = "code";
     
-    public final static String SERVICE = "service";
-    
     public final static String THEME = "theme";
     
     public final static String LOCALE = "locale";
     
     public final static String METHOD = "method";
-    
-    public final static String TICKET = "ticket";
     
     public final static String ACCESS_TOKEN = "access_token";
     

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20AuthorizeController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20AuthorizeController.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.lang.StringUtils;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.support.oauth.OAuthConstants;
@@ -106,7 +107,7 @@ public final class OAuth20AuthorizeController extends AbstractController {
             .replace("/" + OAuthConstants.AUTHORIZE_URL, "/" + OAuthConstants.CALLBACK_AUTHORIZE_URL);
         logger.debug("callbackAuthorizeUrl : {}", callbackAuthorizeUrl);
         
-        String loginUrlWithService = OAuthUtils.addParameter(loginUrl, OAuthConstants.SERVICE, callbackAuthorizeUrl);
+        String loginUrlWithService = OAuthUtils.addParameter(loginUrl, CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, callbackAuthorizeUrl);
         logger.debug("loginUrlWithService : {}", loginUrlWithService);
         return OAuthUtils.redirectTo(loginUrlWithService);
     }

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20CallbackAuthorizeController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20CallbackAuthorizeController.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.support.oauth.OAuthConstants;
 import org.jasig.cas.support.oauth.OAuthUtils;
 import org.slf4j.Logger;
@@ -47,7 +48,7 @@ public final class OAuth20CallbackAuthorizeController extends AbstractController
     protected ModelAndView handleRequestInternal(final HttpServletRequest request, final HttpServletResponse response)
         throws Exception {
         // get CAS ticket
-        final String ticket = request.getParameter(OAuthConstants.TICKET);
+        final String ticket = request.getParameter(CentralAuthenticationService.PROTOCOL_PARAMETER_TICKET);
         logger.debug("ticket : {}", ticket);
         
         // retrieve callback url from session

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/flow/OAuthAction.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/flow/OAuthAction.java
@@ -45,10 +45,11 @@ import org.springframework.webflow.execution.RequestContext;
 
 /**
  * This class represents an action in the webflow to retrieve OAuth information on the callback url which is the webflow url (/login). The
- * {@link org.jasig.cas.support.oauth.OAuthConstants.OAUTH_PROVIDER} and the other OAuth parameters are expected after OAuth authentication.
- * Providers are defined by configuration. The {@link org.jasig.cas.support.oauth.OAuthConstants.SERVICE},
- * {@link org.jasig.cas.support.oauth.OAuthConstants.THEME}, {@link org.jasig.cas.support.oauth.OAuthConstants.LOCALE} and
- * {@link org.jasig.cas.support.oauth.OAuthConstants.METHOD} parameters are saved and restored from web session after OAuth authentication.
+ * {@link org.jasig.cas.support.oauth.OAuthConstants#OAUTH_PROVIDER} and the other OAuth parameters are expected after OAuth authentication.
+ * Providers are defined by configuration. The {@link CentralAuthenticationService#PROTOCOL_PARAMETER_SERVICE},
+ * {@link org.jasig.cas.support.oauth.OAuthConstants#THEME}, {@link org.jasig.cas.support.oauth.OAuthConstants#LOCALE} and
+ * {@link org.jasig.cas.support.oauth.OAuthConstants#METHOD} parameters are saved and restored from web session after OAuth authentication.
+ * 
  * 
  * @author Jerome Leleu
  * @since 3.5.0
@@ -88,8 +89,8 @@ public final class OAuthAction extends AbstractAction {
             logger.debug("credential : {}", credential);
             
             // retrieve parameters from web session
-            final Service service = (Service) session.getAttribute(OAuthConstants.SERVICE);
-            context.getFlowScope().put(OAuthConstants.SERVICE, service);
+            final Service service = (Service) session.getAttribute(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE);
+            context.getFlowScope().put(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, service);
             restoreRequestAttribute(request, session, OAuthConstants.THEME);
             restoreRequestAttribute(request, session, OAuthConstants.LOCALE);
             restoreRequestAttribute(request, session, OAuthConstants.METHOD);
@@ -108,9 +109,9 @@ public final class OAuthAction extends AbstractAction {
             // no authentication : go to login page
             
             // save parameters in web session
-            final Service service = (Service) context.getFlowScope().get(OAuthConstants.SERVICE);
+            final Service service = (Service) context.getFlowScope().get(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE);
             if (service != null) {
-                session.setAttribute(OAuthConstants.SERVICE, service);
+                session.setAttribute(CentralAuthenticationService.PROTOCOL_PARAMETER_SERVICE, service);
             }
             saveRequestParameter(request, session, OAuthConstants.THEME);
             saveRequestParameter(request, session, OAuthConstants.LOCALE);


### PR DESCRIPTION
This pull attempts to find a number of protocol level constants, such as service and ticket that currently exist in the codebase as mere strings, hardcoded here and there. The constants should be part of the API and the interface contract that defines the protocol.

JIRA:
https://issues.jasig.org/browse/CAS-1145
