### PR TITLE
Clearpass reference to decorated map is incorrect.

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -70,7 +70,7 @@
         <property name="authenticationMetaDataPopulators">
            <util:list>
               <bean class="org.jasig.cas.extension.clearpass.CacheCredentialsMetaDataPopulator"
-                    c:credentialCache-ref="credentialsCache" />
+                    c:credentialCache-ref="encryptedMap" />
            </util:list>
         </property>
         -->


### PR DESCRIPTION
The default/sample configuration points to the plain credentials cache for keeping track of the credential, while the actual instance should be the decorated encrypted map.
