### PR TITLE
CAS-1264: Move OpenIdProviderController from webapp to OpenID module

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -146,11 +146,6 @@
 
   <servlet-mapping>
     <servlet-name>cas</servlet-name>
-    <url-pattern>/openid/*</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
-    <servlet-name>cas</servlet-name>
     <url-pattern>/status</url-pattern>
   </servlet-mapping>
 


### PR DESCRIPTION
My fault, I forget to remove the mapping for /openid/*...
