### PR TITLE
Allow for time skewing of the issue instant when validating saml requests

### DIFF
--- a/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/cas-server-support-saml/src/main/java/org/jasig/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -81,10 +81,22 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
     }
 
     /**
-    * Sets the allowance for time skew between CAS and the client server.  Default 0s.
+    * Sets the allowance for time skew in seconds
+    * between CAS and the client server.  Default 0s.
     * This value will be subtracted from the current time when setting the SAML
-    * <code>NotBeforeDate</code> attribute, thereby allowing for the CAS server to be ahead of the
-    * client by as much as the value defined here.
+    * <code>NotBeforeDate</code> attribute, thereby allowing for the
+    * CAS server to be ahead of the client by as much as the value defined here.
+    *
+    * <p><strong>Note:</strong> Skewing of the issue instant via setting this property
+    * applies to all saml assertions that are issued by CAS and it
+    * currently cannot be controlled on a per relying party basis.
+    * Before configuring this, it is recommended that each service provider
+    * attempt to correctly sync their system time with an NTP server
+    * so as to match the CAS server's issue instant config and to
+    * avoid applying this setting globally. This should only
+    * be used in situations where the NTP server is unresponsive to
+    * sync time on the client, or the client is simply unable
+    * to adjust their server time configuration.</p>
     *
     * @param skewAllowance Number of seconds to allow for variance.
     */


### PR DESCRIPTION
This PR fixes #480

When a SAML 1.1 CAS client's system time is behind the CAS server's, there exists a possibility that the SAML Artifact validation will fail at the client server when it checks the NotBeforeDate attribute and finds it to be [to its perception] in the future.

For local clients this is a fairly easy fix, as it usually just means that the server needs to be more regularly NTP-sync'd; not a problem. When working with external commercial services which are integrated through your CAS installation, however, this is more problematic as they are loathe to change system time for the sake of one client [say, if your commercial provider is, oh I don't know, Google ;) ].

The actual timing can be pretty sensitive for this as the current implementation in AbstractSaml10ResponseView uses the current system time at response generation, meaning that if the server isn't under load and the network is quick, even a skew of 1s could (principally) throw off the timing.

In any case, this leaves a number of potential solutions, only one of which (IMNSQO - In My Not So Qualified Opinion) is good:
1.) Adjust the allowance for skew in the client [only valid in local instances where the client code is available - N/A here].
2.) Adjust the system clock on the CAS server - functions, but means putting a deliberate delta in the system clock relative to other servers on the network and induces all sorts of new headaches.
3.) Like the SAML 2.0 validator, simply inject a static 'way-back' NotBeforeDate to ensure that it will always be valid. Works, but my IA team would crucify me if I introduced the code to do that.
4.) Introduce a server-side skew allowance in the validator code to allow 'wiggle room' for clock variance upon client inspection of the response.

Obviously my inclination [and our local workaround] is predicated upon #4, but my questions are then the following:
1.) The code has survived like this for years without [to my limited knowledge] anyone else having issue. That leads me to think that as this is a commercial provider not often used with SAML 1.1 AuthN, we may be the only user who cares. Is there larger interest in allowing for #4 above as a solution?
2.) I'm happy to create a pull request in the coming days for a patch to allow this, but would appreciate feedback on whether it would be better to introduce a static skew allowance, an injectable property value defaulting to 0, or an injectable value set to something static and which must be dropped by those really wanting to lock things down?

In all cases, if you're still reading, thanks for your time and attention!
