### PR TITLE
CAS-1264: Move OpenIdProviderController from webapp to OpenID module

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/uniqueIdGenerators.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/uniqueIdGenerators.xml
@@ -71,9 +71,6 @@
 		<entry
 			key="org.jasig.cas.authentication.principal.SimpleWebApplicationServiceImpl"
 			value-ref="serviceTicketUniqueIdGenerator" />
-        <entry
-            key="org.jasig.cas.support.openid.authentication.principal.OpenIdService"
-            value-ref="serviceTicketUniqueIdGenerator" />
 	</util:map>
 
 </beans>


### PR DESCRIPTION
The identifiers generator for OpenIdService must be defined explicitely when using the OpenID support and not always
