### PR TITLE
CAS-1380: Fixed conflicts between spring and spring-security dependencies

### DIFF
--- a/cas-server-webapp-support/pom.xml
+++ b/cas-server-webapp-support/pom.xml
@@ -88,7 +88,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-expression</artifactId>
-      <version>${spring.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -961,9 +961,9 @@ pTSqrOnmqmUUnopqmvummmmmmUUnopqmvummmmmmUUA1jJ
     <cs.dir>${project.basedir}</cs.dir>
     <issues.projectKey>CAS</issues.projectKey>
     <spring.webflow.version>2.3.2.RELEASE</spring.webflow.version>
-    <spring.version>3.2.2.RELEASE</spring.version>
+    <spring.version>3.2.6.RELEASE</spring.version>
     <ldaptive.version>1.0.1</ldaptive.version>
-    <spring.security.version>3.1.2.RELEASE</spring.security.version>
+    <spring.security.version>3.2.0.RELEASE</spring.security.version>
     <clover.version>2.6.3</clover.version>
     <aspectj.version>1.7.2</aspectj.version>
     <javax.validation.version>1.0.0.GA</javax.validation.version>


### PR DESCRIPTION
Including the `cas-server-webapp-support` module in the overlay causes older versions of Spring to be included in the build. This is because the module references an older version of spring-security that is incompatible with Spring that CAS uses. 

To fix the problem, versions of spring-security and spring are upgraded and matched to avoid incorrect transient dependencies.
