### PR TITLE
Fix for #763: fetch ticket and do proxy check before callback.

### DIFF
--- a/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/jasig/cas/CentralAuthenticationServiceImpl.java
@@ -293,11 +293,8 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
         Assert.notNull(credentials, "credentials cannot be null");
 
         try {
-            final Authentication authentication = this.authenticationManager
-                .authenticate(credentials);
-
-            final ServiceTicket serviceTicket;
-            serviceTicket = (ServiceTicket) this.serviceTicketRegistry.getTicket(serviceTicketId, ServiceTicket.class);
+            final ServiceTicket serviceTicket = (ServiceTicket) this.serviceTicketRegistry.getTicket(
+                    serviceTicketId, ServiceTicket.class);
 
             if (serviceTicket == null || serviceTicket.isExpired()) {
                 throw new InvalidTicketException();
@@ -311,6 +308,8 @@ public final class CentralAuthenticationServiceImpl implements CentralAuthentica
                 log.warn("ServiceManagement: Service Attempted to Proxy, but is not allowed.  Service: [" + serviceTicket.getService().getId() + "]");
                 throw new UnauthorizedProxyingException();
             }
+
+            final Authentication authentication = this.authenticationManager.authenticate(credentials);
 
             final TicketGrantingTicket ticketGrantingTicket = serviceTicket
                 .grantTicketGrantingTicket(

--- a/cas-server-core/src/test/java/org/jasig/cas/util/HttpClientTests.java
+++ b/cas-server-core/src/test/java/org/jasig/cas/util/HttpClientTests.java
@@ -38,10 +38,10 @@ public class HttpClientTests extends TestCase {
     }
     
     public void testOkayUrl() {
-        assertTrue(this.httpClient.isValidEndPoint("http://www.jasig.org"));
+        assertTrue(this.httpClient.isValidEndPoint("https://www.apereo.org"));
     }
     
     public void testBadUrl() {
-        assertFalse(this.httpClient.isValidEndPoint("http://www.jasig.org/scottb.html"));
+        assertFalse(this.httpClient.isValidEndPoint("https://www.apereo.org/scottb.html"));
     }
 }


### PR DESCRIPTION
This fix simply puts the ticket retrieval and proxy checks before the callback attempt, which happens in `this.authenticationManager.authenticate(credentials)`. Testing in our preprod environment indicates this prevents the callback with an invalid or unauthorized proxy while still permitting a successful proxy validation under expected success conditions.
