### PR TITLE
CAS-1341: Offer the option to provide a new HTTP client implementation

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/util/HttpClient.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/util/HttpClient.java
@@ -18,92 +18,15 @@
  */
 package org.jasig.cas.util;
 
-import java.io.BufferedReader;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Serializable;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.SocketTimeoutException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.DisposableBean;
-import org.springframework.util.Assert;
 
 /**
- * @author Scott Battaglia
- * @since 3.1
+ * Define the behaviour of a HTTP client.
+ *
+ * @author Jerome Leleu
+ * @since 4.0
  */
-public final class HttpClient implements Serializable, DisposableBean {
-
-    /** Unique Id for serialization. */
-    private static final long serialVersionUID = -5306738686476129516L;
-
-    /** The default status codes we accept. */
-    private static final int[] DEFAULT_ACCEPTABLE_CODES = new int[] {
-        HttpURLConnection.HTTP_OK, HttpURLConnection.HTTP_NOT_MODIFIED,
-        HttpURLConnection.HTTP_MOVED_TEMP, HttpURLConnection.HTTP_MOVED_PERM,
-        HttpURLConnection.HTTP_ACCEPTED};
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
-
-    private static ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(100);
-
-    /** List of HTTP status codes considered valid by this AuthenticationHandler. */
-    @NotNull
-    @Size(min = 1)
-    private int[] acceptableCodes = DEFAULT_ACCEPTABLE_CODES;
-
-    @Min(0)
-    private int connectionTimeout = 5000;
-
-    @Min(0)
-    private int readTimeout = 5000;
-
-    private boolean followRedirects = true;
-
-    /**
-     * The socket factory to be used when verifying the validity of the endpoint.
-     *
-     * @see #setSSLSocketFactory(SSLSocketFactory)
-     */
-    private SSLSocketFactory sslSocketFactory = null;
-
-    /**
-     * The hostname verifier to be used when verifying the validity of the endpoint.
-     *
-     * @see #setHostnameVerifier(HostnameVerifier)
-     */
-    private HostnameVerifier hostnameVerifier = null;
-
-    /**
-     * Note that changing this executor will affect all httpClients.  While not ideal, this change
-     * was made because certain ticket registries
-     * were persisting the HttpClient and thus getting serializable exceptions.
-     * @param executorService The executor service to send messages to end points.
-     */
-    public void setExecutorService(@NotNull final ExecutorService executorService) {
-        Assert.notNull(executorService);
-        EXECUTOR_SERVICE = executorService;
-    }
+public interface HttpClient {
 
     /**
      * Sends a message to a particular endpoint.  Option of sending it without
@@ -116,212 +39,21 @@ public final class HttpClient implements Serializable, DisposableBean {
      * @param async true if you don't want to wait for the response, false otherwise.
      * @return boolean if the message was sent, or async was used.  false if the message failed.
      */
-    public boolean sendMessageToEndPoint(final String url, final String message, final boolean async) {
-        final Future<Boolean> result = EXECUTOR_SERVICE.submit(new MessageSender(url, message,
-                this.readTimeout, this.connectionTimeout, this.followRedirects));
-
-        if (async) {
-            return true;
-        }
-
-        try {
-            return result.get();
-        } catch (final Exception e) {
-            return false;
-        }
-    }
-
-    public boolean isValidEndPoint(final String url) {
-        try {
-            final URL u = new URL(url);
-            return isValidEndPoint(u);
-        } catch (final MalformedURLException e) {
-            LOGGER.error(e.getMessage(), e);
-            return false;
-        }
-    }
-
-    public boolean isValidEndPoint(final URL url) {
-        HttpURLConnection connection = null;
-        InputStream is = null;
-        try {
-            connection = (HttpURLConnection) url.openConnection();
-            connection.setConnectTimeout(this.connectionTimeout);
-            connection.setReadTimeout(this.readTimeout);
-            connection.setInstanceFollowRedirects(this.followRedirects);
-
-            if (connection instanceof HttpsURLConnection) {
-                final HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
-
-                if (this.sslSocketFactory != null) {
-                    httpsConnection.setSSLSocketFactory(this.sslSocketFactory);
-                }
-
-                if (this.hostnameVerifier != null) {
-                    httpsConnection.setHostnameVerifier(this.hostnameVerifier);
-                }
-            }
-
-            connection.connect();
-
-            final int responseCode = connection.getResponseCode();
-
-            for (final int acceptableCode : this.acceptableCodes) {
-                if (responseCode == acceptableCode) {
-                    LOGGER.debug("Response code from server matched {}.", responseCode);
-                    return true;
-                }
-            }
-
-            LOGGER.debug("Response Code did not match any of the acceptable response codes. Code returned was {}",
-                    responseCode);
-
-            // if the response code is an error and we don't find that error acceptable above:
-            if (responseCode == 500) {
-                is = connection.getInputStream();
-                final String value = IOUtils.toString(is);
-                LOGGER.error("There was an error contacting the endpoint: {}; The error was:\n{}", url.toExternalForm(),
-                        value);
-            }
-        } catch (final IOException e) {
-            LOGGER.error(e.getMessage(), e);
-        } finally {
-            IOUtils.closeQuietly(is);
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-        return false;
-    }
+    boolean sendMessageToEndPoint(String url, String message, boolean async);
 
     /**
-     * Set the acceptable HTTP status codes that we will use to determine if the
-     * response from the URL was correct.
+     * Make a synchronous HTTP(S) call to ensure that the url is reachable.
      *
-     * @param acceptableCodes an array of status code integers.
+     * @param url the url to call
+     * @return whether the url is valid
      */
-    public void setAcceptableCodes(final int[] acceptableCodes) {
-        this.acceptableCodes = acceptableCodes;
-    }
+    boolean isValidEndPoint(String url);
 
     /**
-     * Sets a specified timeout value, in milliseconds, to be used when opening the endpoint url.
-     * @param connectionTimeout specified timeout value in milliseconds
-     */
-    public void setConnectionTimeout(final int connectionTimeout) {
-        this.connectionTimeout = connectionTimeout;
-    }
-
-    /**
-     * Sets a specified timeout value, in milliseconds, to be used when reading from the endpoint url.
-     * @param readTimeout specified timeout value in milliseconds
-     */
-    public void setReadTimeout(final int readTimeout) {
-        this.readTimeout = readTimeout;
-    }
-
-    /**
-     * Determines the behavior on receiving 3xx responses from HTTP endpoints.
+     * Make a synchronous HTTP(S) call to ensure that the url is reachable.
      *
-     * @param follow True to follow 3xx redirects (default), false otherwise.
+     * @param url the url to call
+     * @return whether the url is valid
      */
-    public void setFollowRedirects(final boolean follow) {
-        this.followRedirects = follow;
-    }
-
-    /**
-     * Set the SSL socket factory be used by the URL when submitting
-     * request to check for URL endpoint validity.
-     * @param factory ssl socket factory instance to use
-     * @see #isValidEndPoint(URL)
-     */
-    public void setSSLSocketFactory(final SSLSocketFactory factory) {
-        this.sslSocketFactory = factory;
-    }
-
-    /**
-     * Set the hostname verifier be used by the URL when submitting
-     * request to check for URL endpoint validity.
-     * @param verifier hostname verifier instance to use
-     * @see #isValidEndPoint(URL)
-     */
-    public void setHostnameVerifier(final HostnameVerifier verifier) {
-        this.hostnameVerifier = verifier;
-    }
-
-    /**
-     * Shutdown the executor service.
-     * @throws Exception if the executor cannot properly shut down
-     */
-    public void destroy() throws Exception {
-        EXECUTOR_SERVICE.shutdown();
-    }
-
-    private static final class MessageSender implements Callable<Boolean> {
-
-        private String url;
-
-        private String message;
-
-        private int readTimeout;
-
-        private int connectionTimeout;
-
-        private boolean followRedirects;
-
-        public MessageSender(final String url, final String message, final int readTimeout,
-                final int connectionTimeout, final boolean followRedirects) {
-            this.url = url;
-            this.message = message;
-            this.readTimeout = readTimeout;
-            this.connectionTimeout = connectionTimeout;
-            this.followRedirects = followRedirects;
-        }
-
-        public Boolean call() throws Exception {
-            HttpURLConnection connection = null;
-            BufferedReader in = null;
-            try {
-                LOGGER.debug("Attempting to access {}", url);
-                final URL logoutUrl = new URL(url);
-                final String output = "logoutRequest=" + URLEncoder.encode(message, "UTF-8");
-
-                connection = (HttpURLConnection) logoutUrl.openConnection();
-                connection.setDoInput(true);
-                connection.setDoOutput(true);
-                connection.setRequestMethod("POST");
-                connection.setReadTimeout(this.readTimeout);
-                connection.setConnectTimeout(this.connectionTimeout);
-                connection.setInstanceFollowRedirects(this.followRedirects);
-                connection.setRequestProperty("Content-Length", Integer.toString(output.getBytes().length));
-                connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-                final DataOutputStream printout = new DataOutputStream(connection.getOutputStream());
-                printout.writeBytes(output);
-                printout.flush();
-                printout.close();
-
-                in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-
-                boolean readInput = true;
-                while (readInput) {
-                    readInput =StringUtils.isNotBlank(in.readLine());
-                }
-
-                LOGGER.debug("Finished sending message to {}", url);
-                return true;
-            } catch (final SocketTimeoutException e) {
-                LOGGER.warn("Socket Timeout Detected while attempting to send message to [{}]", url);
-                return false;
-            } catch (final Exception e) {
-                LOGGER.warn("Error Sending message to url endpoint [{}]. Error is [{}]", url, e.getMessage());
-                return false;
-            } finally {
-                IOUtils.closeQuietly(in);
-                if (connection != null) {
-                    connection.disconnect();
-                }
-            }
-        }
-
-    }
+    boolean isValidEndPoint(URL url);
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/util/SimpleHttpClient.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/util/SimpleHttpClient.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.util;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.util.Assert;
+
+/**
+ * @author Scott Battaglia
+ * @since 3.1
+ */
+public final class SimpleHttpClient implements HttpClient, Serializable, DisposableBean {
+
+    /** Unique Id for serialization. */
+    private static final long serialVersionUID = -5306738686476129516L;
+
+    /** The default status codes we accept. */
+    private static final int[] DEFAULT_ACCEPTABLE_CODES = new int[] {
+        HttpURLConnection.HTTP_OK, HttpURLConnection.HTTP_NOT_MODIFIED,
+        HttpURLConnection.HTTP_MOVED_TEMP, HttpURLConnection.HTTP_MOVED_PERM,
+        HttpURLConnection.HTTP_ACCEPTED};
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleHttpClient.class);
+
+    private static ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(100);
+
+    /** List of HTTP status codes considered valid by this AuthenticationHandler. */
+    @NotNull
+    @Size(min = 1)
+    private int[] acceptableCodes = DEFAULT_ACCEPTABLE_CODES;
+
+    @Min(0)
+    private int connectionTimeout = 5000;
+
+    @Min(0)
+    private int readTimeout = 5000;
+
+    private boolean followRedirects = true;
+
+    /**
+     * The socket factory to be used when verifying the validity of the endpoint.
+     *
+     * @see #setSSLSocketFactory(SSLSocketFactory)
+     */
+    private SSLSocketFactory sslSocketFactory = null;
+
+    /**
+     * The hostname verifier to be used when verifying the validity of the endpoint.
+     *
+     * @see #setHostnameVerifier(HostnameVerifier)
+     */
+    private HostnameVerifier hostnameVerifier = null;
+
+    /**
+     * Note that changing this executor will affect all httpClients.  While not ideal, this change
+     * was made because certain ticket registries
+     * were persisting the HttpClient and thus getting serializable exceptions.
+     * @param executorService The executor service to send messages to end points.
+     */
+    public void setExecutorService(@NotNull final ExecutorService executorService) {
+        Assert.notNull(executorService);
+        EXECUTOR_SERVICE = executorService;
+    }
+
+    /**
+     * Sends a message to a particular endpoint.  Option of sending it without
+     * waiting to ensure a response was returned.
+     * <p>
+     * This is useful when it doesn't matter about the response as you'll perform no action based on the response.
+     *
+     * @param url the url to send the message to
+     * @param message the message itself
+     * @param async true if you don't want to wait for the response, false otherwise.
+     * @return boolean if the message was sent, or async was used.  false if the message failed.
+     */
+    public boolean sendMessageToEndPoint(final String url, final String message, final boolean async) {
+        final Future<Boolean> result = EXECUTOR_SERVICE.submit(new MessageSender(url, message,
+                this.readTimeout, this.connectionTimeout, this.followRedirects));
+
+        if (async) {
+            return true;
+        }
+
+        try {
+            return result.get();
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Make a synchronous HTTP(S) call to ensure that the url is reachable.
+     *
+     * @param url the url to call
+     * @return whether the url is valid
+     */
+    public boolean isValidEndPoint(final String url) {
+        try {
+            final URL u = new URL(url);
+            return isValidEndPoint(u);
+        } catch (final MalformedURLException e) {
+            LOGGER.error(e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Make a synchronous HTTP(S) call to ensure that the url is reachable.
+     *
+     * @param url the url to call
+     * @return whether the url is valid
+     */
+    public boolean isValidEndPoint(final URL url) {
+        HttpURLConnection connection = null;
+        InputStream is = null;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(this.connectionTimeout);
+            connection.setReadTimeout(this.readTimeout);
+            connection.setInstanceFollowRedirects(this.followRedirects);
+
+            if (connection instanceof HttpsURLConnection) {
+                final HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
+
+                if (this.sslSocketFactory != null) {
+                    httpsConnection.setSSLSocketFactory(this.sslSocketFactory);
+                }
+
+                if (this.hostnameVerifier != null) {
+                    httpsConnection.setHostnameVerifier(this.hostnameVerifier);
+                }
+            }
+
+            connection.connect();
+
+            final int responseCode = connection.getResponseCode();
+
+            for (final int acceptableCode : this.acceptableCodes) {
+                if (responseCode == acceptableCode) {
+                    LOGGER.debug("Response code from server matched {}.", responseCode);
+                    return true;
+                }
+            }
+
+            LOGGER.debug("Response Code did not match any of the acceptable response codes. Code returned was {}",
+                    responseCode);
+
+            // if the response code is an error and we don't find that error acceptable above:
+            if (responseCode == 500) {
+                is = connection.getInputStream();
+                final String value = IOUtils.toString(is);
+                LOGGER.error("There was an error contacting the endpoint: {}; The error was:\n{}", url.toExternalForm(),
+                        value);
+            }
+        } catch (final IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        } finally {
+            IOUtils.closeQuietly(is);
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Set the acceptable HTTP status codes that we will use to determine if the
+     * response from the URL was correct.
+     *
+     * @param acceptableCodes an array of status code integers.
+     */
+    public void setAcceptableCodes(final int[] acceptableCodes) {
+        this.acceptableCodes = acceptableCodes;
+    }
+
+    /**
+     * Sets a specified timeout value, in milliseconds, to be used when opening the endpoint url.
+     * @param connectionTimeout specified timeout value in milliseconds
+     */
+    public void setConnectionTimeout(final int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    /**
+     * Sets a specified timeout value, in milliseconds, to be used when reading from the endpoint url.
+     * @param readTimeout specified timeout value in milliseconds
+     */
+    public void setReadTimeout(final int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    /**
+     * Determines the behavior on receiving 3xx responses from HTTP endpoints.
+     *
+     * @param follow True to follow 3xx redirects (default), false otherwise.
+     */
+    public void setFollowRedirects(final boolean follow) {
+        this.followRedirects = follow;
+    }
+
+    /**
+     * Set the SSL socket factory be used by the URL when submitting
+     * request to check for URL endpoint validity.
+     * @param factory ssl socket factory instance to use
+     * @see #isValidEndPoint(URL)
+     */
+    public void setSSLSocketFactory(final SSLSocketFactory factory) {
+        this.sslSocketFactory = factory;
+    }
+
+    /**
+     * Set the hostname verifier be used by the URL when submitting
+     * request to check for URL endpoint validity.
+     * @param verifier hostname verifier instance to use
+     * @see #isValidEndPoint(URL)
+     */
+    public void setHostnameVerifier(final HostnameVerifier verifier) {
+        this.hostnameVerifier = verifier;
+    }
+
+    /**
+     * Shutdown the executor service.
+     * @throws Exception if the executor cannot properly shut down
+     */
+    public void destroy() throws Exception {
+        EXECUTOR_SERVICE.shutdown();
+    }
+
+    private static final class MessageSender implements Callable<Boolean> {
+
+        private String url;
+
+        private String message;
+
+        private int readTimeout;
+
+        private int connectionTimeout;
+
+        private boolean followRedirects;
+
+        public MessageSender(final String url, final String message, final int readTimeout,
+                final int connectionTimeout, final boolean followRedirects) {
+            this.url = url;
+            this.message = message;
+            this.readTimeout = readTimeout;
+            this.connectionTimeout = connectionTimeout;
+            this.followRedirects = followRedirects;
+        }
+
+        public Boolean call() throws Exception {
+            HttpURLConnection connection = null;
+            BufferedReader in = null;
+            try {
+                LOGGER.debug("Attempting to access {}", url);
+                final URL logoutUrl = new URL(url);
+                final String output = "logoutRequest=" + URLEncoder.encode(message, "UTF-8");
+
+                connection = (HttpURLConnection) logoutUrl.openConnection();
+                connection.setDoInput(true);
+                connection.setDoOutput(true);
+                connection.setRequestMethod("POST");
+                connection.setReadTimeout(this.readTimeout);
+                connection.setConnectTimeout(this.connectionTimeout);
+                connection.setInstanceFollowRedirects(this.followRedirects);
+                connection.setRequestProperty("Content-Length", Integer.toString(output.getBytes().length));
+                connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                final DataOutputStream printout = new DataOutputStream(connection.getOutputStream());
+                printout.writeBytes(output);
+                printout.flush();
+                printout.close();
+
+                in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+
+                boolean readInput = true;
+                while (readInput) {
+                    readInput =StringUtils.isNotBlank(in.readLine());
+                }
+
+                LOGGER.debug("Finished sending message to {}", url);
+                return true;
+            } catch (final SocketTimeoutException e) {
+                LOGGER.warn("Socket Timeout Detected while attempting to send message to [{}]", url);
+                return false;
+            } catch (final Exception e) {
+                LOGGER.warn("Error Sending message to url endpoint [{}]. Error is [{}]", url, e.getMessage());
+                return false;
+            } finally {
+                IOUtils.closeQuietly(in);
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        }
+
+    }
+}

--- a/cas-server-core/src/test/java/org/jasig/cas/authentication/handler/support/HttpBasedServiceCredentialsAuthenticationHandlerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/authentication/handler/support/HttpBasedServiceCredentialsAuthenticationHandlerTests.java
@@ -21,7 +21,7 @@ package org.jasig.cas.authentication.handler.support;
 import javax.security.auth.login.FailedLoginException;
 
 import org.jasig.cas.TestUtils;
-import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.util.SimpleHttpClient;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +39,7 @@ public final class HttpBasedServiceCredentialsAuthenticationHandlerTests {
     @Before
     public void setUp() throws Exception {
         this.authenticationHandler = new HttpBasedServiceCredentialsAuthenticationHandler();
-        this.authenticationHandler.setHttpClient(new HttpClient());
+        this.authenticationHandler.setHttpClient(new SimpleHttpClient());
     }
 
     @Test
@@ -70,7 +70,7 @@ public final class HttpBasedServiceCredentialsAuthenticationHandlerTests {
 
     @Test
     public void testAcceptsNonHttpsCredentials() throws Exception {
-        this.authenticationHandler.setHttpClient(new HttpClient());
+        this.authenticationHandler.setHttpClient(new SimpleHttpClient());
         this.authenticationHandler.setRequireSecure(false);
         assertNotNull(this.authenticationHandler.authenticate(
                 TestUtils.getHttpBasedServiceCredentials("http://www.jasig.org")));
@@ -84,7 +84,7 @@ public final class HttpBasedServiceCredentialsAuthenticationHandlerTests {
 
     @Test(expected = FailedLoginException.class)
     public void testNoAcceptableStatusCodeButOneSet() throws Exception {
-        final HttpClient httpClient = new HttpClient();
+        final SimpleHttpClient httpClient = new SimpleHttpClient();
         httpClient.setAcceptableCodes(new int[] {900});
         this.authenticationHandler.setHttpClient(httpClient);
         this.authenticationHandler.authenticate(TestUtils.getHttpBasedServiceCredentials("https://www.ja-sig.org"));

--- a/cas-server-core/src/test/java/org/jasig/cas/logout/LogoutManagerImplTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/logout/LogoutManagerImplTests.java
@@ -32,7 +32,7 @@ import org.jasig.cas.services.LogoutType;
 import org.jasig.cas.services.RegisteredServiceImpl;
 import org.jasig.cas.services.ServicesManager;
 import org.jasig.cas.ticket.TicketGrantingTicket;
-import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.util.SimpleHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,7 +59,7 @@ public class LogoutManagerImplTests {
     @Before
     public void setUp() {
         final ServicesManager servicesManager = mock(ServicesManager.class);
-        this.logoutManager = new LogoutManagerImpl(servicesManager, new HttpClient());
+        this.logoutManager = new LogoutManagerImpl(servicesManager, new SimpleHttpClient());
         this.tgt = mock(TicketGrantingTicket.class);
         this.services = new HashMap<String, Service>();
         this.simpleWebApplicationServiceImpl = new SimpleWebApplicationServiceImpl(URL);

--- a/cas-server-core/src/test/java/org/jasig/cas/ticket/proxy/support/Cas20ProxyHandlerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/ticket/proxy/support/Cas20ProxyHandlerTests.java
@@ -24,7 +24,7 @@ import java.net.URL;
 
 import org.jasig.cas.authentication.HttpBasedServiceCredential;
 import org.jasig.cas.util.DefaultUniqueTicketIdGenerator;
-import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.util.SimpleHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class Cas20ProxyHandlerTests {
     @Before
     public void setUp() throws Exception {
         this.handler = new Cas20ProxyHandler();
-        this.handler.setHttpClient(new HttpClient());
+        this.handler.setHttpClient(new SimpleHttpClient());
         this.handler.setUniqueTicketIdGenerator(new DefaultUniqueTicketIdGenerator());
     }
 
@@ -59,7 +59,7 @@ public class Cas20ProxyHandlerTests {
 
     @Test
     public void testNonValidProxyTicket() throws Exception {
-        final HttpClient httpClient = new HttpClient();
+        final SimpleHttpClient httpClient = new SimpleHttpClient();
         httpClient.setAcceptableCodes(new int[] {900});
         this.handler.setHttpClient(httpClient);
         assertNull(this.handler.handle(new HttpBasedServiceCredential(new URL(

--- a/cas-server-core/src/test/java/org/jasig/cas/util/SimpleHttpClientTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/util/SimpleHttpClientTests.java
@@ -36,10 +36,10 @@ import org.junit.Test;
  * @author Scott Battaglia
  * @since 3.1
  */
-public class HttpClientTests  {
+public class SimpleHttpClientTests  {
 
-    private HttpClient getHttpClient() {
-        final HttpClient httpClient = new HttpClient();
+    private SimpleHttpClient getHttpClient() {
+        final SimpleHttpClient httpClient = new SimpleHttpClient();
         httpClient.setConnectionTimeout(1000);
         httpClient.setReadTimeout(1000);
         return httpClient;
@@ -63,7 +63,7 @@ public class HttpClientTests  {
 
     @Test
     public void testBypassedInvalidHttpsUrl() throws Exception {
-        final HttpClient client = this.getHttpClient();
+        final SimpleHttpClient client = this.getHttpClient();
         client.setSSLSocketFactory(this.getFriendlyToAllSSLSocketFactory());
         client.setHostnameVerifier(this.getFriendlyToAllHostnameVerifier());
         client.setAcceptableCodes(new int[] {200, 403});

--- a/cas-server-core/src/test/resources/core-context.xml
+++ b/cas-server-core/src/test/resources/core-context.xml
@@ -49,7 +49,7 @@
             value-ref="uniqueTicketIdGenerator"/>
     </util:map>
 
-    <bean id="httpClient" class="org.jasig.cas.util.HttpClient"
+    <bean id="httpClient" class="org.jasig.cas.util.SimpleHttpClient"
           p:readTimeout="5000"
           p:connectionTimeout="5000" />
 

--- a/cas-server-core/src/test/resources/mfa-test-context.xml
+++ b/cas-server-core/src/test/resources/mfa-test-context.xml
@@ -83,7 +83,7 @@
         </property>
     </bean>
 
-    <bean id="httpClient" class="org.jasig.cas.util.HttpClient"
+    <bean id="httpClient" class="org.jasig.cas.util.SimpleHttpClient"
           p:readTimeout="5000"
           p:connectionTimeout="5000" />
 

--- a/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/support/kryo/serial/SamlServiceSerializer.java
+++ b/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/support/kryo/serial/SamlServiceSerializer.java
@@ -25,6 +25,7 @@ import com.esotericsoftware.kryo.Kryo;
 import org.jasig.cas.support.saml.authentication.principal.SamlService;
 import org.jasig.cas.ticket.registry.support.kryo.FieldHelper;
 import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.util.SimpleHttpClient;
 
 /**
  * Serializer for {@link SamlService} class.
@@ -61,7 +62,7 @@ public final class SamlServiceSerializer extends AbstractWebApplicationServiceSe
 
         final String requestId = kryo.readObject(buffer, String.class);
         try {
-            return (SamlService) CONSTRUCTOR.newInstance(id, originalUrl, artifactId, new HttpClient(), requestId);
+            return (SamlService) CONSTRUCTOR.newInstance(id, originalUrl, artifactId, new SimpleHttpClient(), requestId);
         } catch (final Exception e) {
             throw new IllegalStateException("Error creating SamlService", e);
         }

--- a/cas-server-webapp-support/src/test/java/org/jasig/cas/web/ServiceValidateControllerTests.java
+++ b/cas-server-webapp-support/src/test/java/org/jasig/cas/web/ServiceValidateControllerTests.java
@@ -25,7 +25,7 @@ import org.jasig.cas.TestUtils;
 import org.jasig.cas.mock.MockValidationSpecification;
 import org.jasig.cas.ticket.proxy.support.Cas10ProxyHandler;
 import org.jasig.cas.ticket.proxy.support.Cas20ProxyHandler;
-import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.util.SimpleHttpClient;
 import org.jasig.cas.validation.Cas20ProtocolValidationSpecification;
 import org.jasig.cas.web.support.CasArgumentExtractor;
 import org.junit.Before;
@@ -60,7 +60,7 @@ public class ServiceValidateControllerTests extends AbstractCentralAuthenticatio
         this.serviceValidateController
         .setCentralAuthenticationService(getCentralAuthenticationService());
         final Cas20ProxyHandler proxyHandler = new Cas20ProxyHandler();
-        proxyHandler.setHttpClient(new HttpClient());
+        proxyHandler.setHttpClient(new SimpleHttpClient());
         this.serviceValidateController.setProxyHandler(proxyHandler);
         this.serviceValidateController.setApplicationContext(context);
         this.serviceValidateController.setArgumentExtractor(new CasArgumentExtractor());

--- a/cas-server-webapp-support/src/test/java/org/jasig/cas/web/flow/FrontChannelLogoutActionTests.java
+++ b/cas-server-webapp-support/src/test/java/org/jasig/cas/web/flow/FrontChannelLogoutActionTests.java
@@ -37,7 +37,7 @@ import org.jasig.cas.logout.LogoutManagerImpl;
 import org.jasig.cas.logout.LogoutRequest;
 import org.jasig.cas.logout.LogoutRequestStatus;
 import org.jasig.cas.services.ServicesManager;
-import org.jasig.cas.util.HttpClient;
+import org.jasig.cas.util.SimpleHttpClient;
 import org.jasig.cas.web.support.WebUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +70,7 @@ public class FrontChannelLogoutActionTests {
 
     @Before
     public void onSetUp() throws Exception {
-        final LogoutManager logoutManager = new LogoutManagerImpl(mock(ServicesManager.class), new HttpClient());
+        final LogoutManager logoutManager = new LogoutManagerImpl(mock(ServicesManager.class), new SimpleHttpClient());
         this.frontChannelLogoutAction = new FrontChannelLogoutAction(logoutManager);
 
         this.request = new MockHttpServletRequest();

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
@@ -78,11 +78,11 @@
           p:startDelay="${service.registry.quartz.reloader.startDelay:120000}"
           p:repeatInterval="${service.registry.quartz.reloader.repeatInterval:120000}"/>
 
-    <bean id="httpClient" class="org.jasig.cas.util.HttpClient"
+    <bean id="httpClient" class="org.jasig.cas.util.SimpleHttpClient"
           p:readTimeout="5000"
           p:connectionTimeout="5000"/>
 
-    <bean id="noRedirectHttpClient" class="org.jasig.cas.util.HttpClient" parent="httpClient"
+    <bean id="noRedirectHttpClient" class="org.jasig.cas.util.SimpleHttpClient" parent="httpClient"
           p:followRedirects="false" />
 
     <bean id="persistentIdGenerator"


### PR DESCRIPTION
Let's take an example :
I have a CAS server with internal applications and internet applications integrated.
For logout process, I use back-channel HTTP communications which are different according to the services (direct communications for internal services and use of a proxy for internet applications).
I would need a specific HTTP client implementation.

The main idea is now to have an interface : `HttpClient` and a default implementation (sufficient in almost all cases) : `SimpleHttpClient` (the old HttpClient renamed).
