### PR TITLE
CAS-1251

### DIFF
--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -95,7 +95,7 @@
 	    <groupId>net.sf.spring-json</groupId>
 	    <artifactId>spring-json</artifactId>
 	    <version>1.3.1</version>
-	    <scope>runtime</scope>
+	    <scope>compile</scope>
 	    <exclusions>
 	    	<exclusion>
 		    	<groupId>net.sf.sojo</groupId>

--- a/cas-server-webapp/src/main/java/org/jasig/cas/web/view/HtmlEscapedExceptionMessageExceptionHandler.java
+++ b/cas-server-webapp/src/main/java/org/jasig/cas/web/view/HtmlEscapedExceptionMessageExceptionHandler.java
@@ -1,0 +1,32 @@
+package org.jasig.cas.web.view;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.springframework.web.servlet.view.json.JsonExceptionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+/**
+ * Implementation of JsonView's exception handler that provides an XML-escaped response to prevent cross-site scripting attacks.
+ *
+ * @author Scott Battaglia
+ * @since 4.0.0
+ */
+public final class HtmlEscapedExceptionMessageExceptionHandler implements JsonExceptionHandler {
+
+    public static final String MESSAGE_MODEL_KEY = "exception.message";
+
+    @NotNull
+    private String modelKey = MESSAGE_MODEL_KEY;
+
+    @Override
+    public void triggerException(final Exception e, final Map model, final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse) throws Exception {
+        model.put(this.modelKey, StringEscapeUtils.escapeHtml(e.getMessage()));
+    }
+
+    public void setModelKey(final String modelKey) {
+        this.modelKey = modelKey;
+    }
+}

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
@@ -123,7 +123,7 @@
         </property>
         <property name="exceptionHandler">
 	        <list>
-	        	<bean class="org.springframework.web.servlet.view.json.exception.ExceptionMessageExceptionHandler" />
+	        	<bean class="org.jasig.cas.web.view.HtmlEscapedExceptionMessageExceptionHandler" />
 	            <bean class="org.springframework.web.servlet.view.json.exception.StackTraceExceptionHandler" />
 	        </list>
         </property>


### PR DESCRIPTION
disable unescaped user input from being reprinted. This is probably a short term fix.  Long term this view resolver should not be called for these types of errors.

Is this resolver still needed in the main application?  If so, then we need to make sure this error resolver is only called for AJAX calls.
