### PR TITLE
memory creep on deleteTicket

### DIFF
--- a/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
+++ b/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
@@ -93,6 +93,16 @@ public final class EhCacheTicketRegistry extends AbstractDistributedTicketRegist
         if (StringUtils.isBlank(ticketId)) {
             return false;
         }
+        
+        Ticket ticket = getTicket(ticketId);
+        if (ticket instanceof ServiceTicket) {
+            this.serviceTicketsCache.put(new Element(ticket.getId(),null));
+        } else if (ticket instanceof TicketGrantingTicket) {
+            this.ticketGrantingTicketsCache.put(new Element(ticket.getId(), null));
+        } else {
+            throw new IllegalArgumentException("Invalid ticket type " + ticket);
+        }
+        
         return this.serviceTicketsCache.remove(ticketId) || this.ticketGrantingTicketsCache.remove(ticketId);
     }
 


### PR DESCRIPTION
We have been seeing the following eviction problem when tickets are expired but the ehcache threshold has not been reached.  This can be a problem because old ticket references "hang around" in the cache despite being expired.

See http://lists.terracotta.org/pipermail/ehcache-list/2011-November/000423.html

By updating the ticket to null, ticket can garbage collected and prevent memory creep.
