### PR TITLE
updated security filter to 2.0.6 to fix issue with double logging

### DIFF
--- a/cas-server-documentation/installation/JSON-Service-Management.md
+++ b/cas-server-documentation/installation/JSON-Service-Management.md
@@ -76,7 +76,7 @@ A given JSON file for instance could be formatted as such in CAS:
     Generic service definition that applies to https/imaps urls 
     that wish to register with CAS for authentication.
   */
-  "@class" : "org.apereo.cas.services.RegexRegisteredService",
+  "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "serviceId" : "^(https|imaps)://.*",
   "name" : "HTTPS and IMAPS",
   "id" : 10000001,

--- a/cas-server-webapp/build.gradle
+++ b/cas-server-webapp/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile group: 'com.lmax', name: 'disruptor', version: disruptorVersion
     runtime group: 'org.springframework', name: 'spring-expression', version: springVersion
     runtime group: 'javax.servlet', name: 'jstl', version: javaxJstlVersion
-    runtime group: 'org.jasig.cas', name: 'cas-server-security-filter', version: casSecurityFilterVersion
+    runtime group: 'org.apereo.cas', name: 'cas-server-security-filter', version: casSecurityFilterVersion
     runtime(group: 'com.ryantenney.metrics', name: 'metrics-spring', version: dropwizardMetricsVersion) {
         exclude(group: 'org.slf4j', module: 'slf4j-api')
         exclude(group: 'org.springframework', module: 'spring-core')

--- a/cas-server-webapp/src/main/resources/log4j2.xml
+++ b/cas-server-webapp/src/main/resources/log4j2.xml
@@ -56,7 +56,11 @@
             <AppenderRef ref="file"/>
         </AsyncLogger>
         -->
-
+        <AsyncLogger  name="org.apereo.cas.security" level="warn" additivity="false" includeLocation="true">
+            <AppenderRef ref="console"/>
+            <AppenderRef ref="file"/>
+        </AsyncLogger>
+        
         <AsyncLogger name="perfStatsLogger" level="info" additivity="false" includeLocation="true">
             <AppenderRef ref="perfFileAppender"/>
         </AsyncLogger>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/filters.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/filters.xml
@@ -10,7 +10,7 @@
             p:encoding="${httprequest.web.encoding:UTF-8}"
             p:forceEncoding="${httprequest.web.encoding.force:true}" />
 
-    <bean id="responseHeadersSecurityFilter" class="org.jasig.cas.security.ResponseHeadersEnforcementFilter"
+    <bean id="responseHeadersSecurityFilter" class="org.apereo.cas.security.ResponseHeadersEnforcementFilter"
           p:enableCacheControl="${httpresponse.header.cache:false}"
           p:enableStrictTransportSecurity="${httpresponse.header.hsts:false}"
           p:enableXFrameOptions="${httpresponse.header.xframe:false}"
@@ -18,7 +18,7 @@
           p:enableXSSProtection="${httpresponse.header.xss:false}" />
 
     <bean id="requestParameterSecurityFilter"
-          class="org.jasig.cas.security.RequestParameterPolicyEnforcementFilter"
+          class="org.apereo.cas.security.RequestParameterPolicyEnforcementFilter"
           p:allowMultiValueParameters="${cas.http.allow.multivalue.params:false}">
         <property name="parametersToCheck">
             <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ hibernateVersion=5.0.3.Final
 hibernateValidatorVersion=5.2.2.Final
 
 casClientVersion=3.4.1
-casSecurityFilterVersion=2.0.4
+casSecurityFilterVersion=2.0.6
 
 fongoVersion=2.0.2
 mongoDriverVersion=3.1.0


### PR DESCRIPTION
Closes https://github.com/apereo/cas/issues/1848

Upgrades the security filter to ensure errors logged and produced by the filter are routed back to the CAS logging configuration and controlled in one spot. 

