### PR TITLE
POM JA-SIG and JBoss repository update

### DIFF
--- a/cas-server-integration-jboss/pom.xml
+++ b/cas-server-integration-jboss/pom.xml
@@ -84,6 +84,14 @@
 			<name>JBoss Repository</name>
 			<url>http://repository.jboss.org/nexus/content/repositories/deprecated</url>
 		</repository>
+
+	    <repository>
+	      <id>jboss</id>
+	      <name>JBoss Repository</name>
+	      <layout>default</layout>
+	      <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+	    </repository>
+
 	</repositories>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -523,14 +523,7 @@
     <repository>
       <id>jasig-repository</id>
       <name>Jasig Maven2 Repository</name>
-      <url>http://developer.ja-sig.org/maven2</url>
-    </repository>
-
-    <repository>
-      <id>jboss</id>
-      <name>JBoss Repository</name>
-      <layout>default</layout>
-      <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+      <url>http://developer.jasig.org/repo/content/groups/m2-legacy/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
- Moves JBOSS repo config into its own module pom
- Updates JA-SIG pom url. This is still used for legacy cases. Some jars for SPNEGO are found here. 
