### PR TITLE
corrected dialect and batchSize property names

### DIFF
--- a/cas-server-documentation/installation/JPA-Service-Management.md
+++ b/cas-server-documentation/installation/JPA-Service-Management.md
@@ -20,8 +20,8 @@ The following settings are expected:
 
 ```properties
 # svcreg.database.ddl.auto=create-drop
-# svcreg.database.hibernate.dialect=org.hibernate.dialect.OracleDialect|MySQLInnoDBDialect|HSQLDialect
-# svcreg.database.hibernate.batchSize=10
+# svcreg.database.dialect=org.hibernate.dialect.OracleDialect|MySQLInnoDBDialect|HSQLDialect
+# svcreg.database.batchSize=10
 # svcreg.database.driverClass=org.hsqldb.jdbcDriver
 # svcreg.database.url=jdbc:hsqldb:mem:cas-ticket-registry
 # svcreg.database.user=sa


### PR DESCRIPTION
This changes the JPA Service Registry documentation by renaming 2 configuration properties (`dialect` and `batchSize`) to match [jpa-svc-reg-context.xml](https://github.com/apereo/cas/blob/4.2.x/cas-server-support-jpa-service-registry/src/main/resources/META-INF/spring/jpa-svc-reg-context.xml). Without this change, setting the properties suggested by the documentaion will result in you not being able to change `dialect` or `batchSize` from the default.

I have signed the ICLA.

