### PR TITLE
Allow to customize search filter for LDAP. Fixes #CAS-1482

### DIFF
--- a/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/support/UpnSearchEntryResolver.java
+++ b/cas-server-support-ldap/src/main/java/org/jasig/cas/authentication/support/UpnSearchEntryResolver.java
@@ -39,7 +39,10 @@ import org.ldaptive.auth.SearchEntryResolver;
 public class UpnSearchEntryResolver extends SearchEntryResolver {
 
     /** UPN-based search filter. */
-    private static final String SEARCH_FILTER = "userPrincipalName={0}";
+    private static final String DEFAULT_SEARCH_FILTER = "userPrincipalName={0}";
+
+    private String searchFilter = DEFAULT_SEARCH_FILTER;
+    private boolean searchUserOnly = false;
 
     /** Base DN of LDAP subtree search. */
     private String baseDn;
@@ -53,13 +56,33 @@ public class UpnSearchEntryResolver extends SearchEntryResolver {
         this.baseDn = dn;
     }
 
+    /**
+     * Use only user (without domain) for search filter.
+     * default false
+     *
+     * @param searchUserOnly true or false
+     */
+    public void setSearchUserOnly(final boolean searchUserOnly) {
+        this.searchUserOnly = searchUserOnly;
+    }
+
+    /**
+     * Search filter string.
+     *
+     * @param searchFilter search filter
+     */
+     public void setSearchFilter(final String searchFilter) {
+         this.searchFilter = searchFilter;
+     }
+
     /** {@inheritDoc} */
     @Override
     protected SearchRequest createSearchRequest(final AuthenticationCriteria ac) {
         final SearchRequest sr = new SearchRequest();
         sr.setSearchScope(SearchScope.SUBTREE);
         sr.setBaseDn(this.baseDn);
-        sr.setSearchFilter(new SearchFilter(SEARCH_FILTER, new Object[] {ac.getDn()}));
+        final String principal = searchUserOnly ? ac.getAuthenticationRequest().getUser() : ac.getDn();
+        sr.setSearchFilter(new SearchFilter(searchFilter, new Object[] {principal}));
         sr.setSearchEntryHandlers(getSearchEntryHandlers());
         sr.setReturnAttributes(ac.getAuthenticationRequest().getReturnAttributes());
         return sr;


### PR DESCRIPTION
[ copied from https://issues.jasig.org/browse/CAS-1482 ]
Our corporate Active Directory has users migrated to another domain. As a result, it is necessary to bind to LDAP with DN including domain name (like `user@COMPANY`), but to perform the search with user name only. I created a patch, which adds property `searchUserOnly` which defaults to false to keep the current behavior. Also, I created a property `searchFilter` to override the current string: 

```
userPrincipalName={0}
```

with search filter I had to use for our Active Directory:

```
(&(objectClass=user)(sAMAccountName={0}))
```

So I can define bean like:

```
<bean id="entryResolver"
  class="org.jasig.cas.authentication.support.UpnSearchEntryResolver"
  p:baseDn="${ldap.baseDn}"
  p:searchUserOnly="true"
  p:searchFilter="${ldap.searchFilter}"/>
```

in a property file I have ldap.searchFilter specified as:

```
ldap.searchFilter=(&(objectClass=user)(sAMAccountName={0}))
```
