### PR TITLE
Deleted ticket counts should include PGTs in the final cumulative count

### DIFF
--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -90,7 +90,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
             final Iterator<ProxyGrantingTicket> it = proxyGrantingTickets.iterator();
             while(it.hasNext()) {
                 final ProxyGrantingTicket pgt = it.next();
-                deleteTicket(pgt.getId());
+                count += deleteTicket(pgt.getId());
                 count++;
             }
         }

--- a/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/cas-server-core-tickets/src/main/java/org/jasig/cas/ticket/registry/AbstractTicketRegistry.java
@@ -91,7 +91,6 @@ public abstract class AbstractTicketRegistry implements TicketRegistry, TicketRe
             while(it.hasNext()) {
                 final ProxyGrantingTicket pgt = it.next();
                 count += deleteTicket(pgt.getId());
-                count++;
             }
         }
         logger.debug("Removing ticket [{}] from the registry.", ticket);

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/MockOnlyOneTicketRegistry.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/MockOnlyOneTicketRegistry.java
@@ -42,7 +42,7 @@ public final class MockOnlyOneTicketRegistry implements TicketRegistry {
     @Override
     public int deleteTicket(final String ticketId) {
         this.ticket = null;
-        return 0;
+        return 1;
     }
 
     @Override

--- a/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
+++ b/cas-server-core-tickets/src/test/java/org/jasig/cas/ticket/registry/DistributedTicketRegistryTests.java
@@ -126,6 +126,7 @@ public final class DistributedTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
+        this.ticketRegistry.addTicket(pgt);
         assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 3);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));

--- a/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/cas-server-integration-ehcache/src/test/java/org/jasig/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -274,6 +274,7 @@ public final class EhCacheTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
+        this.ticketRegistry.addTicket(pgt);
         assertTrue("TGT and children were deleted", this.ticketRegistry.deleteTicket(tgt.getId()) == 3);
 
         assertNull(this.ticketRegistry.getTicket("TGT", TicketGrantingTicket.class));

--- a/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/cas-server-integration-infinispan/src/test/java/org/jasig/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -96,6 +96,7 @@ public class InfinispanTicketRegistryTests {
         final TicketGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
+        this.infinispanTicketRegistry.addTicket(pgt);
         assertTrue("TGT and children were deleted", this.infinispanTicketRegistry.deleteTicket(tgt.getId()) == 3);
 
         assertNull(this.infinispanTicketRegistry.getTicket("TGT", TicketGrantingTicket.class));


### PR DESCRIPTION
Closes #1969

- Reported deleted ticket counts may not include PGTs in the final cumulative count. This would not affect TGTs and STs.
- Test cases have been updated to add PGTs to the registry after they are created. The counts are checked to make sure of accuracy.
- Related pull request: #1978

