### PR TITLE
Use default theme, if no theme is found for the service

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/web/support/WebUtils.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/support/WebUtils.java
@@ -18,16 +18,15 @@
  */
 package org.jasig.cas.web.support;
 
-import java.util.List;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.jasig.cas.authentication.principal.WebApplicationService;
 import org.jasig.cas.logout.LogoutRequest;
 import org.springframework.util.Assert;
 import org.springframework.webflow.context.servlet.ServletExternalContext;
 import org.springframework.webflow.execution.RequestContext;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 /**
  * Common utilities for the web tier.
@@ -119,9 +118,8 @@ public final class WebUtils {
      * @param context the context
      * @return the service
      */
-    public static WebApplicationService getService(
-        final RequestContext context) {
-        return (WebApplicationService) context.getFlowScope().get("service");
+    public static WebApplicationService getService(final RequestContext context) {
+        return context != null ? (WebApplicationService) context.getFlowScope().get("service") : null;
     }
 
     /**

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/services/web/ServiceThemeResolver.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/services/web/ServiceThemeResolver.java
@@ -18,20 +18,25 @@
  */
 package org.jasig.cas.services.web;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.services.RegisteredService;
 import org.jasig.cas.services.ServicesManager;
-import org.jasig.cas.web.support.ArgumentExtractor;
 import org.jasig.cas.web.support.WebUtils;
-import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.web.servlet.theme.AbstractThemeResolver;
+import org.springframework.webflow.execution.RequestContext;
+import org.springframework.webflow.execution.RequestContextHolder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.util.HashMap;
-import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 import java.util.regex.Pattern;
 
 /**
@@ -46,10 +51,10 @@ import java.util.regex.Pattern;
  */
 public final class ServiceThemeResolver extends AbstractThemeResolver {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceThemeResolver.class);
+
     /** The ServiceRegistry to look up the service. */
     private ServicesManager servicesManager;
-
-    private List<ArgumentExtractor> argumentExtractors;
 
     private Map<Pattern, String> overrides = new HashMap<Pattern, String>();
 
@@ -58,15 +63,10 @@ public final class ServiceThemeResolver extends AbstractThemeResolver {
         if (this.servicesManager == null) {
             return getDefaultThemeName();
         }
-
-        final Service service = WebUtils.getService(this.argumentExtractors, request);
-
-        final RegisteredService rService = this.servicesManager.findServiceBy(service);
-
         // retrieve the user agent string from the request
         final String userAgent = request.getHeader("User-Agent");
 
-        if (userAgent == null) {
+        if (StringUtils.isBlank(userAgent)) {
             return getDefaultThemeName();
         }
 
@@ -78,8 +78,24 @@ public final class ServiceThemeResolver extends AbstractThemeResolver {
             }
         }
 
-        return service != null && rService != null && StringUtils.hasText(rService.getTheme())
-                ? rService.getTheme() : getDefaultThemeName();
+        final RequestContext context = RequestContextHolder.getRequestContext();
+        final Service service = WebUtils.getService(context);
+        if (service != null) {
+            final RegisteredService rService = this.servicesManager.findServiceBy(service);
+            if (rService != null && rService.isEnabled() && StringUtils.isNotBlank(rService.getTheme())) {
+                LOGGER.debug("Service [{}] is configured to use a custom theme [{}]", rService, rService.getTheme());
+                final CasThemeResourceBundleMessageSource messageSource = new CasThemeResourceBundleMessageSource();
+                messageSource.setBasename(rService.getTheme());
+                if (messageSource.doGetBundle(rService.getTheme(), request.getLocale()) != null) {
+                    LOGGER.debug("Found custom theme [{}] for service [{}]", rService.getTheme(), rService);
+                    return rService.getTheme();
+                } else {
+                    LOGGER.warn("Custom theme {} for service {} cannot be located. Falling back to default theme...",
+                            rService.getTheme(), rService);
+                }
+            }
+        }
+        return getDefaultThemeName();
     }
 
     @Override
@@ -89,10 +105,6 @@ public final class ServiceThemeResolver extends AbstractThemeResolver {
 
     public void setServicesManager(final ServicesManager servicesManager) {
         this.servicesManager = servicesManager;
-    }
-
-    public void setArgumentExtractors(final List<ArgumentExtractor> argumentExtractors) {
-        this.argumentExtractors = argumentExtractors;
     }
 
     /**
@@ -109,6 +121,21 @@ public final class ServiceThemeResolver extends AbstractThemeResolver {
 
         for (final Map.Entry<String, String> entry : mobileOverrides.entrySet()) {
             this.overrides.put(Pattern.compile(entry.getKey()), entry.getValue());
+        }
+    }
+
+    private static class CasThemeResourceBundleMessageSource extends ResourceBundleMessageSource {
+        @Override
+        protected ResourceBundle doGetBundle(final String basename, final Locale locale) throws MissingResourceException {
+            try {
+                final ResourceBundle bundle = ResourceBundle.getBundle(basename, locale, getBundleClassLoader());
+                if (bundle != null && bundle.keySet().size() > 0) {
+                    return bundle;
+                }
+            } catch (final Exception e) {
+                LOGGER.debug(e.getMessage(), e);
+            }
+            return null;
         }
     }
 }

--- a/cas-server-webapp-support/src/test/java/org/jasig/cas/services/web/ServiceThemeResolverTests.java
+++ b/cas-server-webapp-support/src/test/java/org/jasig/cas/services/web/ServiceThemeResolverTests.java
@@ -18,21 +18,24 @@
  */
 package org.jasig.cas.services.web;
 
-import static org.junit.Assert.*;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.jasig.cas.TestUtils;
 import org.jasig.cas.services.DefaultServicesManagerImpl;
 import org.jasig.cas.services.InMemoryServiceRegistryDaoImpl;
 import org.jasig.cas.services.RegisteredServiceImpl;
 import org.jasig.cas.services.ServicesManager;
-import org.jasig.cas.web.support.ArgumentExtractor;
-import org.jasig.cas.web.support.CasArgumentExtractor;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.webflow.core.collection.LocalAttributeMap;
+import org.springframework.webflow.core.collection.MutableAttributeMap;
+import org.springframework.webflow.execution.RequestContext;
+import org.springframework.webflow.execution.RequestContextHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  *
@@ -53,14 +56,13 @@ public class ServiceThemeResolverTests {
         this.serviceThemeResolver = new ServiceThemeResolver();
         this.serviceThemeResolver.setDefaultThemeName("test");
         this.serviceThemeResolver.setServicesManager(this.servicesManager);
-        this.serviceThemeResolver.setArgumentExtractors(Arrays.asList((ArgumentExtractor) new CasArgumentExtractor()));
         final Map<String, String> mobileBrowsers = new HashMap<String, String>();
         mobileBrowsers.put("Mozilla", "theme");
         this.serviceThemeResolver.setMobileBrowsers(mobileBrowsers);
     }
 
     @Test
-    public void testGetServiceTheme() {
+    public void testGetServiceThemeDoesNotExist() {
         final RegisteredServiceImpl r = new RegisteredServiceImpl();
         r.setTheme("myTheme");
         r.setId(1000);
@@ -70,9 +72,13 @@ public class ServiceThemeResolverTests {
         this.servicesManager.save(r);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("service", "myServiceId");
+        final RequestContext ctx = mock(RequestContext.class);
+        final MutableAttributeMap scope = new LocalAttributeMap();
+        scope.put("service", TestUtils.getService(r.getServiceId()));
+        when(ctx.getFlowScope()).thenReturn(scope);
+        RequestContextHolder.setRequestContext(ctx);
         request.addHeader("User-Agent", "Mozilla");
-        assertEquals("myTheme", this.serviceThemeResolver.resolveThemeName(request));
+        assertEquals("test", this.serviceThemeResolver.resolveThemeName(request));
     }
 
     @Test

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas-servlet.xml
@@ -34,7 +34,6 @@
   <!-- Theme Resolver -->
   <bean id="themeResolver" class="org.jasig.cas.services.web.ServiceThemeResolver"
         p:defaultThemeName="${cas.themeResolver.defaultThemeName}"
-        p:argumentExtractors-ref="argumentExtractors"
         p:servicesManager-ref="servicesManager">
     <property name="mobileBrowsers">
       <util:map>
@@ -45,6 +44,9 @@
       </util:map>
     </property>
   </bean>
+
+  <bean id="themeChangeInterceptor" class="org.springframework.web.servlet.theme.ThemeChangeInterceptor"
+        p:paramName="theme" />
 
   <!-- View Resolver -->
   <bean id="viewResolver" class="org.springframework.web.servlet.view.ResourceBundleViewResolver"

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
@@ -33,7 +33,7 @@
   
   <title>CAS &#8211; Central Authentication Service</title>
   
-  <spring:theme code="standard.custom.css.file" var="customCssFile" text="/css/cas.css"  />
+  <spring:theme code="standard.custom.css.file" var="customCssFile" />
   <link rel="stylesheet" href="<c:url value="${customCssFile}" />" />
   <link rel="icon" href="<c:url value="/favicon.ico" />" type="image/x-icon" />
   


### PR DESCRIPTION
Deals with https://github.com/Jasig/cas/issues/699

In the event that a theme is misconfigured for a service in registry, fall back onto the default CSS theme file and do not crash. 
