### PR TITLE
Calling @PostConstruct method of LdaptivePersonAttributeDao manually

### DIFF
--- a/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasPersonDirectoryAttributeRepositoryConfiguration.java
+++ b/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasPersonDirectoryAttributeRepositoryConfiguration.java
@@ -162,6 +162,7 @@ public class CasPersonDirectoryAttributeRepositoryConfiguration {
             }
             constraints.setDerefLinkFlag(true);
             ldapDao.setSearchControls(constraints);
+            ldapDao.initialize();
             list.add(ldapDao);
         }
     }


### PR DESCRIPTION
Closes -- Issue not submitted --

Ensure that you include the following:

- [X] Brief description of changes applied: We need to call post constructors of beans manually, because we dont use DI for creation
- [X] Any documentation on how to configure, test: nothing to config, but checking for more of such traps
- [X] Any possible limitations, side effects, etc: nothing
- [X] Reference any other pull requests that might be related.: none
- [X] I have signed the Apereo ICLA form, located here: https://www.apereo.org/licensing/agreements/icla

<!--
Thanks for your contribution. 
-->