### PR TITLE
Fix #763: validate ticket before proxy callback attempt.

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/web/ServiceValidateController.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/web/ServiceValidateController.java
@@ -128,6 +128,8 @@ public class ServiceValidateController extends DelegateController {
         }
 
         try {
+            final Assertion assertion = this.centralAuthenticationService.validateServiceTicket(serviceTicketId, service);
+
             final Credentials serviceCredentials = getServiceCredentialsFromRequest(request);
             String proxyGrantingTicketId = null;
 
@@ -142,8 +144,6 @@ public class ServiceValidateController extends DelegateController {
                         + serviceCredentials, e);
                 }
             }
-
-            final Assertion assertion = this.centralAuthenticationService.validateServiceTicket(serviceTicketId, service);
 
             final ValidationSpecification validationSpecification = this.getCommandClass();
             final ServletRequestDataBinder binder = new ServletRequestDataBinder(validationSpecification, "validationSpecification");

--- a/cas-server-core/src/test/java/org/jasig/cas/util/HttpClientTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/util/HttpClientTests.java
@@ -38,10 +38,10 @@ public class HttpClientTests extends TestCase {
     }
     
     public void testOkayUrl() {
-        assertTrue(this.httpClient.isValidEndPoint("http://www.jasig.org"));
+        assertTrue(this.httpClient.isValidEndPoint("https://www.apereo.org"));
     }
     
     public void testBadUrl() {
-        assertFalse(this.httpClient.isValidEndPoint("http://www.jasig.org/scottb.html"));
+        assertFalse(this.httpClient.isValidEndPoint("https://www.apereo.org/scottb.html"));
     }
 }


### PR DESCRIPTION
Trivial patch that simply reorders service component calls to perform ticket validation (`validateServiceTicket`) before proxy callback attempt (`delegateTicketGrantingTicket`). I have tested this on a live CAS server and it performs as expected.
