### PR TITLE
Add X509 Alternative Names resolver

### DIFF
--- a/cas-server-support-x509/src/main/java/org/jasig/cas/adaptors/x509/authentication/principal/X509CertificateCredentialsToAlternativeNamesPrincipalResolver.java
+++ b/cas-server-support-x509/src/main/java/org/jasig/cas/adaptors/x509/authentication/principal/X509CertificateCredentialsToAlternativeNamesPrincipalResolver.java
@@ -135,48 +135,48 @@ public class X509CertificateCredentialsToAlternativeNamesPrincipalResolver
             if (subjAltNames != null) {
                 for ( List<?> next : subjAltNames) {
                     String value = "";
-                    bool implemented = false;
+                    boolean implemented = false;
 
                     int code = ((Integer)next.get(0)).intValue();
                     if (code < NameTypes.values().length) {
                         try {
                             switch (NameTypes.fromCode(code))
                             {
-                            case NameTypes.OTHERNAME: 
+                            case OTHERNAME: 
                                 name = "OTHERNAME";
                                 break;
-                            case NameTypes.RFC822NAME:
+                            case RFC822NAME:
                                 name = "RFC822NAME";
                                 value = (String) next.get(1);
                                 implemented = true;
                                 break;
-                            case NameTypes.DNSNAME:
+                            case DNSNAME:
                                 name = "DNSNAME";
                                 value = (String) next.get(1);
                                 implemented = true;
                                 break;
-                            case NameTypes.X400ADDRESS:
+                            case X400ADDRESS:
                                 name = "X400ADDRESS";
                                 break;
-                            case NameTypes.DIRECTORYNAME:
+                            case DIRECTORYNAME:
                                 name = "DIRECTORYNAME";
                                 value = (String) next.get(1);
                                 implemented = true;
                                 break;
-                            case NameTypes.EDIPARTYNAME:
+                            case EDIPARTYNAME:
                                 name = "EDIPARTYNAME";
                                 break;
-                            case NameTypes.URI:
+                            case URI:
                                 name = "URI";
                                 value = (String) next.get(1);
                                 implemented = true;
                                 break;
-                            case NameTypes.IPADDRESS:
+                            case IPADDRESS:
                                 name = "IPADDRESS";
                                 value = (String) next.get(1);
                                 implemented = true;
                                 break;
-                            case NameTypes.REGISTEREDID:
+                            case REGISTEREDID:
                                 name = "REGISTEREDID";
                                 value = (String) next.get(1);
                                 implemented = true;
@@ -199,7 +199,7 @@ public class X509CertificateCredentialsToAlternativeNamesPrincipalResolver
                                 context = new AttributeContext(name, values);
                             } else {
                                 context = attrMap.get(name);
-                                context.addValue((String) value next.get(1));
+                                context.addValue( value);
                             }
 
                             attrMap.put(name,context);


### PR DESCRIPTION
Hi, 

I have written an X.509 Alternative names resolver. Besides others it allows to read Email addresses from the certificates and provide them as user names. This is especially useful for lightweight integration with Liferay in case there is no LDAP access to the certificate authority availlable and Liferay authenticates users according to their Email address.

It is a fork from the X509CertificateCredentialsToSubjectPrinciplalResolver class.

I'm using it with

<bean class="org.jasig.cas.adaptors.x509.authentication.principal.X509CertificateCredentialsToAlternativeNamesPrincipalResolver" p:descriptor="$RFC822NAME" />

In my project for which I developed it. It would be nice if you could include this feature in future CAS versions.
