### PR TITLE
NOJIRA - Removed the unused mobile css file from the theme default props.

### DIFF
--- a/cas-server-webapp/src/main/resources/cas-theme-default.properties
+++ b/cas-server-webapp/src/main/resources/cas-theme-default.properties
@@ -17,6 +17,5 @@
 # under the License.
 #
 
-mobile.custom.css.file=/css/default-mobile-custom.css
 standard.custom.css.file=/css/cas.css
 cas.javascript.file=/js/cas.js


### PR DESCRIPTION
The entry is no longer used anywhere, as mobile styling and themes are natively provided by through the cas.css file.
