### PR TITLE
Update Configuration-Properties.md

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1596,7 +1596,7 @@ To learn more about this topic, [please review this guide](Configuring-SAML2-Aut
 
 # cas.authn.samlIdp.metadata.cacheExpirationMinutes=30
 # cas.authn.samlIdp.metadata.failFast=true
-# cas.authn.samlIdp.metadata.location=file:/etc/cas/saml
+# cas.authn.samlIdp.metadata.location=/etc/cas/saml
 # cas.authn.samlIdp.metadata.privateKeyAlgName=RSA
 # cas.authn.samlIdp.metadata.requireValidMetadata=true
 


### PR DESCRIPTION
Issue 2108.

Corrected the value of cas.authn.samlIdp.metadata.location to be a simple file system path name instead of a uri (delete the "file:").

Should be fixed in the code and the docs later on, but for now this will at least let the doc match what the code is doing today.