### PR TITLE
[Fix][4.1.x] Login Throttle

### DIFF
--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -139,10 +139,8 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
      * @param request the request
      */
     protected void recordThrottle(final HttpServletRequest request) {
-        logger.warn("Throttling submission from {}.  More than {} failed login attempts within {} seconds. "
-                + "Authentication attempt exceeds the failure threshold {}",
-                request.getRemoteAddr(), this.failureThreshold, this.failureRangeInSeconds,
-                this.failureThreshold);
+        logger.warn("Throttling submission from {}. Login rate goes above threshold rate: {} logins/second",
+                request.getRemoteAddr(), this.getThresholdRate());
     }
 
     /**

--- a/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -44,7 +44,7 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
 
     private static final int DEFAULT_FAILURE_THRESHOLD = 5;
 
-    private static final int DEFAULT_FAILURE_RANGE_IN_SECONDS = 2;
+    private static final int DEFAULT_FAILURE_RANGE_IN_SECONDS = 3;
 
     private static final String DEFAULT_USERNAME_PARAMETER = "username";
 

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -50,7 +50,7 @@ screen.rememberme.checkbox.title=Remember Me
 
 # Blocked Errors Page
 screen.blocked.header=Access Denied
-screen.blocked.message=You've entered the wrong password for the user too many times. You've been throttled.
+screen.blocked.message=You've been throttled for having exceeded the threshold rate of failed login attempts.
 AbstractAccessDecisionManager.accessDenied=You are not authorized to access this resource. Contact your CAS administrator for more info.
 
 #Confirmation Screen Messages

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -50,7 +50,7 @@ screen.rememberme.checkbox.title=Remember Me
 
 # Blocked Errors Page
 screen.blocked.header=Access Denied
-screen.blocked.message=You've been throttled for having exceeded the threshold rate of failed login attempts.
+screen.blocked.message=You've been throttled for having exceeded the threshold rate of failed login attempts. Please try again later.
 AbstractAccessDecisionManager.accessDenied=You are not authorized to access this resource. Contact your CAS administrator for more info.
 
 #Confirmation Screen Messages

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -140,7 +140,7 @@
     </view-state>
 
     <action-state id="handleAuthenticationFailure">
-        <evaluate expression="authenticationExceptionHandler.handle(currentEvent.attributes.error, messageContext)"/>
+        <evaluate expression="authenticationExceptionHandler.handle(flowRequestContext, currentEvent.attributes.error, messageContext)"/>
         <transition on="AccountDisabledException" to="casAccountDisabledView"/>
         <transition on="AccountLockedException" to="casAccountLockedView"/>
         <transition on="AccountPasswordMustChangeException" to="casMustChangePassView"/>


### PR DESCRIPTION
### Version

4.1.x
### Issue

The problem with current Login Throttle lies in how CAS decides if a login is failed and when failure should be recorded. The default behavior is:
- when loading a CAS page initiated by `POST`, if the current event is not `SUCCESSFUL_AUTHENTICATION_EVENT` (defined as a string literal `"success"`), CAS considers the login as failed and records the failure.

However, CAS users need to override the [AbstractThrottledSubmissionHandlerInterceptorAdapter](https://github.com/apereo/cas/blob/4.1.x/cas-server-webapp-support/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java) class if they have customized their login flow. There is no documentation for this.

In addition, the warning message and docs are misleading. It took us some time to figure out that this is a "rate" based throttling, which is considered as the expected behavior #486. And the fix provided by #719 can be further improved.
### Fix

In this PR, I propose an "context-based" approach.
1. Update `AuthenticationExceptionHandler.handle()` to not only handle exceptions as before but also recognize excpetions to record submission failure and update request context.
2. Update `AbstractThrottledSubmissionHandlerInterceptorAdapter.postHandle()` to only record submission failure if throttle triggering exceptions are in flow context (and if `POST`).
3. Update the warning message to explicitly mention "threshold rate" instead of "number of logins in a period of time".
### Side Effects
- [ ] Fix test (In progress)
### Related PR
- #1808: i opened a PR five months ago which does not work.
- FYI: here is a [patch](https://github.com/CenterForOpenScience/cas-overlay/pull/19) for our own CAS server which uses the same idea.
