### PR TITLE
do not focus username field, if another field is already selected

### DIFF
--- a/cas-server-webapp/src/main/webapp/js/cas.js
+++ b/cas-server-webapp/src/main/webapp/js/cas.js
@@ -19,7 +19,10 @@
 
 $(document).ready(function(){
     //focus username field
-    $("input:visible:enabled:first").focus();
+    if ($(":focus").length === 0){
+      $("input:visible:enabled:first").focus();
+    }
+
     //flash error box
     $('#msg.errors').animate({ backgroundColor: 'rgb(187,0,0)' }, 30).animate({ backgroundColor: 'rgb(255,238,221)' }, 500);
 

--- a/cas-server-webapp/src/main/webapp/themes/apereo/js/cas.js
+++ b/cas-server-webapp/src/main/webapp/themes/apereo/js/cas.js
@@ -19,7 +19,10 @@
 
 $(document).ready(function(){
     //focus username field
-    $("input:visible:enabled:first").focus();
+    if ($(":focus").length === 0){
+      $("input:visible:enabled:first").focus();
+    }
+
     //flash error box
     $('#msg.errors').animate({ backgroundColor: 'rgb(187,0,0)' }, 30).animate({ backgroundColor: 'rgb(255,238,221)' }, 500);
 


### PR DESCRIPTION
The problem seems to occur with a slow internet connection or if the theme contain big images. In both cases a javascript, which is placed in the footer, is loaded after the user began to type in his credentials.

The script switches the focus automatically to the “Username”-field. When you start to type in your password before the script is loaded, the focus will jump to the “Username”-field and it is possible that you type in your password in the wrong field.

The patch will only focus the username field, if no other field is focused.
