### PR TITLE
Fix LDAP authentication 

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
@@ -153,7 +153,7 @@ public class LdapAuthenticationHandler implements AuthenticationHandler {
         examineAccountState(response);
 
         if (response.getResult()) {
-            doPostAuthentication(response);
+            return doPostAuthentication(response);
         }
 
         throw new FailedLoginException("LDAP authentication failed.");


### PR DESCRIPTION
Previously, even a successful login would result in 
"LDAP authentication failed."
