### PR TITLE
[fix][4.2.x] Add HttpOnly flag for JSESSIONID

### DIFF
--- a/cas-server-webapp-cookie/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/cas-server-webapp-cookie/src/main/java/org/jasig/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -47,12 +47,6 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
      */
     public CookieRetrievingCookieGenerator(final CookieValueManager casCookieValueManager) {
         super();
-        final Method setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
-        if(setHttpOnlyMethod != null) {
-            super.setCookieHttpOnly(true);
-        } else {
-            logger.debug("Cookie cannot be marked as HttpOnly; container is not using servlet 3.0.");
-        }
         this.casCookieValueManager = casCookieValueManager;
     }
     /**
@@ -73,6 +67,14 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
             cookie.setMaxAge(this.rememberMeMaxAge);
             if (isCookieSecure()) {
                 cookie.setSecure(true);
+            }
+            if (isCookieHttpOnly()) {
+                final Method setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
+                if(setHttpOnlyMethod != null) {
+                    cookie.setHttpOnly(true);
+                } else {
+                    logger.debug("Cookie cannot be marked as HttpOnly; container is not using servlet 3.0.");
+                }
             }
             response.addCookie(cookie);
         }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -228,6 +228,9 @@
         <!-- Default to 5 minute session timeouts -->
         <session-timeout>5</session-timeout>
         <tracking-mode>COOKIE</tracking-mode>
+        <cookie-config>
+            <http-only>true</http-only>
+        </cookie-config>
     </session-config>
 
     <error-page>


### PR DESCRIPTION
### Version
4.2.x

### Description
Add `HttpOnly` flag to JSESSIONID:
```
<cookie-config>
    <http-only>true</http-only>
</cookie-config>
```
This does not affect the `Secure` flag. For our CAS, it will be `true` for production (https) and `false` for development (http). We guess that the jetty server internally configure the `Secure` flag.

### Related PR
Version 4.1.x: https://github.com/apereo/cas/pull/1796
