### PR TITLE
CAS-1286: Extract the OAuth client support in its own module

### DIFF
--- a/cas-server-support-pac4j/pom.xml
+++ b/cas-server-support-pac4j/pom.xml
@@ -64,7 +64,7 @@
 	</dependencies>
 
 	<properties>
-		<pac4j.version>1.4.0-SNAPSHOT</pac4j.version>
+		<pac4j.version>1.4.0</pac4j.version>
     <cs.dir>${project.parent.basedir}</cs.dir>
   </properties>
 </project>

--- a/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/authentication/principal/ClientCredentialsToPrincipalResolver.java
+++ b/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/authentication/principal/ClientCredentialsToPrincipalResolver.java
@@ -28,7 +28,7 @@ import org.jasig.cas.authentication.principal.CredentialsToPrincipalResolver;
  * @author Jerome Leleu
  * @since 3.5.0
  */
-public final class ClientCredentialsToPrincipalResolver extends AbstractPersonDirectoryCredentialsToPrincipalResolver
+public class ClientCredentialsToPrincipalResolver extends AbstractPersonDirectoryCredentialsToPrincipalResolver
         implements CredentialsToPrincipalResolver {
 
     /**

--- a/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
+++ b/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
@@ -38,6 +38,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.RequiresHttpAction;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.webflow.action.AbstractAction;
@@ -103,6 +104,7 @@ public final class ClientAction extends AbstractAction {
             final Clients theClients) {
         this.centralAuthenticationService = theCentralAuthenticationService;
         this.clients = theClients;
+        ProfileHelper.setKeepRawData(true);
     }
 
     /**


### PR DESCRIPTION
Upgrade to pac4j release (1.4.0), make ClientCredentialsToPrincipalResolver inheritable, store 'raw data' to be send to CAS client applications.
