### PR TITLE
Set spring.jmx.default-domain in bootstrap.properties in cas-server-w…

### DIFF
--- a/cas-management-webapp/src/main/resources/bootstrap.properties
+++ b/cas-management-webapp/src/main/resources/bootstrap.properties
@@ -12,3 +12,4 @@ spring.cloud.config.server.bootstrap=true
 spring.application.name=management
 spring.cloud.config.fail-fast=true
 spring.cloud.config.server.prefix=/configserver
+spring.jmx.default-domain=management

--- a/cas-server-webapp/src/main/resources/bootstrap.properties
+++ b/cas-server-webapp/src/main/resources/bootstrap.properties
@@ -22,3 +22,4 @@ spring.cloud.config.server.native.searchLocations=file:///etc/cas/config
 # spring.cloud.config.server.git.password=
 spring.cloud.config.server.bootstrap=true
 spring.cloud.config.server.prefix=/configserver
+spring.jmx.default-domain=server


### PR DESCRIPTION
Closes #1962 

- Set spring.jmx.default-domain in bootstrap.properties in cas-server-webapp and cas-management-webapp so there are no naming collisions resulting in an MBeanException.
- Deploy cas-server-webapp and cas-management-webapp on the same server/JVM.
