### PR TITLE
Fix for Issue #1869 Destroying the TGT Does Not Remove the PGT

### DIFF
--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/TicketGrantingTicket.java
@@ -5,6 +5,9 @@ import org.jasig.cas.authentication.principal.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
+
+import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 
 /**
  * Interface for a ticket granting ticket. A TicketGrantingTicket is the main
@@ -58,6 +61,13 @@ public interface TicketGrantingTicket extends Ticket {
      * @return an immutable map of service ticket and services accessed by this ticket-granting ticket.
     */
     Map<String, Service> getServices();
+
+    /**
+     * Gets proxy granting tickets created by this TGT.
+     *
+     * @return the proxy granting tickets
+     */
+    Collection<ProxyGrantingTicket> getProxyGrantingTickets();
 
     /**
      * Remove all services of the TGT (at logout).

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/ServiceTicketImpl.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/ServiceTicketImpl.java
@@ -134,8 +134,10 @@ public class ServiceTicketImpl extends AbstractTicket implements ServiceTicket {
             this.grantedTicketAlready = Boolean.TRUE;
         }
 
-        return new ProxyGrantingTicketImpl(id, service,
-                this.getGrantingTicket(), authentication, expirationPolicy);
+        final ProxyGrantingTicket pgt = new ProxyGrantingTicketImpl(id, this.service,
+                 this.getGrantingTicket(), authentication, expirationPolicy);
+        getGrantingTicket().getProxyGrantingTickets().add(pgt);
+        return pgt;
     }
 
     @Override

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
@@ -23,6 +23,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
+import javax.persistence.OneToMany;
+import javax.persistence.FetchType;
+import java.util.Set;
+import java.util.HashSet;
+
 /**
  * Concrete implementation of a TicketGrantingTicket. A TicketGrantingTicket is
  * the global identifier of a principal into the system. It grants the Principal
@@ -66,6 +72,10 @@ public class TicketGrantingTicketImpl extends AbstractTicket implements TicketGr
     @Lob
     @Column(name="SUPPLEMENTAL_AUTHENTICATIONS", nullable=false, length = Integer.MAX_VALUE)
     private final ArrayList<Authentication> supplementalAuthentications = new ArrayList<>();
+
+    /** The PGTs associated to this ticket. */
+    @OneToMany(targetEntity = TicketGrantingTicketImpl.class, mappedBy = "ticketGrantingTicket", fetch = FetchType.EAGER)
+    private Set<ProxyGrantingTicket> proxyGrantingTickets = new HashSet<>();
 
     /**
      * Instantiates a new ticket granting ticket impl.
@@ -194,6 +204,11 @@ public class TicketGrantingTicketImpl extends AbstractTicket implements TicketGr
     @Override
     public final synchronized Map<String, Service> getServices() {
         return ImmutableMap.copyOf(this.services);
+    }
+
+    @Override
+    public Collection<ProxyGrantingTicket> getProxyGrantingTickets() {
+        return this.proxyGrantingTickets;
     }
 
     /**

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/TicketGrantingTicketImpl.java
@@ -302,6 +302,4 @@ public class TicketGrantingTicketImpl extends AbstractTicket implements TicketGr
                 .append(ticket.getId(), this.getId())
                 .isEquals();
     }
-
-
 }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -85,10 +85,10 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
             deleteChildren(tgt);
 
             final Collection<ProxyGrantingTicket> proxyGrantingTickets = tgt.getProxyGrantingTickets();
-            Iterator<ProxyGrantingTicket> it = proxyGrantingTickets.iterator();
+            final Iterator<ProxyGrantingTicket> it = proxyGrantingTickets.iterator();
             while(it.hasNext()) {
-            	ProxyGrantingTicket pgt = it.next();
-            	deleteTicket(pgt.getId());
+                final ProxyGrantingTicket pgt = it.next();
+                deleteTicket(pgt.getId());
             }
         }
         logger.debug("Removing ticket [{}] from the registry.", ticket);
@@ -104,10 +104,10 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
         // delete service tickets
         final Map<String, Service> services = ticket.getServices();
         if (services != null && !services.isEmpty()) {
-            Iterator<String> it = services.keySet().iterator();
-        	
+            final Iterator<String> it = services.keySet().iterator();
+
             while (it.hasNext()) {
-                String ticketId = it.next();
+                final String ticketId = it.next();
                 if (deleteSingleTicket(ticketId)) {
                     logger.debug("Removed ticket [{}]", ticketId);
                 } else {

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -113,7 +113,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
                 } else {
                     logger.debug("Unable to remove ticket [{}]", ticketId);
                 }
-       	    }
+            }
         }
     }
 

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
+import java.util.Iterator;
 
 /**
  * @author Scott Battaglia
@@ -84,7 +85,11 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
             deleteChildren(tgt);
 
             final Collection<ProxyGrantingTicket> proxyGrantingTickets = tgt.getProxyGrantingTickets();
-            proxyGrantingTickets.stream().map(Ticket::getId).forEach(this::deleteTicket);
+            Iterator<ProxyGrantingTicket> it = proxyGrantingTickets.iterator();
+            while(it.hasNext()) {
+            	ProxyGrantingTicket pgt = it.next();
+            	deleteTicket(pgt.getId());
+            }
         }
         logger.debug("Removing ticket [{}] from the registry.", ticket);
         return deleteSingleTicket(ticketId);

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -104,13 +104,16 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
         // delete service tickets
         final Map<String, Service> services = ticket.getServices();
         if (services != null && !services.isEmpty()) {
-            services.keySet().stream().forEach(ticketId -> {
+            Iterator<String> it = services.keySet().iterator();
+        	
+            while (it.hasNext()) {
+                String ticketId = it.next();
                 if (deleteSingleTicket(ticketId)) {
                     logger.debug("Removed ticket [{}]", ticketId);
                 } else {
                     logger.debug("Unable to remove ticket [{}]", ticketId);
                 }
-            });
+       	    }
         }
     }
 

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
@@ -124,42 +124,8 @@ public final class DefaultTicketRegistry extends AbstractTicketRegistry implemen
     }
 
     @Override
-    public boolean deleteTicket(final String ticketId) {
-        if (ticketId == null) {
-            return false;
-        }
-
-        final Ticket ticket = getTicket(ticketId);
-        if (ticket == null) {
-            return false;
-        }
-
-        if (ticket instanceof TicketGrantingTicket) {
-            logger.debug("Removing children of ticket [{}] from the registry.", ticket);
-            deleteChildren((TicketGrantingTicket) ticket);
-        }
-
-        logger.debug("Removing ticket [{}] from the registry.", ticket);
-        return (this.cache.remove(ticketId) != null);
-    }
-
-    /**
-     * Delete TGT's service tickets.
-     *
-     * @param ticket the ticket
-     */
-    private void deleteChildren(final TicketGrantingTicket ticket) {
-        // delete service tickets
-        final Map<String, Service> services = ticket.getServices();
-        if (services != null && !services.isEmpty()) {
-            for (final Map.Entry<String, Service> entry : services.entrySet()) {
-                if (this.cache.remove(entry.getKey()) != null) {
-                    logger.trace("Removed service ticket [{}]", entry.getKey());
-                } else {
-                    logger.trace("Unable to remove service ticket [{}]", entry.getKey());
-                }
-            }
-        }
+    public boolean deleteSingleTicket(final String ticketId) {
+        return this.cache.remove(ticketId) != null;
     }
 
     @Override

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/DefaultTicketRegistry.java
@@ -2,7 +2,6 @@ package org.jasig.cas.ticket.registry;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
-import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.logout.LogoutManager;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.Ticket;

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/TicketGrantingTicketDelegator.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/TicketGrantingTicketDelegator.java
@@ -10,6 +10,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 
+import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
+import java.util.Collection;
+
 /**
  * This is {@link TicketGrantingTicketDelegator}.
  *
@@ -89,5 +92,10 @@ public class TicketGrantingTicketDelegator<T extends TicketGrantingTicket> exten
     @Override
     public void removeAllServices() {
         this.getTicket().removeAllServices();
+    }
+
+    @Override
+    public Collection<ProxyGrantingTicket> getProxyGrantingTickets() {
+       return this.getTicket().getProxyGrantingTickets();
     }
 }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockServiceTicket.java
@@ -10,6 +10,8 @@ import org.jasig.cas.ticket.TicketGrantingTicket;
 
 import java.util.Date;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 /**
  * Mock service ticket.
  *
@@ -91,5 +93,15 @@ public class MockServiceTicket implements ServiceTicket {
     @Override
     public boolean equals(final Object obj) {
         return compareTo((Ticket) obj) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(7, 31)
+                .append(this.id)
+                .append(this.created)
+                .append(this.service)
+                .append(this.parent)
+                .toHashCode();
     }
 }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
 import java.util.Collection;
 import java.util.HashSet;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Mock ticket-granting ticket.
@@ -168,5 +169,19 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
     @Override
     public boolean equals(final Object obj) {
         return compareTo((Ticket) obj) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(7, 31)
+                .append(this.id)
+                .append(this.authentication)
+                .append(this.created)
+                .append(this.usageCount)
+                .append(this.expired)
+                .append(this.proxiedBy)
+                .append(this.services)
+                .append(this.proxyGrantingTickets)
+                .toHashCode();
     }
 }

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/mock/MockTicketGrantingTicket.java
@@ -23,6 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jasig.cas.ticket.proxy.ProxyGrantingTicket;
+import java.util.Collection;
+import java.util.HashSet;
+
 /**
  * Mock ticket-granting ticket.
  *
@@ -47,6 +51,8 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
     private Service proxiedBy;
 
     private final Map<String, Service> services = new HashMap<>();
+
+    private HashSet<ProxyGrantingTicket> proxyGrantingTickets = new HashSet<>();
 
     public MockTicketGrantingTicket(final String principal, final Credential c, final Map attributes) {
         id = ID_GENERATOR.getNewTicketId("TGT");
@@ -138,6 +144,11 @@ public class MockTicketGrantingTicket implements TicketGrantingTicket {
     @Override
     public Map<String, Service> getServices() {
         return this.services;
+    }
+
+    @Override
+    public Collection<ProxyGrantingTicket> getProxyGrantingTickets() {
+        return this.proxyGrantingTickets;
     }
 
     @Override

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
@@ -123,7 +123,7 @@ public final class DistributedTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
 
-        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         this.ticketRegistry.deleteTicket(tgt.getId());

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
@@ -14,6 +14,10 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
+import org.jasig.cas.authentication.Authentication;
+import org.jasig.cas.authentication.TestUtils;
+import org.jasig.cas.authentication.principal.Service;
+
 /**
  *
  * @author Scott Battaglia
@@ -101,6 +105,34 @@ public final class DistributedTicketRegistryTests {
         assertNull(this.ticketRegistry.getTicket("fdfas"));
     }
 
+    @Test
+    public void verifyDeleteTicketWithPGT() {
+       final Authentication a = TestUtils.getAuthentication();
+        this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(
+                "TGT", a, new NeverExpiresExpirationPolicy()));
+        final TicketGrantingTicket tgt = this.ticketRegistry.getTicket(
+                "TGT", TicketGrantingTicket.class);
+
+        final Service service = TestUtils.getService("TGT_DELETE_TEST");
+
+        final ServiceTicket st1 = tgt.grantServiceTicket(
+                "ST1", service, new NeverExpiresExpirationPolicy(), true, false);
+
+        this.ticketRegistry.addTicket(st1);
+
+        assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
+
+        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        assertEquals(a, pgt.getAuthentication());
+
+        this.ticketRegistry.deleteTicket(tgt.getId());
+
+        assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
+        assertNull(this.ticketRegistry.getTicket("PGT-1", ServiceTicket.class));
+    }
+
     private static class TestDistributedTicketRegistry extends AbstractDistributedTicketRegistry {
         private final DistributedTicketRegistryTests parent;
         private final Map<String, Ticket> tickets = new HashMap<>();
@@ -120,11 +152,6 @@ public final class DistributedTicketRegistryTests {
         }
 
         @Override
-        public boolean deleteTicket(final String ticketId) {
-            return this.tickets.remove(ticketId) != null;
-        }
-
-        @Override
         public Ticket getTicket(final String ticketId) {
             return getProxiedTicketInstance(this.tickets.get(ticketId));
         }
@@ -137,6 +164,11 @@ public final class DistributedTicketRegistryTests {
         @Override
         protected boolean needsCallback() {
             return true;
+        }
+
+        @Override
+        public boolean deleteSingleTicket(final String ticketId) {
+            return this.tickets.remove(ticketId) != null;
         }
     }
 }

--- a/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/TicketRegistryDecorator.java
+++ b/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/TicketRegistryDecorator.java
@@ -62,14 +62,7 @@ public final class TicketRegistryDecorator extends AbstractTicketRegistry {
     }
 
     @Override
-    public boolean deleteTicket(final String ticketId) {
-        final String userName = this.cache.get(ticketId);
-
-        if (userName != null) {
-            logger.debug("Removing mapping ticket {} for user name {}", ticketId, userName);
-            this.cache.remove(userName);
-        }
-
+    public boolean deleteSingleTicket(final String ticketId) {
         return this.ticketRegistry.deleteTicket(ticketId);
     }
 

--- a/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
+++ b/cas-server-integration-ehcache/src/main/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistry.java
@@ -4,11 +4,9 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
 import net.sf.ehcache.config.CacheConfiguration;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
-import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.ticket.registry.encrypt.AbstractCrypticTicketRegistry;
 import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.InitializingBean;
@@ -19,7 +17,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 
 /**
  * <p>

--- a/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -271,7 +271,7 @@ public final class EhCacheTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
 
-        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         this.ticketRegistry.deleteTicket(tgt.getId());

--- a/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -3,7 +3,6 @@ package org.jasig.cas.ticket.registry;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.PagingPredicate;
-import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 

--- a/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/cas-server-integration-hazelcast/src/main/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -123,43 +123,9 @@ public class HazelcastTicketRegistry extends AbstractCrypticTicketRegistry imple
         return getProxiedTicketInstance(ticket);
     }
 
-
     @Override
-    public boolean deleteTicket(final String ticketId) {
-        final String encTicketId = encodeTicketId(ticketId);
-        logger.debug("Removing ticket [{}]", encTicketId);
-
-        final Ticket ticket = getTicket(encTicketId);
-        if (ticket == null) {
-            return false;
-        }
-
-        if (ticket instanceof TicketGrantingTicket) {
-            logger.debug("Removing ticket [{}] and its children from the registry.", ticket);
-            deleteChildren((TicketGrantingTicket) ticket);
-        }
-
-        logger.debug("Removing ticket [{}] from the registry.", ticket);
-        return this.registry.remove(encTicketId) != null;
-    }
-
-    /**
-     * Delete TGT's service tickets.
-     *
-     * @param ticket the ticket
-     */
-    private void deleteChildren(final TicketGrantingTicket ticket) {
-        // delete service tickets
-        final Map<String, Service> services = ticket.getServices();
-        if (services != null && !services.isEmpty()) {
-            for (final Map.Entry<String, Service> entry : services.entrySet()) {
-                if (this.registry.remove(entry.getKey()) != null) {
-                    logger.trace("Removed service ticket [{}]", entry.getKey());
-                } else {
-                    logger.trace("Ticket not found or is already removed. Unable to remove service ticket [{}]", entry.getKey());
-                }
-            }
-        }
+    public boolean deleteSingleTicket(final String ticketId) {
+        return this.registry.remove(ticketId) != null;
     }
     
     @Override

--- a/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -139,7 +139,7 @@ public class HazelcastTicketRegistryTests {
         assertNotNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
 
-        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         this.hzTicketRegistry1.deleteTicket(tgt.getId());

--- a/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
+++ b/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
@@ -1,6 +1,5 @@
 package org.jasig.cas.ticket.registry;
 
-import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.ticket.registry.encrypt.AbstractCrypticTicketRegistry;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.Ticket;
@@ -28,7 +27,6 @@ import org.springframework.stereotype.Component;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.HashSet;
-import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.cache.Cache;

--- a/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
+++ b/cas-server-integration-ignite/src/main/java/org/jasig/cas/ticket/registry/IgniteTicketRegistry.java
@@ -130,39 +130,22 @@ public final class IgniteTicketRegistry extends AbstractCrypticTicketRegistry {
     }
 
     @Override
-    public boolean deleteTicket(final String ticketIdToDelete) {
-        final String ticketId = encodeTicketId(ticketIdToDelete);
-        if (StringUtils.isBlank(ticketId)) {
-            return false;
-        }
-
+    public boolean deleteSingleTicket(final String ticketId) {
         final Ticket ticket = getTicket(ticketId);
+        
         if (ticket == null) {
-            return false;
+            logger.debug("Ticket {} cannot be retrieved from the cache", ticketId);
+            return true;
         }
 
-        if (ticket instanceof TicketGrantingTicket) {
-            logger.debug("Removing ticket [{}] and its children from the registry.", ticket);
-            return deleteTicketAndChildren((TicketGrantingTicket) ticket);
+        if (this.ticketGrantingTicketsCache.remove(ticket.getId())) {
+            logger.debug("Ticket {} is removed", ticket.getId());
         }
-
-        logger.debug("Removing ticket [{}] from the registry.", ticket);
-        return this.serviceTicketsCache.remove(ticketId);
-    }
-
-    /**
-     * Delete the TGT and all of its service tickets.
-     *
-     * @param ticket the ticket
-     * @return boolean indicating whether ticket was deleted or not
-     */
-    private boolean deleteTicketAndChildren(final TicketGrantingTicket ticket) {
-        final Map<String, Service> services = ticket.getServices();
-        if (services != null && !services.isEmpty()) {
-            this.serviceTicketsCache.removeAll(services.keySet());
+        if (this.serviceTicketsCache.remove(ticket.getId())) {
+            logger.debug("Ticket {} is removed", ticket.getId());
         }
-
-        return this.ticketGrantingTicketsCache.remove(ticket.getId());
+        
+        return true;
     }
 
     @Override

--- a/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -256,7 +256,7 @@ public final class IgniteTicketRegistryTests {
 
     @Test
     public void verifyDeleteTicketWithPGT() {
-    	final Authentication a = TestUtils.getAuthentication();
+        final Authentication a = TestUtils.getAuthentication();
         this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(
                 "TGT", a, new NeverExpiresExpirationPolicy()));
         final TicketGrantingTicket tgt = this.ticketRegistry.getTicket(

--- a/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -272,7 +272,7 @@ public final class IgniteTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
 
-        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
         this.ticketRegistry.deleteTicket(tgt.getId());

--- a/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -23,6 +23,8 @@ import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
+import org.jasig.cas.authentication.Authentication;
+
 /**
  * Unit test for {@link IgniteTicketRegistry}.
  *
@@ -252,6 +254,33 @@ public final class IgniteTicketRegistryTests {
         assertNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
     }
 
+    @Test
+    public void verifyDeleteTicketWithPGT() {
+    	final Authentication a = TestUtils.getAuthentication();
+        this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(
+                "TGT", a, new NeverExpiresExpirationPolicy()));
+        final TicketGrantingTicket tgt = this.ticketRegistry.getTicket(
+                "TGT", TicketGrantingTicket.class);
+
+        final Service service = org.jasig.cas.services.TestUtils.getService("TGT_DELETE_TEST");
+
+        final ServiceTicket st1 = tgt.grantServiceTicket(
+                "ST1", service, new NeverExpiresExpirationPolicy(), true, false);
+
+        this.ticketRegistry.addTicket(st1);
+
+        assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
+
+        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        assertEquals(a, pgt.getAuthentication());
+        
+        this.ticketRegistry.deleteTicket(tgt.getId());
+        
+        assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
+        assertNull(this.ticketRegistry.getTicket("PGT-1", ServiceTicket.class));
+    }
 
     /**
      * Cleaning ticket registry to start afresh, after newing up the instance.

--- a/cas-server-integration-infinispan/src/main/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistry.java
+++ b/cas-server-integration-infinispan/src/main/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistry.java
@@ -68,13 +68,9 @@ public final class InfinispanTicketRegistry extends AbstractCrypticTicketRegistr
      *         exist.
      */
     @Override
-    public boolean deleteTicket(final String ticketId) {
-        if (getTicket(ticketId) == null) {
-            return false;
-        }
+    public boolean deleteSingleTicket(final String ticketId) {
         this.cache.evict(ticketId);
-        return true;
-
+        return getTicket(ticketId) == null;
     }
 
     /**

--- a/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -15,6 +15,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.junit.Assert.*;
 
+import org.jasig.cas.authentication.principal.Service;
+import org.jasig.cas.ticket.ServiceTicket;
+
 /**
  * This is {@link InfinispanTicketRegistryTests}.
  *
@@ -71,5 +74,33 @@ public class InfinispanTicketRegistryTests {
     private Ticket getTicket() {
         final Authentication authentication = TestUtils.getAuthentication();
         return new TicketGrantingTicketImpl("123", authentication, new NeverExpiresExpirationPolicy());
+    }
+
+    @Test
+    public void verifyDeleteTicketWithPGT() {
+        final Authentication a = TestUtils.getAuthentication();
+        this.infinispanTicketRegistry.addTicket(new TicketGrantingTicketImpl(
+                "TGT", a, new NeverExpiresExpirationPolicy()));
+        final TicketGrantingTicket tgt = this.infinispanTicketRegistry.getTicket(
+                "TGT", TicketGrantingTicket.class);
+
+        final Service service = org.jasig.cas.services.TestUtils.getService("TGT_DELETE_TEST");
+
+        final ServiceTicket st1 = tgt.grantServiceTicket(
+                "ST1", service, new NeverExpiresExpirationPolicy(), true, false);
+
+        this.infinispanTicketRegistry.addTicket(st1);
+
+        assertNotNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
+
+        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        assertEquals(a, pgt.getAuthentication());
+
+        this.infinispanTicketRegistry.deleteTicket(tgt.getId());
+
+        assertNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
+        assertNull(this.infinispanTicketRegistry.getTicket("PGT-1", ServiceTicket.class));
     }
 }

--- a/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -94,7 +94,7 @@ public class InfinispanTicketRegistryTests {
         assertNotNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
 
-        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         this.infinispanTicketRegistry.deleteTicket(tgt.getId());

--- a/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistry.java
+++ b/cas-server-integration-memcached/src/main/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistry.java
@@ -1,13 +1,11 @@
 package org.jasig.cas.ticket.registry;
 
-import java.util.Map;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.MemcachedClientIF;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
-import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.ticket.registry.encrypt.AbstractCrypticTicketRegistry;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
@@ -153,7 +153,7 @@ public class MemCacheTicketRegistryTests extends AbstractMemcachedTests {
         assertNotNull(this.registry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.registry.getTicket("ST1", ServiceTicket.class));
 
-        TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
         this.registry.deleteTicket(tgt.getId());

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
@@ -137,7 +137,7 @@ public class MemCacheTicketRegistryTests extends AbstractMemcachedTests {
 
     @Test
     public void verifyDeleteTicketWithPGT() {
-    	final Authentication a = TestUtils.getAuthentication();
+        final Authentication a = TestUtils.getAuthentication();
         this.registry.addTicket(new TicketGrantingTicketImpl(
                 "TGT", a, new NeverExpiresExpirationPolicy()));
         final TicketGrantingTicket tgt = this.registry.getTicket(

--- a/cas-server-support-couchbase-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/CouchbaseTicketRegistry.java
+++ b/cas-server-support-couchbase-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/CouchbaseTicketRegistry.java
@@ -99,11 +99,10 @@ public final class CouchbaseTicketRegistry extends AbstractCrypticTicketRegistry
     }
 
     @Override
-    public boolean deleteTicket(final String ticketId) {
+    public boolean deleteSingleTicket(final String ticketId) {
         logger.debug("Deleting ticket {}", ticketId);
         try {
-            couchbase.bucket().remove(ticketId);
-            return true;
+            return this.couchbase.bucket().remove(ticketId) != null;
         } catch (final Exception e) {
             logger.error("Failed deleting {}: {}", ticketId, e);
             return false;

--- a/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
+++ b/cas-server-support-jpa-ticket-registry/src/main/java/org/jasig/cas/ticket/registry/JpaTicketRegistry.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
-import javax.persistence.LockModeType;
 import javax.persistence.PersistenceContext;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -79,7 +78,7 @@ public class JpaTicketRegistry extends AbstractDistributedTicketRegistry {
      * Removes the ticket.
      *
      * @param ticket the ticket
-     * @return true if ticket was removed 
+     * @return true if ticket was removed
      */
     public boolean removeTicket(final Ticket ticket) {
         try {
@@ -88,7 +87,7 @@ public class JpaTicketRegistry extends AbstractDistributedTicketRegistry {
                 logger.debug("Removing Ticket [{}] created: {}", ticket, creationDate.toString());
              }
             entityManager.remove(ticket);
-	    return true;
+            return true;
         } catch (final Exception e) {
             logger.error("Error removing {} from registry.", ticket, e);
         }


### PR DESCRIPTION
Closes #1869 

- Back-ported CAS 5.0 TicketRegistry changes into 4.2.5 to fix issue with Proxy Granting Tickets not being deleted with the Ticket Granting Ticket is destroyed.
- Unit tests are included in the build. Check each TicketRegistry's test that has a new unit test: verifyDeleteTicketWithPGT(). No unit tests for Couchbase though as that will be coming later on.
- No known possible limitations or side effects.

