### PR TITLE
Fix : Wrong package name in REST module

### DIFF
--- a/cas-server-support-rest/src/main/resources/META-INF/spring/rest-context.xml
+++ b/cas-server-support-rest/src/main/resources/META-INF/spring/rest-context.xml
@@ -27,6 +27,6 @@
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
     <mvc:annotation-driven/>
-    <context:component-scan base-package="org.jasig.cas.extension.rest"/>
+    <context:component-scan base-package="org.jasig.cas.support.rest"/>
 
 </beans>


### PR DESCRIPTION
In 4.1.0-SNAPSHOT, I tried to activate the new rest module and discovered a small typo in the config file.
