### PR TITLE
trivial: adds blank line to `..-webapp-support/pom.xml`

### DIFF
--- a/cas-server-webapp-support/pom.xml
+++ b/cas-server-webapp-support/pom.xml
@@ -36,6 +36,7 @@
       <scope>test</scope>
       <type>jar</type>
     </dependency>
+
     <dependency>
       <groupId>com.github.inspektr</groupId>
       <artifactId>inspektr-support-spring</artifactId>


### PR DESCRIPTION
adds blank line to `cas-server-webapp-support/pom.xml` to make `com.github.inspektr` dependency declaration spaced like the others
