### PR TITLE
Don't hard-code the name of a Logger to be the name of a particular subclass

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/AbstractAuthenticationManager.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/AbstractAuthenticationManager.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractAuthenticationManager implements AuthenticationManager {
 
     /** Log instance for logging events, errors, warnings, etc. */
-    protected final Logger log = LoggerFactory.getLogger(AuthenticationManagerImpl.class);
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     /** An array of AuthenticationAttributesPopulators. */
     @NotNull


### PR DESCRIPTION
The Logger of AbstractAuthenticationManager is now named for one of its concrete children, AuthenticationManagerImpl. This is confusing (although not necessarily incorrect, but that's a discussion about semantics), because log statements actually originating from AAM are rendered as coming from AMI.

This becomes more than a nuisance when you subclass AbstractAuthenticationManager. In this scenario, AuthenticationManagerImpl is never involved at any point, but still the Logger is named after it, so you're sent a wild goose chase trying to find the responsible code.

This change fixes the problem for classes extending AbstractAuthenticationManager, while preserving the old behaviour for AuthenticationManagerImpl.
