### PR TITLE
Update OpenID4Java; Removes dependency on missing guice:2.0

### DIFF
--- a/cas-server-support-openid/pom.xml
+++ b/cas-server-support-openid/pom.xml
@@ -44,30 +44,23 @@
 
         <dependency>
             <groupId>org.openid4java</groupId>
-            <artifactId>openid4java-nodeps</artifactId>
-            <version>0.9.6</version>
+            <artifactId>openid4java</artifactId>
+            <version>${openid4java.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.1.3</version>
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
-            <scope>test</scope>
+          <groupId>org.jasig.cas</groupId>
+          <artifactId>cas-server-core</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
         </dependency>
-
-    <dependency>
-      <groupId>org.jasig.cas</groupId>
-      <artifactId>cas-server-core</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
     </dependencies>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1132,6 +1132,7 @@
     <opensaml.version>2.6.1</opensaml.version>
     <xml.apis.version>1.4.01</xml.apis.version>
     <jstl.version>1.2</jstl.version>
+    <openid4java.version>0.9.8</openid4java.version>
 
     <!-- Plugin Versions -->
     <coveralls-maven-plugin.version>3.0.1</coveralls-maven-plugin.version>


### PR DESCRIPTION
Our OpenID for Java dependency relies on some obsolete and deprecated dependencies, namely `com.google.code.guice:2.0`. This pull updates the OpenID version, and fixed a few other duplicate entries in the pom. As a result, our current build failure is fixed by this pull as well, since `com.google.code.guice:2.0` is nowhere to be found.
