### PR TITLE
Spring Cloud is not needed for the Management application.  Removed t…

### DIFF
--- a/cas-management-webapp-support/build.gradle
+++ b/cas-management-webapp-support/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile libraries.hibernate
     compile libraries.groovy
     compile project(":cas-server-core-configuration")
-    compile project(":cas-server-core-configuration-cloud-amqp")
     compile project(":cas-server-core-services")
     compile project(":cas-server-support-oauth-core")
     compile project(":cas-server-support-saml-idp-core")

--- a/cas-management-webapp/src/main/resources/application.properties
+++ b/cas-management-webapp/src/main/resources/application.properties
@@ -42,3 +42,9 @@ cas.authn.attributeRepository.attributes.givenName=givenName
 server.session.timeout=1800
 server.session.cookie.http-only=true
 server.session.tracking-modes=COOKIE
+
+##
+# CAS Cloud Bus Configuration
+# Please leave spring.cloud.bus.enabled set to false
+#
+spring.cloud.bus.enabled=false


### PR DESCRIPTION
There is no issue number for this pull request.

- Spring Cloud is not needed for the Management application.  Removed the cas-server-core-configuration-cloud-amqp dependency from the cas-management-webapp-support project and set the spring.cloud.bus.enabled flag to false in application.properties in the cas-management-webapp project.