### PR TITLE
CAS-1251: Possible Cross-Site Scripting on /login using execution parameter

### DIFF
--- a/cas-server-webapp/src/main/java/org/jasig/cas/web/FlowExecutionExceptionResolver.java
+++ b/cas-server-webapp/src/main/java/org/jasig/cas/web/FlowExecutionExceptionResolver.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
+import org.springframework.webflow.execution.repository.BadlyFormattedFlowExecutionKeyException;
 import org.springframework.webflow.execution.repository.FlowExecutionRepositoryException;
 
 /**
@@ -62,8 +63,13 @@ public final class FlowExecutionExceptionResolver implements HandlerExceptionRes
          * Since FlowExecutionRepositoryException is a common ancestor to these exceptions and other 
          * error cases we would likely want to hide from the user, it seems reasonable to check for
          * FlowExecutionRepositoryException.
+         * 
+         * BadlyFormattedFlowExecutionKeyException is specifically ignored by this handler
+         * because redirecting to the requested URI with this exception may cause an infinite
+         * redirect loop (i.e. when invalid "execution" parameter exists as part of the query string
          */
-        if (!(exception instanceof FlowExecutionRepositoryException)) {
+        if (!(exception instanceof FlowExecutionRepositoryException) || 
+              exception instanceof BadlyFormattedFlowExecutionKeyException) {
             log.debug("Ignoring the received exception due to a type mismatch", exception);
             return null;
         }

--- a/cas-server-webapp/src/test/java/org/jasig/cas/web/FlowExecutionExceptionResolverTests.java
+++ b/cas-server-webapp/src/test/java/org/jasig/cas/web/FlowExecutionExceptionResolverTests.java
@@ -30,6 +30,7 @@ import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.webflow.conversation.impl.BadlyFormattedConversationIdException;
 import org.springframework.webflow.execution.FlowExecutionKey;
 import org.springframework.webflow.execution.repository.BadlyFormattedFlowExecutionKeyException;
+import org.springframework.webflow.execution.repository.FlowExecutionRepositoryException;
 import org.springframework.webflow.execution.repository.NoSuchFlowExecutionException;
 
 /**
@@ -82,15 +83,9 @@ public class FlowExecutionExceptionResolverTests {
     
     @Test
     public void testBadlyFormattedExecutionException() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setRequestURI("test");
-        request.setQueryString("execution=e2s1<iframe src=javascript:alert(26748)");
-        ModelAndView model = (this.resolver.resolveException(request,
-            new MockHttpServletResponse(), null,
-            new BadlyFormattedFlowExecutionKeyException("invalidKey", "e2s1")));
-
-        assertEquals(request.getRequestURI() + "?" + request.getQueryString(), ((RedirectView) model.getView())
-                .getUrl());
+        assertNull(this.resolver.resolveException(new MockHttpServletRequest(),
+                   new MockHttpServletResponse(), null, 
+                   new BadlyFormattedFlowExecutionKeyException("invalidKey", "e2s1")));
     }
     
     @Test
@@ -122,5 +117,4 @@ public class FlowExecutionExceptionResolverTests {
         assertEquals(request.getRequestURI() + "?" + request.getQueryString(), ((RedirectView) model.getView())
             .getUrl());
     }
-
 }


### PR DESCRIPTION
Fixed an issue with the webflow exception resolver to also ignore badly formatted key exception, since it will result in an infinite redirect loop.
