### PR TITLE
Catch exceptions thrown by decoratedMap

### DIFF
--- a/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/EncryptedMapDecorator.java
+++ b/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/EncryptedMapDecorator.java
@@ -211,8 +211,6 @@ public final class EncryptedMapDecorator implements Map<String, String> {
             }
 
             return decrypt(hashedValue, hashedKey);
-        } catch (final InterruptedException e) {
-            logger.error("Interrupted while retrieving hashed value for key [" + hashedKey + "]");
         } catch (final Exception e) {
             logger.error("Failed to retrieve hashed value for key [" + hashedKey + "]: " + e.getMessage());
         }
@@ -232,8 +230,6 @@ public final class EncryptedMapDecorator implements Map<String, String> {
             }
 
             return decrypt(oldValue, hashedKey);
-        } catch (final InterruptedException e) {
-            logger.error("Interrupted while storing hashed value for key [" + hashedKey + "]");
         } catch (final Exception e) {
             logger.error("Failed to stored hashed value for key [" + hashedKey + "]: " + e.getMessage());
         }


### PR DESCRIPTION
This pull request has been recreated via fork. Please see https://github.com/Jasig/cas/pull/377.

---

No logging implemented for handling possible decoratedMap exceptions.

For example, using spymemcached specified in Spring configuration for clearpass-configuration.xml could throw OperationTimeoutException. See http://stackoverflow.com/q/10800101/901156

JIRA: https://issues.jasig.org/browse/CAS-1397

This is also related to JIRA https://issues.jasig.org/browse/CAS-1394 as we are looking to propose these changes because we are still getting an empty pgtIou and this serves as means of adding debugging capabilities for spymemcached implementations.
