### PR TITLE
CAS-1253 Avoid duplicate joda-time dependencies.

### DIFF
--- a/cas-server-core/pom.xml
+++ b/cas-server-core/pom.xml
@@ -187,6 +187,10 @@
               <groupId>org.slf4j</groupId>
               <artifactId>log4j-over-slf4j</artifactId>
             </exclusion>
+            <exclusion>
+              <groupId>joda-time</groupId>
+              <artifactId>joda-time</artifactId>
+            </exclusion>
           </exclusions>
         </dependency>
 
@@ -224,6 +228,12 @@
             <version>${commons.io.version}</version>
             <scope>compile</scope>
             <type>jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <scope>compile</scope>
         </dependency>
             
         <dependency>

--- a/cas-server-support-ldap/pom.xml
+++ b/cas-server-support-ldap/pom.xml
@@ -79,12 +79,11 @@
       <scope>test</scope>
     </dependency>
 
-	<dependency>
-		<groupId>joda-time</groupId>
-		<artifactId>joda-time</artifactId>
-		<version>2.1</version>
-		<scope>compile</scope>
-	</dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -826,6 +826,12 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
         <artifactId>hsqldb</artifactId>
         <version>${hsqldb.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>${joda-time.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -983,6 +989,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
     <mockito.version>1.9.0</mockito.version>
     <ehcache.version>2.6.2</ehcache.version>
     <hsqldb.version>2.0.0</hsqldb.version>
+    <joda-time.version>2.1</joda-time.version>
 	
     <project.build.sourceVersion>1.6</project.build.sourceVersion>
     <project.build.targetVersion>1.6</project.build.targetVersion>


### PR DESCRIPTION
Duplicate joda-time dependencies may arise in overlays that include cas-server-support-ldap. Declare direct depencency on joda-time for core and cas-server-support-ldap and exclude from transitive dependencies to ensure single consistent version.
