### PR TITLE
Configure checkstyle plugin to support execution in modules.

### DIFF
--- a/cas-management-webapp/pom.xml
+++ b/cas-management-webapp/pom.xml
@@ -188,4 +188,8 @@
       </plugin>
     </plugins>
    </build>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-compatibility/pom.xml
+++ b/cas-server-compatibility/pom.xml
@@ -75,4 +75,8 @@
             <scope>test</scope>
         </dependency>
 	</dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-core/pom.xml
+++ b/cas-server-core/pom.xml
@@ -228,4 +228,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-documentation/pom.xml
+++ b/cas-server-documentation/pom.xml
@@ -145,4 +145,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-extension-clearpass/pom.xml
+++ b/cas-server-extension-clearpass/pom.xml
@@ -33,6 +33,7 @@
 
 	<properties>
 		<cas.client.version>3.2.1</cas.client.version>
+    <cs.dir>${project.parent.basedir}</cs.dir>
 	</properties>
 
 	<build>

--- a/cas-server-integration-ehcache/pom.xml
+++ b/cas-server-integration-ehcache/pom.xml
@@ -87,4 +87,8 @@
       </roles>
     </contributor>
   </contributors>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-integration-jboss/pom.xml
+++ b/cas-server-integration-jboss/pom.xml
@@ -72,4 +72,8 @@
 			<url>http://repository.jboss.org/nexus/content/repositories/deprecated</url>
 		</repository>
 	</repositories>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-integration-memcached/pom.xml
+++ b/cas-server-integration-memcached/pom.xml
@@ -73,4 +73,8 @@
 
 	</dependencies>
 
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
+
 </project>

--- a/cas-server-integration-restlet/pom.xml
+++ b/cas-server-integration-restlet/pom.xml
@@ -82,6 +82,7 @@
 
     <properties>
         <restlet.version>2.1.0</restlet.version>
+        <cs.dir>${project.parent.basedir}</cs.dir>
     </properties>
 
 </project>

--- a/cas-server-support-generic/pom.xml
+++ b/cas-server-support-generic/pom.xml
@@ -36,4 +36,8 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-jdbc/pom.xml
+++ b/cas-server-support-jdbc/pom.xml
@@ -41,4 +41,8 @@
 			<artifactId>spring-jdbc</artifactId>
 		</dependency>
 	</dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-ldap/pom.xml
+++ b/cas-server-support-ldap/pom.xml
@@ -106,5 +106,9 @@
       </plugin>
     </plugins>
   </build>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
   
 </project>

--- a/cas-server-support-legacy/pom.xml
+++ b/cas-server-support-legacy/pom.xml
@@ -42,4 +42,8 @@
             <version>2.0.12</version>
         </dependency>
 	</dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-oauth/pom.xml
+++ b/cas-server-support-oauth/pom.xml
@@ -54,4 +54,8 @@
 			<version>2.0.6</version>
 		</dependency>
     </dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-openid/pom.xml
+++ b/cas-server-support-openid/pom.xml
@@ -62,4 +62,8 @@
         </dependency>
 
     </dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-pac4j/pom.xml
+++ b/cas-server-support-pac4j/pom.xml
@@ -65,5 +65,6 @@
 
 	<properties>
 		<pac4j.version>1.4.0-SNAPSHOT</pac4j.version>
-	</properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-radius/pom.xml
+++ b/cas-server-support-radius/pom.xml
@@ -70,4 +70,8 @@
           <url>http://coova-dev.s3.amazonaws.com/mvn</url>
         </repository>
   </repositories>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-saml/pom.xml
+++ b/cas-server-support-saml/pom.xml
@@ -87,4 +87,8 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-spnego/pom.xml
+++ b/cas-server-support-spnego/pom.xml
@@ -55,4 +55,8 @@
         </dependency>
 
 	</dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-trusted/pom.xml
+++ b/cas-server-support-trusted/pom.xml
@@ -43,4 +43,8 @@
       </dependency>
 
   </dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-support-x509/pom.xml
+++ b/cas-server-support-x509/pom.xml
@@ -77,4 +77,8 @@
       </dependency>
 
   </dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-uber-webapp/pom.xml
+++ b/cas-server-uber-webapp/pom.xml
@@ -99,4 +99,8 @@
             <scope>runtime</scope>
         </dependency>
     </dependencies>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -167,4 +167,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <properties>
+    <cs.dir>${project.parent.basedir}</cs.dir>
+  </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -238,8 +238,8 @@
             <version>2.10</version>
             <configuration>
                 <consoleOutput>true</consoleOutput>
-                <configLocation>/checkstyle-rules.xml</configLocation>
-                <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+                <configLocation>${cs.dir}/checkstyle-rules.xml</configLocation>
+                <suppressionsLocation>${cs.dir}/checkstyle-suppressions.xml</suppressionsLocation>
                 <failsOnError>true</failsOnError>
             </configuration>
             <executions>
@@ -947,6 +947,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
   </profiles>
   
   <properties>
+    <cs.dir>${project.basedir}</cs.dir>
     <issues.projectKey>CAS</issues.projectKey>
     <spring.webflow.version>2.3.2.RELEASE</spring.webflow.version>
     <spring.version>3.2.2.RELEASE</spring.version>


### PR DESCRIPTION
The current checkstyle plugin configuration prevents builds from within a module. This change provides a fix.
