### PR TITLE
Only update jar manifest if jar was compiled/changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -332,14 +332,22 @@ subprojects {
     sourceSets {
         test.resources.srcDirs = ["${projectDir}/src/test/resources", "${projectDir}/src/test/java"]
     }
+
+    ext.buildDate = null
+    compileJava.doLast {
+        buildDate = java.time.ZonedDateTime.now()
+        jar.manifest {
+            attributes("Implementation-Date": project.buildDate)
+        }
+    }
+    tasks.jar.onlyIf { return project.buildDate != null}
     
     jar {
         manifest {
             attributes("Implementation-Title": project.name,
-                    "Implementation-Vendor": project.group,
-                    "Created-By": project.group,
-                    "Implementation-Date": java.time.ZonedDateTime.now(),
-                    "Implementation-Version": project.version)
+                       "Implementation-Vendor": project.group,
+                       "Created-By": project.group,
+                       "Implementation-Version": project.version)
         }
     }
 


### PR DESCRIPTION
Without this change, build took about 3 minutes to complete. With the change, 1 minute 10 seconds. The idea here is to only update the jar manifest if the module jar was actually changed and compiled.

We probably have to do the same sort of trick to the war artifacts; I'll track that separately. 