### PR TITLE
CAS-1272: Renamed SimpleTestUsernamePasswordAuthN Handler

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/MatchingUsernamePasswordAuthenticationHandler.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/handler/support/MatchingUsernamePasswordAuthenticationHandler.java
@@ -28,16 +28,13 @@ import org.springframework.util.StringUtils;
  * load testing.
  * 
  * @author Scott Battaglia
- * @version $Revision$ $Date$
  * @since 3.0
  */
-public final class SimpleTestUsernamePasswordAuthenticationHandler extends
-    AbstractUsernamePasswordAuthenticationHandler {
+public final class MatchingUsernamePasswordAuthenticationHandler extends AbstractUsernamePasswordAuthenticationHandler {
 
-    public SimpleTestUsernamePasswordAuthenticationHandler() {
-        log
-            .warn(this.getClass().getName()
-                + " is only to be used in a testing environment.  NEVER enable this in a production environment.");
+    public MatchingUsernamePasswordAuthenticationHandler() {
+        log.warn("{} is only to be used in a testing environment. NEVER enable this in a production environment.",
+                  this.getClass().getName());
     }
 
     public boolean authenticateUsernamePasswordInternal(final UsernamePasswordCredentials credentials) {
@@ -46,13 +43,11 @@ public final class SimpleTestUsernamePasswordAuthenticationHandler extends
 
         if (StringUtils.hasText(username) && StringUtils.hasText(password)
             && username.equals(getPasswordEncoder().encode(password))) {
-            log
-                .debug("User [" + username
-                    + "] was successfully authenticated.");
+            log.debug("User [{}] was successfully authenticated.", username);
             return true;
         }
 
-        log.debug("User [" + username + "] failed authentication");
+        log.debug("User [{}] failed authentication", username);
 
         return false;
     }

--- a/cas-server-core/src/test/java/org/jasig/cas/authentication/handler/support/MatchingUsernamePasswordAuthenticationHandlerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/authentication/handler/support/MatchingUsernamePasswordAuthenticationHandlerTests.java
@@ -21,81 +21,79 @@ package org.jasig.cas.authentication.handler.support;
 import org.jasig.cas.TestUtils;
 import org.jasig.cas.authentication.handler.AuthenticationException;
 import org.jasig.cas.authentication.handler.PlainTextPasswordEncoder;
-import org.jasig.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler;
+import org.jasig.cas.authentication.handler.support.MatchingUsernamePasswordAuthenticationHandler;
 import org.jasig.cas.authentication.principal.UsernamePasswordCredentials;
+import org.junit.Before;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
 /**
  * Test of the simple username/password handler
  * 
  * @author Scott Battaglia
- * @version $Revision$ $Date$
  * @since 3.0
  */
-public final class SimpleTestUsernamePasswordHandlerTests extends TestCase {
+public final class MatchingUsernamePasswordAuthenticationHandlerTests {
 
-    private SimpleTestUsernamePasswordAuthenticationHandler authenticationHandler;
+    private MatchingUsernamePasswordAuthenticationHandler authenticationHandler;
 
-    protected void setUp() throws Exception {
-        this.authenticationHandler = new SimpleTestUsernamePasswordAuthenticationHandler();
-        this.authenticationHandler
-            .setPasswordEncoder(new PlainTextPasswordEncoder());
+    @Before
+    public void setUp() throws Exception {
+        this.authenticationHandler = new MatchingUsernamePasswordAuthenticationHandler();
+        this.authenticationHandler.setPasswordEncoder(new PlainTextPasswordEncoder());
     }
 
+    @Test
     public void testSupportsProperUserCredentials() {
         assertTrue(this.authenticationHandler.supports(TestUtils
             .getCredentialsWithSameUsernameAndPassword()));
     }
 
+    @Test
     public void testDoesntSupportBadUserCredentials() {
         assertFalse(this.authenticationHandler.supports(TestUtils
             .getHttpBasedServiceCredentials()));
     }
 
+    @Test
     public void testValidUsernamePassword() throws AuthenticationException {
         assertTrue(this.authenticationHandler.authenticate(TestUtils
             .getCredentialsWithSameUsernameAndPassword()));
     }
 
-    public void testInvalidUsernamePassword() {
-        try {
-            assertFalse(this.authenticationHandler.authenticate(TestUtils
+    @Test
+    public void testInvalidUsernamePassword() throws AuthenticationException {
+        assertFalse(this.authenticationHandler.authenticate(TestUtils
                 .getCredentialsWithDifferentUsernameAndPassword()));
-        } catch (AuthenticationException ae) {
-            // this is okay
-        }
     }
 
-    public void testNullUsernamePassword() {
-        try {
-            assertFalse(this.authenticationHandler.authenticate(TestUtils
-                .getCredentialsWithSameUsernameAndPassword(null)));
-        } catch (AuthenticationException ae) {
-            // this is okay
-        }
+    @Test
+    public void testNullUsernamePassword() throws AuthenticationException {
+        assertFalse(this.authenticationHandler.authenticate(TestUtils.getCredentialsWithSameUsernameAndPassword(null)));
     }
     
+    @Test
     public void testAlternateClass() {
         this.authenticationHandler.setClassToSupport(UsernamePasswordCredentials.class);
         assertTrue(this.authenticationHandler.supports(new UsernamePasswordCredentials()));
     }
     
+    @Test
     public void testAlternateClassWithSubclassSupport() {
         this.authenticationHandler.setClassToSupport(UsernamePasswordCredentials.class);
         this.authenticationHandler.setSupportSubClasses(true);
         assertTrue(this.authenticationHandler.supports(new ExtendedCredentials()));
     }
     
+    @Test
     public void testAlternateClassWithNoSubclassSupport() {
         this.authenticationHandler.setClassToSupport(UsernamePasswordCredentials.class);
         this.authenticationHandler.setSupportSubClasses(false);
         assertFalse(this.authenticationHandler.supports(new ExtendedCredentials()));
     }
-    
-    protected class ExtendedCredentials extends UsernamePasswordCredentials {
-
+   
+    private class ExtendedCredentials extends UsernamePasswordCredentials {
         private static final long serialVersionUID = 406992293105518363L;
-        // nothing to see here
     }
 }

--- a/cas-server-core/src/test/resources/core-context.xml
+++ b/cas-server-core/src/test/resources/core-context.xml
@@ -133,7 +133,7 @@
 			name="authenticationHandlers">
 			<list>
 				<ref
-					local="simpleTestUsernamePasswordAuthenticationHandler" />
+					local="matchingUsernamePasswordAuthenticationHandler" />
 				<ref
 					local="httpBasedServiceCredentialsAuthenticationHandler" />
 <!--				<bean
@@ -182,8 +182,8 @@
 	</bean>
 	
 	<bean
-		id="simpleTestUsernamePasswordAuthenticationHandler"
-		class="org.jasig.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler" />		
+		id="matchingUsernamePasswordAuthenticationHandler"
+		class="org.jasig.cas.authentication.handler.support.MatchingUsernamePasswordAuthenticationHandler" />		
 		
 	<bean
 		id="authenticationMetaDataPopulator"

--- a/cas-server-support-ldap/src/main/resources/deployerConfigContext.xml
+++ b/cas-server-support-ldap/src/main/resources/deployerConfigContext.xml
@@ -30,7 +30,7 @@
 	| file is among those declared in the context parameter "contextConfigLocation".
 	|
 	| By far the most common change you will need to make in this file is to change the last bean
-	| declaration to replace the default SimpleTestUsernamePasswordAuthenticationHandler with
+	| declaration to replace the default MatchingUsernamePasswordAuthenticationHandler with
 	| one implementing your approach for authenticating usernames and passwords.
 	+-->
 <beans>
@@ -101,7 +101,7 @@
 
 				<!--
 					| This is the authentication handler declaration that every CAS deployer will need to change before deploying CAS 
-					| into production.  The default SimpleTestUsernamePasswordAuthenticationHandler authenticates UsernamePasswordCredentials
+					| into production.  The default MatchingUsernamePasswordAuthenticationHandler authenticates UsernamePasswordCredentials
 					| where the username equals the password.  You will need to replace this with an AuthenticationHandler that implements your
 					| local authentication strategy.  You might accomplish this by coding a new such handler and declaring
 					| edu.someschool.its.cas.MySpecialHandler here, or you might use one of the handlers provided in the adaptors modules.

--- a/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/DirectMappingAuthenticationManagerImplTests.java
+++ b/cas-server-support-saml/src/test/java/org/jasig/cas/support/saml/authentication/DirectMappingAuthenticationManagerImplTests.java
@@ -31,7 +31,7 @@ import org.jasig.cas.authentication.AuthenticationMetaDataPopulator;
 import org.jasig.cas.authentication.DirectMappingAuthenticationManagerImpl;
 import org.jasig.cas.authentication.DirectMappingAuthenticationManagerImpl.DirectAuthenticationHandlerMappingHolder;
 import org.jasig.cas.authentication.handler.BadCredentialsAuthenticationException;
-import org.jasig.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler;
+import org.jasig.cas.authentication.handler.support.MatchingUsernamePasswordAuthenticationHandler;
 import org.jasig.cas.authentication.principal.Credentials;
 import org.jasig.cas.authentication.principal.HttpBasedServiceCredentials;
 import org.jasig.cas.authentication.principal.UsernamePasswordCredentials;
@@ -52,7 +52,7 @@ public class DirectMappingAuthenticationManagerImplTests extends TestCase {
         this.manager.setAuthenticationMetaDataPopulators(populators);
         
         final DirectAuthenticationHandlerMappingHolder d = new DirectAuthenticationHandlerMappingHolder();
-        d.setAuthenticationHandler(new SimpleTestUsernamePasswordAuthenticationHandler());
+        d.setAuthenticationHandler(new MatchingUsernamePasswordAuthenticationHandler());
         d.setCredentialsToPrincipalResolver(new UsernamePasswordCredentialsToPrincipalResolver());
         
         mappings.put(UsernamePasswordCredentials.class, d);

--- a/cas-server-support-x509/src/main/resources/deployerConfigContext.xml
+++ b/cas-server-support-x509/src/main/resources/deployerConfigContext.xml
@@ -100,13 +100,13 @@
 				</bean>
 				<!--
 					| This is the authentication handler declaration that every CAS deployer will need to change before deploying CAS 
-					| into production.  The default SimpleTestUsernamePasswordAuthenticationHandler authenticates UsernamePasswordCredentials
+					| into production.  The default MatchingUsernamePasswordAuthenticationHandler authenticates UsernamePasswordCredentials
 					| where the username equals the password.  You will need to replace this with an AuthenticationHandler that implements your
 					| local authentication strategy.  You might accomplish this by coding a new such handler and declaring
 					| edu.someschool.its.cas.MySpecialHandler here, or you might use one of the handlers provided in the adaptors modules.
 					+-->
 				<bean
-					class="org.jasig.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler" />
+					class="org.jasig.cas.authentication.handler.support.MatchingUsernamePasswordAuthenticationHandler" />
 
                 <!--
                     X.509 authentication handler example.

--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -29,7 +29,7 @@
 	| file is among those declared in the context parameter "contextConfigLocation".
 	|
 	| By far the most common change you will need to make in this file is to change the last bean
-	| declaration to replace the default SimpleTestUsernamePasswordAuthenticationHandler with
+	| declaration to replace the default MatchingUsernamePasswordAuthenticationHandler with
 	| one implementing your approach for authenticating usernames and passwords.
 	+-->
 
@@ -121,13 +121,13 @@
 					p:httpClient-ref="httpClient" />
 				<!--
 					| This is the authentication handler declaration that every CAS deployer will need to change before deploying CAS 
-					| into production.  The default SimpleTestUsernamePasswordAuthenticationHandler authenticates UsernamePasswordCredentials
+					| into production.  The default MatchingUsernamePasswordAuthenticationHandler authenticates UsernamePasswordCredentials
 					| where the username equals the password.  You will need to replace this with an AuthenticationHandler that implements your
 					| local authentication strategy.  You might accomplish this by coding a new such handler and declaring
 					| edu.someschool.its.cas.MySpecialHandler here, or you might use one of the handlers provided in the adaptors modules.
 					+-->
 				<bean 
-					class="org.jasig.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler" />
+					class="org.jasig.cas.authentication.handler.support.MatchingUsernamePasswordAuthenticationHandler" />
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
Renamed to `MatchingUsernamePasswordAuthenticationHandler`
