### PR TITLE
CAS-1355: Set allowedToProxy to false by default (SEC_3)

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/services/AbstractRegisteredService.java
@@ -83,7 +83,7 @@ public abstract class AbstractRegisteredService
 
     private String theme;
 
-    private boolean allowedToProxy = true;
+    private boolean allowedToProxy = false;
 
     private boolean enabled = true;
 

--- a/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/services/AbstractRegisteredServiceTests.java
@@ -49,6 +49,14 @@ public class AbstractRegisteredServiceTests {
     };
 
     @Test
+    public void testAllowToProxyIsFalseByDefault() {
+        RegexRegisteredService regexRegisteredService = new RegexRegisteredService();
+        assertFalse(regexRegisteredService.isAllowedToProxy());
+        RegisteredServiceImpl registeredServiceImpl = new RegisteredServiceImpl();
+        assertFalse(registeredServiceImpl.isAllowedToProxy());
+    }
+    
+    @Test
     public void testSettersAndGetters() {
         final long ID = 1000;
         final String DESCRIPTION = "test";

--- a/cas-server-core/src/test/resources/applicationContext.xml
+++ b/cas-server-core/src/test/resources/applicationContext.xml
@@ -79,6 +79,7 @@
                     <property name="name" value="Test Service" />
                     <property name="serviceId" value="test$" />
                     <property name="evaluationOrder" value="1" />
+                    <property name="allowedToProxy" value="true" />
                 </bean>
                 
                 <bean class="org.jasig.cas.services.RegisteredServiceImpl">


### PR DESCRIPTION
https://wiki.jasig.org/display/CAS/Proposals+to+mitigate+security+risks

Originally targeted for 4.0, it could make sense to have it already for 3.5.3...
