### PR TITLE
Use static loggers for the principal repositories

### DIFF
--- a/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/principal/DefaultPrincipalAttributesRepository.java
+++ b/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/principal/DefaultPrincipalAttributesRepository.java
@@ -4,6 +4,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apereo.cas.authentication.principal.cache.AbstractPrincipalAttributesRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Map;
@@ -17,15 +19,17 @@ import java.util.Map;
 public class DefaultPrincipalAttributesRepository extends AbstractPrincipalAttributesRepository {
     private static final long serialVersionUID = -4535358847021241725L;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPrincipalAttributesRepository.class);
+    
     @Override
     protected void addPrincipalAttributes(final String id, final Map<String, Object> attributes) {
-        logger.debug("Using {}, no caching takes place for {} to add attributes.", id,
+        LOGGER.debug("Using {}, no caching takes place for {} to add attributes.", id,
                 this.getClass().getSimpleName());
     }
 
     @Override
     protected Map<String, Object> getPrincipalAttributes(final Principal p) {
-        logger.debug("{} will return the collection of attributes directly associated with the principal object which are [{}]",
+        LOGGER.debug("{} will return the collection of attributes directly associated with the principal object which are [{}]",
                 this.getClass().getSimpleName(), p.getAttributes());
         return p.getAttributes();
     }

--- a/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/principal/cache/AbstractPrincipalAttributesRepository.java
+++ b/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/principal/cache/AbstractPrincipalAttributesRepository.java
@@ -40,9 +40,8 @@ public abstract class AbstractPrincipalAttributesRepository implements Principal
 
     private static final long serialVersionUID = 6350245643948535906L;
 
-    /** Logger instance. */
-    protected transient Logger logger = LoggerFactory.getLogger(getClass());
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPrincipalAttributesRepository.class);
+    
     /** The expiration time. */
     protected long expiration;
 
@@ -143,7 +142,7 @@ public abstract class AbstractPrincipalAttributesRepository implements Principal
      * @param p  the principal carrying attributes
      * @return person attributes
      */
-    private Map<String, List<Object>> convertPrincipalAttributesToPersonAttributes(final Principal p) {
+    private static Map<String, List<Object>> convertPrincipalAttributesToPersonAttributes(final Principal p) {
         final Map<String, List<Object>> convertedAttributes = new HashMap<>(p.getAttributes().size());
         final Map<String, Object> principalAttributes = p.getAttributes();
 
@@ -171,13 +170,13 @@ public abstract class AbstractPrincipalAttributesRepository implements Principal
         final IPersonAttributes attrs = getAttributeRepository().getPerson(id);
 
         if (attrs == null) {
-            logger.debug("Could not find principal [{}] in the repository so no attributes are returned.", id);
+            LOGGER.debug("Could not find principal [{}] in the repository so no attributes are returned.", id);
             return Collections.emptyMap();
         }
 
         final Map<String, List<Object>> attributes = attrs.getAttributes();
         if (attributes == null) {
-            logger.debug("Principal [{}] has no attributes and so none are returned.", id);
+            LOGGER.debug("Principal [{}] has no attributes and so none are returned.", id);
             return Collections.emptyMap();
         }
         return attributes;
@@ -187,29 +186,29 @@ public abstract class AbstractPrincipalAttributesRepository implements Principal
     public Map<String, Object> getAttributes(final Principal p) {
         final Map<String, Object> cachedAttributes = getPrincipalAttributes(p);
         if (cachedAttributes != null && !cachedAttributes.isEmpty()) {
-            logger.debug("Found [{}] cached attributes for principal [{}] that are {}", cachedAttributes.size(), p.getId(),
+            LOGGER.debug("Found [{}] cached attributes for principal [{}] that are {}", cachedAttributes.size(), p.getId(),
                     cachedAttributes);
             return cachedAttributes;
         }
 
         if (getAttributeRepository() == null) {
-            logger.debug("No attribute repository is defined for [{}]. Returning default principal attributes for {}",
+            LOGGER.debug("No attribute repository is defined for [{}]. Returning default principal attributes for {}",
                     getClass().getName(), p.getId());
             return cachedAttributes;
         }
 
         final Map<String, List<Object>> sourceAttributes = retrievePersonAttributesToPrincipalAttributes(p.getId());
-        logger.debug("Found [{}] attributes for principal [{}] from the attribute repository.",
+        LOGGER.debug("Found [{}] attributes for principal [{}] from the attribute repository.",
                 sourceAttributes.size(), p.getId());
 
         if (this.mergingStrategy == null || this.mergingStrategy.getAttributeMerger() == null) {
-            logger.debug("No merging strategy found, so attributes retrieved from the repository will be used instead.");
+            LOGGER.debug("No merging strategy found, so attributes retrieved from the repository will be used instead.");
             return convertAttributesToPrincipalAttributesAndCache(p, sourceAttributes);
         }
 
         final Map<String, List<Object>> principalAttributes = convertPrincipalAttributesToPersonAttributes(p);
 
-        logger.debug("Merging current principal attributes with that of the repository via strategy [{}]",
+        LOGGER.debug("Merging current principal attributes with that of the repository via strategy [{}]",
                 this.mergingStrategy.getClass().getSimpleName());
         final Map<String, List<Object>> mergedAttributes =
                 this.mergingStrategy.getAttributeMerger().mergeAttributes(principalAttributes, sourceAttributes);
@@ -257,7 +256,7 @@ public abstract class AbstractPrincipalAttributesRepository implements Principal
             if (context != null) {
                 return context.getBean("attributeRepository", IPersonAttributeDao.class);
             } else {
-                logger.warn("No application context could be retrieved, so no attribute repository instance can be determined.");
+                LOGGER.warn("No application context could be retrieved, so no attribute repository instance can be determined.");
             }
         }
         return this.attributeRepository;

--- a/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/principal/cache/CachingPrincipalAttributesRepository.java
+++ b/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/principal/cache/CachingPrincipalAttributesRepository.java
@@ -5,6 +5,8 @@ import org.apereo.cas.authentication.principal.Principal;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -21,6 +23,8 @@ public class CachingPrincipalAttributesRepository extends AbstractPrincipalAttri
     private static final long serialVersionUID = 6350244643948535906L;
     private static final long DEFAULT_MAXIMUM_CACHE_SIZE = 1000;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CachingPrincipalAttributesRepository.class);
+    
     private transient Cache<String, Map<String, Object>> cache;
     private transient PrincipalAttributesCacheLoader cacheLoader =
             new PrincipalAttributesCacheLoader();
@@ -66,18 +70,18 @@ public class CachingPrincipalAttributesRepository extends AbstractPrincipalAttri
     @Override
     protected void addPrincipalAttributes(final String id, final Map<String, Object> attributes) {
         this.cache.put(id, attributes);
-        logger.debug("Cached attributes for {}", id);
+        LOGGER.debug("Cached attributes for {}", id);
     }
 
     @Override
     protected Map<String, Object> getPrincipalAttributes(final Principal p) {
         try {
             return this.cache.get(p.getId(), () -> {
-                logger.debug("No cached attributes could be found for {}", p.getId());
+                LOGGER.debug("No cached attributes could be found for {}", p.getId());
                 return new HashMap<>();
             });
         } catch (final Exception e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
         }
         return null;
     }


### PR DESCRIPTION
This should be backported to 4.2.x. Fixes the NPE issue with serialization-based ops. 