### PR TITLE
Fix Markdown table formatting by replacing -+- with -|- and then -+ w…

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Management.md
+++ b/docs/cas-server-documentation/installation/Configuration-Management.md
@@ -59,7 +59,7 @@ The configuration server is controlled and defined by the `bootstrap.properties`
 The following endpoints are secured and exposed by the configuration server's `/configserver` endpoint:
 
 | Parameter                         | Description
-|-----------------------------------+-----------------------------------------+
+|-----------------------------------|------------------------------------------
 | `/encrypt`           | Accepts a `POST` to encrypt CAS configuration settings.
 | `/decrypt`           | Accepts a `POST` to decrypt CAS configuration settings.
 | `/cas/default`       | Describes what the configuration server knows about the `default` settings profile.

--- a/docs/cas-server-documentation/installation/Configuring-Authentication-Events.md
+++ b/docs/cas-server-documentation/installation/Configuring-Authentication-Events.md
@@ -16,7 +16,7 @@ By default, no events are recorded by this functionality.
 The following metadata is captured and recorded by the event machinery when enabled:
 
 | Field                             | Description
-|-----------------------------------+----------------------------------------------------------------+
+|-----------------------------------|-----------------------------------------------------------------
 | `principalId`                              | The principal id of the authenticated subject
 | `timestamp`                                | Timestamp of this event
 | `creationTime`                             | Timestamp of this authentication event

--- a/docs/cas-server-documentation/installation/Configuring-Multifactor-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-Multifactor-Authentication.md
@@ -25,7 +25,7 @@ The following multifactor providers are supported by CAS.
 Configure authentication per instructions [here](DuoSecurity-Authentication.html). 
 
 | Field                | Description
-|----------------------+---------------------------------+
+|----------------------|----------------------------------
 | `id`                 | `mfa-duo`
 
 ### Authy Authenticator
@@ -33,7 +33,7 @@ Configure authentication per instructions [here](DuoSecurity-Authentication.html
 Configure authentication per instructions [here](AuthyAuthenticator-Authentication.html). 
 
 | Field                | Description
-|----------------------+---------------------------------+
+|----------------------|----------------------------------
 | `id`                 | `mfa-authy`
 
 ### YubiKey
@@ -41,7 +41,7 @@ Configure authentication per instructions [here](AuthyAuthenticator-Authenticati
 Configure authentication per instructions [here](YubiKey-Authentication.html). 
 
 | Field                | Description
-|----------------------+---------------------------------+
+|----------------------|----------------------------------
 | `id`                 | `mfa-yubikey`
 
 ### RSA/RADIUS
@@ -49,7 +49,7 @@ Configure authentication per instructions [here](YubiKey-Authentication.html).
 Configure authentication per instructions [here](RADIUS-Authentication.html). 
 
 | Field                | Description
-|----------------------+---------------------------------+
+|----------------------|----------------------------------
 | `id`                 | `mfa-radius`
 
 ### Google Authenticator
@@ -57,7 +57,7 @@ Configure authentication per instructions [here](RADIUS-Authentication.html).
 Configure authentication per instructions [here](GoogleAuthenticator-Authentication.html). 
 
 | Field                | Description
-|----------------------+---------------------------------+
+|----------------------|----------------------------------
 | `id`                 | `mfa-gauth`
 
 ## Triggers
@@ -187,7 +187,7 @@ functionality, if that provider cannot respond.
 The following failure modes are supported:
 
 | Field                | Description
-|----------------------+---------------------------------+
+|----------------------|----------------------------------
 | `CLOSED`                  | Authentication is blocked if the provider cannot be reached. 
 | `OPEN`                    | Authentication proceeds yet requested MFA is NOT communicated to the client if provider is unavailable.
 | `PHANTOM`                 | Authentication proceeds and requested MFA is communicated to the client if provider is unavailable.

--- a/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
@@ -19,7 +19,7 @@ The following CAS endpoints respond to supported SAML2 profiles:
 SAML2 IdP Unsolicited/Initiated SSO profile supports the following parameters:
 
 | Parameter                         | Description
-|-----------------------------------+-----------------------------------------+
+|-----------------------------------|------------------------------------------
 | `providerId`                      | Required. Entity ID of the service provider.
 | `shire`                           | Optional. Response location (ACS URL) of the service provider.
 | `target`                          | Optional. Relay state.
@@ -92,7 +92,7 @@ This endpoint will attempt to generate metadata for relying party upon receiving
 service providers that do not publish a defined metadata. The following parameters are expected by this point:
 
 | Parameter                         | Description
-|-----------------------------------+-----------------------------------------+
+|-----------------------------------|------------------------------------------
 | `entityId`                        | Required.
 | `authnRequestSigned`              | Optional. Defaults to `false`.
 | `wantAssertionsSigned`            | Optional. Defaults to `false`.
@@ -149,7 +149,7 @@ the <code>serviceId</code> field. </p></div>
 The following fields are available for SAML services:
 
 | Field                                | Description
-|--------------------------------------+-----------------------------------------------------------------+
+|--------------------------------------|------------------------------------------------------------------
 | `metadataLocation`                   | Location of service metadata defined from system files, classpath or URL resources. 
 | `metadataSignatureLocation`          | Location of the metadata *public key* to validate the metadata which must be defined from system files or classpath. If defined, will enforce the `SignatureValidationFilter` validation filter on metadata.
 | `metadataMaxValidity`                | If defined, will enforce the `RequiredValidUntilFilter` validation filter on metadata.

--- a/docs/cas-server-documentation/installation/Configuring-Service-Access-Strategy.md
+++ b/docs/cas-server-documentation/installation/Configuring-Service-Access-Strategy.md
@@ -16,7 +16,7 @@ validated when an authentication request from the application arrives.
 The `DefaultRegisteredServiceAccessStrategy` allows one to configure a service with the following properties:
 
 | Field                             | Description
-|-----------------------------------+--------------------------------------------------------------------------------+
+|-----------------------------------|---------------------------------------------------------------------------------
 | `enabled`                         | Flag to toggle whether the entry is active; a disabled entry produces behavior equivalent to a non-existent entry.
 | `ssoEnabled`                      | Set to `false` to force users to authenticate to the service regardless of protocol flags (e.g. `renew=true`). This flag provides some support for centralized application of security policy.
 | `requiredAttributes`              | A `Map` of required principal attribute names along with the set of values for each attribute. These attributes **MUST** be available to the authenticated Principal and resolved before CAS can proceed, providing an option for role-based access control from the CAS perspective. If no required attributes are presented, the check will be entirely ignored.
@@ -36,7 +36,7 @@ The `TimeBasedRegisteredServiceAccessStrategy` access strategy is an extension o
 allows one to configure a service with the following properties:
 
 | Field                             | Description
-|-----------------------------------+--------------------------------------------------------------------------------+
+|-----------------------------------|---------------------------------------------------------------------------------
 | `startingDateTime`                | Indicates the starting date/time whence service access may be granted.  (i.e. `2015-10-11T09:55:16.552-07:00`)
 | `endingDateTime`                  | Indicates the ending date/time whence service access may be granted.  (i.e. `2015-10-20T09:55:16.552-07:00`)
 
@@ -45,7 +45,7 @@ The `RemoteEndpointServiceAccessStrategy` is an extension of the default which a
 allows one to configure a service with the following properties:
 
 | Field                             | Description
-|-----------------------------------+--------------------------------------------------------------------------------+
+|-----------------------------------|---------------------------------------------------------------------------------
 | `endpointUrl`                | Endpoint that receives the authorization request from CAS for the authenticated principal. 
 | `acceptableResponseCodes`    | Comma-separated response codes that are considered accepted for service access.
 
@@ -70,7 +70,7 @@ are collected as CAS attributes and examined against the list of required attrib
 The following properties are available:
 
 | Field                             | Description
-|-----------------------------------+--------------------------------------------------------------------------------+
+|-----------------------------------|---------------------------------------------------------------------------------
 | `groupField`                | Decides which attribute of the Grouper group should be used when converting the group to a CAS attribute. Possible values are `NAME`, `EXTENSION`, `DISPLAY_NAME`, `DISPLAY_EXTENSION`.
 
 You will also need to ensure `grouper.client.properties` is available on the classpath

--- a/docs/cas-server-documentation/installation/LDAP-Service-Management.md
+++ b/docs/cas-server-documentation/installation/LDAP-Service-Management.md
@@ -26,7 +26,7 @@ Support is enabled by adding the following module into the Maven overlay:
 The default mapper has support for the following optional items:
 
 | Field                             | Default Value
-|-----------------------------------+--------------------------------------------------+
+|-----------------------------------|---------------------------------------------------
 | `objectClass`                     | casRegisteredService
 | `serviceDefinitionAttribute`      | description
 | `idAttribute`                     | uid

--- a/docs/cas-server-documentation/installation/Logging.md
+++ b/docs/cas-server-documentation/installation/Logging.md
@@ -129,7 +129,7 @@ translates to a number of special variables available to the logging context tha
 may convey additional information about the nature of the request or the authentication event.
 
 | Variable                                     | Description
-|-----------------------------------+------------------------------------+
+|-----------------------------------|-------------------------------------
 | `remoteAddress`                     | Remote address of the HTTP request.
 | `remoteUser`                        | Remote user of the HTTP request.
 | `serverName`                        | Server name of the HTTP request.

--- a/docs/cas-server-documentation/installation/Monitoring-Statistics.md
+++ b/docs/cas-server-documentation/installation/Monitoring-Statistics.md
@@ -8,7 +8,7 @@ title: CAS - Monitoring & Statistics
 The following endpoints are secured and available:
 
 | Parameter                         | Description
-|-----------------------------------+-----------------------------------------+
+|-----------------------------------|------------------------------------------
 | `/status/dashboard`               | A good starting point, that is a control panel to CAS server functionality and management.
 | `/status`                         | [Monitor status information](Configuring-Monitoring.html).
 | `/status/autoconfig`              | Describes how the application context is auto configured.

--- a/docs/cas-server-documentation/installation/OIDC-Authentication.md
+++ b/docs/cas-server-documentation/installation/OIDC-Authentication.md
@@ -29,7 +29,7 @@ The current implementation provides support for:
 ## Endpoints
 
 | Field                                     | Description
-|-------------------------------------------+------------------------------------------------------+
+|-------------------------------------------|-------------------------------------------------------
 | `/cas/oidc/.well-known`                       | Discovery endpoint.
 | `/cas/oidc/.well-known/openid-configuration`  | Discovery endpoint.
 | `/cas/oidc/jwks`                              | Provides an aggregate of all keystores.
@@ -56,7 +56,7 @@ OpenID Connect clients can be registered with CAS as such:
 ```
 
 | Field                   | Description
-|-------------------------+-----------------------------------------------------------------+
+|-------------------------|------------------------------------------------------------------
 | `serviceId`             | The authorized redirect URI for this OIDC client.
 | `signIdToken`           | Whether ID tokens should be signed. Default is `true`.
 | `jwks`                  | Path to the location of the keystore that holds the signing keys for this application. If none defined, defaults will be used.

--- a/docs/cas-server-documentation/installation/Service-Management.md
+++ b/docs/cas-server-documentation/installation/Service-Management.md
@@ -31,7 +31,7 @@ the CAS server itself so the entire system can load the same services data. To l
 Registered services present the following metadata:
 
 | Field                             | Description
-|-----------------------------------+--------------------------------------------------------------------------------+
+|-----------------------------------|---------------------------------------------------------------------------------
 | `id`                              | Required unique identifier. In most cases this is managed automatically by the `ServiceRegistryDao`. This **MUST** be a valid numeric value.
 | `name`                            | Required name (255 characters or less).
 | `description`                     | Optional free-text description of the service. (255 characters or less)

--- a/docs/cas-server-documentation/installation/X509-Authentication.md
+++ b/docs/cas-server-documentation/installation/X509-Authentication.md
@@ -43,7 +43,7 @@ configurability in the revocation machinery built into the JSSE.
 The following configuration is shared by all components:
 
 | Field                             | Description
-|-----------------------------------+---------------------------------------------------------
+|-----------------------------------|---------------------------------------------------------
 | `unavailableCRLPolicy`    | Policy applied when CRL data is unavailable upon fetching. (default=`DenyRevocationPolicy`)
 | `expiredCRLPolicy`        | Policy applied when CRL data is expired. (default=`ThresholdExpiredCRLRevocationPolicy`)
 

--- a/docs/cas-server-documentation/integration/Attribute-Release-Policies.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Policies.md
@@ -11,7 +11,7 @@ the ability to apply an optional filter.
 The following settings are shared by all attribute release policies:
 
 | Name                    | Value
-|---------------------------------------+---------------------------------------------------------------+
+|---------------------------------------|----------------------------------------------------------------
 | `authorizedToReleaseCredentialPassword` | Boolean to define whether the service is authorized to [release the credential as an attribute](ClearPass.html).
 | `authorizedToReleaseProxyGrantingTicket` | Boolean to define whether the service is authorized to [release the proxy-granting ticket id as an attribute](../installation/Configuring-Proxy-Authentication.html)
 
@@ -205,7 +205,7 @@ matches a certain regex pattern are released.
 Suppose that the following attributes are resolved:
 
 | Name       							| Value
-|---------------------------------------+---------------------------------------------------------------+
+|---------------------------------------|----------------------------------------------------------------
 | `uid`        							| jsmith
 | `groupMembership`        	| std  
 | `cn`        							| JohnSmith   

--- a/docs/cas-server-documentation/integration/Attribute-Resolution.md
+++ b/docs/cas-server-documentation/integration/Attribute-Resolution.md
@@ -35,7 +35,7 @@ Suppose CAS is configured to authenticate against Active Directory. The account 
 authenticates via `sAMAccountName`.
 
 | Attribute            | Value
-|------------+-------------------------------+
+|------------|--------------------------------
 | `sAMAccountName`     | `johnsmith`
 | `cn`                 | `John Smith`
 


### PR DESCRIPTION
Markdown tables were very hard to read once transformed to HTML as markdown formatting was in error.  Markdown support plugin for Intellij is very helpful for viewing documentation as it will render before committing.

Fix Markdown table formatting by replacing -+- with -|- and then -+ with --.  These -+- and -+ were causing tables not to display as tables when rendering Markdown to HTML.