### PR TITLE
CAS-1248: CASImpl ignores authentication attributes when registered 

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -369,7 +369,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
             final Principal principal = authentication.getPrincipal();
            
             final String principalId = determinePrincipalIdForRegisteredService(principal, registeredService, serviceTicket);
-            Map<String, Object> attributesToRelease =  new HashMap<String, Object>();
+            final Map<String, Object> attributesToRelease = new HashMap<String, Object>();
             
             if (!registeredService.isIgnoreAttributes()) {
                 for (final String attribute : registeredService.getAllowedAttributes()) {


### PR DESCRIPTION
service is set to ignore attribute release policy of svc registry
