### PR TITLE
record not expired ticket usage。

### DIFF
--- a/cas-server-core/src/main/java/org/apereo/cas/CentralAuthenticationServiceImpl.java
+++ b/cas-server-core/src/main/java/org/apereo/cas/CentralAuthenticationServiceImpl.java
@@ -357,6 +357,8 @@ public class CentralAuthenticationServiceImpl extends AbstractCentralAuthenticat
         } finally {
             if (serviceTicket.isExpired()) {
                 this.ticketRegistry.deleteTicket(serviceTicketId);
+            } else {
+                this.ticketRegistry.updateTicket(serviceTicket);
             }
         }
     }


### PR DESCRIPTION
Although the current service ticket is one active, but if there can be used multiple times Ticket should record usage.

This is useful when the user's own custom Ticket
