### PR TITLE
Dependency upgrades prior to M1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     dependencies {
         classpath "nl.eveoh:gradle-aspectj:1.6"
         classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
-        classpath "com.netflix.nebula:gradle-lint-plugin:0.10.0"
+        classpath "com.netflix.nebula:gradle-lint-plugin:0.27.0"
         classpath "org.standardout:gradle-versioneye-plugin:1.3.0"
     }
 }

--- a/cas-server-support-gauth/src/main/java/org/apereo/cas/adaptors/gauth/GoogleAuthenticatorInstance.java
+++ b/cas-server-support-gauth/src/main/java/org/apereo/cas/adaptors/gauth/GoogleAuthenticatorInstance.java
@@ -72,4 +72,14 @@ public class GoogleAuthenticatorInstance implements IGoogleAuthenticator {
     public boolean authorizeUser(final String userName, final int verificationCode) throws GoogleAuthenticatorException {
         return this.googleAuthenticator.authorizeUser(userName, verificationCode);
     }
+
+    @Override
+    public boolean authorize(final String secret, final int verificationCode, final long time) throws GoogleAuthenticatorException {
+        return this.googleAuthenticator.authorize(secret, verificationCode, time);
+    }
+
+    @Override
+    public boolean authorizeUser(final String userName, final int verificationCode, final long time) throws GoogleAuthenticatorException {
+        return this.googleAuthenticator.authorize(userName, verificationCode, time);
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ springCloudBusAmqpVersion=1.0.6.RELEASE
 springIntegrationVersion=4.2.5.RELEASE
 
 springBootVersion=1.3.5.RELEASE
-springBootTomcatVersion=8.0.33
+springBootTomcatVersion=8.5.0
 
 hibernateVersion=5.1.0.Final
 hibernateValidatorVersion=5.2.4.Final
@@ -77,11 +77,11 @@ dropwizardMetricsSpringVersion=3.1.3
 jacksonDatabindVersion=2.6.6
 hjsonVersion=1.1.4
 personDirectoryVersion=1.8.1
-quartzVersion=2.2.2
+quartzVersion=2.2.3
 
 yubicoVersion=3.0.1
 duoVersion=1.1
-googleAuthVersion=0.5.0
+googleAuthVersion=0.6.0
 googleZxingVersion=3.2.1
 maxmindVersion=2.7.0
 
@@ -104,11 +104,11 @@ spymemcachedVersion=2.12.1
 kryoVersion=3.0.3
 kryoSerializersVersion=0.37
 
-ehcacheVersion=2.10.1
-jcacheVersion=1.0.0
+ehcacheVersion=2.10.2
+jcacheVersion=1.0.1
 
 hsqlVersion=2.3.3
-hikariVersion=2.4.5
+hikariVersion=2.4.6
 
 shiroVersion=1.2.4
 jose4jVersion=0.5.0
@@ -126,7 +126,7 @@ grouperVersion=2.2.2
 
 jsonassertVersion=1.3.0
 
-couchbaseVersion=2.2.6
+couchbaseVersion=2.2.7
 
 igniteVersion=1.5.0.final
 infinispanVersion=7.2.5.Final


### PR DESCRIPTION
Upgrading a number of CAS dependencies prior to the M1 release. Leaving out Thymeleaf v3 for now.