### PR TITLE
Update JcifsConfig.java

### DIFF
--- a/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JcifsConfig.java
+++ b/cas-server-support-spnego/src/main/java/org/jasig/cas/support/spnego/authentication/handler/support/JcifsConfig.java
@@ -94,7 +94,7 @@ public final class JcifsConfig implements InitializingBean {
                 System.setProperty(SYS_PROP_LOGIN_CONF, url.toExternalForm());
             }
         }
-        logger.debug("configured login configuration path : {}", propValue);
+        logger.debug("configured login configuration path : {}", System.getProperty(SYS_PROP_LOGIN_CONF));
     }
 
 


### PR DESCRIPTION
Issue #1909

login.conf path is mark as null in cas.log file if "cas.spnego.login.conf.file" is set in cas.properties and not in JAVA_OPTS