### PR TITLE
Fix IV handling in clustered environments (EncryptedMapDecorator.java)

### DIFF
--- a/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/EncryptedMapDecorator.java
+++ b/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/EncryptedMapDecorator.java
@@ -277,6 +277,9 @@ public final class EncryptedMapDecorator implements Map<String, String> {
     }
 
     protected String encrypt(String plaintext, String ignore) {
+        if (plaintext == null)
+            return null;
+
         try {
             final Cipher cipher = getCipherObject();
 
@@ -298,9 +301,12 @@ public final class EncryptedMapDecorator implements Map<String, String> {
     }
 
     protected String decrypt(String iv_ciphertext_encoded, String ignore) {
+        if (iv_ciphertext_encoded == null)
+            return null;
+
         try {
             final Cipher cipher = getCipherObject();
-
+            
             byte[] iv_ciphertext = decode(iv_ciphertext_encoded.getBytes());
             byte[] iv = Arrays.copyOfRange(iv_ciphertext, 0, IV_LEN);
             byte[] ciphertext = Arrays.copyOfRange(iv_ciphertext, IV_LEN, iv_ciphertext.length);


### PR DESCRIPTION
Patch for EncryptedMapDecorator.java (cas-server-extension-clearpass). Returns IV (16 bytes) prepended to ciphertext on encrypt(); mandatory for proper decryption. Useful in clustered environments where IVs saved to thread-safe ConcurrentHashMaps are being stored locally in memory, thus rendering other systems in the cluster unable to decrypt a ciphertext without the original IV being made accessible. This solves the problem by including the IV as part of encrypt()'s return value. Added IV_ROUNDS and SALT_ROUNDS for demonstration purposes.

See https://gist.github.com/rdev5/7570750 for details.
