### PR TITLE
CAS-1355: Set allowedToProxy to false by default (SEC_3)

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
@@ -90,7 +90,7 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
     @Column(length = 255, updatable = true, insertable = true, nullable = true)
     private String theme;
 
-    private boolean allowedToProxy = true;
+    private boolean allowedToProxy = false;
 
     private boolean enabled = true;
 

--- a/cas-server-core/src/test/java/org/jasig/cas/monitor/SessionMonitorTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/monitor/SessionMonitorTests.java
@@ -115,7 +115,7 @@ public class SessionMonitorTests {
                     TEST_EXP_POLICY);
             registry.addTicket(ticket);
         }
-        
+
         if (ticket != null) {
           for (int i = 0; i < stCount; i++) {
               registry.addTicket(ticket.grantServiceTicket(

--- a/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
@@ -50,6 +50,14 @@ public class AbstractRegisteredServiceTests {
     };
 
     @Test
+    public void testAllowToProxyIsFalseByDefault() {
+        RegexRegisteredService regexRegisteredService = new RegexRegisteredService();
+        assertFalse(regexRegisteredService.isAllowedToProxy());
+        RegisteredServiceImpl registeredServiceImpl = new RegisteredServiceImpl();
+        assertFalse(registeredServiceImpl.isAllowedToProxy());
+    }
+
+    @Test
     public void testSettersAndGetters() {
         final long ID = 1000;
         final String DESCRIPTION = "test";

--- a/cas-server-core/src/test/resources/core-context.xml
+++ b/cas-server-core/src/test/resources/core-context.xml
@@ -79,6 +79,7 @@
                     <property name="name" value="Test Service"/>
                     <property name="serviceId" value="test$"/>
                     <property name="evaluationOrder" value="1"/>
+                    <property name="allowedToProxy" value="true" />
                 </bean>
 
                 <bean class="org.jasig.cas.services.RegisteredServiceImpl">


### PR DESCRIPTION
https://wiki.jasig.org/display/CAS/Proposals+to+mitigate+security+risks

A first proposal for this version 4.0, a simple but important one : no proxy capability by default for the service...
