### PR TITLE
CAS-1181 Logging Tweaks in AbstractAuthenticationManager

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/AbstractAuthenticationManager.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/AbstractAuthenticationManager.java
@@ -103,9 +103,9 @@ public abstract class AbstractAuthenticationManager implements AuthenticationMan
     protected void logAuthenticationHandlerError(final String handlerName, final Credentials credentials, final Exception e) {
         if (e instanceof AuthenticationException) {
             // CAS-1181 Log common authentication failures at INFO without stack trace
-            this.log.info("{} failed authenticating {}", handlerName, credentials);
+            log.info("{} failed authenticating {}", handlerName, credentials);
         } else {
-            this.log.error("{} threw error authenticating {}", handlerName, credentials, e);
+            log.error("{} threw error authenticating {}", handlerName, credentials, e);
         }
     }
 


### PR DESCRIPTION
From CAS-1181:
Further testing reveals AuthenticationHandler changes are not sufficient to remedy the issue. Code review and testing indicates that logging changes in AbstractAuthenticationManager introduced in the LPPE changesets produce stack traces under nominal circumstances with all authentication handlers.

This pull provides special treatment of AuthenticationException in logAuthenticationHandlerError, without which a stack trace is produced for all AuthenticationHandler errors. The change here logs AuthenticationExceptions, which are thrown for non-error conditions such as authn failures, at INFO level without a stack trace. Some additional log cleanup is included while we're making logging changes in this component.
