### PR TITLE
Issue #552 Avoid usage count in SSO opt-out check.

### DIFF
--- a/cas-server-core/src/test/java/org/jasig/cas/CentralAuthenticationServiceImplWithMokitoTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/CentralAuthenticationServiceImplWithMokitoTests.java
@@ -236,6 +236,7 @@ public class CentralAuthenticationServiceImplWithMokitoTests {
         final RegisteredService mockRegSvc = mock(RegisteredService.class);
         when(mockRegSvc.getServiceId()).thenReturn(svcId);
         when(mockRegSvc.isEnabled()).thenReturn(enabled);
+        when(mockRegSvc.isSsoEnabled()).thenReturn(true);
         when(mockRegSvc.getProxyPolicy()).thenReturn(proxy);
         when(mockRegSvc.getName()).thenReturn(svcId);
         when(mockRegSvc.matches(argThat(new VerifyServiceByIdMatcher(svcId)))).thenReturn(true);


### PR DESCRIPTION
Reorganize code to perform authentication beforehand and store reference
to successful Authentication event that can be consulted for SSO opt-out
check afterward.

Deals with #552 
