### PR TITLE
Add support for servlet overrides

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -214,5 +214,5 @@
   <bean id="credentialsValidator" class="org.springframework.validation.beanvalidation.LocalValidatorFactoryBean"
         p:messageInterpolator-ref="messageInterpolator"/>
 
-  <import resource="spring-configuration/casServletOverrides.xml"/>
+  <import resource="casServletOverrides.xml"/>
 </beans>


### PR DESCRIPTION
Defines an import line in WEB-INF/cas-servlet.xml that allows easier customization of the servlet via an imported file. Thus, the user doesn't have to maintain a copy of cas-servlet.xml in their overlay.
