### PR TITLE
[fix][4.1.x] Only record failed login attempts for throttling login attempts + Fix misleading warning messages.

### DIFF
--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -139,10 +139,8 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
      * @param request the request
      */
     protected void recordThrottle(final HttpServletRequest request) {
-        logger.warn("Throttling submission from {}.  More than {} failed login attempts within {} seconds. "
-                + "Authentication attempt exceeds the failure threshold {}",
-                request.getRemoteAddr(), this.failureThreshold, this.failureRangeInSeconds,
-                this.failureThreshold);
+        logger.warn("Throttling submission from {}. Login rate goes above threshold rate: {} logins/second",
+                request.getRemoteAddr(), this.getThresholdRate());
     }
 
     /**

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -50,7 +50,7 @@ screen.rememberme.checkbox.title=Remember Me
 
 # Blocked Errors Page
 screen.blocked.header=Access Denied
-screen.blocked.message=You've entered the wrong password for the user too many times. You've been throttled.
+screen.blocked.message=You've been throttled for having exceeded the threshold rate of failed login attempts.
 AbstractAccessDecisionManager.accessDenied=You are not authorized to access this resource. Contact your CAS administrator for more info.
 
 #Confirmation Screen Messages


### PR DESCRIPTION
### Version
This PR is for 4.1.x.
I will fix 4.2.x if this looks good to you.

### Issue & Fix
First, only requests that successfully log users in are considered successful. All the rest will trigger `recordSubmissionFailure()` even there is no submission. In our CAS, each login fires two consecutive requests. The first (no form data) will add to the failure throttle, which directly causes the second (with form data) to be blocked (if the threshold is faster than 500 logins/second).
```
Request URL:https://accounts.osf.io/login?service=https://osf.io/&auto=true
Request URL:https://accounts.osf.io/login?service=https://osf.io/
```
To fix this, I simply copy the correct behavior from [master](
https://github.com/apereo/cas/blob/master/cas-server-support-throttle/src/main/java/org/apereo/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java#L85) to [4.1.x](https://github.com/apereo/cas/blob/4.1.x/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java#L110).

Second, the warning message and docs are misleading. It took us some time to figure out that this is a "rate" based throttling, which is considered as the expected behavior https://github.com/apereo/cas/issues/486. The fix provided by https://github.com/apereo/cas/issues/719 can be further improved. We explicitly mention "threshold rate" instead of "number of logins in a period of time".

### Further Thoughts (not implemented)
Can we just have `thresholdRate` instead of `failureThreshold` and `failureRangeInSeconds`?

### Much Further Thoughts (not for this PR)
If you are interested, I've implemented an alternative approach which keeps a short queue of recent failed logins for each `ip` or `(ip, user)`. Maybe we can provide both to give users more choices. I will make another PR earlier next week. :)