### PR TITLE
CAS-1267: Remove the need to CAST the returned ticket object from ticket registry

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -159,7 +159,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
         if (log.isDebugEnabled()) {
             log.debug("Removing ticket [" + ticketGrantingTicketId + "] from registry.");
         }
-        final TicketGrantingTicket ticket = (TicketGrantingTicket) this.ticketRegistry.getTicket(ticketGrantingTicketId, TicketGrantingTicket.class);
+        final TicketGrantingTicket ticket =  this.ticketRegistry.getTicket(ticketGrantingTicketId, TicketGrantingTicket.class);
 
         if (ticket == null) {
             return;
@@ -185,7 +185,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
         Assert.notNull(ticketGrantingTicketId, "ticketGrantingticketId cannot be null");
         Assert.notNull(service, "service cannot be null");
 
-        final TicketGrantingTicket ticketGrantingTicket = (TicketGrantingTicket) this.ticketRegistry.getTicket(ticketGrantingTicketId, TicketGrantingTicket.class);
+        final TicketGrantingTicket ticketGrantingTicket =  this.ticketRegistry.getTicket(ticketGrantingTicketId, TicketGrantingTicket.class);
 
         if (ticketGrantingTicket == null) {
             throw new InvalidTicketException();
@@ -294,7 +294,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
         Assert.notNull(credentials, "credentials cannot be null");
 
         try {
-            final ServiceTicket serviceTicket = (ServiceTicket) this.serviceTicketRegistry.getTicket(serviceTicketId, ServiceTicket.class);
+            final ServiceTicket serviceTicket =  this.serviceTicketRegistry.getTicket(serviceTicketId, ServiceTicket.class);
 
             if (serviceTicket == null || serviceTicket.isExpired()) {
                 throw new InvalidTicketException();
@@ -339,7 +339,7 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
         Assert.notNull(serviceTicketId, "serviceTicketId cannot be null");
         Assert.notNull(service, "service cannot be null");
 
-        final ServiceTicket serviceTicket = (ServiceTicket) this.serviceTicketRegistry.getTicket(serviceTicketId, ServiceTicket.class);
+        final ServiceTicket serviceTicket =  this.serviceTicketRegistry.getTicket(serviceTicketId, ServiceTicket.class);
 
         final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
 

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/AbstractDistributedTicketRegistry.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/AbstractDistributedTicketRegistry.java
@@ -98,7 +98,7 @@ public abstract class AbstractDistributedTicketRegistry extends AbstractTicketRe
                 return old;
             }
 
-            return (TicketGrantingTicket) this.ticketRegistry.getTicket(old.getId(), Ticket.class);
+            return this.ticketRegistry.getTicket(old.getId(), Ticket.class);
         }
 
         public final long getCreationTime() {

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -41,8 +41,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
      * @throws ClassCastException if class does not match requested ticket
      * class.
      */
-    public final Ticket getTicket(final String ticketId,
-        final Class<? extends Ticket> clazz) {
+    public final <T extends Ticket> T getTicket(final String ticketId, final Class<? extends Ticket> clazz) {
         Assert.notNull(clazz, "clazz cannot be null");
 
         final Ticket ticket = this.getTicket(ticketId);
@@ -57,7 +56,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
                 + " when we were expecting " + clazz);
         }
 
-        return ticket;
+        return (T) ticket;
     }
     
     public int sessionCount() {

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/TicketRegistry.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/TicketRegistry.java
@@ -54,7 +54,7 @@ public interface TicketRegistry {
      * @param clazz The expected class of the ticket we wish to retrieve.
      * @return the requested ticket.
      */
-    Ticket getTicket(String ticketId, Class<? extends Ticket> clazz);
+    <T extends Ticket> T getTicket(String ticketId, Class<? extends Ticket> clazz);
 
     /**
      * Retrieve a ticket from the registry.

--- a/cas-server-support-openid/src/main/java/org/jasig/cas/support/openid/authentication/handler/support/OpenIdCredentialsAuthenticationHandler.java
+++ b/cas-server-support-openid/src/main/java/org/jasig/cas/support/openid/authentication/handler/support/OpenIdCredentialsAuthenticationHandler.java
@@ -48,8 +48,7 @@ public final class OpenIdCredentialsAuthenticationHandler implements
         final OpenIdCredentials c = (OpenIdCredentials) credentials;
 
         boolean result = false;
-        final TicketGrantingTicket t = (TicketGrantingTicket) this.ticketRegistry
-                .getTicket(c.getTicketGrantingTicketId(),
+        final TicketGrantingTicket t = this.ticketRegistry.getTicket(c.getTicketGrantingTicketId(),
                         TicketGrantingTicket.class);
 
         if (t == null || t.isExpired()) {


### PR DESCRIPTION
This pull is continued from https://github.com/Jasig/cas/pull/211, after a merge with master. 
