### PR TITLE
Changed the deleteTicket(String) method on the org.jasig.cas.ticket.r…

### DIFF
--- a/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
+++ b/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
@@ -47,10 +47,9 @@ public interface TicketRegistry {
      * If ticket to delete is TGT then related service tickets are removed as well.
      *
      * @param ticketId The id of the ticket to delete.
-     * @return true if the ticket was removed and false if the ticket did not
-     * exist.
+     * @return the number of tickets deleted including children.
      */
-    boolean deleteTicket(String ticketId);
+    int deleteTicket(String ticketId);
 
     /**
      * Retrieve all tickets from the registry.

--- a/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
+++ b/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
@@ -68,19 +68,21 @@ public class DefaultTicketRegistryCleaner implements TicketRegistryCleaner {
                     .collect(Collectors.toSet());
             LOGGER.debug("{} expired tickets found.", ticketsToRemove.size());
 
+            int count = 0;
+
             for (final Ticket ticket : ticketsToRemove) {
                 if (ticket instanceof TicketGrantingTicket) {
                     LOGGER.debug("Cleaning up expired ticket-granting ticket [{}]", ticket.getId());
                     logoutManager.performLogout((TicketGrantingTicket) ticket);
-                    ticketRegistry.deleteTicket(ticket.getId());
+                    count += ticketRegistry.deleteTicket(ticket.getId());
                 } else if (ticket instanceof ServiceTicket) {
                     LOGGER.debug("Cleaning up expired service ticket [{}]", ticket.getId());
-                    ticketRegistry.deleteTicket(ticket.getId());
+                    count += ticketRegistry.deleteTicket(ticket.getId());
                 } else {
                     LOGGER.warn("Unknown ticket type [{} found to clean", ticket.getClass().getSimpleName());
                 }
             }
-            LOGGER.info("{} expired tickets removed.", ticketsToRemove.size());
+            LOGGER.info("{} expired tickets removed.", count);
 
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);

--- a/cas-server-core-tickets/src/test/java/org/apereo/cas/MockOnlyOneTicketRegistry.java
+++ b/cas-server-core-tickets/src/test/java/org/apereo/cas/MockOnlyOneTicketRegistry.java
@@ -40,9 +40,9 @@ public class MockOnlyOneTicketRegistry implements TicketRegistry {
     }
 
     @Override
-    public boolean deleteTicket(final String ticketId) {
+    public int deleteTicket(final String ticketId) {
         this.ticket = null;
-        return false;
+        return 0;
     }
 
     @Override

--- a/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -134,7 +134,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST") == 1);
+            assertSame(1, this.ticketRegistry.deleteTicket("TEST"));
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
         }
@@ -146,7 +146,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1") == 1);
+            assertSame(0, this.ticketRegistry.deleteTicket("TEST1"));
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -228,7 +228,7 @@ public abstract class AbstractTicketRegistryTests {
             assertNotNull(this.ticketRegistry.getTicket("ST2", ServiceTicket.class));
             assertNotNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
 
-            assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 4);
+            assertSame(4, this.ticketRegistry.deleteTicket(tgt.getId()));
 
             assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -134,7 +134,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST"));
+            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST") == 1);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
         }
@@ -146,7 +146,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1"));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1") == 1);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -158,7 +158,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
                     TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null));
+            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null) == 1);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -228,7 +228,7 @@ public abstract class AbstractTicketRegistryTests {
             assertNotNull(this.ticketRegistry.getTicket("ST2", ServiceTicket.class));
             assertNotNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
 
-            this.ticketRegistry.deleteTicket(tgt.getId());
+            assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 4);
 
             assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DistributedTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DistributedTicketRegistryTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.ticket.AbstractTicketException;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.authentication.Authentication;
@@ -124,14 +125,14 @@ public class DistributedTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
 
-        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         assertSame(3, this.ticketRegistry.deleteTicket(tgt.getId()));
 
         assertNull(this.ticketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
-        assertNull(this.ticketRegistry.getTicket("PGT-1", ServiceTicket.class));
+        assertNull(this.ticketRegistry.getTicket("PGT-1", ProxyGrantingTicket.class));
     }
 
     private static class TestDistributedTicketRegistry extends AbstractTicketRegistry {

--- a/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DistributedTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DistributedTicketRegistryTests.java
@@ -24,11 +24,13 @@ import static org.junit.Assert.*;
  * @since 3.1
  */
 public class DistributedTicketRegistryTests {
+    private static final String TGT_NAME = "TGT";
 
     private TestDistributedTicketRegistry ticketRegistry;
 
     private boolean wasTicketUpdated;
 
+    
     public void setWasTicketUpdated(final boolean wasTicketUpdated) {
         this.wasTicketUpdated = wasTicketUpdated;
     }
@@ -106,11 +108,11 @@ public class DistributedTicketRegistryTests {
 
     @Test
     public void verifyDeleteTicketWithPGT() {
-       final Authentication a = TestUtils.getAuthentication();
+        final Authentication a = TestUtils.getAuthentication();
         this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(
-                "TGT", a, new NeverExpiresExpirationPolicy()));
+                TGT_NAME, a, new NeverExpiresExpirationPolicy()));
         final TicketGrantingTicket tgt = this.ticketRegistry.getTicket(
-                "TGT", TicketGrantingTicket.class);
+                TGT_NAME, TicketGrantingTicket.class);
 
         final Service service = TestUtils.getService("TGT_DELETE_TEST");
 
@@ -119,15 +121,15 @@ public class DistributedTicketRegistryTests {
 
         this.ticketRegistry.addTicket(st1);
 
-        assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.ticketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
 
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 3);
+        assertSame(3, this.ticketRegistry.deleteTicket(tgt.getId()));
 
-        assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.ticketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
         assertNull(this.ticketRegistry.getTicket("PGT-1", ServiceTicket.class));
     }

--- a/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -146,7 +146,7 @@ public class EhCacheTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST") == 1);
+            assertSame(1, this.ticketRegistry.deleteTicket("TEST"));
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -158,7 +158,7 @@ public class EhCacheTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("DOESNOTEXIST") == 1);
+            assertSame(0, this.ticketRegistry.deleteTicket("DOESNOTEXIST"));
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -242,7 +242,7 @@ public class EhCacheTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
 
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 4);
+        assertSame(4, this.ticketRegistry.deleteTicket(tgt.getId()));
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
@@ -271,7 +271,7 @@ public class EhCacheTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 3);
+        assertSame(3, this.ticketRegistry.deleteTicket(tgt.getId()));
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -12,6 +12,7 @@ import org.apereo.cas.config.EhcacheTicketRegistryConfiguration;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.junit.Before;
@@ -268,14 +269,14 @@ public class EhCacheTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
 
-        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         assertSame(3, this.ticketRegistry.deleteTicket(tgt.getId()));
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
-        assertNull(this.ticketRegistry.getTicket("PGT-1", ServiceTicket.class));
+        assertNull(this.ticketRegistry.getTicket("PGT-1", ProxyGrantingTicket.class));
     }
 
     /**

--- a/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -128,7 +128,7 @@ public class HazelcastTicketRegistryTests {
 
     @Test
     public void verifyDeleteTicketWithPGT() {
-        final Authentication a = org.apereo.cas.authentication.TestUtils.getAuthentication();
+        final Authentication a = TestUtils.getAuthentication();
         this.hzTicketRegistry1.addTicket(new TicketGrantingTicketImpl(
                 "TGT", a, new NeverExpiresExpirationPolicy()));
         final TicketGrantingTicket tgt = this.hzTicketRegistry1.getTicket(
@@ -148,7 +148,7 @@ public class HazelcastTicketRegistryTests {
         assertEquals(a, pgt.getAuthentication());
 
         this.hzTicketRegistry1.updateTicket(tgt);
-        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) == 3);
+        assertSame(3, this.hzTicketRegistry1.deleteTicket(tgt.getId()));
 
         assertNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -8,6 +8,7 @@ import org.apereo.cas.mock.MockTicketGrantingTicket;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.junit.Test;
@@ -144,7 +145,7 @@ public class HazelcastTicketRegistryTests {
         assertNotNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
 
-        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         this.hzTicketRegistry1.updateTicket(tgt);
@@ -152,7 +153,7 @@ public class HazelcastTicketRegistryTests {
 
         assertNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
-        assertNull(this.hzTicketRegistry1.getTicket("PGT-1", ServiceTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket("PGT-1", ProxyGrantingTicket.class));
     }
 
     private static TicketGrantingTicket newTestTgt() {

--- a/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.TestUtils;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.mock.MockServiceTicket;
@@ -76,8 +77,8 @@ public class HazelcastTicketRegistryTests {
 
         assertNotNull(this.hzTicketRegistry1.getTicket(tgt.getId()));
         assertNotNull(this.hzTicketRegistry2.getTicket(tgt.getId()));
-        assertTrue(this.hzTicketRegistry2.deleteTicket(tgt.getId()));
-        assertFalse(this.hzTicketRegistry1.deleteTicket(tgt.getId()));
+        assertEquals(1, this.hzTicketRegistry2.deleteTicket(tgt.getId()));
+        assertEquals(0, this.hzTicketRegistry1.deleteTicket(tgt.getId()));
         assertNull(this.hzTicketRegistry1.getTicket(tgt.getId()));
         assertNull(this.hzTicketRegistry2.getTicket(tgt.getId()));
 
@@ -86,7 +87,7 @@ public class HazelcastTicketRegistryTests {
 
         assertNotNull(this.hzTicketRegistry1.getTicket("ST-TEST"));
         assertNotNull(this.hzTicketRegistry2.getTicket("ST-TEST"));
-        this.hzTicketRegistry1.deleteTicket("ST-TEST");
+        assertEquals(1, this.hzTicketRegistry1.deleteTicket("ST-TEST"));
         assertNull(this.hzTicketRegistry1.getTicket("ST-TEST"));
         assertNull(this.hzTicketRegistry2.getTicket("ST-TEST"));
     }
@@ -117,12 +118,41 @@ public class HazelcastTicketRegistryTests {
         assertNotNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
 
-        this.hzTicketRegistry1.deleteTicket(tgt.getId());
+        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) > 0);
 
         assertNull(this.hzTicketRegistry1.getTicket(tgt.getId(), TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
+    }
+
+    @Test
+    public void verifyDeleteTicketWithPGT() {
+        final Authentication a = org.apereo.cas.authentication.TestUtils.getAuthentication();
+        this.hzTicketRegistry1.addTicket(new TicketGrantingTicketImpl(
+                "TGT", a, new NeverExpiresExpirationPolicy()));
+        final TicketGrantingTicket tgt = this.hzTicketRegistry1.getTicket(
+                "TGT", TicketGrantingTicket.class);
+
+        final Service service = org.apereo.cas.services.TestUtils.getService("TGT_DELETE_TEST");
+
+        final ServiceTicket st1 = tgt.grantServiceTicket(
+                "ST1", service, new NeverExpiresExpirationPolicy(), null, true);
+
+        this.hzTicketRegistry1.addTicket(st1);
+
+        assertNotNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
+
+        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        assertEquals(a, pgt.getAuthentication());
+
+        this.hzTicketRegistry1.updateTicket(tgt);
+        assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) == 3);
+
+        assertNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket("PGT-1", ServiceTicket.class));
     }
 
     private static TicketGrantingTicket newTestTgt() {

--- a/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -145,7 +145,7 @@ public class IgniteTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertTrue("Ticket was not deleted.", this.ticketRegistry.deleteTicket("TEST") == 1);
+            assertSame(1, this.ticketRegistry.deleteTicket("TEST"));
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -157,7 +157,7 @@ public class IgniteTicketRegistryTests {
         try {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST", TestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket("TEST1") == 1);
+            assertSame(0, this.ticketRegistry.deleteTicket("TEST1"));
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             fail("Caught an exception. But no exception should have been thrown.");
@@ -242,7 +242,7 @@ public class IgniteTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST3", ServiceTicket.class));
 
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 4);
+        assertSame(4, this.ticketRegistry.deleteTicket(tgt.getId()));
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
@@ -272,7 +272,7 @@ public class IgniteTicketRegistryTests {
         assertEquals(a, pgt.getAuthentication());
         
         this.ticketRegistry.updateTicket(tgt);
-        assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 3);
+        assertSame(3, this.ticketRegistry.deleteTicket(tgt.getId()));
         
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -7,6 +7,7 @@ import org.apereo.cas.config.IgniteTicketRegistryConfiguration;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.junit.Before;
@@ -268,7 +269,7 @@ public class IgniteTicketRegistryTests {
         assertNotNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
 
-        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
         this.ticketRegistry.updateTicket(tgt);
@@ -276,7 +277,7 @@ public class IgniteTicketRegistryTests {
         
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.ticketRegistry.getTicket("ST1", ServiceTicket.class));
-        assertNull(this.ticketRegistry.getTicket("PGT-1", ServiceTicket.class));
+        assertNull(this.ticketRegistry.getTicket("PGT-1", ProxyGrantingTicket.class));
     }
 
     /**

--- a/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.*;
 @SpringBootTest(
         classes = {RefreshAutoConfiguration.class, InfinispanTicketRegistryConfiguration.class})
 public class InfinispanTicketRegistryTests {
+    private static final String TGT_NAME = "TGT";
 
     @Autowired
     @Qualifier("infinispanTicketRegistry")
@@ -57,14 +58,14 @@ public class InfinispanTicketRegistryTests {
     public void deleteTicketRemovesFromCacheReturnsTrue() {
         final Ticket ticket = getTicket();
         infinispanTicketRegistry.addTicket(ticket);
-        assertTrue(infinispanTicketRegistry.deleteTicket(ticket.getId()) == 1);
+        assertSame(1, infinispanTicketRegistry.deleteTicket(ticket.getId()));
         assertNull(infinispanTicketRegistry.getTicket(ticket.getId()));
     }
 
     @Test
     public void deleteTicketOnNonExistingTicketReturnsFalse() {
         final String ticketId = "does_not_exist";
-        assertFalse(infinispanTicketRegistry.deleteTicket(ticketId) == 1);
+        assertSame(0, infinispanTicketRegistry.deleteTicket(ticketId));
     }
 
     @Test
@@ -84,9 +85,9 @@ public class InfinispanTicketRegistryTests {
     public void verifyDeleteTicketWithPGT() {
         final Authentication a = TestUtils.getAuthentication();
         this.infinispanTicketRegistry.addTicket(new TicketGrantingTicketImpl(
-                "TGT", a, new NeverExpiresExpirationPolicy()));
+                TGT_NAME, a, new NeverExpiresExpirationPolicy()));
         final TicketGrantingTicket tgt = this.infinispanTicketRegistry.getTicket(
-                "TGT", TicketGrantingTicket.class);
+                TGT_NAME, TicketGrantingTicket.class);
 
         final Service service = org.apereo.cas.services.TestUtils.getService("TGT_DELETE_TEST");
 
@@ -95,14 +96,14 @@ public class InfinispanTicketRegistryTests {
 
         this.infinispanTicketRegistry.addTicket(st1);
 
-        assertNotNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.infinispanTicketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNotNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         assertTrue("TGT and children were deleted", this.infinispanTicketRegistry.deleteTicket(tgt.getId()) == 3);
 
-        assertNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.infinispanTicketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
         assertNull(this.infinispanTicketRegistry.getTicket("PGT-1", ServiceTicket.class));
     }

--- a/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.authentication.TestUtils;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.registry.config.InfinispanTicketRegistryConfiguration;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
@@ -98,13 +99,13 @@ public class InfinispanTicketRegistryTests {
 
         assertNotNull(this.infinispanTicketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNotNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
-        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         assertSame(3, this.infinispanTicketRegistry.deleteTicket(tgt.getId()));
 
         assertNull(this.infinispanTicketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));
-        assertNull(this.infinispanTicketRegistry.getTicket("PGT-1", ServiceTicket.class));
+        assertNull(this.infinispanTicketRegistry.getTicket("PGT-1", ProxyGrantingTicket.class));
     }
 }

--- a/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -101,7 +101,7 @@ public class InfinispanTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
-        assertTrue("TGT and children were deleted", this.infinispanTicketRegistry.deleteTicket(tgt.getId()) == 3);
+        assertSame(3, this.infinispanTicketRegistry.deleteTicket(tgt.getId()));
 
         assertNull(this.infinispanTicketRegistry.getTicket(TGT_NAME, TicketGrantingTicket.class));
         assertNull(this.infinispanTicketRegistry.getTicket("ST1", ServiceTicket.class));

--- a/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistryTests.java
+++ b/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistryTests.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.TestUtils;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.apereo.cas.AbstractMemcachedTests;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
@@ -152,13 +153,13 @@ public class MemCacheTicketRegistryTests extends AbstractMemcachedTests {
         assertNotNull(this.registry.getTicket("TGT", TicketGrantingTicket.class));
         assertNotNull(this.registry.getTicket("ST1", ServiceTicket.class));
 
-        final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
         assertSame(3, this.registry.deleteTicket(tgt.getId()));
         
         assertNull(this.registry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.registry.getTicket("ST1", ServiceTicket.class));
-        assertNull(this.registry.getTicket("PGT-1", ServiceTicket.class));
+        assertNull(this.registry.getTicket("PGT-1", ProxyGrantingTicket.class));
     }
 }

--- a/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistryTests.java
+++ b/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistryTests.java
@@ -155,7 +155,7 @@ public class MemCacheTicketRegistryTests extends AbstractMemcachedTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
         
-        assertTrue("TGT and children were deleted", this.registry.deleteTicket(tgt.getId()) == 3);
+        assertSame(3, this.registry.deleteTicket(tgt.getId()));
         
         assertNull(this.registry.getTicket("TGT", TicketGrantingTicket.class));
         assertNull(this.registry.getTicket("ST1", ServiceTicket.class));


### PR DESCRIPTION
Closes #1969 

- Changed org.apereo.cas.ticket.registry.TicketRegistry's deleteTicket method to return the total count of tickets deleted which includes any child tickets.
- Unit tests have been updated to account for this change.