### PR TITLE
CAS-1365: Access rules to the management webapp are externalized.

### DIFF
--- a/cas-management-webapp/src/main/resources/user-details.properties
+++ b/cas-management-webapp/src/main/resources/user-details.properties
@@ -1,0 +1,29 @@
+ #
+# Licensed to Jasig under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Jasig licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# This file lists the set of users that are allowed access to the management app.
+# See this link for more info: 
+# http://docs.spring.io/spring-security/site/docs/3.0.x/reference/ns-config.html
+#
+# The syntax of each entry should be in the form of:
+# 
+# username=password,grantedAuthority[,grantedAuthority][,enabled|disabled]
+
+# Example:
+# casuser=notused,ROLE_ADMIN

--- a/cas-management-webapp/src/main/webapp/WEB-INF/cas-management.properties
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/cas-management.properties
@@ -33,6 +33,12 @@ cas-management.securityContext.serviceProperties.adminRoles=ROLE_ADMIN
 cas-management.viewResolver.basename=default_views
 
 ##
+# User details file location that contains list of users
+# who are allowed access to the management webapp:
+# 
+# user.details.file.location = classpath:user-details.properties
+
+##
 # Database flavors for Hibernate
 #
 # One of these is needed if you are storing Services in an RDBMS via JPA.

--- a/cas-management-webapp/src/main/webapp/WEB-INF/managementConfigContext.xml
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/managementConfigContext.xml
@@ -46,11 +46,8 @@
 	
 	The name of this should remain "userDetailsService" in order for Spring Security to find it.
 	 -->
-    <!-- <sec:user name="@@THIS SHOULD BE REPLACED@@" password="notused" authorities="ROLE_ADMIN" />-->
-
-    <sec:user-service id="userDetailsService">
-        <sec:user name="@@THIS SHOULD BE REPLACED@@" password="notused" authorities="ROLE_ADMIN" />
-    </sec:user-service>
+    <sec:user-service id="userDetailsService" 
+                      properties="${user.details.file.location:classpath:user-details.properties}" />
 	
     <!-- 
     Bean that defines the attributes that a service may return.  This example uses the Stub/Mock version.  A real implementation


### PR DESCRIPTION
Instead of having adopters tweak the xml file, by default an external file is provided
that can list the user accounts who may have access to the webapp. This appears to
moderately address use cases better in situations where ldap or jdbc backends are not
available or may not be at all needed.

https://issues.jasig.org/browse/CAS-1365
