### PR TITLE
Update to pac4j v1.9.2 and spring-webmvc v1.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -87,8 +87,8 @@ reflectionsVersion=0.9.10
 guavaVersion=19.0
 groovyVersion=2.4.7
 
-springWebmvcPac4jVersion=1.1.1
-pac4jVersion=1.9.1
+springWebmvcPac4jVersion=1.1.2
+pac4jVersion=1.9.2
 dropwizardMetricsVersion=3.1.2
 dropwizardMetricsSpringVersion=3.1.3
 jacksonDatabindVersion=2.8.2

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -45,8 +45,8 @@ import org.pac4j.cas.client.CasClient;
 import org.pac4j.core.client.RedirectAction;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.authenticator.Authenticator;
-import org.pac4j.core.credentials.authenticator.UsernamePasswordAuthenticator;
 import org.pac4j.core.http.CallbackUrlResolver;
 import org.pac4j.http.client.direct.DirectBasicAuthClient;
 import org.pac4j.http.client.direct.DirectFormClient;
@@ -233,7 +233,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    public UsernamePasswordAuthenticator oAuthClientAuthenticator() {
+    public Authenticator<UsernamePasswordCredentials> oAuthClientAuthenticator() {
         final OAuthClientAuthenticator c = new OAuthClientAuthenticator();
         c.setValidator(oAuthValidator());
         c.setServicesManager(this.servicesManager);
@@ -241,7 +241,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    public UsernamePasswordAuthenticator oAuthUserAuthenticator() {
+    public Authenticator<UsernamePasswordCredentials> oAuthUserAuthenticator() {
         final OAuthUserAuthenticator w = new OAuthUserAuthenticator();
         w.setAuthenticationSystemSupport(authenticationSystemSupport);
         return w;

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/DefaultOAuthCasClientRedirectActionBuilder.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/DefaultOAuthCasClientRedirectActionBuilder.java
@@ -3,6 +3,7 @@ package org.apereo.cas.support.oauth;
 import org.apereo.cas.CasProtocolConstants;
 import org.jasig.cas.client.util.CommonUtils;
 import org.pac4j.cas.client.CasClient;
+import org.pac4j.cas.config.CasConfiguration;
 import org.pac4j.core.client.RedirectAction;
 import org.pac4j.core.context.WebContext;
 import org.slf4j.Logger;
@@ -20,9 +21,10 @@ public class DefaultOAuthCasClientRedirectActionBuilder implements OAuthCasClien
     @Override
     public RedirectAction build(final CasClient casClient, final WebContext context) {
         try {
-            final String redirectionUrl = CommonUtils.constructRedirectUrl(casClient.getCasLoginUrl(),
+            final CasConfiguration casConfiguration = casClient.getConfiguration();
+            final String redirectionUrl = CommonUtils.constructRedirectUrl(casConfiguration.getLoginUrl(),
                     CasProtocolConstants.PARAMETER_SERVICE,
-                    casClient.computeFinalCallbackUrl(context), casClient.isRenew(), casClient.isGateway());
+                    casClient.computeFinalCallbackUrl(context), casConfiguration.isRenew(), casConfiguration.isGateway());
             LOGGER.debug("Final redirect url is {}", redirectionUrl);
             return RedirectAction.redirect(redirectionUrl);
         } catch (final Exception e) {

--- a/support/cas-server-support-pac4j-authentication/src/main/java/org/apereo/cas/integration/pac4j/authentication/handler/support/UsernamePasswordWrapperAuthenticationHandler.java
+++ b/support/cas-server-support-pac4j-authentication/src/main/java/org/apereo/cas/integration/pac4j/authentication/handler/support/UsernamePasswordWrapperAuthenticationHandler.java
@@ -6,7 +6,6 @@ import org.apereo.cas.authentication.UsernamePasswordCredential;
 import org.apereo.cas.authentication.handler.PrincipalNameTransformer;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.authenticator.Authenticator;
-import org.pac4j.core.credentials.authenticator.UsernamePasswordAuthenticator;
 import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,7 +26,7 @@ public class UsernamePasswordWrapperAuthenticationHandler
     /**
      * The underlying pac4j authenticator.
      */
-    protected UsernamePasswordAuthenticator authenticator = new SimpleTestUsernamePasswordAuthenticator();
+    protected Authenticator<UsernamePasswordCredentials> authenticator = new SimpleTestUsernamePasswordAuthenticator();
 
     /**
      * PasswordEncoder to be used by subclasses to encode passwords for
@@ -67,7 +66,7 @@ public class UsernamePasswordWrapperAuthenticationHandler
         return this.authenticator;
     }
 
-    public void setAuthenticator(final UsernamePasswordAuthenticator authenticator) {
+    public void setAuthenticator(final Authenticator<UsernamePasswordCredentials> authenticator) {
         this.authenticator = authenticator;
     }
 

--- a/support/cas-server-support-stormpath/src/main/java/org/apereo/cas/authentication/StormpathAuthenticationHandler.java
+++ b/support/cas-server-support-stormpath/src/main/java/org/apereo/cas/authentication/StormpathAuthenticationHandler.java
@@ -3,8 +3,6 @@ package org.apereo.cas.authentication;
 import org.apereo.cas.integration.pac4j.authentication.handler.support.UsernamePasswordWrapperAuthenticationHandler;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.authenticator.Authenticator;
-import org.pac4j.core.credentials.password.NopPasswordEncoder;
-import org.pac4j.core.credentials.password.PasswordEncoder;
 import org.pac4j.stormpath.credentials.authenticator.StormpathAuthenticator;
 
 /**
@@ -19,9 +17,7 @@ public class StormpathAuthenticationHandler extends UsernamePasswordWrapperAuthe
     private String applicationId;
     private String secretkey;
 
-    private PasswordEncoder stormpathPasswordEncoder = new NopPasswordEncoder();
-    
-    public StormpathAuthenticationHandler(final String apiKey, final String applicationId, 
+    public StormpathAuthenticationHandler(final String apiKey, final String applicationId,
                                           final String secretkey) {
         this.apiKey = apiKey;
         this.applicationId = applicationId;
@@ -30,17 +26,8 @@ public class StormpathAuthenticationHandler extends UsernamePasswordWrapperAuthe
 
     @Override
     protected Authenticator<UsernamePasswordCredentials> getAuthenticator(final Credential credential) {
-        final StormpathAuthenticator authenticator = new StormpathAuthenticator(this.apiKey, 
+        final StormpathAuthenticator authenticator = new StormpathAuthenticator(this.apiKey,
                 this.secretkey, this.applicationId);
-        authenticator.setPasswordEncoder(this.stormpathPasswordEncoder);
         return authenticator;
-    }
-
-    public PasswordEncoder getStormpathPasswordEncoder() {
-        return stormpathPasswordEncoder;
-    }
-
-    public void setStormpathPasswordEncoder(final PasswordEncoder stormpathPasswordEncoder) {
-        this.stormpathPasswordEncoder = stormpathPasswordEncoder;
     }
 }

--- a/support/cas-server-support-stormpath/src/main/java/org/apereo/cas/config/StormpathAuthenticationConfiguration.java
+++ b/support/cas-server-support-stormpath/src/main/java/org/apereo/cas/config/StormpathAuthenticationConfiguration.java
@@ -9,7 +9,6 @@ import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.services.ServicesManager;
-import org.pac4j.core.credentials.password.NopPasswordEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -31,10 +30,6 @@ public class StormpathAuthenticationConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
-
-    @Autowired(required = false)
-    @Qualifier("stormpathPac4jPasswordEncoder")
-    private org.pac4j.core.credentials.password.PasswordEncoder stormpathPasswordEncoder = new NopPasswordEncoder();
 
     @Autowired
     @Qualifier("servicesManager")
@@ -63,8 +58,6 @@ public class StormpathAuthenticationConfiguration {
 
         handler.setPasswordEncoder(Beans.newPasswordEncoder(casProperties.getAuthn().getStormpath().getPasswordEncoder()));
         handler.setPrincipalNameTransformer(Beans.newPrincipalNameTransformer(casProperties.getAuthn().getStormpath().getPrincipalTransformation()));
-
-        handler.setStormpathPasswordEncoder(this.stormpathPasswordEncoder);
 
         handler.setPrincipalFactory(stormpathPrincipalFactory());
         handler.setServicesManager(servicesManager);


### PR DESCRIPTION
The CAS server widely uses pac4j and some changes in 1.9.2 are breaking ones for CAS. So it's better to upgrade to this version and be more cautious for 1.9.3, 1.9.4...

