### PR TITLE
updates ServiceValidateController : JavaDoc that handles /proxyValidate

### DIFF
--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/ServiceValidateController.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/ServiceValidateController.java
@@ -41,7 +41,7 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
- * Process the /validate and /serviceValidate URL requests.
+ * Process the /validate , /serviceValidate , and /proxyValidate URL requests.
  * <p>
  * Obtain the Service Ticket and Service information and present them to the CAS
  * validation services. Receive back an Assertion containing the user Principal


### PR DESCRIPTION
The `ServiceValidateController` Java class handles `/proxyValidate` as well as `/validate` and `/serviceValidate`.  This pull request updates `ServiceValidateController`'s JavaDoc to reflect.

`/proxyValidate` path --> `proxyValidateController` bean --> `ServiceValidateController` Java class.

that is, in `cas-servlet.xml`:

```
<bean
  id="handlerMappingC"
  class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping"
  ... >
<property name="mappings">
  <util:properties>
    ...
    <prop key="/proxyValidate">proxyValidateController</prop>
```

and

```
<bean id="proxyValidateController" class="org.jasig.cas.web.ServiceValidateController"
    ... />
```
