### PR TITLE
CAS-1347: Missing language keys prevents access should not cause a crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -924,7 +924,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
     <commons.io.version>2.0</commons.io.version>
     <mockito.version>1.9.0</mockito.version>
     <jdk.version>1.6</jdk.version>
-    <ehcache.version>2.6.6</ehcache.version>
+    <ehcache.version>2.7.2</ehcache.version>
     <hsqldb.version>2.0.0</hsqldb.version>
     <joda-time.version>2.1</joda-time.version>
   </properties>


### PR DESCRIPTION
I added the missing French properties.
I also replaced the French accents by their unicode values, to avoid new mistakes on encoding. I should do that for the next change on 4.0.

I also changed the EhCache version. First, I wanted to keep the 2.7.2 version, but there was some impacts on the `cas-server-integration-ehcache` module so I downgraded to the 2.6.6 version.
