### PR TITLE
CAS-1364: The ehcache-core dependency version 2.7.2 does not exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -924,7 +924,7 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
     <commons.io.version>2.0</commons.io.version>
     <mockito.version>1.9.0</mockito.version>
     <jdk.version>1.6</jdk.version>
-    <ehcache.version>2.7.2</ehcache.version>
+    <ehcache.version>2.6.6</ehcache.version>
     <hsqldb.version>2.0.0</hsqldb.version>
     <joda-time.version>2.1</joda-time.version>
   </properties>


### PR DESCRIPTION
It could be replaced by the `ehcache` dependency version 2.7.2 (same groupId : `net.sf.ehcache`).

However, in fact, the `net.sf.ehcache.statistics.LiveCacheStatistics` class used by the `cas-server-integration-ehcache` module does not exist any more in the version 2.7.2.
To avoid too much modification, I'll propose to downgrad to version 2.6.6.
