### PR TITLE
CAS-1200: Had to rename the messages_en.properties file to messages.properties...

### DIFF
--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -212,7 +212,7 @@
 	    </executions>
 	    <configuration>
 	        <messagesDirectory>${basedir}/src/main/webapp/WEB-INF/classes/</messagesDirectory>
-	        <mainMessagesFile>messages_en.properties</mainMessagesFile>
+	        <mainMessagesFile>messages.properties</mainMessagesFile>
 	    </configuration>
 	  </plugin>
     </plugins>


### PR DESCRIPTION
...for the maven translate plugin to work correctly.
