### PR TITLE
Improved configuration of cas.properties location

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/propertyFileConfigurer.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/propertyFileConfigurer.xml
@@ -23,14 +23,19 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 	<description>
 		This file lets CAS know where you've stored the cas.properties file which details some of the configuration options
 		that are specific to your environment.  You can specify the location of the file here.  You may wish to place the file outside
 		of the Servlet context if you have options that are specific to a tier (i.e. test vs. production) so that the WAR file 
 		can be moved between tiers without modification.
 	</description>
-    
-    <context:property-placeholder location="/WEB-INF/cas.properties"/> 
+
+    <util:properties id="casProperties" location="${cas.properties.filepath:/WEB-INF/cas.properties}" />
+
+    <context:property-placeholder properties-ref="casProperties" />
+
 </beans>


### PR DESCRIPTION
Introduced a properties object which represents the cas.properties file in order to make accessible these properties also after the startup of the web-app. Introduced the cas.properties.filepath property in order to make easier the configuration of the cas.properties location using a context-parameter in the web.xml or a JVM argument, instead to change a specific spring configuration file.
