### PR TITLE
Upgrade aspectj plugin - support for jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1154,7 +1154,7 @@
     <maven-checkstyle-plugin.version>2.10</maven-checkstyle-plugin.version>
     <maven-enforcer-plugin.version>1.2</maven-enforcer-plugin.version>
     <maven-assembly-plugin.version>2.2.1</maven-assembly-plugin.version>
-    <maven-aspectj-plugin.version>1.5</maven-aspectj-plugin.version>
+    <maven-aspectj-plugin.version>1.7</maven-aspectj-plugin.version>
     <maven-antrun-plugin.version>1.5</maven-antrun-plugin.version>
 
     <!-- Project configuration -->


### PR DESCRIPTION
Relates to https://github.com/Jasig/cas/pull/606

I ran builds on JDK8 without any issues. Deploys fine under Tomcat7 as well. We should probably also enable JDK8 support for Travis as well to keep an eye on the build config.
