### PR TITLE
Fix Proxy Tickets Issue Where After Being Issued They Are Already Used/Expired Immediately

### DIFF
--- a/cas-management-webapp/src/main/resources/bootstrap.properties
+++ b/cas-management-webapp/src/main/resources/bootstrap.properties
@@ -12,3 +12,4 @@ spring.cloud.config.server.bootstrap=true
 spring.application.name=management
 spring.cloud.config.fail-fast=true
 spring.cloud.config.server.prefix=/configserver
+spring.jmx.default-domain=management

--- a/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
+++ b/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
@@ -195,7 +195,7 @@ public class CasValidationConfiguration {
     @Bean
     public ProxyValidateController proxyValidateController() {
         final ProxyValidateController c = new ProxyValidateController();
-        c.setValidationSpecification(this.cas20WithoutProxyProtocolValidationSpecification);
+        c.setValidationSpecification(cas20ProtocolValidationSpecification);
         c.setSuccessView(cas3ServiceSuccessView());
         c.setFailureView(cas3ServiceFailureView);
         c.setProxyHandler(proxy20Handler);

--- a/cas-server-webapp/src/main/resources/bootstrap.properties
+++ b/cas-server-webapp/src/main/resources/bootstrap.properties
@@ -22,3 +22,4 @@ spring.cloud.config.server.native.searchLocations=file:///etc/cas/config
 # spring.cloud.config.server.git.password=
 spring.cloud.config.server.bootstrap=true
 spring.cloud.config.server.prefix=/configserver
+spring.jmx.default-domain=server


### PR DESCRIPTION
Closes #1966 and #1963 

- Brief description of changes applied: Set the ProxyValidateController's `validationSpecification `field (on line 198) to `cas20ProtocolValidationSpecification` instead of `this.cas20WithoutProxyProtocolValidationSpecification`.
- Any documentation on how to configure, test: Run [MultiLevelProxySpec.groovy](https://github.com/wcrowell/cas-functional-tests/blob/master/src/test/groovy/org/jasig/cas/test/validation/MultiLevelProxySpec.groovy) to validate.
- Any possible limitations, side effects, etc: None/Unknown
- Reference any other pull requests that might be related: Includes a fix for #1963 where the Travis build failed for some unknown issue.
