### PR TITLE
Fix to issue CAS-1249

### DIFF
--- a/cas-server-webapp/src/main/java/org/jasig/cas/web/support/AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp/src/main/java/org/jasig/cas/web/support/AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapter.java
@@ -40,6 +40,11 @@ import javax.servlet.http.HttpServletRequest;
 public abstract class AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapter extends AbstractThrottledSubmissionHandlerInterceptorAdapter {
 
     private final ConcurrentMap<String, Date> ipMap = new ConcurrentHashMap<String, Date>();
+	private String IPAddressParam;
+	
+	public void setIPAddressParam(String IPAddressParam) {
+		this.IPAddressParam = IPAddressParam;
+	}
 
     @Override
     protected final boolean exceedsThreshold(final HttpServletRequest request) {
@@ -75,6 +80,22 @@ public abstract class AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapt
         }
         log.debug("Done decrementing count for throttler.");
     }
+	
+	/**
+     * Gets the IP address of a request, using either the standard getRemoteAddr() or
+	 * if IPAddressParam is non-null use getHeader(IPAddressParam)
+     *
+     * @param request The HttpServletRequest
+	 
+     * @return The value of either getRemoteAddr() or the configured header value. If the header vaule is null returns getRemoteAddr
+	 *		   to avoid the possibility of returning null
+     */
+	protected String getRemoteAddr(final HttpServletRequest request) {
+		if(IPAddressParam==null) 
+			return request.getRemoteAddr();
+		else 
+			return (request.getHeader(IPAddressParam)!=null) ? request.getHeader(IPAddressParam):request.getRemoteAddr();					
+	}
 
     /**
      * Computes the instantaneous rate in between two given dates corresponding to two submissions.

--- a/cas-server-webapp/src/main/java/org/jasig/cas/web/support/InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
+++ b/cas-server-webapp/src/main/java/org/jasig/cas/web/support/InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
@@ -35,9 +35,9 @@ public final class InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInter
         final String username = request.getParameter(getUsernameParameter());
 
         if (username == null) {
-            return request.getRemoteAddr();
+            return getRemoteAddr(request);
         }
 
-        return request.getRemoteAddr() + ";" + username.toLowerCase();
+        return getRemoteAddr(request) + ";" + username.toLowerCase();
     }
 }

--- a/cas-server-webapp/src/main/java/org/jasig/cas/web/support/InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapter.java
+++ b/cas-server-webapp/src/main/java/org/jasig/cas/web/support/InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapter.java
@@ -32,6 +32,6 @@ public final class InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapt
 
     @Override
     protected String constructKey(final HttpServletRequest request) {
-        return request.getRemoteAddr();
+        return getRemoteAddr(request);
     }
 }


### PR DESCRIPTION
Adds an optional parameter to AbstractInMemoryThrottledSubmissionHandlerInterceptorAdapter that configures the IPAddress Interceptors
to use the configured header instead of  the value of request.getRemoteAddr() for reading the client IP address.

Example configuration:

```
<bean id="throttleInterceptor" class="org.jasig.cas.web.support.InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter">
<property name="IPAddressParam"><value>X-Forwarded-For</value></property>
</bean>
```
