### PR TITLE
split console OR logic into two if statements to handle javascript error...

### DIFF
--- a/cas-server-webapp/src/main/webapp/js/cas.js
+++ b/cas-server-webapp/src/main/webapp/js/cas.js
@@ -29,7 +29,7 @@ $(document).ready(function(){
     //flash confirm box
     $('#msg.question').animate({ backgroundColor: 'rgb(51,204,0)' }, 30).animate({ backgroundColor: 'rgb(221,255,170)' }, 500);
     
-    if (!window.console || window.console == {}) {
-        window.console.log = function() {};
-    }
+    //make console available for older browsers when dev tools not on
+    if (!window.console) window.console = {};
+    if (window.console == {}) window.console.log = function() {};
 });


### PR DESCRIPTION
... in older browsers

This came to me as a bug ticket at Oregon State University. Using CAS in IE8 did not focus in the username field, and instead focus was in the search bar and there was a javascript error. I believe this is due to the older browser not making the console available until development tools have been toggled at least once. I replicated the bug with IE8 .0.7600.16385 on a win7 vm.

The previous if block did not handle the case of !window.console returning null or undefined.

The JIRA issue number is CAS-1277
https://issues.jasig.org/browse/CAS-1277
