### PR TITLE
screen.success.security message can be confusing

### DIFF
--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -44,7 +44,7 @@ screen.confirmation.message=Click <a href="{0}">here</a> to go to the applicatio
 #Generic Success Screen Messages
 screen.success.header=Log In Successful
 screen.success.success=You have successfully logged into the Central Authentication Service.
-screen.success.security=For security reasons, please Log Out and Exit your web browser when you are done accessing services that require authentication!
+screen.success.security=When you are finished, for security reasons, please Log Out and Exit your web browser.
 
 #Logout Screen Messages
 screen.logout.header=Logout successful


### PR DESCRIPTION
The current wording for screen.success.security causes some users to only read the first half of the instruction, getting as far as "For security please log out". The user then gets stuck signing in to be immediately told to sign out.

I think the qualifier that the instruction is for when they have finished should come first.
