### PR TITLE
CAS-1260: Trimming the username on set 

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/UsernamePasswordCredential.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/UsernamePasswordCredential.java
@@ -57,8 +57,8 @@ public class UsernamePasswordCredential implements Credential, Serializable {
      * @param password Non-null password.
      */
     public UsernamePasswordCredential(final String userName, final String password) {
-        this.username = userName;
-        this.password = password;
+        this.setUsername(userName);
+        this.setPassword(password);
     }
 
     /**
@@ -86,7 +86,7 @@ public class UsernamePasswordCredential implements Credential, Serializable {
      * @param userName The userName to set.
      */
     public final void setUsername(final String userName) {
-        this.username = userName;
+        this.username = userName.trim();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
to avoid the dangling space added by certain mobile clients.
