### PR TITLE
Fix TicketCleaner can't clean expired OAuthTokens

### DIFF
--- a/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
@@ -116,9 +116,13 @@ public class JpaTicketRegistry extends AbstractTicketRegistry {
         final List<ServiceTicketImpl> sts = this.entityManager
                 .createQuery("select s from " + TABLE_SERVICE_TICKETS + " s", ServiceTicketImpl.class)
                 .getResultList();
+        final List<OAuthCodeImpl> ots = this.entityManager
+                .createQuery("select s from " + TABLE_OAUTH_TICKETS + " s", OAuthCodeImpl.class)
+                .getResultList();
 
         final List<Ticket> tickets = new ArrayList<>(tgts);
         tickets.addAll(sts);
+        tickets.addAll(ots);
 
         return tickets;
     }


### PR DESCRIPTION
CAS Server: 5.0.0.RC1 SNAPSHOT

DefaultTicketCleaner can't clean expired OAuthTokens, when using JpaTicketRegistry as default tickets registry.

Caused by: The implement of getTickets in JpaTicketRegistry never loads OAuthTokens.
