### PR TITLE
Update Basic-Authentication.md

### DIFF
--- a/cas-server-documentation/installation/Basic-Authentication.md
+++ b/cas-server-documentation/installation/Basic-Authentication.md
@@ -23,3 +23,12 @@ curl <APPLICATION-URL> -L -u <USER>:<PASSWORD>
 ```
 
 Use `--insecure -v` flags to bypass certificate validation and receive additional logs from `curl`. 
+
+If your APPLICATION-URL and CAS-SERVER-URL are not on the same host, curl will NOT send the Basic Authentication header to the CAS server when redirected. This behaivour in curl can be overriden by passing the `--location-trusted` flag to curl.
+
+From CURL man page:
+```
+      --location-trusted
+              (HTTP/HTTPS) Like -L, --location, but will allow sending the name + password to all hosts that the site may redirect to. This may or may
+              not  introduce a security breach if the site redirects you to a site to which you'll send your authentication info (which is plaintext in the case of HTTP Basic authentication).
+```


### PR DESCRIPTION
**Enhance Basic Authentication documentation page to help users trying it out.** 

Added a comment about the `--location-trusted` flag in CURL allowing the BasicAuth credentials to be sent again to CAS then the application redirects there. I wasted a few hours rebuilding the overlay war trying to get this working, as CAS would just send back the HTML, not a redirect to the original app.