### PR TITLE
CAS-1337: Improve pattern to detect unprintable characters

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/Response.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/principal/Response.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 public final class Response {
     /** Pattern to detect unprintable ASCII characters. */
     private static final Pattern NON_PRINTABLE =
-        Pattern.compile("[\\x00-\\x19\\x7F]+");
+        Pattern.compile("[\\x00-\\x1F\\x7F]+");
 
     /** Log instance. */
     protected static final Logger LOGGER = LoggerFactory.getLogger(Response.class);


### PR DESCRIPTION
Conventional non-printable characters also include 0x1A - 0x1F.
