### PR TITLE
fixed serialiation issue with the service ticket lock when granting p…

### DIFF
--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/ServiceTicketImpl.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/ServiceTicketImpl.java
@@ -45,8 +45,6 @@ public class ServiceTicketImpl extends AbstractTicket implements ServiceTicket {
     @Column(name="TICKET_ALREADY_GRANTED", nullable=false)
     private Boolean grantedTicketAlready = Boolean.FALSE;
 
-    private final transient Object lock = new Object();
-
     /**
      * Instantiates a new service ticket impl.
      */
@@ -128,7 +126,7 @@ public class ServiceTicketImpl extends AbstractTicket implements ServiceTicket {
     public ProxyGrantingTicket grantProxyGrantingTicket(
         final String id, final Authentication authentication,
         final ExpirationPolicy expirationPolicy) {
-        synchronized (this.lock) {
+        synchronized (this) {
             if(this.grantedTicketAlready) {
                 throw new IllegalStateException(
                     "PGT already generated for this ST. Cannot grant more than one TGT for ST");


### PR DESCRIPTION
Service tickets fail to generate proxy granting tickets today in ticket registries that do serialization. The granting of the proxy ticket operates on a lock that is today marked as transient, which during deserialization turns into NULL and causes NPEs when PGTs are requested from the ST. 

This patch fixes this problem by reverting the lock to synchronize on this, a strategy that is present today in 4.1.x