### PR TITLE
CAS-1229: Provide support for better site generation of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Please [see the maven docs][skip] on how to disable the tests.
 ## Documentation
 - [CAS Protocol][protocol]
 - [CAS User Manual](https://wiki.jasig.org/display/CASUM/Home)
-- [Javadocs](http://jasig.github.com/cas/apidocs/index.html)
+- [Javadocs](https://oss.sonatype.org/content/repositories/releases/org/jasig/cas/) 
+Javadocs may also be created locally using the Maven command: `mvn clean site site:stage` and will then be available at the `target/staging` folder of the root project directory.
 - [Release Notes](https://issues.jasig.org/secure/ReleaseNote.jspa?projectId=10007)
 
 ## Addons

--- a/cas-management-webapp/src/site/site.xml
+++ b/cas-management-webapp/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-compatibility/src/site/site.xml
+++ b/cas-server-compatibility/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-core/src/site/site.xml
+++ b/cas-server-core/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-documentation/src/site/site.xml
+++ b/cas-server-documentation/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-extension-clearpass/src/site/site.xml
+++ b/cas-server-extension-clearpass/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-integration-ehcache/src/site/site.xml
+++ b/cas-server-integration-ehcache/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-integration-jboss/src/site/site.xml
+++ b/cas-server-integration-jboss/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-integration-memcached/src/site/site.xml
+++ b/cas-server-integration-memcached/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-integration-restlet/src/site/site.xml
+++ b/cas-server-integration-restlet/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-generic/src/site/site.xml
+++ b/cas-server-support-generic/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-jdbc/src/site/site.xml
+++ b/cas-server-support-jdbc/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-ldap/src/site/site.xml
+++ b/cas-server-support-ldap/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-legacy/src/site/site.xml
+++ b/cas-server-support-legacy/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-oauth/src/site/site.xml
+++ b/cas-server-support-oauth/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-openid/src/site/site.xml
+++ b/cas-server-support-openid/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-radius/src/site/site.xml
+++ b/cas-server-support-radius/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-spnego/src/site/site.xml
+++ b/cas-server-support-spnego/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-trusted/src/site/site.xml
+++ b/cas-server-support-trusted/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-support-x509/src/site/site.xml
+++ b/cas-server-support-x509/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-uber-webapp/src/site/site.xml
+++ b/cas-server-uber-webapp/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/cas-server-webapp/src/site/site.xml
+++ b/cas-server-webapp/src/site/site.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="Jasig CAS ${project.version}">
+    <body>        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" inherit="top" />
+		<menu ref="modules" name="Modules" inherit="top" />
+    </body>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,15 @@
     <developerConnection>scm:git:git@github.com:Jasig/cas.git</developerConnection>
     <url>https://github.com/Jasig/cas</url>
   </scm>
-
+	
+  <distributionManagement>
+    <site>
+      <id>cas-site</id>
+      <name>CAS Staging Site Documentation</name>
+      <url>file:${project.site.deployDirectory}</url>
+    </site>
+  </distributionManagement>
+	
   <build>
     <testResources>
       <testResource>
@@ -280,7 +288,7 @@
                   <version>2.0.9</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>${jdk.version}</version>
+                  <version>${project.build.sourceVersion}</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -298,7 +306,7 @@ mi2KuXZFGad>>Lz0ULLXhqIo2KPjARsdren1aP3vzebzkM
 qNNNUvQNpqopPoOQRqmTvqoPnOnMopRPqpSUtxrWTxOxTu
 pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
 97W9kZkUUnmm]]></license>
-          <jdk>${jdk.version}</jdk>
+          <jdk>${project.build.sourceVersion}</jdk>
           <generateXml>true</generateXml>
           <generateHtml>true</generateHtml>
           <includes>
@@ -324,8 +332,8 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
+          <source>${project.build.sourceVersion}</source>
+          <target>${project.build.targetVersion}</target>
         </configuration>
       </plugin>
       <plugin>
@@ -361,8 +369,8 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
           </execution>
         </executions>
         <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
+          <source>${project.build.sourceVersion}</source>
+          <target>${project.build.targetVersion}</target>
         </configuration>
       </plugin>
       <plugin>
@@ -830,6 +838,11 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <version>2.4</version>
         <reportSets>
@@ -850,15 +863,6 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.9.1</version>
       </plugin>
-      <!--
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId> 
-        <configuration>
-          <minmemory>128m</minmemory>
-          <maxmemory>512</maxmemory>
-        </configuration> 
-      </plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
@@ -868,6 +872,28 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>2.7.1</version>
+        <configuration>
+          <targetJdk>${project.build.targetVersion}</targetJdk>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>1.3.1</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>dependency-updates-report</report>
+              <report>plugin-updates-report</report>
+              <report>property-updates-report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>taglist-maven-plugin</artifactId>
+        <version>2.4</version>
       </plugin>
     </plugins>
   </reporting>
@@ -893,11 +919,11 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.8</version>
+						<version>2.9</version>
             <configuration>
-              <charset>UTF-8</charset>
-              <encoding>UTF-8</encoding>
-              <docencoding>UTF-8</docencoding>
+              <charset>${project.reporting.outputEncoding}</charset>
+              <encoding>${project.reporting.outputEncoding}</encoding>
+              <docencoding>${project.reporting.outputEncoding}</docencoding>
             </configuration>
             <executions>
               <execution>
@@ -937,7 +963,12 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
     <inspektr.version>1.0.7.GA</inspektr.version>
     <commons.io.version>2.0</commons.io.version>
     <mockito.version>1.9.0</mockito.version>
-    <jdk.version>1.6</jdk.version>
     <ehcache.version>2.6.0</ehcache.version>
+		
+    <project.build.sourceVersion>1.6</project.build.sourceVersion>
+    <project.build.targetVersion>1.6</project.build.targetVersion>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.site.deployDirectory>/tmp/cas-deploy-site</project.site.deployDirectory>
   </properties>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -20,6 +20,27 @@
 
 -->
 <project name="Jasig CAS ${project.version}">
+	<skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.3.0</version>
+    </skin>
+    <custom>
+        <fluidoSkin>
+          <sideBarEnabled>true</sideBarEnabled>
+          <googlePlusOne />
+          <googleSearch>
+            <sitesearch/>
+          </googleSearch>
+          <twitter>
+            <user>Jasig</user>
+            <showUser>true</showUser>
+            <showFollowers>true</showFollowers>
+          </twitter>
+          <facebookLike />
+        </fluidoSkin>
+    </custom>
+		
     <bannerLeft>
         <name>CAS</name>
         <src>images/cas-logo-150x83.png</src>
@@ -41,7 +62,9 @@
           <item name="CAS User Manual" href="casum/html/chunked/index.html" />
           <item name="CAS User Manual (Single Page)" href="casum/html/single/manual.html" />
         </menu>
-          
-        <menu ref="reports" />
+        
+		<menu ref="parent" />
+        <menu ref="reports" name="Reports" />
+		<menu ref="modules" name="Modules" />
     </body>
 </project>


### PR DESCRIPTION
Allow the maven 'site' to include javadocs in its set of reports.
Add additional reports for taglist and dependency/plugins version report.
Correct the javadoc links in the README file.

https://issues.jasig.org/browse/CAS-1229
