### PR TITLE
Fixes issue 1969: STs that are attached to a TGT are not counted in t…

### DIFF
--- a/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/registry/TicketRegistry.java
+++ b/cas-server-core-api-ticket/src/main/java/org/jasig/cas/ticket/registry/TicketRegistry.java
@@ -51,10 +51,9 @@ public interface TicketRegistry {
      * If ticket to delete is TGT then related service tickets are removed as well.
      *
      * @param ticketId The id of the ticket to delete.
-     * @return true if the ticket was removed and false if the ticket did not
-     * exist.
+     * @return the number of tickets deleted including children.
      */
-    boolean deleteTicket(String ticketId);
+    int deleteTicket(String ticketId);
 
     /**
      * Retrieve all tickets from the registry.

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -90,7 +90,8 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
             final Iterator<ProxyGrantingTicket> it = proxyGrantingTickets.iterator();
             while(it.hasNext()) {
                 final ProxyGrantingTicket pgt = it.next();
-                count += deleteTicket(pgt.getId());
+                deleteTicket(pgt.getId());
+                count++;
             }
         }
         logger.debug("Removing ticket [{}] from the registry.", ticket);

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/MockOnlyOneTicketRegistry.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/MockOnlyOneTicketRegistry.java
@@ -40,9 +40,9 @@ public final class MockOnlyOneTicketRegistry implements TicketRegistry {
     }
 
     @Override
-    public boolean deleteTicket(final String ticketId) {
+    public int deleteTicket(final String ticketId) {
         this.ticket = null;
-        return false;
+        return 0;
     }
 
     @Override

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -133,7 +133,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     org.jasig.cas.authentication.TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST"));
+            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST") == 1);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -145,7 +145,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     org.jasig.cas.authentication.TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1"));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1") == 1);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -157,7 +157,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     org.jasig.cas.authentication.TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null) == 1);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -230,7 +230,7 @@ public abstract class AbstractTicketRegistryTests {
             assertNotNull(this.ticketRegistry.getTicket("ST2", ServiceTicket.class));
             assertNotNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
 
-            this.ticketRegistry.deleteTicket(tgt.getId());
+            assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 4);
 
             assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
@@ -126,7 +126,7 @@ public final class DistributedTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 2);
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 3);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
@@ -126,7 +126,7 @@ public final class DistributedTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        this.ticketRegistry.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 2);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/TicketRegistryDecorator.java
+++ b/cas-server-extension-clearpass/src/main/java/org/jasig/cas/extension/clearpass/TicketRegistryDecorator.java
@@ -63,7 +63,10 @@ public final class TicketRegistryDecorator extends AbstractTicketRegistry {
 
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
-        return this.ticketRegistry.deleteTicket(ticketId);
+        if (this.ticketRegistry.deleteTicket(ticketId) > 0) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -274,7 +274,7 @@ public final class EhCacheTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 2);
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 3);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -146,7 +146,7 @@ public final class EhCacheTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST"));
+            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST") == 1);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -158,7 +158,7 @@ public final class EhCacheTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1"));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1") == 1);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -170,7 +170,7 @@ public final class EhCacheTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null) == 1);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -245,7 +245,7 @@ public final class EhCacheTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
 
-        this.ticketRegistry.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 4);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
@@ -274,7 +274,7 @@ public final class EhCacheTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        this.ticketRegistry.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 2);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -113,7 +113,7 @@ public class HazelcastTicketRegistryTests {
         assertNotNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
 
-        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) == 4);
+        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) > 0);
 
         assertNull(this.hzTicketRegistry1.getTicket(tgt.getId(), TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
@@ -142,7 +142,7 @@ public class HazelcastTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) == 2);
+        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) > 0);
 
         assertNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-integration-hazelcast/src/test/java/org/jasig/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -73,8 +73,8 @@ public class HazelcastTicketRegistryTests {
 
         assertNotNull(this.hzTicketRegistry1.getTicket(tgt.getId()));
         assertNotNull(this.hzTicketRegistry2.getTicket(tgt.getId()));
-        assertTrue(this.hzTicketRegistry2.deleteTicket(tgt.getId()));
-        assertFalse(this.hzTicketRegistry1.deleteTicket(tgt.getId()));
+        assertEquals(1, this.hzTicketRegistry2.deleteTicket(tgt.getId()));
+        assertEquals(0, this.hzTicketRegistry1.deleteTicket(tgt.getId()));
         assertNull(this.hzTicketRegistry1.getTicket(tgt.getId()));
         assertNull(this.hzTicketRegistry2.getTicket(tgt.getId()));
 
@@ -113,7 +113,7 @@ public class HazelcastTicketRegistryTests {
         assertNotNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
 
-        this.hzTicketRegistry1.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) == 4);
 
         assertNull(this.hzTicketRegistry1.getTicket(tgt.getId(), TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
@@ -142,7 +142,7 @@ public class HazelcastTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        this.hzTicketRegistry1.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) == 2);
 
         assertNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -275,7 +275,7 @@ public final class IgniteTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 2);
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) > 0);
         
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/cas-server-integration-ignite/src/test/java/org/jasig/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -147,7 +147,7 @@ public final class IgniteTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST"));
+            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST") == 1);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -159,7 +159,7 @@ public final class IgniteTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1"));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1") == 1);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -171,7 +171,7 @@ public final class IgniteTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null) == 1);
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -246,7 +246,7 @@ public final class IgniteTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
 
-        this.ticketRegistry.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 4);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
@@ -275,7 +275,7 @@ public final class IgniteTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
-        this.ticketRegistry.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 2);
         
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -93,11 +93,10 @@ public class InfinispanTicketRegistryTests {
 
         assertNotNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
-
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        assertTrue("TGT and children were deleted", this.infinispanTicketRegistry.deleteTicket(tgt.getId()) == 2);
+        assertTrue("TGT and children were deleted", this.infinispanTicketRegistry.deleteTicket(tgt.getId()) == 3);
 
         assertNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -53,14 +53,14 @@ public class InfinispanTicketRegistryTests {
     public void deleteTicketRemovesFromCacheReturnsTrue() {
         final Ticket ticket = getTicket();
         infinispanTicketRegistry.addTicket(ticket);
-        assertTrue(infinispanTicketRegistry.deleteTicket(ticket.getId()));
+        assertTrue(infinispanTicketRegistry.deleteTicket(ticket.getId()) == 1);
         assertNull(infinispanTicketRegistry.getTicket(ticket.getId()));
     }
 
     @Test
     public void deleteTicketOnNonExistingTicketReturnsFalse() {
         final String ticketId = "does_not_exist";
-        assertFalse(infinispanTicketRegistry.deleteTicket(ticketId));
+        assertFalse(infinispanTicketRegistry.deleteTicket(ticketId) == 1);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class InfinispanTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        this.infinispanTicketRegistry.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.infinispanTicketRegistry.deleteTicket(tgt.getId()) == 2);
 
         assertNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
@@ -156,7 +156,7 @@ public class MemCacheTicketRegistryTests extends AbstractMemcachedTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
-        this.registry.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.registry.deleteTicket(tgt.getId()) == 2);
         
         assertNull(this.registry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.registry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
+++ b/cas-server-integration-memcached/src/test/java/org/jasig/cas/ticket/registry/MemCacheTicketRegistryTests.java
@@ -156,7 +156,7 @@ public class MemCacheTicketRegistryTests extends AbstractMemcachedTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
-        assertTrue("TGT and children were deleted", this.registry.deleteTicket(tgt.getId()) == 2);
+        assertTrue("TGT and children were deleted", this.registry.deleteTicket(tgt.getId()) == 3);
         
         assertNull(this.registry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.registry.getTicket("ST1", ServiceTicket.class));


### PR DESCRIPTION
Closes #1969 

- Changed org.jasig.cas.ticket.registry.TicketRegistry's deleteTicket method to return the total count of tickets deleted which includes any child tickets.
- Unit tests have been updated to account for this change.
