### PR TITLE
CAS-1053 Switch to Spring EL for parsing Webflow expressions.

### DIFF
--- a/cas-server-webapp-support/pom.xml
+++ b/cas-server-webapp-support/pom.xml
@@ -99,13 +99,6 @@
     </dependency>
 
     <dependency>
-      <groupId>ognl</groupId>
-      <artifactId>ognl</artifactId>
-      <version>2.7.3</version>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
       <scope>runtime</scope>

--- a/cas-server-webapp/pom.xml
+++ b/cas-server-webapp/pom.xml
@@ -28,12 +28,17 @@
   <packaging>war</packaging>
   <name>Jasig CAS Web Application</name>
   <dependencies>
-
     <dependency>
       <groupId>org.jasig.cas</groupId>
       <artifactId>cas-server-webapp-support</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>${spring.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -161,8 +161,12 @@
 
   <bean id="terminateWebSessionListener" class="org.jasig.cas.web.flow.TerminateWebSessionListener" />
 
-  <bean id="expressionParser" class="org.springframework.webflow.expression.WebFlowOgnlExpressionParser"
-        p:conversionService-ref="logoutConversionService" />
+  <bean id="expressionParser" class="org.springframework.webflow.expression.spel.WebFlowSpringELExpressionParser"
+        c:conversionService-ref="logoutConversionService">
+    <constructor-arg>
+        <bean class="org.springframework.expression.spel.standard.SpelExpressionParser" />
+    </constructor-arg>
+  </bean>
 
   <bean id="viewFactoryCreator" class="org.springframework.webflow.mvc.builder.MvcViewFactoryCreator">
     <property name="viewResolvers">

--- a/cas-server-webapp/src/main/webapp/WEB-INF/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/login-webflow.xml
@@ -214,7 +214,7 @@
 		The "redirect" end state allows CAS to properly end the workflow while still redirecting
 		the user back to the service required.
 	-->
-	<end-state id="redirectView" view="externalRedirect:${requestScope.response.url}" />
+	<end-state id="redirectView" view="externalRedirect:#{requestScope.response.url}" />
 	
 	<end-state id="viewServiceErrorView" view="viewServiceErrorView" />
     

--- a/cas-server-webapp/src/main/webapp/WEB-INF/logout-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/logout-webflow.xml
@@ -35,7 +35,7 @@
     <transition on="redirectApp" to="redirectToFrontApp" />
   </action-state>
 
-  <view-state id="redirectToFrontApp" view="externalRedirect:${currentEvent.attributes.logoutUrl}&amp;RelayState=${flowExecutionContext.key}">
+  <view-state id="redirectToFrontApp" view="externalRedirect:#{currentEvent.attributes.logoutUrl}&amp;RelayState=#{flowExecutionContext.key}">
     <transition on="next" to="frontLogout" />
   </view-state>
 
@@ -43,7 +43,7 @@
     <if test="flowScope.logoutRedirectUrl != null" then="redirectView" else="logoutView" />
   </decision-state>
 
-  <end-state id="redirectView" view="externalRedirect:${flowScope.logoutRedirectUrl}" />
+  <end-state id="redirectView" view="externalRedirect:#{flowScope.logoutRedirectUrl}" />
 
   <view-state id="logoutView" view="casLogoutView" />
 


### PR DESCRIPTION
The driving force here is updating to the default EL in recent SWF versions and divesting OGNL, which has been a source of support issues over the years due to an edge-case bug.
