### PR TITLE
CAS-1244 Restore error handling behavior of AuthenticationManager components.

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationManagerImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationManagerImpl.java
@@ -98,12 +98,8 @@ public final class AuthenticationManagerImpl extends AbstractAuthenticationManag
                         authenticated = true;
                         break;
                     }
-                } catch (AuthenticationException e) {
-                    logAuthenticationHandlerError(handlerName, credentials, e);
-                    throw e;
-                } catch (RuntimeException e) {
-                    logAuthenticationHandlerError(handlerName, credentials, e);
-                    throw e;
+                } catch (final Exception e) {
+                    handleError(handlerName, credentials, e);
                 }
             }
         }

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/DirectMappingAuthenticationManagerImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/DirectMappingAuthenticationManagerImpl.java
@@ -60,12 +60,8 @@ public final class DirectMappingAuthenticationManagerImpl extends AbstractAuthen
 
         try {
             authenticated = d.getAuthenticationHandler().authenticate(credentials);
-        } catch (AuthenticationException e) {
-            logAuthenticationHandlerError(handlerName, credentials, e);
-            throw e;
-        } catch (RuntimeException e) {
-            logAuthenticationHandlerError(handlerName, credentials, e);
-            throw e;
+        } catch (final Exception e) {
+            handleError(handlerName, credentials, e);
         }
 
         if (!authenticated) {

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/LinkedAuthenticationHandlerAndCredentialsToPrincipalResolverAuthenticationManager.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/LinkedAuthenticationHandlerAndCredentialsToPrincipalResolverAuthenticationManager.java
@@ -63,12 +63,8 @@ public class LinkedAuthenticationHandlerAndCredentialsToPrincipalResolverAuthent
                         
             try {
                 authenticated = authenticationHandler.authenticate(credentials);
-            } catch (AuthenticationException e) {
-                logAuthenticationHandlerError(handlerName, credentials, e);
-                throw e;
-            } catch (RuntimeException e) {
-                logAuthenticationHandlerError(handlerName, credentials, e);
-                throw e;
+            } catch (final Exception e) {
+                handleError(handlerName, credentials, e);
             }
 
             if (authenticated) {


### PR DESCRIPTION
Commit baf4ff7f7d9f0c60341be70aad49b5895667da20 broke the documented behavior of AuthenticationManagerImpl and the undocumented behavior of the other AuthetnicationManager implementations. The former behavior, to throw the first exception of any kind produced by an AuthenticationHandler, has been restored.

This change should be reviewed for compatibility with LPPE changes that have occurred since baf4ff.
