### PR TITLE
WS-FED: Support encrypted assertions

### DIFF
--- a/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/PolicyBasedAuthenticationManager.java
+++ b/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/PolicyBasedAuthenticationManager.java
@@ -275,7 +275,7 @@ public class PolicyBasedAuthenticationManager implements AuthenticationManager {
                                                  final PrincipalResolver resolver, final AuthenticationHandler handler)
             throws GeneralSecurityException, PreventedException {
 
-        final Principal principal;
+        Principal principal;
         final HandlerResult result = handler.authenticate(credential);
         builder.addSuccess(handler.getName(), result);
         logger.info("{} successfully authenticated {}", handler.getName(), credential);
@@ -287,12 +287,21 @@ public class PolicyBasedAuthenticationManager implements AuthenticationManager {
                     principal);
         } else {
             principal = resolvePrincipal(handler.getName(), resolver, credential);
+            
+            if (principal == null) {
+                logger.warn("Principal resolution handled by {} produced a null principal. "
+                           + "This is likely due to misconfiguration or missing attributes; CAS will attempt to use the principal "
+                           + "produced by the authentication handler, if any.", resolver.getClass().getSimpleName());
+                principal = result.getPrincipal();
+            }
         }
         // Must avoid null principal since AuthenticationBuilder/ImmutableAuthentication
         // require principal to be non-null
         if (principal != null) {
             builder.setPrincipal(principal);
         }
+        
+        logger.debug("Final principal resolved for this authentication event is {}", principal);
     }
 
 

--- a/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/principal/PersonDirectoryPrincipalResolver.java
+++ b/cas-server-core-authentication/src/main/java/org/jasig/cas/authentication/principal/PersonDirectoryPrincipalResolver.java
@@ -106,7 +106,6 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
         logger.debug("Creating SimplePrincipal for [{}]", principalId);
 
         final Map<String, List<Object>> attributes = retrievePersonAttributes(principalId, credential);
-        logger.debug("Principal id [{}] could not be found", principalId);
 
         if (attributes == null || attributes.isEmpty()) {
             logger.debug("Principal id [{}] did not specify any attributes", principalId);

--- a/cas-server-documentation/integration/ADFS-Integration.md
+++ b/cas-server-documentation/integration/ADFS-Integration.md
@@ -82,7 +82,7 @@ openssl x509 -outform der -in x509.pem -out certificate.crt
 ```
 
 Configure CAS to reference the keypair, and configure the relying party trust settings
-in ADFS use the `certificate.crt` file for encryption.
+in ADFS to use the `certificate.crt` file for encryption.
 
 ## Modifying ADFS Claims
 

--- a/cas-server-documentation/integration/ADFS-Integration.md
+++ b/cas-server-documentation/integration/ADFS-Integration.md
@@ -59,8 +59,30 @@ cas.wsfed.idp.signingcerts=classpath:adfs-signing.crt
 
 # cas.wsfed.idp.attribute.resolver.enabled=true
 # cas.wsfed.idp.attribute.resolver.type=WSFED
+
+# Private/Public keypair used to decrypt assertions, if any.
+# cas.wsfed.idp.enc.privateKey=classpath:private.key
+# cas.wsfed.idp.enc.cert=classpath:certificate.crt
+# cas.wsfed.idp.enc.privateKeyPassword=NONE
 ```
 
+## Encrypted Assertions
+
+CAS is able to automatically decrypt SAML assertions that are issued by ADFS. To do this, 
+you will first need to generate a private/public keypair:
+
+```bash
+openssl genrsa -out private.key 1024
+openssl rsa -pubout -in private.key -out public.key -inform PEM -outform DER
+openssl pkcs8 -topk8 -inform PER -outform DER -nocrypt -in private.key -out private.p8
+openssl req -new -x509 -key private.key -out x509.pem -days 365
+
+# convert the X509 certificate to DER format
+openssl x509 -outform der -in x509.pem -out certificate.crt
+```
+
+Configure CAS to reference the keypair, and configure the relying party trust settings
+in ADFS use the `certificate.crt` file for encryption.
 
 ## Modifying ADFS Claims
 

--- a/cas-server-support-wsfederation/build.gradle
+++ b/cas-server-support-wsfederation/build.gradle
@@ -1,22 +1,24 @@
-
 description = 'Apereo CAS WS-Federation Support'
 dependencies {
-  
-  compile(project(':cas-server-support-saml')) {
-    exclude(group: 'xml-apis', module: 'xml-apis')
-  }
-  testCompile project(':cas-server-core')
-  testCompile project(':cas-server-core-logout')
-  testCompile(project(path: ":cas-server-support-saml", configuration: "tests")) {
-    exclude(group: 'xml-apis', module: 'xml-apis')  
-  }
-  testCompile project(':cas-server-core-authentication')
-  testCompile group: 'org.apache.logging.log4j', name: 'log4j-web', version:log4jVersion
-  testCompile(group: 'com.ryantenney.metrics', name: 'metrics-spring', version:dropwizardMetricsVersion) {
-    exclude(group: 'org.slf4j', module: 'slf4j-api')
-    exclude(group: 'org.springframework', module: 'spring-core')
-    exclude(group: 'org.springframework', module: 'spring-beans')
-    exclude(group: 'org.springframework', module: 'spring-context-support')
-    exclude(group: 'org.springframework', module: 'spring-aop')
-  }
+
+    compile(project(':cas-server-support-saml')) {
+        exclude(group: 'xml-apis', module: 'xml-apis')
+    }
+    compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: bouncyCastleVersion
+    compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: bouncyCastleVersion
+
+    testCompile project(':cas-server-core')
+    testCompile project(':cas-server-core-logout')
+    testCompile(project(path: ":cas-server-support-saml", configuration: "tests")) {
+        exclude(group: 'xml-apis', module: 'xml-apis')
+    }
+    testCompile project(':cas-server-core-authentication')
+    testCompile group: 'org.apache.logging.log4j', name: 'log4j-web', version: log4jVersion
+    testCompile(group: 'com.ryantenney.metrics', name: 'metrics-spring', version: dropwizardMetricsVersion) {
+        exclude(group: 'org.slf4j', module: 'slf4j-api')
+        exclude(group: 'org.springframework', module: 'spring-core')
+        exclude(group: 'org.springframework', module: 'spring-beans')
+        exclude(group: 'org.springframework', module: 'spring-context-support')
+        exclude(group: 'org.springframework', module: 'spring-aop')
+    }
 }

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationConfiguration.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationConfiguration.java
@@ -84,6 +84,15 @@ public final class WsFederationConfiguration implements Serializable {
 
     private List<Credential> signingWallet;
 
+    @Value("#{'${cas.wsfed.idp.enc.privateKey:classpath:private.key}'.split(',')}")
+    private Resource encryptionPrivateKey;
+
+    @Value("#{'${cas.wsfed.idp.enc.cert:classpath:certificate.crt}'.split(',')}")
+    private Resource encryptionCertificate;
+
+    @Value("${cas.wsfed.idp.enc.privateKeyPassword:NONE}")
+    private String encryptionPrivateKeyPassword;
+    
     @PostConstruct
     private void initCertificates() {
         createSigningWallet(this.signingCertificateFiles);
@@ -239,6 +248,30 @@ public final class WsFederationConfiguration implements Serializable {
 
     public void setAttributesType(final WsFedPrincipalResolutionAttributesType attributesType) {
         this.attributesType = attributesType;
+    }
+
+    public Resource getEncryptionPrivateKey() {
+        return encryptionPrivateKey;
+    }
+
+    public void setEncryptionPrivateKey(final Resource encryptionPrivateKey) {
+        this.encryptionPrivateKey = encryptionPrivateKey;
+    }
+
+    public Resource getEncryptionCertificate() {
+        return encryptionCertificate;
+    }
+
+    public void setEncryptionCertificate(final Resource encryptionCertificate) {
+        this.encryptionCertificate = encryptionCertificate;
+    }
+
+    public String getEncryptionPrivateKeyPassword() {
+        return encryptionPrivateKeyPassword;
+    }
+
+    public void setEncryptionPrivateKeyPassword(final String encryptionPrivateKeyPassword) {
+        this.encryptionPrivateKeyPassword = encryptionPrivateKeyPassword;
     }
 
     /**

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationHelper.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationHelper.java
@@ -14,6 +14,7 @@ import org.opensaml.saml.criterion.EntityRoleCriterion;
 import org.opensaml.saml.criterion.ProtocolCriterion;
 import org.opensaml.saml.saml1.core.Assertion;
 import org.opensaml.saml.saml1.core.Attribute;
+import org.opensaml.saml.saml1.core.AttributeStatement;
 import org.opensaml.saml.saml1.core.Conditions;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
@@ -93,18 +94,21 @@ public final class WsFederationHelper {
 
         //retrieve an attributes from the assertion
         final HashMap<String, List<Object>> attributes = new HashMap<>();
-        for (final Attribute item : assertion.getAttributeStatements().get(0).getAttributes()) {
-            LOGGER.debug("Processed attribute: {}", item.getAttributeName());
+        for (final AttributeStatement attributeStatement : assertion.getAttributeStatements()) {
+            for (final Attribute item : attributeStatement.getAttributes()) {
+                LOGGER.debug("Processed attribute: {}", item.getAttributeName());
 
-            final List<Object> itemList = new ArrayList<>();
-            for (int i = 0; i < item.getAttributeValues().size(); i++) {
-                itemList.add(((XSAny) item.getAttributeValues().get(i)).getTextContent());
-            }
+                final List<Object> itemList = new ArrayList<>();
+                for (int i = 0; i < item.getAttributeValues().size(); i++) {
+                    itemList.add(((XSAny) item.getAttributeValues().get(i)).getTextContent());
+                }
 
-            if (!itemList.isEmpty()) {
-                attributes.put(item.getAttributeName(), itemList);
+                if (!itemList.isEmpty()) {
+                    attributes.put(item.getAttributeName(), itemList);
+                }
             }
         }
+        
         credential.setAttributes(attributes);
         LOGGER.debug("Credential: {}", credential);
         return credential;

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationHelper.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/WsFederationHelper.java
@@ -1,11 +1,22 @@
 package org.jasig.cas.support.wsfederation;
 
+import com.google.common.base.Throwables;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jce.provider.X509CertParser;
+import org.bouncycastle.jce.provider.X509CertificateObject;
+import org.bouncycastle.openssl.PEMDecryptorProvider;
+import org.bouncycastle.openssl.PEMEncryptedKeyPair;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.jasig.cas.support.saml.OpenSamlConfigBean;
 import org.jasig.cas.support.wsfederation.authentication.principal.WsFederationCredential;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.Unmarshaller;
 import org.opensaml.core.xml.io.UnmarshallerFactory;
 import org.opensaml.core.xml.schema.XSAny;
@@ -16,15 +27,24 @@ import org.opensaml.saml.saml1.core.Assertion;
 import org.opensaml.saml.saml1.core.Attribute;
 import org.opensaml.saml.saml1.core.AttributeStatement;
 import org.opensaml.saml.saml1.core.Conditions;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.encryption.EncryptedElementTypeEncryptedKeyResolver;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
 import org.opensaml.security.SecurityException;
+import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.CredentialResolver;
 import org.opensaml.security.credential.UsageType;
 import org.opensaml.security.credential.impl.StaticCredentialResolver;
 import org.opensaml.security.criteria.UsageCriterion;
+import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.soap.wsfed.RequestSecurityTokenResponse;
 import org.opensaml.soap.wsfed.RequestedSecurityToken;
+import org.opensaml.xmlsec.encryption.EncryptedData;
+import org.opensaml.xmlsec.encryption.support.ChainingEncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.EncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.InlineEncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.SimpleRetrievalMethodEncryptedKeyResolver;
 import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
 import org.opensaml.xmlsec.keyinfo.impl.StaticKeyInfoCredentialResolver;
 import org.opensaml.xmlsec.signature.support.SignatureException;
@@ -39,8 +59,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.validation.constraints.NotNull;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.KeyPair;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -108,21 +132,21 @@ public final class WsFederationHelper {
                 }
             }
         }
-        
+
         credential.setAttributes(attributes);
         LOGGER.debug("Credential: {}", credential);
         return credential;
     }
 
 
-
     /**
      * parseTokenFromString converts a raw wresult and extracts it into an assertion.
      *
      * @param wresult the raw token returned by the IdP
+     * @param config  the config
      * @return an assertion
      */
-    public Assertion parseTokenFromString(final String wresult) {
+    public Assertion parseTokenFromString(final String wresult, final WsFederationConfiguration config) {
         try (final InputStream in = new ByteArrayInputStream(wresult.getBytes("UTF-8"))) {
 
             final Document document = configBean.getParserPool().parse(in);
@@ -134,16 +158,36 @@ public final class WsFederationHelper {
             }
 
             final RequestSecurityTokenResponse rsToken = (RequestSecurityTokenResponse) unmarshaller.unmarshall(metadataRoot);
-
+            if (rsToken == null || rsToken.getRequestedSecurityToken() == null) {
+                throw new IllegalArgumentException("Request security token response is null");
+            }
             //Get our SAML token
             final List<RequestedSecurityToken> rst = rsToken.getRequestedSecurityToken();
-            final Assertion assertion = (Assertion) rst.get(0).getSecurityTokens().get(0);
+            if (rst.isEmpty()) {
+                throw new IllegalArgumentException("No requested security token response is provided in the response");
+            }
+            final RequestedSecurityToken reqToken = rst.get(0);
+            if (reqToken.getSecurityTokens() == null || reqToken.getSecurityTokens().isEmpty()) {
+                throw new IllegalArgumentException("Requested security token response is not carrying any security tokens");
+            }
+
+            Assertion assertion = null;
+
+            XMLObject securityToken = reqToken.getSecurityTokens().get(0);
+            if (securityToken != null) {
+                if (securityToken instanceof EncryptedData) {
+                    final EncryptedData encryptedData = EncryptedData.class.cast(securityToken);
+                    securityToken = buildAssertionDecrypter(config).decryptData(encryptedData);
+                }
+            }
+            if (securityToken instanceof Assertion) {
+                assertion = Assertion.class.cast(securityToken);
+            }
 
             if (assertion == null) {
-                LOGGER.debug("Assertion is null");
-            } else {
-                LOGGER.debug("Assertion: {}", assertion);
+                throw new IllegalArgumentException("Assertion is null");
             }
+            LOGGER.debug("Assertion: {}", assertion);
             return assertion;
         } catch (final Exception ex) {
             LOGGER.warn(ex.getMessage());
@@ -154,7 +198,7 @@ public final class WsFederationHelper {
     /**
      * validateSignature checks to see if the signature on an assertion is valid.
      *
-     * @param assertion a provided assertion
+     * @param assertion                 a provided assertion
      * @param wsFederationConfiguration WS-Fed configuration provided.
      * @return true if the assertion's signature is valid, otherwise false
      */
@@ -213,5 +257,49 @@ public final class WsFederationHelper {
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private Credential getEncryptionCredential(final WsFederationConfiguration config) {
+        try {
+            // This will need to contain the private keypair in PEM format
+            final BufferedReader br = new BufferedReader(new InputStreamReader(config.getEncryptionPrivateKey().getInputStream()));
+            Security.addProvider(new BouncyCastleProvider());
+            final PEMParser pemParser = new PEMParser(br);
+
+            final Object privateKeyPemObject = pemParser.readObject();
+            final JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider(new BouncyCastleProvider());
+
+            final KeyPair kp;
+            if (privateKeyPemObject instanceof PEMEncryptedKeyPair) {
+                final PEMEncryptedKeyPair ckp = (PEMEncryptedKeyPair) privateKeyPemObject;
+                final PEMDecryptorProvider decProv = new JcePEMDecryptorProviderBuilder()
+                        .build(config.getEncryptionPrivateKeyPassword().toCharArray());
+                kp = converter.getKeyPair(ckp.decryptKeyPair(decProv));
+            } else {
+                kp = converter.getKeyPair((PEMKeyPair) privateKeyPemObject);
+            }
+
+            final X509CertParser certParser = new X509CertParser();
+            // This is the certificate shared with ADFS in DER format, i.e certificate.crt
+            certParser.engineInit(config.getEncryptionCertificate().getInputStream());
+            final X509CertificateObject cert = (X509CertificateObject) certParser.engineRead();
+            return new BasicX509Credential(cert, kp.getPrivate());
+        } catch (final Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+
+    private Decrypter buildAssertionDecrypter(final WsFederationConfiguration config) {
+        final List<EncryptedKeyResolver> list = new ArrayList<EncryptedKeyResolver>();
+        list.add(new InlineEncryptedKeyResolver());
+        list.add(new EncryptedElementTypeEncryptedKeyResolver());
+        list.add(new SimpleRetrievalMethodEncryptedKeyResolver());
+        final ChainingEncryptedKeyResolver encryptedKeyResolver = new ChainingEncryptedKeyResolver(list);
+        final Credential encryptionCredential = getEncryptionCredential(config);
+        final KeyInfoCredentialResolver resolver = new StaticKeyInfoCredentialResolver(encryptionCredential);
+        final Decrypter decrypter = new Decrypter(null, resolver, encryptedKeyResolver);
+        decrypter.setRootInNewDocument(true);
+        return decrypter;
     }
 }

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/authentication/principal/WsFederationCredentialsToPrincipalResolver.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/authentication/principal/WsFederationCredentialsToPrincipalResolver.java
@@ -56,7 +56,9 @@ public final class WsFederationCredentialsToPrincipalResolver extends PersonDire
             return principalId;
         }
 
-        logger.warn("Credential attributes do not include an attribute for {}", idAttribute);
+        logger.warn("Credential attributes do not include an attribute for {}. "
+                + "This will prohibit CAS to construct a meaningful authenticated principal. "
+                + "Examine the released claims and ensure {} is allowed", idAttribute, idAttribute);
         return null;
     }
 

--- a/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/web/flow/WsFederationAction.java
+++ b/cas-server-support-wsfederation/src/main/java/org/jasig/cas/support/wsfederation/web/flow/WsFederationAction.java
@@ -97,7 +97,7 @@ public final class WsFederationAction extends AbstractAction {
                 }
 
                 // create credentials
-                final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult);
+                final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, this.configuration);
 
                 if (assertion == null) {
                     logger.error("Could not validate assertion via parsing the token from {}", WRESULT);

--- a/cas-server-support-wsfederation/src/test/java/org/jasig/cas/support/wsfederation/WsFederationHelperTests.java
+++ b/cas-server-support-wsfederation/src/test/java/org/jasig/cas/support/wsfederation/WsFederationHelperTests.java
@@ -35,14 +35,14 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
     @Test
     public void verifyParseTokenString() throws Exception {
         final String wresult = testTokens.get("goodToken");
-        final Assertion result = wsFederationHelper.parseTokenFromString(wresult);
+        final Assertion result = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         assertNotNull("testParseTokenString() - Not null", result);
     }
 
     @Test
     public void verifyCreateCredentialFromToken() throws Exception {
         final String wresult = testTokens.get("goodToken");
-        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult);
+        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         
         final WsFederationCredential expResult = new WsFederationCredential();
         expResult.setIssuedOn(new DateTime("2014-02-26T22:51:16.504Z").withZone(DateTimeZone.UTC));
@@ -74,7 +74,7 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
     @Test
     public void verifyValidateSignatureGoodToken() throws Exception {
         final String wresult = testTokens.get("goodToken");
-        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult);
+        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         final boolean result = wsFederationHelper.validateSignature(assertion, wsFedConfig);
         assertTrue("testValidateSignatureGoodToken() - True", result);
     }
@@ -82,7 +82,7 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
     @Test
     public void verifyValidateSignatureModifiedAttribute() throws Exception {
         final String wresult = testTokens.get("badTokenModifiedAttribute");
-        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult);
+        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         final boolean result = wsFederationHelper.validateSignature(assertion, wsFedConfig);
         assertFalse("testValidateSignatureModifiedAttribute() - False", result);
     }
@@ -96,7 +96,7 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
 
         signingWallet.addAll(cfg.getSigningCertificates());
         final String wresult = testTokens.get("goodToken");
-        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult);
+        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         wsFedConfig.getSigningCertificates().clear();
         wsFedConfig.getSigningCertificates().addAll(signingWallet);
         final boolean result = wsFederationHelper.validateSignature(assertion, wsFedConfig);
@@ -106,7 +106,7 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
     @Test
     public void verifyValidateSignatureModifiedSignature() throws Exception {
         final String wresult = testTokens.get("badTokenModifiedSignature");
-        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult);
+        final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         final boolean result = wsFederationHelper.validateSignature(assertion, wsFedConfig);
         assertFalse("testValidateSignatureModifiedSignature() - False", result);
     }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/cas.properties
@@ -510,6 +510,11 @@ accept.authn.users=casuser::Mellon
 # Decides which bundle of attributes should be resolved during WS-FED authentication.
 # cas.wsfed.idp.attribute.resolver.enabled=true
 # cas.wsfed.idp.attribute.resolver.type=WSFED
+# 
+# Private/Public keypair used to decrypt assertions, if any.
+# cas.wsfed.idp.enc.privateKey=classpath:private.key
+# cas.wsfed.idp.enc.cert=classpath:certificate.crt
+# cas.wsfed.idp.enc.privateKeyPassword=NONE
 
 ##
 # LDAP User Details

--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -30,7 +30,7 @@
             <property name="severity" value="error"/>
         </module>
         <module name="ClassFanOutComplexity">
-            <property name="max" value="50"/>
+            <property name="max" value="60"/>
             <property name="severity" value="error"/>
         </module>
         <module name="CommentsIndentation">


### PR DESCRIPTION
Closes #1887 

CAS is able to automatically decrypt SAML assertions that are issued by ADFS. To do this, 
you will first need to generate a private/public keypair:

```bash
openssl genrsa -out private.key 1024
openssl rsa -pubout -in private.key -out public.key -inform PEM -outform DER
openssl pkcs8 -topk8 -inform PER -outform DER -nocrypt -in private.key -out private.p8
openssl req -new -x509 -key private.key -out x509.pem -days 365

# convert the X509 certificate to DER format
openssl x509 -outform der -in x509.pem -out certificate.crt
```

Configure CAS to reference the keypair, and configure the relying party trust settings
in ADFS use the `certificate.crt` file for encryption.