### PR TITLE
LDAP return attributes not initialized.

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/LdapAuthenticationHandler.java
@@ -39,6 +39,7 @@ import org.jasig.cas.authentication.support.LdapPasswordPolicyConfiguration;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
+import org.ldaptive.ReturnAttributes;
 import org.ldaptive.auth.AuthenticationRequest;
 import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.AuthenticationResultCode;
@@ -83,7 +84,7 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     protected List<String> additionalAttributes = Collections.emptyList();
 
     /** Set of LDAP attributes fetch from an entry as part of the authentication process. */
-    private String[] authenticatedEntryAttributes;
+    private String[] authenticatedEntryAttributes = ReturnAttributes.NONE.value();
 
     /**
      * Creates a new authentication handler that delegates to the given authenticator.
@@ -267,9 +268,15 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
         if (this.principalIdAttribute != null) {
             attributes.add(this.principalIdAttribute);
         }
-        attributes.addAll(this.principalAttributeMap.keySet());
-        attributes.addAll(this.additionalAttributes);
-        this.authenticatedEntryAttributes = attributes.toArray(new String[attributes.size()]);
+        if (!this.principalAttributeMap.isEmpty()) {
+          attributes.addAll(this.principalAttributeMap.keySet());
+        }
+        if (!this.additionalAttributes.isEmpty()) {
+          attributes.addAll(this.additionalAttributes);
+        }
+        if (!attributes.isEmpty()) {
+          this.authenticatedEntryAttributes = attributes.toArray(new String[attributes.size()]);
+        }
     }
 
 }

--- a/cas-server-support-ldap/src/test/resources/ad-authn-test.xml
+++ b/cas-server-support-ldap/src/test/resources/ad-authn-test.xml
@@ -29,6 +29,7 @@
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="classpath:/ad.properties"/>
+    <context:component-scan base-package="org.jasig.cas.authentication" />
 
     <bean id="usersLdif"
           class="org.springframework.core.io.ClassPathResource"

--- a/cas-server-support-ldap/src/test/resources/openldap-anonsearchbind-authn-test.xml
+++ b/cas-server-support-ldap/src/test/resources/openldap-anonsearchbind-authn-test.xml
@@ -29,6 +29,7 @@
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="classpath:/openldap.properties"/>
+    <context:component-scan base-package="org.jasig.cas.authentication" />
 
     <bean id="usersLdif"
           class="org.springframework.core.io.ClassPathResource"

--- a/cas-server-support-ldap/src/test/resources/openldap-directbind-authn-test.xml
+++ b/cas-server-support-ldap/src/test/resources/openldap-directbind-authn-test.xml
@@ -29,6 +29,7 @@
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="classpath:/openldap.properties"/>
+    <context:component-scan base-package="org.jasig.cas.authentication" />
 
     <bean id="usersLdif"
           class="org.springframework.core.io.ClassPathResource"

--- a/cas-server-support-ldap/src/test/resources/openldap-searchbind-authn-test.xml
+++ b/cas-server-support-ldap/src/test/resources/openldap-searchbind-authn-test.xml
@@ -29,6 +29,7 @@
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="classpath:/openldap.properties"/>
+    <context:component-scan base-package="org.jasig.cas.authentication" />
 
     <bean id="usersLdif"
           class="org.springframework.core.io.ClassPathResource"


### PR DESCRIPTION
The @PostConstruct annotation is not being honored, consequently return attributes are not set in the authentication request.
This results in all attributes being requested after authentication.

Note that it may be useful to add functionality to LdapAuthenticationHandler for requesting all user attributes.
