### PR TITLE
Ignore case when comparing attributes for release

### DIFF
--- a/cas-server-core-authentication/src/main/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicy.java
+++ b/cas-server-core-authentication/src/main/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicy.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Return only the collection of allowed attributes out of what's resolved
@@ -61,7 +62,9 @@ public class ReturnAllowedAttributeReleasePolicy extends AbstractRegisteredServi
     }
     
     @Override
-    protected Map<String, Object> getAttributesInternal(final Map<String, Object> resolvedAttributes) {
+    protected Map<String, Object> getAttributesInternal(final Map<String, Object> attrs) {
+        final Map<String, Object> resolvedAttributes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        resolvedAttributes.putAll(attrs);
         final Map<String, Object> attributesToRelease = new HashMap<>(resolvedAttributes.size());
 
         this.allowedAttributes.stream().map(attr -> new Object[]{attr, resolvedAttributes.get(attr)}).filter(pair -> pair[1] != null)

--- a/cas-server-core-authentication/src/main/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicy.java
+++ b/cas-server-core-authentication/src/main/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicy.java
@@ -59,9 +59,12 @@ public class ReturnMappedAttributeReleasePolicy extends AbstractRegisteredServic
     }
     
     @Override
-    protected Map<String, Object> getAttributesInternal(final Map<String, Object> resolvedAttributes) {
+    protected Map<String, Object> getAttributesInternal(final Map<String, Object> attrs) {
+        final Map<String, Object> resolvedAttributes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        resolvedAttributes.putAll(attrs);
+        
         final Map<String, Object> attributesToRelease = new HashMap<>(resolvedAttributes.size());
-
+        
         this.allowedAttributes.entrySet().stream()
                 .map(entry -> {
                     final String key = entry.getKey();

--- a/cas-server-core-authentication/src/test/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicyTests.java
+++ b/cas-server-core-authentication/src/test/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicyTests.java
@@ -10,6 +10,7 @@ import org.apereo.services.persondir.IPersonAttributes;
 import org.apereo.services.persondir.support.StubPersonAttributeDao;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +26,46 @@ import static org.mockito.Mockito.*;
  * @since 4.0.0
  */
 public class RegisteredServiceAttributeReleasePolicyTests {
+    @Test
+    public void verifyMappedAttributeFilterMappedAttributesIsCaseInsensitive() {
+        final ReturnMappedAttributeReleasePolicy policy = new ReturnMappedAttributeReleasePolicy();
+        final Map<String, String> mappedAttr = new HashMap<>();
+        mappedAttr.put("attr1", "newAttr1");
+        policy.setAllowedAttributes(mappedAttr);
+
+        final Principal p = mock(Principal.class);
+        final Map<String, Object> map = new HashMap<>();
+        map.put("ATTR1", "value1");
+        when(p.getAttributes()).thenReturn(map);
+        when(p.getId()).thenReturn("principalId");
+
+        final Map<String, Object> attr = policy.getAttributes(p);
+        assertEquals(attr.size(), 1);
+        assertTrue(attr.containsKey("newAttr1"));
+    }
+    
+    @Test
+    public void verifyAttributeFilterMappedAttributesIsCaseInsensitive() {
+        final ReturnAllowedAttributeReleasePolicy policy = new ReturnAllowedAttributeReleasePolicy();
+        final List<String> attrs = new ArrayList<>();
+        attrs.add("attr1");
+        attrs.add("attr2");
+
+        policy.setAllowedAttributes(attrs);
+
+        final Principal p = mock(Principal.class);
+        final Map<String, Object> map = new HashMap<>();
+        map.put("ATTR1", "value1");
+        map.put("ATTR2", "value2");
+        when(p.getAttributes()).thenReturn(map);
+        when(p.getId()).thenReturn("principalId");
+
+        final Map<String, Object> attr = policy.getAttributes(p);
+        assertEquals(attr.size(), 2);
+        assertTrue(attr.containsKey("attr1"));
+        assertTrue(attr.containsKey("attr2"));
+    }
+    
     @Test
     public void verifyAttributeFilterMappedAttributes() {
         final ReturnMappedAttributeReleasePolicy policy = new ReturnMappedAttributeReleasePolicy();


### PR DESCRIPTION
Presently, when attributes are calculated for release the comparison between what is allowed in the policy and what is available as a principal attribute is case sensitive. For instance, you may have an attribute defined as `givenName` that becomes `givenname` retrieved from LDAP as it may ignore case. You are then today forced to make sure your release policy for the service also matches `givenname`. This is difficult to troubleshoot as it may not be immediately obvious why attributes are not released. 

This patch makes sure the comparison rules for attribute release are done in a case insensitive manner. 

Example with `ReturnAllowedAttributeReleasePolicy`:

- Define `givenName`
- Retrieved as `givenname`
- May be released as `givenName` (as it was defined)

Example with `ReturnMappedAttributeReleasePolicy`:

- Define `givenName`
- Retrieved as `givenname`
- May be found under `givenName` and then remapped to `HelloWorld` at release time. 