### PR TITLE
CAS-1220 : Set content type to JSON for profile in OAuth server mode

### DIFF
--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20CallbackAuthorizeController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20CallbackAuthorizeController.java
@@ -41,7 +41,7 @@ import org.springframework.web.servlet.mvc.AbstractController;
  */
 public final class OAuth20CallbackAuthorizeController extends AbstractController {
     
-    private static final Logger log = LoggerFactory.getLogger(OAuth20CallbackAuthorizeController.class);
+    private final Logger log = LoggerFactory.getLogger(OAuth20CallbackAuthorizeController.class);
     
     @Override
     protected ModelAndView handleRequestInternal(final HttpServletRequest request, final HttpServletResponse response)

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20ProfileController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20ProfileController.java
@@ -62,6 +62,8 @@ public final class OAuth20ProfileController extends AbstractController {
         final JsonFactory jsonFactory = new JsonFactory();
         final JsonGenerator jsonGenerator = jsonFactory.createJsonGenerator(response.getWriter());
         
+        response.setContentType("application/json");
+        
         // accessToken is required
         if (StringUtils.isBlank(accessToken)) {
             log.error("missing accessToken");

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/flow/OAuthAction.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/flow/OAuthAction.java
@@ -55,7 +55,7 @@ import org.springframework.webflow.execution.RequestContext;
  */
 public final class OAuthAction extends AbstractAction {
     
-    private static final Logger log = LoggerFactory.getLogger(OAuthAction.class);
+    private final Logger log = LoggerFactory.getLogger(OAuthAction.class);
     
     @NotNull
     private OAuthConfiguration configuration;

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20ProfileControllerTests.java
@@ -54,6 +54,8 @@ public final class OAuth20ProfileControllerTests extends TestCase {
     
     private static final String VALUE = "attributeValue";
     
+    private static final String CONTENT_TYPE = "application/json";
+    
     public void testNoAccessToken() throws Exception {
         final MockHttpServletRequest mockRequest = new MockHttpServletRequest("GET", CONTEXT
                                                                                      + OAuthConstants.PROFILE_URL);
@@ -64,6 +66,7 @@ public final class OAuth20ProfileControllerTests extends TestCase {
         OAuth20ProfileController.setLogger(logger);
         oauth20WrapperController.handleRequest(mockRequest, mockResponse);
         assertEquals(200, mockResponse.getStatus());
+        assertEquals(CONTENT_TYPE, mockResponse.getContentType());
         assertEquals("{\"error\":\"" + OAuthConstants.MISSING_ACCESS_TOKEN + "\"}", mockResponse.getContentAsString());
         verify(logger).error("missing accessToken");
     }
@@ -82,6 +85,7 @@ public final class OAuth20ProfileControllerTests extends TestCase {
         OAuth20ProfileController.setLogger(logger);
         oauth20WrapperController.handleRequest(mockRequest, mockResponse);
         assertEquals(200, mockResponse.getStatus());
+        assertEquals(CONTENT_TYPE, mockResponse.getContentType());
         assertEquals("{\"error\":\"" + OAuthConstants.EXPIRED_ACCESS_TOKEN + "\"}", mockResponse.getContentAsString());
         verify(logger).error("expired accessToken : {}", TGT_ID);
     }
@@ -102,6 +106,7 @@ public final class OAuth20ProfileControllerTests extends TestCase {
         OAuth20ProfileController.setLogger(logger);
         oauth20WrapperController.handleRequest(mockRequest, mockResponse);
         assertEquals(200, mockResponse.getStatus());
+        assertEquals(CONTENT_TYPE, mockResponse.getContentType());
         assertEquals("{\"error\":\"" + OAuthConstants.EXPIRED_ACCESS_TOKEN + "\"}", mockResponse.getContentAsString());
         verify(logger).error("expired accessToken : {}", TGT_ID);
     }
@@ -128,6 +133,7 @@ public final class OAuth20ProfileControllerTests extends TestCase {
         oauth20WrapperController.afterPropertiesSet();
         oauth20WrapperController.handleRequest(mockRequest, mockResponse);
         assertEquals(200, mockResponse.getStatus());
+        assertEquals(CONTENT_TYPE, mockResponse.getContentType());
         assertEquals("{\"id\":\"" + ID + "\",\"attributes\":[{\"" + NAME + "\":\"" + VALUE + "\"}]}",
                      mockResponse.getContentAsString());
     }


### PR DESCRIPTION
Small improvment for OAuth server support in 4.0.0 : set content type for profile response.

Same as #161.
