### PR TITLE
Adds missing argument in the constructor

### DIFF
--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/config/CasSupportActionsConfiguration.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/config/CasSupportActionsConfiguration.java
@@ -190,7 +190,7 @@ public class CasSupportActionsConfiguration {
 
     @Bean
     public Action gatewayServicesManagementCheck() {
-        return new GatewayServicesManagementCheck();
+        return new GatewayServicesManagementCheck(this.servicesManager);
     }
 
     @Bean


### PR DESCRIPTION
Closes #2011

Pass the servicesManager as an argument while creating the GatewayServicesManagementCheck.