### PR TITLE
Fix oauth token deserialize issue

### DIFF
--- a/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -188,7 +188,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         return new OAuth20CallbackAuthorizeViewResolver() {
         };
     }
-    
+
     @Bean
     public SecurityInterceptor requiresAuthenticationAccessTokenInterceptor() {
         return new SecurityInterceptor(oauthSecConfig(), "clientBasicAuth,clientForm,userForm");
@@ -254,6 +254,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
+    @RefreshScope
     public AccessTokenFactory defaultAccessTokenFactory() {
         final DefaultAccessTokenFactory f = new DefaultAccessTokenFactory();
         f.setAccessTokenIdGenerator(accessTokenIdGenerator());
@@ -261,8 +262,6 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         return f;
     }
 
-    @Bean
-    @RefreshScope
     public ExpirationPolicy accessTokenExpirationPolicy() {
         return new OAuthAccessTokenExpirationPolicy(
                 casProperties.getAuthn().getOauth().getAccessToken().getMaxTimeToLiveInSeconds(),
@@ -271,8 +270,6 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         );
     }
 
-    @Bean
-    @RefreshScope
     public ExpirationPolicy oAuthCodeExpirationPolicy() {
         return new OAuthCodeExpirationPolicy(casProperties.getAuthn().getOauth().getCode().getNumberOfUses(),
                 TimeUnit.SECONDS.toMillis(casProperties.getAuthn().getOauth().getCode().getTimeToKillInSeconds()));
@@ -289,6 +286,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
+    @RefreshScope
     public OAuthCodeFactory defaultOAuthCodeFactory() {
         final DefaultOAuthCodeFactory f = new DefaultOAuthCodeFactory();
         f.setExpirationPolicy(oAuthCodeExpirationPolicy());
@@ -348,6 +346,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
+    @RefreshScope
     public RefreshTokenFactory defaultRefreshTokenFactory() {
         final DefaultRefreshTokenFactory f = new DefaultRefreshTokenFactory();
         f.setExpirationPolicy(refreshTokenExpirationPolicy());
@@ -355,8 +354,6 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         return f;
     }
 
-    @Bean
-    @RefreshScope
     public ExpirationPolicy refreshTokenExpirationPolicy() {
         return new OAuthRefreshTokenExpirationPolicy(
                 TimeUnit.SECONDS.toMillis(casProperties.getAuthn().getOauth().getRefreshToken().getTimeToKillInSeconds())

--- a/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -285,7 +285,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         return new DefaultUniqueTicketIdGenerator();
     }
 
-    @Bean(name = "defaultOAuthCodeFactory")
+    @Bean
     @RefreshScope
     public OAuthCodeFactory defaultOAuthCodeFactory() {
         final DefaultOAuthCodeFactory f = new DefaultOAuthCodeFactory();

--- a/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -285,7 +285,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         return new DefaultUniqueTicketIdGenerator();
     }
 
-    @Bean
+    @Bean(name = "defaultOAuthCodeFactory")
     @RefreshScope
     public OAuthCodeFactory defaultOAuthCodeFactory() {
         final DefaultOAuthCodeFactory f = new DefaultOAuthCodeFactory();

--- a/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -262,7 +262,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         return f;
     }
 
-    public ExpirationPolicy accessTokenExpirationPolicy() {
+    private ExpirationPolicy accessTokenExpirationPolicy() {
         return new OAuthAccessTokenExpirationPolicy(
                 casProperties.getAuthn().getOauth().getAccessToken().getMaxTimeToLiveInSeconds(),
                 casProperties.getAuthn().getOauth().getAccessToken().getTimeToKillInSeconds(),
@@ -270,7 +270,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         );
     }
 
-    public ExpirationPolicy oAuthCodeExpirationPolicy() {
+    private ExpirationPolicy oAuthCodeExpirationPolicy() {
         return new OAuthCodeExpirationPolicy(casProperties.getAuthn().getOauth().getCode().getNumberOfUses(),
                 TimeUnit.SECONDS.toMillis(casProperties.getAuthn().getOauth().getCode().getTimeToKillInSeconds()));
     }
@@ -354,7 +354,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         return f;
     }
 
-    public ExpirationPolicy refreshTokenExpirationPolicy() {
+    private ExpirationPolicy refreshTokenExpirationPolicy() {
         return new OAuthRefreshTokenExpirationPolicy(
                 TimeUnit.SECONDS.toMillis(casProperties.getAuthn().getOauth().getRefreshToken().getTimeToKillInSeconds())
         );

--- a/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -20,8 +20,10 @@ import org.apereo.cas.support.oauth.OAuthConstants;
 import org.apereo.cas.support.oauth.services.OAuthRegisteredService;
 import org.apereo.cas.support.oauth.services.OAuthWebApplicationService;
 import org.apereo.cas.support.oauth.ticket.accesstoken.AccessToken;
+import org.apereo.cas.support.oauth.ticket.code.OAuthCodeFactory;
 import org.apereo.cas.support.oauth.ticket.code.DefaultOAuthCodeFactory;
 import org.apereo.cas.support.oauth.ticket.code.OAuthCode;
+import org.apereo.cas.support.oauth.ticket.refreshtoken.RefreshTokenFactory;
 import org.apereo.cas.support.oauth.ticket.refreshtoken.DefaultRefreshTokenFactory;
 import org.apereo.cas.support.oauth.ticket.refreshtoken.RefreshToken;
 import org.apereo.cas.ticket.support.AlwaysExpiresExpirationPolicy;
@@ -86,11 +88,11 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
 
     @Autowired
     @Qualifier("defaultOAuthCodeFactory")
-    private DefaultOAuthCodeFactory oAuthCodeFactory;
+    private OAuthCodeFactory oAuthCodeFactory;
 
     @Autowired
     @Qualifier("defaultRefreshTokenFactory")
-    private DefaultRefreshTokenFactory oAuthRefreshTokenFactory;
+    private RefreshTokenFactory oAuthRefreshTokenFactory;
 
     @Autowired
     @Qualifier("accessTokenController")

--- a/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20ProfileControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20ProfileControllerTests.java
@@ -14,6 +14,7 @@ import org.apereo.cas.authentication.TestUtils;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.support.oauth.OAuthConstants;
 import org.apereo.cas.support.oauth.ticket.accesstoken.AccessTokenImpl;
+import org.apereo.cas.support.oauth.ticket.accesstoken.AccessTokenFactory;
 import org.apereo.cas.support.oauth.ticket.accesstoken.DefaultAccessTokenFactory;
 import org.apereo.cas.ticket.support.AlwaysExpiresExpirationPolicy;
 import org.junit.Test;
@@ -53,7 +54,7 @@ public class OAuth20ProfileControllerTests extends AbstractOAuth20Tests {
     private static final String CONTENT_TYPE = "application/json";
 
     @Autowired
-    private DefaultAccessTokenFactory accessTokenFactory;
+    private AccessTokenFactory accessTokenFactory;
 
     @Autowired
     private OAuth20ProfileController oAuth20ProfileController;


### PR DESCRIPTION
OAuth tokens can't be deserialize, because all of these tokens' ExpirationPolicy has been wrapped by spring with CGILib.

<img width="717" alt="2016-07-27 7 34 21" src="https://cloud.githubusercontent.com/assets/1735804/17174460/4813681c-5434-11e6-8516-83b8a4fdbbfd.png">

I suggests we should avoid by defining spring bean to create any persisted entity.