### PR TITLE
Added BatchedTicketRegistryCleaner which supports cleaning of a JpaTicke...

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/BatchableTicketRegistry.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/BatchableTicketRegistry.java
@@ -1,0 +1,34 @@
+package org.jasig.cas.ticket.registry;
+
+import org.jasig.cas.ticket.Ticket;
+
+import java.util.Collection;
+
+/**
+ * Interface for a ticket registry that allows retrieving tickets from it in batches.
+ *
+ * @author Ahsan Rabbani
+ */
+public interface BatchableTicketRegistry extends TicketRegistry {
+
+    /**
+     * Retrieve a batch of TicketGrantingTickets starting from the given offset. Ordering is determined by the
+     * implementing class.
+     *
+     * @param offset the number of rows to skip from the start of the result set
+     * @param batchSize the number of tickets to retrieve in the batch. The actual number returned could be less.
+     * @return collection of tickets currently stored in the registry. Tickets might or might not be valid i.e. expired.
+     */
+    Collection<Ticket> getTicketGrantingTicketBatch(int offset, int batchSize);
+
+    /**
+     * Retrieve a batch of ServiceTickets starting from the given offset. Ordering is determined by the implementing
+     * class.
+     *
+     * @param offset the number of rows to skip from the start of the result set
+     * @param batchSize the number of tickets to retrieve in the batch. The actual number returned could be less.
+     * @return collection of tickets currently stored in the registry. Tickets might or might not be valid i.e. expired.
+     */
+    Collection<Ticket> getServiceTicketBatch(int offset, int batchSize);
+
+}

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
@@ -43,7 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @since 3.2.1
  *
  */
-public final class JpaTicketRegistry extends AbstractDistributedTicketRegistry {
+public final class JpaTicketRegistry extends AbstractDistributedTicketRegistry implements BatchableTicketRegistry {
     
     @NotNull
     @PersistenceContext
@@ -150,7 +150,29 @@ public final class JpaTicketRegistry extends AbstractDistributedTicketRegistry {
         
         return tickets;
     }
-    
+
+    @Transactional(readOnly=true)
+    public Collection<Ticket> getTicketGrantingTicketBatch(int offset, int batchSize) {
+        final List<TicketGrantingTicketImpl> tgts = entityManager
+                .createQuery("select t from TicketGrantingTicketImpl t order by t.creationTime asc", TicketGrantingTicketImpl.class)
+                .setFirstResult(offset)
+                .setMaxResults(batchSize)
+                .getResultList();
+
+        return new ArrayList<Ticket>(tgts);
+    }
+
+    @Transactional(readOnly=true)
+    public Collection<Ticket> getServiceTicketBatch(int offset, int batchSize) {
+        final List<ServiceTicketImpl> sts = entityManager
+                .createQuery("select s from ServiceTicketImpl s order by s.creationTime asc", ServiceTicketImpl.class)
+                .setFirstResult(offset)
+                .setMaxResults(batchSize)
+                .getResultList();
+
+        return new ArrayList<Ticket>(sts);
+    }
+
     public void setTicketGrantingTicketPrefix(final String ticketGrantingTicketPrefix) {
         this.ticketGrantingTicketPrefix = ticketGrantingTicketPrefix;
     }

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/support/BatchedTicketRegistryCleaner.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/support/BatchedTicketRegistryCleaner.java
@@ -1,0 +1,160 @@
+package org.jasig.cas.ticket.registry.support;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.jasig.cas.ticket.Ticket;
+import org.jasig.cas.ticket.registry.BatchableTicketRegistry;
+import org.jasig.cas.ticket.registry.RegistryCleaner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+
+/**
+ * This class tries to address the issue with ${@link DefaultTicketRegistryCleaner} when used in conjunction with a
+ * ${@link org.jasig.cas.ticket.registry.JpaTicketRegistryy} discussed in the below thread by processing the tickets in
+ * the registry in batches. This should prevent the CAS server from running out of memory in certain scenarios (ie when
+ * a large number of tickets get created in a short period of time) when the ticket registry cleaner runs.
+ *
+ * http://jasig.275507.n4.nabble.com/JpaTicketRegistry-A-Sinking-Ship-td4256973.html
+ *
+ * @author Ahsan Rabbani
+ */
+public class BatchedTicketRegistryCleaner implements RegistryCleaner
+{
+    /** The Commons Logging instance. */
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final int DEFAULT_BATCH_SIZE = 2000;
+
+    /** The instance of the TicketRegistry to clean. */
+    @NotNull
+    private BatchableTicketRegistry ticketRegistry;
+
+    /** Execution locking strategy */
+    @NotNull
+    private LockingStrategy lock = new NoOpLockingStrategy();
+
+    private TicketRegistryCleanerHelper registryCleanerHelper = new TicketRegistryCleanerHelper();
+
+    private boolean logUserOutOfServices = true;
+
+    private int batchSize = DEFAULT_BATCH_SIZE;
+
+    @Override
+    public void clean()
+    {
+        this.log.info("Beginning ticket cleanup.");
+
+        this.log.debug("Attempting to acquire ticket cleanup lock.");
+        if (!this.lock.acquire())
+        {
+            this.log.info("Could not obtain lock.  Aborting cleanup.");
+            return;
+        }
+        this.log.debug("Acquired lock.  Proceeding with cleanup.");
+
+        try
+        {
+            this.log.info("Processing TicketGrantingTickets for cleanup.");
+            int numTicketsRemoved = cleanTickets(
+                    new BatchedTicketRetriever()
+                    {
+                        @Override
+                        public Collection<Ticket> getBatch(int offset, int batchSize)
+                        {
+                            return ticketRegistry.getTicketGrantingTicketBatch(offset, batchSize);
+                        }
+                    }
+            );
+            this.log.info("{} total TicketGrantingTickets removed.", numTicketsRemoved);
+
+            this.log.info("Processing ServiceTickets for cleanup.");
+            numTicketsRemoved = cleanTickets(
+                    new BatchedTicketRetriever()
+                    {
+                        @Override
+                        public Collection<Ticket> getBatch(int offset, int batchSize)
+                        {
+                            return ticketRegistry.getServiceTicketBatch(offset, batchSize);
+                        }
+                    }
+            );
+            this.log.info("{} total ServiceTickets removed.", numTicketsRemoved);
+        }
+        finally
+        {
+            this.log.debug("Releasing ticket cleanup lock.");
+            this.lock.release();
+        }
+
+        this.log.info("Finished ticket cleanup.");
+    }
+
+    int cleanTickets(BatchedTicketRetriever ticketRetriever)
+    {
+        int offset = 0;
+        int numTicketsRemoved = 0;
+
+        Collection<Ticket> ticketBatch;
+        while (CollectionUtils.isNotEmpty(ticketBatch = ticketRetriever.getBatch(offset, batchSize)))
+        {
+            int ticketsRemovedFromBatch = registryCleanerHelper.deleteExpiredTickets(ticketRegistry, ticketBatch, logUserOutOfServices);
+            offset += (ticketBatch.size() - ticketsRemovedFromBatch);
+            numTicketsRemoved += ticketsRemovedFromBatch;
+        }
+
+        return numTicketsRemoved;
+    }
+
+    interface BatchedTicketRetriever
+    {
+        Collection<Ticket> getBatch(int offset, int batchSize);
+    }
+
+    /**
+     * @param ticketRegistry The  ticketRegistry to set.
+     */
+    public void setTicketRegistry(final BatchableTicketRegistry ticketRegistry)
+    {
+        this.ticketRegistry = ticketRegistry;
+    }
+
+    /**
+     * @param  strategy  Ticket cleanup locking strategy.  An exclusive locking
+     * strategy is preferable if not required for some ticket backing stores,
+     * such as JPA, in a clustered CAS environment.  Use {@link JdbcLockingStrategy}
+     * for {@link org.jasig.cas.ticket.registry.JpaTicketRegistry} in a clustered
+     * CAS environment.
+     */
+    public void setLock(final LockingStrategy strategy)
+    {
+        this.lock = strategy;
+    }
+
+    /**
+     * Whether to log users out of services when we remove an expired ticket.  The default is true. Set this to
+     * false to disable.
+     *
+     * @param logUserOutOfServices whether to log the user out of services or not.
+     */
+    public void setLogUserOutOfServices(final boolean logUserOutOfServices)
+    {
+        this.logUserOutOfServices = logUserOutOfServices;
+    }
+
+    /**
+     * Batch size to use when retrieving tickets from the registry to process. The default is 2000.
+     *
+     * @param batchSize batch size to use when retrieving tickets from the registry
+     */
+    public void setBatchSize(final int batchSize)
+    {
+        this.batchSize = batchSize;
+    }
+
+    void setRegistryCleanerHelper(TicketRegistryCleanerHelper registryCleanerHelper)
+    {
+        this.registryCleanerHelper = registryCleanerHelper;
+    }
+}

--- a/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/support/TicketRegistryCleanerHelper.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/ticket/registry/support/TicketRegistryCleanerHelper.java
@@ -1,0 +1,45 @@
+package org.jasig.cas.ticket.registry.support;
+
+import org.jasig.cas.ticket.Ticket;
+import org.jasig.cas.ticket.TicketGrantingTicket;
+import org.jasig.cas.ticket.registry.TicketRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TicketRegistryCleanerHelper {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    public int deleteExpiredTickets(final TicketRegistry ticketRegistry, final Collection<Ticket> ticketsInCache, final boolean logUserOutOfServices)
+    {
+        int numTicketsDeleted = 0;
+
+        final List<Ticket> ticketsToRemove = new ArrayList<Ticket>();
+        for (final Ticket ticket : ticketsInCache)
+        {
+            if (ticket.isExpired())
+            {
+                ticketsToRemove.add(ticket);
+            }
+        }
+
+        log.info(ticketsToRemove.size() + " tickets found to be removed.");
+        for (final Ticket ticket : ticketsToRemove)
+        {
+            // CAS-686: Expire TGT to trigger single sign-out
+            if (logUserOutOfServices && ticket instanceof TicketGrantingTicket)
+            {
+                ((TicketGrantingTicket) ticket).expire();
+            }
+            ticketRegistry.deleteTicket(ticket.getId());
+            numTicketsDeleted++;
+        }
+
+        return numTicketsDeleted;
+    }
+
+}

--- a/cas-server-core/src/test/java/org/jasig/cas/ticket/registry/support/BatchedTicketRegistryCleanerTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/ticket/registry/support/BatchedTicketRegistryCleanerTests.java
@@ -1,0 +1,168 @@
+package org.jasig.cas.ticket.registry.support;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.jasig.cas.ticket.Ticket;
+import org.jasig.cas.ticket.registry.BatchableTicketRegistry;
+import org.jasig.cas.ticket.registry.TicketRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BatchedTicketRegistryCleanerTests
+{
+    private BatchedTicketRegistryCleaner registryCleaner;
+
+    private BatchableTicketRegistry ticketRegistry;
+    private BatchedTicketRegistryCleaner.BatchedTicketRetriever ticketRetriever;
+    private TicketRegistryCleanerHelper helper;
+
+    @Before
+    public void setup()
+    {
+        ticketRegistry = mock(BatchableTicketRegistry.class);
+        ticketRetriever = mock(BatchedTicketRegistryCleaner.BatchedTicketRetriever.class);
+        helper = mock(TicketRegistryCleanerHelper.class);
+
+        registryCleaner = new BatchedTicketRegistryCleaner();
+        registryCleaner.setTicketRegistry(ticketRegistry);
+        registryCleaner.setRegistryCleanerHelper(helper);
+    }
+
+    @Test
+    public void cleanTickets_whenBatchIsNull_zeroTicketsAreRemoved()
+    {
+        when(ticketRetriever.getBatch(anyInt(), anyInt())).thenReturn(null);
+
+        int numTicketsRemoved = registryCleaner.cleanTickets(ticketRetriever);
+
+        verifyZeroInteractions(helper);
+        assertEquals(0, numTicketsRemoved);
+    }
+
+    @Test
+    public void cleanTickets_whenBatchIsEmpty_zeroTicketsAreRemoved()
+    {
+        when(ticketRetriever.getBatch(anyInt(), anyInt())).thenReturn(new ArrayList<Ticket>());
+
+        int numTicketsRemoved = registryCleaner.cleanTickets(ticketRetriever);
+
+        verifyZeroInteractions(helper);
+        assertEquals(0, numTicketsRemoved);
+    }
+
+    @Test
+    public void cleanTickets_whenMultipleBatchesWithNoExpiredTickets_offsetIsUpdatedCorrectly()
+    {
+        final int batchSize = 100;
+
+        List<Ticket> batch1 = getListOfNTickets(batchSize);
+        List<Ticket> batch2 = getListOfNTickets(batchSize);
+        List<Ticket> batch3 = getListOfNTickets(75);
+
+        when(ticketRetriever.getBatch(anyInt(), anyInt()))
+                .thenReturn(batch1)
+                .thenReturn(batch2)
+                .thenReturn(batch3)
+                .thenReturn(null);
+
+        when(helper.deleteExpiredTickets(any(TicketRegistry.class), anyCollection(), anyBoolean()))
+                .thenReturn(0)
+                .thenReturn(0)
+                .thenReturn(0);
+
+        registryCleaner.setBatchSize(batchSize);
+        registryCleaner.cleanTickets(ticketRetriever);
+
+        InOrder inOrder = inOrder(ticketRetriever);
+        inOrder.verify(ticketRetriever).getBatch(0, batchSize);
+        inOrder.verify(ticketRetriever).getBatch(100, batchSize);
+        inOrder.verify(ticketRetriever).getBatch(200, batchSize);
+        inOrder.verify(ticketRetriever).getBatch(275, batchSize);
+    }
+
+    @Test
+    public void cleanTickets_whenMultipleBatchesWithSomeExpiredTickets_offsetIsUpdatedCorrectly()
+    {
+        final int batchSize = 100;
+
+        List<Ticket> batch1 = getListOfNTickets(batchSize);
+        List<Ticket> batch2 = getListOfNTickets(batchSize);
+        List<Ticket> batch3 = getListOfNTickets(75);
+
+        final int batch1ExpiredTickets = 25;
+        final int batch2ExpiredTickets = 40;
+        final int batch3ExpiredTickets = 15;
+
+        when(ticketRetriever.getBatch(anyInt(), anyInt()))
+                .thenReturn(batch1)
+                .thenReturn(batch2)
+                .thenReturn(batch3)
+                .thenReturn(null);
+
+        when(helper.deleteExpiredTickets(any(TicketRegistry.class), anyCollection(), anyBoolean()))
+                .thenReturn(batch1ExpiredTickets)
+                .thenReturn(batch2ExpiredTickets)
+                .thenReturn(batch3ExpiredTickets);
+
+        registryCleaner.setBatchSize(batchSize);
+        registryCleaner.cleanTickets(ticketRetriever);
+
+        InOrder inOrder = inOrder(ticketRetriever);
+        inOrder.verify(ticketRetriever).getBatch(0, batchSize);
+        inOrder.verify(ticketRetriever).getBatch(75, batchSize);
+        inOrder.verify(ticketRetriever).getBatch(135, batchSize);
+        inOrder.verify(ticketRetriever).getBatch(195, batchSize);
+    }
+
+    @Test
+    public void cleanTickets_whenMultipleBatchesWithAllExpiredTickets_offsetIsUpdatedCorrectly()
+    {
+        final int batchSize = 100;
+
+        List<Ticket> batch1 = getListOfNTickets(batchSize);
+        List<Ticket> batch2 = getListOfNTickets(batchSize);
+        List<Ticket> batch3 = getListOfNTickets(75);
+
+        when(ticketRetriever.getBatch(anyInt(), anyInt()))
+                .thenReturn(batch1)
+                .thenReturn(batch2)
+                .thenReturn(batch3)
+                .thenReturn(null);
+
+        when(helper.deleteExpiredTickets(any(TicketRegistry.class), anyCollection(), anyBoolean()))
+                .thenReturn(batchSize)
+                .thenReturn(batchSize)
+                .thenReturn(75);
+
+        registryCleaner.setBatchSize(batchSize);
+        registryCleaner.cleanTickets(ticketRetriever);
+
+        verify(ticketRetriever, times(4)).getBatch(0, batchSize);
+    }
+
+    @Test
+    public void clean_processesBothTicketGrantingTicketsAndServiceTickets()
+    {
+        registryCleaner.clean();
+
+        verify(ticketRegistry).getTicketGrantingTicketBatch(anyInt(), anyInt());
+        verify(ticketRegistry).getServiceTicketBatch(anyInt(), anyInt());
+    }
+
+    private List<Ticket> getListOfNTickets(int size)
+    {
+        List<Ticket> tickets = new ArrayList<Ticket>(size);
+
+        for (int i=0; i<size; i++)
+        {
+            tickets.add(mock(Ticket.class));
+        }
+
+        return tickets;
+    }
+}

--- a/cas-server-core/src/test/java/org/jasig/cas/ticket/registry/support/TicketRegistryCleanerHelperTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/ticket/registry/support/TicketRegistryCleanerHelperTests.java
@@ -1,0 +1,101 @@
+package org.jasig.cas.ticket.registry.support;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.jasig.cas.ticket.Ticket;
+import org.jasig.cas.ticket.TicketGrantingTicket;
+import org.jasig.cas.ticket.registry.TicketRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TicketRegistryCleanerHelperTests
+{
+    private TicketRegistryCleanerHelper helper = new TicketRegistryCleanerHelper();
+
+    private TicketRegistry ticketRegistry;
+
+    @Before
+    public void setup()
+    {
+        ticketRegistry = mock(TicketRegistry.class);
+    }
+
+    @Test
+    public void deleteExpiredTickets_whenZeroExpiredTickets_zeroTicketsAreDeleted()
+    {
+        int numTicketsRemoved = helper.deleteExpiredTickets(ticketRegistry, Arrays.asList(getUnexpiredTicket("id"), getUnexpiredTicket("id"), getUnexpiredTicket("id")), false);
+
+        verify(ticketRegistry, times(0)).deleteTicket(anyString());
+        assertEquals(0, numTicketsRemoved);
+    }
+
+    @Test
+    public void deleteExpiredTickets_whenSomeTicketsAreExpired_ticketsAreDeleted()
+    {
+        int numTicketsRemoved = helper.deleteExpiredTickets(ticketRegistry, Arrays.asList(getExpiredTicket("expired1"), getUnexpiredTicket("foo"), getExpiredTicket("expired2")), false);
+
+        verify(ticketRegistry).deleteTicket("expired1");
+        verify(ticketRegistry).deleteTicket("expired2");
+        assertEquals(2, numTicketsRemoved);
+    }
+
+    @Test
+    public void deleteExpiredTickets_whenAllTicketsAreExpired_AlTicketsAreDeleted()
+    {
+        int numTicketsRemoved = helper.deleteExpiredTickets(ticketRegistry, Arrays.asList(getExpiredTicket("expired1"), getExpiredTicket("expired2"), getExpiredTicket("expired3")), false);
+
+        verify(ticketRegistry).deleteTicket("expired1");
+        verify(ticketRegistry).deleteTicket("expired2");
+        verify(ticketRegistry).deleteTicket("expired3");
+        assertEquals(3, numTicketsRemoved);
+    }
+
+    @Test
+    public void deleteExpiredTickets_whenTicketGrantingTicketIsExpiredAndLogUserOfService_expiresTicket()
+    {
+        TicketGrantingTicket ticket = mock(TicketGrantingTicket.class);
+        when(ticket.isExpired()).thenReturn(true);
+
+        List<Ticket> tickets = new ArrayList<Ticket>();
+        tickets.add(ticket);
+
+        helper.deleteExpiredTickets(ticketRegistry, tickets, true);
+
+        verify(ticket).expire();
+    }
+
+    @Test
+    public void deleteExpiredTickets_whenTicketGrantingTicketIsExpiredAndNotLogUserOfService_doesNotExpireTicket()
+    {
+        TicketGrantingTicket ticket = mock(TicketGrantingTicket.class);
+        when(ticket.isExpired()).thenReturn(true);
+
+        List<Ticket> tickets = new ArrayList<Ticket>();
+        tickets.add(ticket);
+
+        helper.deleteExpiredTickets(ticketRegistry, tickets, false);
+
+        verify(ticket, times(0)).expire();
+    }
+
+    private Ticket getExpiredTicket(String id)
+    {
+        Ticket ticket = mock(Ticket.class);
+        when(ticket.isExpired()).thenReturn(true);
+        when(ticket.getId()).thenReturn(id);
+        return ticket;
+    }
+
+    private Ticket getUnexpiredTicket(String id)
+    {
+        Ticket ticket = mock(Ticket.class);
+        when(ticket.isExpired()).thenReturn(false);
+        when(ticket.getId()).thenReturn(id);
+        return ticket;
+    }
+}


### PR DESCRIPTION
...tRegistry in batches to prevent OOM situations

This is an attempt at addressing the issue discussed in the thread: http://jasig.275507.n4.nabble.com/JpaTicketRegistry-A-Sinking-Ship-td4256973.html 
