### PR TITLE
CAS-1331: 'Adapt' pac4j module to new CAS 4 authentication API

### DIFF
--- a/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/authentication/ClientAuthenticationMetaDataPopulator.java
+++ b/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/authentication/ClientAuthenticationMetaDataPopulator.java
@@ -18,17 +18,14 @@
  */
 package org.jasig.cas.support.pac4j.authentication;
 
-import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.AuthenticationBuilder;
 import org.jasig.cas.authentication.AuthenticationMetaDataPopulator;
 import org.jasig.cas.authentication.Credential;
-import org.jasig.cas.authentication.principal.SimplePrincipal;
 import org.jasig.cas.support.pac4j.authentication.principal.ClientCredential;
 
 /**
- * This class is a meta data populator for authentication. As attributes are stored in ClientCredential (inside the
- * user profile), they are added to the returned principal. The client name associated to the authentication is also
- * added to the authentication attributes.
+ * This class is a meta data populator for authentication. The client name associated to the authentication is added
+ * to the authentication attributes.
  *
  * @author Jerome Leleu
  * @since 3.5.0
@@ -46,12 +43,8 @@ public final class ClientAuthenticationMetaDataPopulator implements Authenticati
     @Override
     public void populateAttributes(final AuthenticationBuilder builder, final Credential credential) {
         if (credential instanceof ClientCredential) {
-            final ClientCredential clientCredentials = (ClientCredential) credential;
-            final Authentication temp = builder.build();
-            builder.setPrincipal(new SimplePrincipal(
-                    temp.getPrincipal().getId(),
-                    clientCredentials.getUserProfile().getAttributes()));
-            builder.addAttribute(CLIENT_NAME, clientCredentials.getCredentials().getClientName());
+            final ClientCredential clientCredential = (ClientCredential) credential;
+            builder.addAttribute(CLIENT_NAME, clientCredential.getCredentials().getClientName());
         }
     }
 }

--- a/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/authentication/principal/ClientCredential.java
+++ b/cas-server-support-pac4j/src/main/java/org/jasig/cas/support/pac4j/authentication/principal/ClientCredential.java
@@ -84,6 +84,9 @@ public final class ClientCredential implements Credential, Serializable {
 
     @Override
     public String getId() {
-        return this.userProfile.getTypedId();
+        if (this.userProfile != null) {
+            return this.userProfile.getTypedId();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
I've made complete tests based on the new CAS 4 authentication API (4.0.0-RC2) and there are some problems with the pac4j module :
- a `NullPointerException` has been fixed
- the "aborted" authentication is now properly handled in the `ClientAction` class
- the `ClientAuthenticationMetaDataPopulator` has been simplified as it doesn't need any more to populate user's attributes (already populated by the authentication handler).
