### PR TITLE
[Fix][4.1.x] Add HttpOnly support CookieRetrievingCookieGenerator

### DIFF
--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -65,12 +65,6 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
      */
     public CookieRetrievingCookieGenerator(final CookieValueManager casCookieValueManager) {
         super();
-        final Method setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
-        if(setHttpOnlyMethod != null) {
-            super.setCookieHttpOnly(true);
-        } else {
-            logger.debug("Cookie cannot be marked as HttpOnly; container is not using servlet 3.0.");
-        }
         this.casCookieValueManager = casCookieValueManager;
     }
     /**
@@ -93,7 +87,12 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
                 cookie.setSecure(true);
             }
             if (isCookieHttpOnly()) {
-                cookie.setHttpOnly(true);
+                final Method setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
+                if(setHttpOnlyMethod != null) {
+                    cookie.setHttpOnly(true);
+                } else {
+                    logger.debug("Cookie cannot be marked as HttpOnly; container is not using servlet 3.0.");
+                }
             }
             response.addCookie(cookie);
         }

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -92,6 +92,9 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
             if (isCookieSecure()) {
                 cookie.setSecure(true);
             }
+            if (isCookieHttpOnly()) {
+                cookie.setHttpOnly(true);
+            }
             response.addCookie(cookie);
         }
     }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/warnCookieGenerator.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/warnCookieGenerator.xml
@@ -31,6 +31,7 @@
     </description>
 
     <bean id="warnCookieGenerator" class="org.jasig.cas.web.support.CookieRetrievingCookieGenerator"
+          p:cookieHttpOnly="true"
           p:cookieSecure="true"
           p:cookieMaxAge="-1"
           p:cookieName="CASPRIVACY"


### PR DESCRIPTION
### Version
4.1.x
### Issue
Current `CookieRetrievingCookieGenerator` does not set `HttpOnly` flag when `RememberMe` is true.
### Fix
Move the `HttpOnly` container check from the constructor to `addCookie()` where setting `HttpOnly` flag is added.
```
if (isCookieHttpOnly()) {
    final Method setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
    if(setHttpOnlyMethod != null) {
        cookie.setHttpOnly(true);
    } else {
        logger.debug("Cookie cannot be marked as HttpOnly; container is not using servlet 3.0.");
    }
}
```
### Limitations & Side effects
Need to explicitly set `cookieHttpOnly=true` in `warnCookieGenerator.xml` for `CASPRIVACY`.
### Issues & Other PR
No active related issue or open PR found.
### References
- `HttpOnly` in [CookieGenerator](https://github.com/spring-projects/spring-framework/blob/v4.1.6.RELEASE/spring-web/src/main/java/org/springframework/web/util/CookieGenerator.java#L191)
- Temporary fix for our own CAS: [CAS-PR#14](https://github.com/CenterForOpenScience/cas-overlay/pull/14)