### PR TITLE
CSS generation via Node/SASS cleanup

### DIFF
--- a/cas-server-webapp/build.gradle
+++ b/cas-server-webapp/build.gradle
@@ -65,3 +65,25 @@ dependencies {
     runtime libraries.hibernate
     runtime libraries.bouncycastle
 }
+
+npm_run {
+    args = [
+            'gulp',
+            '--',
+            "sass",
+            "--gulpfile ${project.file('gulpfile.jsp')}",
+            "--cwd", "${project.buildDir}",
+            'sass',
+            "--sassPath", "${project.file('src/main/resources/static/sass')}",
+            "--npmPath", "${project.buildDir}/node_modules",
+            "--cssPath", "${project.buildDir}/generated-src/main/resources/static/csspie"
+    ]
+}
+
+tasks.npm_install.inputs.file(project.file('package.json'))
+
+tasks.npm_run.dependsOn 'npm_install'
+tasks.npm_run.inputs.dir(project.file('src/main/resources/static/sass'))
+tasks.npm_run.inputs.file(project.file('gulpfile.js'))
+tasks.npm_run.outputs.dir("${project.buildDir}/generated-src/main/resources/static/csspie")
+tasks.npm_run.outputs.upToDateWhen { false }

--- a/cas-server-webapp/build.gradle
+++ b/cas-server-webapp/build.gradle
@@ -5,6 +5,14 @@ apply from: '../gradle/node.gradle'
 
 description = 'Apereo CAS Web Application'
 
+sourceSets {
+    main {
+        resources {
+            srcDir "${project.buildDir}/generated-src/main/resources"
+        }
+    }
+}
+
 javadoc {
     enabled false
 }
@@ -17,12 +25,13 @@ war {
                 "Implementation-Date": java.time.ZonedDateTime.now(),
                 "Implementation-Version": project.version)
     }
-    from "${project.buildDir}/generated-src/main/resources"
+    from "${project.buildDir}/generated-src/main/resources", { into "WEB-INF/classes" }
 }
 
 bootRun {
     addResources = true
     jvmArgs = ["-Xrunjdwp:transport=dt_socket,address=5000,server=y,suspend=n"]
+    systemProperties = System.properties
 }
 
 springBoot  {

--- a/cas-server-webapp/build.gradle
+++ b/cas-server-webapp/build.gradle
@@ -17,6 +17,7 @@ war {
                 "Implementation-Date": java.time.ZonedDateTime.now(),
                 "Implementation-Version": project.version)
     }
+    from "${project.buildDir}/generated-src/main/resources"
 }
 
 bootRun {
@@ -75,7 +76,7 @@ npm_run {
             "--cwd", "${project.buildDir}",
             "--sassPath", "${project.file('src/main/resources/static/sass')}",
             "--npmPath", "${project.buildDir}/node_modules",
-            "--cssPath", "${project.buildDir}/generated-src/main/resources/static/csspie"
+            "--cssPath", "${project.buildDir}/generated-src/main/resources/static/css"
     ]
 }
 
@@ -84,5 +85,5 @@ tasks.npm_install.inputs.file(project.file('package.json'))
 tasks.npm_run.dependsOn 'npm_install'
 tasks.npm_run.inputs.dir(project.file('src/main/resources/static/sass'))
 tasks.npm_run.inputs.file(project.file('gulpfile.js'))
-tasks.npm_run.outputs.dir("${project.buildDir}/generated-src/main/resources/static/csspie")
+tasks.npm_run.outputs.dir("${project.buildDir}/generated-src/main/resources/static/css")
 tasks.npm_run.outputs.upToDateWhen { false }

--- a/cas-server-webapp/build.gradle
+++ b/cas-server-webapp/build.gradle
@@ -70,10 +70,9 @@ npm_run {
     args = [
             'gulp',
             '--',
-            "sass",
-            "--gulpfile ${project.file('gulpfile.jsp')}",
-            "--cwd", "${project.buildDir}",
             'sass',
+            "--gulpfile", "${project.file('gulpfile.js')}",
+            "--cwd", "${project.buildDir}",
             "--sassPath", "${project.file('src/main/resources/static/sass')}",
             "--npmPath", "${project.buildDir}/node_modules",
             "--cssPath", "${project.buildDir}/generated-src/main/resources/static/csspie"

--- a/cas-server-webapp/gulpfile.js
+++ b/cas-server-webapp/gulpfile.js
@@ -3,27 +3,45 @@
 var gulp = require('gulp'),
     sass = require('gulp-sass');
 
-var config = {
-    sassPath: './src/main/resources/static/sass',
-    npmPath: './node_modules',
-    cssPath: './src/main/resources/static/css'
-}
+var argv = require('yargs')
+    .option('sassPath', {
+        alias: 's',
+        describe: "where's your sass?",
+        default: './src/main/resources/static/sass'
+    })
+    .option('npmPath', {
+        alias: 'n',
+        describe: "where's your npm?",
+        default: './node_modules'
+    })
+    .option('cssPath', {
+        alias: 'c',
+        describe: "where do you want your css?",
+        default: './src/main/resources/static/css'
+    })
+    .help('help')
+    .argv;
 
 gulp.task('default', ['sass']);
 
 gulp.task('sass', function () {
-    return gulp.src(config.sassPath + '/**/*.scss')
+    process.stdout.write("running with these values:\n");
+    process.stdout.write("\tsassPath: " + argv.sassPath + "\n");
+    process.stdout.write("\tnpmPath: " + argv.npmPath + "\n");
+    process.stdout.write("\tcssPath: " + argv.cssPath + "\n");
+    process.stdout.write("\there: " + argv.here + "\n");
+    return gulp.src(argv.sassPath + '/**/*.scss')
         .pipe(sass({
             //outputStyle: 'compressed',
             includePaths: [
-                config.sassPath,
-                config.npmPath + '/bootstrap-sass/assets/stylesheets'
+                argv.sassPath,
+                argv.npmPath + '/bootstrap-sass/assets/stylesheets'
             ]
         }).on('error', sass.logError))
-        .pipe(gulp.dest(config.cssPath));
+        .pipe(gulp.dest(argv.cssPath));
 
 });
 
 gulp.task('sass:watch', function () {
-    gulp.watch(config.sassPath + '/**/*.scss', ['sass']);
+    gulp.watch(argv.sassPath + '/**/*.scss', ['sass']);
 });

--- a/cas-server-webapp/gulpfile.js
+++ b/cas-server-webapp/gulpfile.js
@@ -29,7 +29,6 @@ gulp.task('sass', function () {
     process.stdout.write("\tsassPath: " + argv.sassPath + "\n");
     process.stdout.write("\tnpmPath: " + argv.npmPath + "\n");
     process.stdout.write("\tcssPath: " + argv.cssPath + "\n");
-    process.stdout.write("\there: " + argv.here + "\n");
     return gulp.src(argv.sassPath + '/**/*.scss')
         .pipe(sass({
             //outputStyle: 'compressed',

--- a/cas-server-webapp/package.json
+++ b/cas-server-webapp/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "gulp": "^3.9.1",
     "gulp-sass": "^2.2.0",
-    "bootstrap-sass": "~> 3.3.6"
+    "bootstrap-sass": "~> 3.3.6",
+    "yargs": "^4.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/gradle/node.gradle
+++ b/gradle/node.gradle
@@ -6,11 +6,13 @@ buildscript {
     }
     dependencies {
         classpath "com.moowork.gradle:gradle-node-plugin:0.12"
+        classpath "com.moowork.gradle:gradle-gulp-plugin:0.12"
     }
 }
 
 if (!project.plugins.findPlugin(com.moowork.gradle.node.NodePlugin)) {
     project.apply(plugin: com.moowork.gradle.node.NodePlugin)
+    project.apply(plugin: com.moowork.gradle.gulp.GulpPlugin)
 }
 
 node {
@@ -34,22 +36,10 @@ node {
     nodeModulesDir = file("${project.buildDir}")
 }
 
-npm_run {
-    args = ['gulp']
-}
-
-task copyPackageFile(type: Copy) {
-    from 'package.json'
-    from 'gulpfile.js'
-    into project.file(project.node.nodeModulesDir)
-}
-
 ['npm_install', 'npm_run'].each {
     project."${it}".inputs.file project.file("${project.node.nodeModulesDir}/package.json")
     project."${it}".outputs.dir project.file("${project.node.nodeModulesDir}/node_modules")
     project."${it}".setWorkingDir(project.node.nodeModulesDir)
 }
-
-npm_install.dependsOn('copyPackageFile')
 
 processResources.dependsOn('npm_install', 'npm_run')

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -23,12 +23,6 @@ task cleanLogs(description: "Clean build log files") {
     delete fileTree(dir: project.projectDir, includes: ['**/*.log', '**/*.gz', '**/*.log.gz'])
 }
 
-task cleanNodeModules(type: Delete) {
-    def loc = new File(project.projectDir, 'node_modules')
-    delete fileTree(dir: loc, includes: ['**/*.*'])
-    delete loc
-}
-
 task findbugs(type: FindBugs, description: "Set up classpath for Findbugs") {
     pluginClasspath = project.configurations.findbugsPlugins
 }
@@ -38,4 +32,4 @@ gradle.buildFinished { buildResult ->
 }
 
 
-clean.dependsOn('cleanLogs', 'cleanNodeModules')
+clean.dependsOn('cleanLogs')


### PR DESCRIPTION
This patch cleans up the build to allow SASS-generated CSS files to be included into the final CAS web artifact without cluttering the actual project directory. 