### PR TITLE
JavaDoc AbstractTicket deliberate lack of protected Logger instance

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/AbstractTicket.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/AbstractTicket.java
@@ -19,7 +19,12 @@ import org.springframework.util.Assert;
  * an abstract class, it cannnot be instanciated. It is recommended that
  * implementations of the Ticket interface extend the AbstractTicket as it
  * handles common functionality amongst different ticket types (such as state
- * updating).
+ * updating).  
+ * 
+ * AbstractTicket does not provide a protected Logger instance to
+ * avoid instantiating many such Loggers at runtime (there will be many instances
+ * of subclasses of AbstractTicket in a typical running CAS server).  Instead 
+ * subclasses should use static Logger instances.
  * 
  * @author Scott Battaglia
  * @version $Revision$ $Date$


### PR DESCRIPTION
AbstractTicket deliberately provides no protected Logger instance to subclasses in order to reduce object creation thrash.  Added documentation of this design decision and advice to subclasses in using static Logger instead.
