### PR TITLE
CAS-1278: fluid reordering javascript throws js exception on add/edit service page

### DIFF
--- a/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/top.jsp
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/includes/top.jsp
@@ -35,7 +35,7 @@
   <link rel="stylesheet" href="<c:url value="/css/management.css" />" type="text/css" />
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/jquery-ui.min.js"></script>
-  <script type="text/javascript" src="<c:url value="/js/MyInfusion.js" />"></script>
+  
   <script type="text/javascript" src="<c:url value="/js/management.js" />"></script>
 
   <style type="text/css">

--- a/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/manage.jsp
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/view/jsp/manage.jsp
@@ -19,6 +19,7 @@
 
 --%>
 <%@include file="includes/top.jsp"%>
+<script type="text/javascript" src="<c:url value="/js/MyInfusion.js" />"></script>
 <h1><spring:message code="${pageTitle}" /></h1>
 <c:if test="${fn:length(services) eq 0}">
        <div id="msg" class="errors"><p><spring:message code="management.services.service.warn" arguments="${defaultServiceUrl}" /></p></div>

--- a/cas-management-webapp/src/main/webapp/js/management.js
+++ b/cas-management-webapp/src/main/webapp/js/management.js
@@ -103,22 +103,26 @@ function updateRegisteredServiceOrder(movedService, pos) {
 
 $(document).ready(function () {
 	$("#errorsDiv").hide();
-	var opts = {
-		selectors: {
-			movables: "tr"
-		},
-		listeners: {
-			onMove: updateRegisteredServiceOrder,
-			onBeginMove: function() {
-				$("#errorsDiv").hide();
-			},
-			afterMove: function() {
-				$("#fluid-ariaLabeller-liveRegion").remove();
-			},
-			onHover: function(item, state) {
-				$(item).css('cursor', state ? 'move' : 'auto');
-			}
-		}
-	};
-	return fluid.reorderList("#tableWrapper #scrollTable tbody", opts);
+	if (typeof fluid != 'undefined') {
+    	var opts = {
+    		selectors: {
+    			movables: "tr"
+    		},
+    		listeners: {
+    			onMove: updateRegisteredServiceOrder,
+    			onBeginMove: function() {
+    				$("#errorsDiv").hide();
+    			},
+    			afterMove: function() {
+    				$("#fluid-ariaLabeller-liveRegion").remove();
+    			},
+    			onHover: function(item, state) {
+    				$(item).css('cursor', state ? 'move' : 'auto');
+    			}
+    		}
+    	};
+	
+        return fluid.reorderList("#tableWrapper #scrollTable tbody", opts);
+    }
+    return;
 });


### PR DESCRIPTION
The fluid reordering javascript utilized in services management should only be included on the main manage.jsp page.

Also classified as a bug:
https://issues.jasig.org/browse/CAS-1278
