### PR TITLE
Fixes issue 2027 where the REST API is no longer accessible.  This fi…

### DIFF
--- a/cas-server-webapp-support/src/main/resources/META-INF/spring/web-ctx-config.xml
+++ b/cas-server-webapp-support/src/main/resources/META-INF/spring/web-ctx-config.xml
@@ -17,7 +17,7 @@
         <mvc:path-matching path-helper="urlPathHelperWeb" trailing-slash="true" />
     </mvc:annotation-driven>
     <bean id="urlPathHelperWeb" class="org.springframework.web.util.UrlPathHelper"
-          p:alwaysUseFullPath="true" />
+          p:alwaysUseFullPath="false" />
     <mvc:interceptors>
         <bean class="org.springframework.web.servlet.mvc.WebContentInterceptor"
               p:cacheSeconds="0"


### PR DESCRIPTION
Closes #2027 

Ensure that you include the following:

- Fixes issue 2027 where the REST API is no longer accessible.  This fix does not render the /statistics and /status endpoints unsecured.
- After deploying hit the following endpoints:
/cas/status
/cas/statistics
/cas/v1/tickets

Ensure that the /cas/status and /cas/statistics endpoints are still secured.  Make sure that the REST API at /cas/v1/tickets is accessible.