### PR TITLE
Restore mapping for the char-encoding filter

### DIFF
--- a/cas-management-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-management-webapp/src/main/webapp/WEB-INF/web.xml
@@ -56,7 +56,7 @@
     <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
   </filter>
   <filter-mapping>
-    <filter-name>springSecurityFilterChain</filter-name>
+    <filter-name>characterEncodingFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 


### PR DESCRIPTION
The `characterEncodingFilter` filter is missing its mapping element. `springSecurityFilterChain` is used twice!
