### PR TITLE
Update Configuring-LongTerm-Authentication.md

### DIFF
--- a/cas-server-documentation/installation/Configuring-LongTerm-Authentication.md
+++ b/cas-server-documentation/installation/Configuring-LongTerm-Authentication.md
@@ -106,7 +106,7 @@ Two sections of `login-webflow.xml` require changes:
 
 Change the `credential` variable declaration as follows:
 {% highlight xml %}
-<var name="credential" class="org.jasig.cas.authentication.principal.RememberMeUsernamePasswordCredential" />
+<var name="credential" class="org.jasig.cas.authentication.RememberMeUsernamePasswordCredential" />
 {% endhighlight %}
 
 Change the `viewLoginForm` action state as follows:


### PR DESCRIPTION
It looks like org.jasig.cas.authentication.principal.RememberMeUsernamePasswordCredential has been moved to org.jasig.cas.authentication package.

Related discussion.
Remember me with 4.0.0
https://groups.google.com/forum/#!topic/jasig-cas-user/jpO8qFnX_BI

Remember ME unable to load class #636
https://github.com/Jasig/cas/issues/636
