### PR TITLE
CAS-1448: Simple attribute value with commas are considered as multi valued attribute

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/3.0/casServiceValidationSuccess.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/3.0/casServiceValidationSuccess.jsp
@@ -19,6 +19,7 @@
 
 --%>
 <%@ page session="false" contentType="application/xml; charset=UTF-8" %>
+<%@ page import="java.util.Map.Entry" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
@@ -43,10 +44,24 @@
                            varStatus="loopStatus" begin="0"
                            end="${fn:length(assertion.primaryAuthentication.principal.attributes)}"
                            step="1">
-                    <%--If attribute is multi-valued, list each value under the same attribute name --%>
-                    <c:forEach var="attrval" items="${attr.value}">
-                        <cas:${fn:escapeXml(attr.key)}>${fn:escapeXml(attrval)}</cas:${fn:escapeXml(attr.key)}>
-                    </c:forEach>
+                   	<%-- ${attr.value['class'].simpleName} fails for List: use scriptlet instead --%>
+                   	<%
+                   	    Entry entry = (Entry) pageContext.getAttribute("attr");
+                   	    Object value = entry.getValue();
+                   	    pageContext.setAttribute("isAString", value instanceof String);
+                   	%>
+                    <c:choose>
+                        <%-- it's a String, output it once --%>
+                        <c:when test="${isAString}">
+                            <cas:${fn:escapeXml(attr.key)}>${fn:escapeXml(attr.value)}</cas:${fn:escapeXml(attr.key)}>
+                        </c:when>
+                        <%-- if attribute is multi-valued, list each value under the same attribute name --%>
+                        <c:otherwise>
+                            <c:forEach var="attrval" items="${attr.value}">
+                                <cas:${fn:escapeXml(attr.key)}>${fn:escapeXml(attrval)}</cas:${fn:escapeXml(attr.key)}>
+                            </c:forEach>
+                        </c:otherwise>
+                    </c:choose>
                 </c:forEach>
             </cas:attributes>
         </c:if>


### PR DESCRIPTION
After struggling a few hours, I haven't been able to find a good solution in JSTL, So that's why there is some scriptlet inside the JSP page...

I made the test for a String (without comma), a String (with commas), a list with just one element and a list with several elements.
