### PR TITLE
CAS-1305 Restore jstl and standard taglib dependencies.

### DIFF
--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -40,12 +40,14 @@
       <artifactId>jstl</artifactId>
       <version>1.1.2</version>
       <type>jar</type>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>taglibs</groupId>
       <artifactId>standard</artifactId>
       <version>1.1.2</version>
       <type>jar</type>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This fixes the following error on hitting /cas/login:

java.lang.NoClassDefFoundError: javax/servlet/jsp/jstl/core/Config
org.springframework.web.servlet.support.JstlUtils.exposeLocalizationContext(JstlUtils.java:97)
org.springframework.web.servlet.view.JstlView.exposeHelpers(JstlView.java:135)
org.springframework.web.servlet.view.InternalResourceView.renderMergedOutputModel(InternalResourceView.java:211)
