### PR TITLE
CAS-1403: Buffer limit exceeded writing object of type: javax.security.auth.login.FailedLoginException

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/Authentication.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/Authentication.java
@@ -93,5 +93,5 @@ public interface Authentication extends Serializable {
      *
      * @return Map of authentication handler names to the authentication errors produced on attempted authentication.
      */
-    Map<String, Exception> getFailures();
+    Map<String, Class<? extends Exception>> getFailures();
 }

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationBuilder.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationBuilder.java
@@ -47,7 +47,7 @@ public class AuthenticationBuilder {
     private Map<String, HandlerResult> successes = new LinkedHashMap<String, HandlerResult>();
 
     /** Map of handler names to authentication failures. */
-    private Map<String, Exception> failures = new LinkedHashMap<String, Exception>();
+    private Map<String, Class<? extends Exception>> failures = new LinkedHashMap<String, Class<? extends Exception>>();
 
 
     /** Authentication date. */
@@ -231,7 +231,7 @@ public class AuthenticationBuilder {
      *
      * @return Non-null authentication failure map.
      */
-    public Map<String, Exception> getFailures() {
+    public Map<String, Class<? extends Exception>> getFailures() {
         return this.failures;
     }
 
@@ -242,7 +242,7 @@ public class AuthenticationBuilder {
      *
      * @return This builder instance.
      */
-    public AuthenticationBuilder setFailures(final Map<String, Exception> failures) {
+    public AuthenticationBuilder setFailures(final Map<String, Class<? extends Exception>> failures) {
         Assert.notNull(failures, "Failures cannot be null");
         this.failures.clear();
         for (final String handler : failures.keySet()) {
@@ -259,7 +259,7 @@ public class AuthenticationBuilder {
      *
      * @return This builder instance.
      */
-    public AuthenticationBuilder addFailure(final String key, final Exception value) {
+    public AuthenticationBuilder addFailure(final String key, final Class<? extends Exception> value) {
         this.failures.put(key, value);
         return this;
     }

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationException.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/AuthenticationException.java
@@ -36,7 +36,7 @@ public class AuthenticationException extends Exception {
     private static final long serialVersionUID = -6032827784134751797L;
 
     /** Immutable map of handler names to the errors they raised. */
-    private final Map<String, Exception> handlerErrors;
+    private final Map<String, Class<? extends Exception>> handlerErrors;
 
     /** Immutable map of handler names to an authentication success metadata instance. */
     private final Map<String, HandlerResult> handlerSuccesses;
@@ -47,7 +47,7 @@ public class AuthenticationException extends Exception {
     public AuthenticationException() {
         this(
             "No supported authentication handlers found for given credentials.",
-            Collections.<String, Exception>emptyMap(),
+            Collections.<String, Class<? extends Exception>>emptyMap(),
             Collections.<String, HandlerResult>emptyMap());
     }
 
@@ -56,7 +56,7 @@ public class AuthenticationException extends Exception {
      *
      * @param handlerErrors Map of handler names to errors.
      */
-    public AuthenticationException(final Map<String, Exception> handlerErrors) {
+    public AuthenticationException(final Map<String, Class<? extends Exception>> handlerErrors) {
         this(handlerErrors, Collections.<String, HandlerResult>emptyMap());
     }
 
@@ -67,7 +67,7 @@ public class AuthenticationException extends Exception {
      * @param handlerSuccesses Map of handler names to authentication successes.
      */
     public AuthenticationException(
-            final Map<String, Exception> handlerErrors, final Map<String, HandlerResult> handlerSuccesses) {
+            final Map<String, Class<? extends Exception>> handlerErrors, final Map<String, HandlerResult> handlerSuccesses) {
         this(
             String.format("%s errors, %s successes", handlerErrors.size(), handlerSuccesses.size()),
             handlerErrors,
@@ -83,7 +83,7 @@ public class AuthenticationException extends Exception {
      */
     public AuthenticationException(
             final String message,
-            final Map<String, Exception> handlerErrors,
+            final Map<String, Class<? extends Exception>> handlerErrors,
             final Map<String, HandlerResult> handlerSuccesses) {
         super(message);
         this.handlerErrors = Collections.unmodifiableMap(handlerErrors);
@@ -95,7 +95,7 @@ public class AuthenticationException extends Exception {
      *
      * @return Immutable map of handler names to errors.
      */
-    public Map<String, Exception> getHandlerErrors() {
+    public Map<String, Class<? extends Exception>> getHandlerErrors() {
         return this.handlerErrors;
     }
 

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/ImmutableAuthentication.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/ImmutableAuthentication.java
@@ -60,7 +60,7 @@ public final class ImmutableAuthentication implements Authentication, Serializab
     private final Map<String, HandlerResult> successes;
 
     /** Map of handler name to handler authentication failure cause. */
-    private final Map<String, Exception> failures;
+    private final Map<String, Class<? extends Exception>> failures;
 
     /** No-arg constructor for serialization support. */
     private ImmutableAuthentication() {
@@ -88,7 +88,7 @@ public final class ImmutableAuthentication implements Authentication, Serializab
             final Principal principal,
             final Map<String, Object> attributes,
             final Map<String, HandlerResult> successes,
-            final Map<String, Exception> failures) {
+            final Map<String, Class<? extends Exception>> failures) {
 
         Assert.notNull(date, "Date cannot be null");
         Assert.notNull(credentials, "Credential cannot be null");
@@ -130,7 +130,7 @@ public final class ImmutableAuthentication implements Authentication, Serializab
     }
 
     @Override
-    public Map<String, Exception> getFailures() {
+    public Map<String, Class<? extends Exception>> getFailures() {
         return wrap(this.failures);
     }
 

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/NotPreventedAuthenticationPolicy.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/NotPreventedAuthenticationPolicy.java
@@ -31,7 +31,7 @@ public class NotPreventedAuthenticationPolicy extends AnyAuthenticationPolicy {
     @Override
     public boolean isSatisfiedBy(final Authentication authentication) {
         for (final String handler : authentication.getFailures().keySet()) {
-            if (authentication.getFailures().get(handler) instanceof PreventedException) {
+            if (authentication.getFailures().get(handler).isAssignableFrom(PreventedException.class)) {
                 return false;
             }
         }

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/PolicyBasedAuthenticationManager.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/PolicyBasedAuthenticationManager.java
@@ -231,9 +231,9 @@ public class PolicyBasedAuthenticationManager implements AuthenticationManager {
                         }
                     } catch (final GeneralSecurityException e) {
                         logger.info("{} failed authenticating {}", handler.getName(), credential);
-                        builder.addFailure(handler.getName(), e);
+                        builder.addFailure(handler.getName(), e.getClass());
                     } catch (final PreventedException e) {
-                        builder.addFailure(handler.getName(), e);
+                        builder.addFailure(handler.getName(), e.getClass());
                     }
                 }
             }

--- a/cas-server-core/src/main/java/org/jasig/cas/authentication/PrincipalException.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/authentication/PrincipalException.java
@@ -40,7 +40,7 @@ public class PrincipalException extends AuthenticationException {
      */
     public PrincipalException(
             final String message,
-            final Map<String, Exception> handlerErrors,
+            final Map<String, Class<? extends Exception>> handlerErrors,
             final Map<String, HandlerResult> handlerSuccesses) {
         super(message, handlerErrors, handlerSuccesses);
     }

--- a/cas-server-core/src/main/java/org/jasig/cas/web/flow/AuthenticationExceptionHandler.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/flow/AuthenticationExceptionHandler.java
@@ -112,11 +112,11 @@ public class AuthenticationExceptionHandler {
     public String handle(final AuthenticationException e, final MessageContext messageContext) {
         if (e != null) {
             for (final Class<? extends Exception> kind : this.errors) {
-                for (final Exception handlerError : e.getHandlerErrors().values()) {
-                    if (handlerError != null && handlerError.getClass().equals(kind)) {
-                        final String messageCode = this.messageBundlePrefix + handlerError.getClass().getSimpleName();
+                for (final Class<? extends Exception> handlerError : e.getHandlerErrors().values()) {
+                    if (handlerError != null && handlerError.equals(kind)) {
+                        final String messageCode = this.messageBundlePrefix + handlerError.getSimpleName();
                         messageContext.addMessage(new MessageBuilder().error().code(messageCode).build());
-                        return handlerError.getClass().getSimpleName();
+                        return handlerError.getSimpleName();
                     }
                 }
 

--- a/cas-server-core/src/test/java/org/jasig/cas/authentication/ImmutableAuthenticationTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/authentication/ImmutableAuthenticationTests.java
@@ -54,8 +54,8 @@ public class ImmutableAuthenticationTests {
         attributes.put("authenticationMethod", "password");
         final Map<String, HandlerResult> successes = new HashMap<String, HandlerResult>();
         successes.put("handler1", new HandlerResult(authenticationHandler, credential1));
-        final Map<String, Exception> failures = new HashMap<String, Exception>();
-        failures.put("handler2", new FailedLoginException());
+        final Map<String, Class<? extends Exception>> failures = new HashMap<String, Class<? extends Exception>>();
+        failures.put("handler2", FailedLoginException.class);
         final ImmutableAuthentication auth = new ImmutableAuthentication(
                 new Date(),
                 credentials,
@@ -82,7 +82,7 @@ public class ImmutableAuthenticationTests {
             logger.debug("Adding authentication success event failed correctly");
         }
         try {
-            auth.getFailures().put("test", new FailedLoginException());
+            auth.getFailures().put("test", FailedLoginException.class);
             fail("Should have failed");
         } catch (final RuntimeException e) {
             logger.debug("Adding authentication failure event failed correctly");

--- a/cas-server-core/src/test/java/org/jasig/cas/web/flow/AuthenticationExceptionHandlerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/web/flow/AuthenticationExceptionHandlerTests.java
@@ -41,8 +41,8 @@ public class AuthenticationExceptionHandlerTests {
         final AuthenticationExceptionHandler handler = new AuthenticationExceptionHandler();
         final MessageContext ctx = mock(MessageContext.class);
         
-        final Map<String, Exception> map = new HashMap<String, Exception>();
-        map.put("notFound", new AccountNotFoundException());
+        final Map<String, Class<? extends Exception>> map = new HashMap<String, Class<? extends Exception>>();
+        map.put("notFound", AccountNotFoundException.class);
         final String id = handler.handle(new AuthenticationException(map), ctx);
         assertEquals(id, AccountNotFoundException.class.getSimpleName());
     }
@@ -52,8 +52,8 @@ public class AuthenticationExceptionHandlerTests {
         final AuthenticationExceptionHandler handler = new AuthenticationExceptionHandler();
         final MessageContext ctx = mock(MessageContext.class);
         
-        final Map<String, Exception> map = new HashMap<String, Exception>();
-        map.put("unknown", new GeneralSecurityException());
+        final Map<String, Class<? extends Exception>> map = new HashMap<String, Class<? extends Exception>>();
+        map.put("unknown", GeneralSecurityException.class);
         final String id = handler.handle(new AuthenticationException(map), ctx);
         assertEquals(id, "UNKNOWN");
     }

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.security.auth.login.FailedLoginException;
+
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.serialize.FieldSerializer;
 import org.jasig.cas.authentication.Authentication;
@@ -194,6 +196,7 @@ public class KryoTranscoderTests {
             } catch (final Exception e) {
                 throw new RuntimeException(e);
             }
+            builder.addFailure(handler.getName(), FailedLoginException.class);
             this.authentication = builder.build();
         }
 


### PR DESCRIPTION
To fix the problem, according to Marvin's advice (https://groups.google.com/forum/?fromgroups#!topic/jasig-cas-dev/DkTXOWi2Q-Q), I replaced the `Exception` object used for failures by a `Class<? extends Exception>` object.
I also updated the serialization test.
