### PR TITLE
Update User-Interface-Customization-Localization.md

### DIFF
--- a/cas-server-documentation/installation/User-Interface-Customization-Localization.md
+++ b/cas-server-documentation/installation/User-Interface-Customization-Localization.md
@@ -10,12 +10,12 @@ The CAS Web application includes a number of localized message files:
 - Spanish
 - French
 - Russian
-- Netherlands (Nederlands)
+- Dutch (Nederlands)
 - Swedish (Svenskt)
 - Italian (Italiano)
 - Urdu
 - Chinese (Simplified)
-- Dutch (Deutsch)
+- German (Deutsch)
 - Japanese
 - Croatian
 - Czech


### PR DESCRIPTION
I noticed that the documentation for the UI localization had a mistake in the text.

The English versions of the Dutch and German languages were not correct.  Deutsch is not Dutch.