### PR TITLE
Update LoggingConfigController.java

### DIFF
--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/LoggingConfigController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/LoggingConfigController.java
@@ -88,21 +88,19 @@ public class LoggingConfigController {
 
     private void registerLogFileTailThreads() throws IOException {
         final Collection<String> outputFileNames = new HashSet<>();
-        final Collection<LoggerConfig> loggerConfigs = getLoggerConfigurations();
-        for (final LoggerConfig config : loggerConfigs) {
-            for (final String key : config.getAppenders().keySet()) {
-                final Appender appender = config.getAppenders().get(key);
-                if (appender instanceof FileAppender) {
-                    outputFileNames.add(((FileAppender) appender).getFileName());
-                } else if (appender instanceof RandomAccessFileAppender) {
-                    outputFileNames.add(((RandomAccessFileAppender) appender).getFileName());
-                } else if (appender instanceof RollingFileAppender) {
-                    outputFileNames.add(((RollingFileAppender) appender).getFileName());
-                } else if (appender instanceof MemoryMappedFileAppender) {
-                    outputFileNames.add(((MemoryMappedFileAppender) appender).getFileName());
-                } else if (appender instanceof RollingRandomAccessFileAppender) {
-                    outputFileNames.add(((RollingRandomAccessFileAppender) appender).getFileName());
-                }
+        final Collection<Appender> loggerAppenders = this.loggerContext.getConfiguration().getAppenders().values();
+        for (final Appender appender : loggerAppenders) {
+            final Appender appender = config.getAppenders().get(key);
+            if (appender instanceof FileAppender) {
+                outputFileNames.add(((FileAppender) appender).getFileName());
+            } else if (appender instanceof RandomAccessFileAppender) {
+                outputFileNames.add(((RandomAccessFileAppender) appender).getFileName());
+            } else if (appender instanceof RollingFileAppender) {
+                outputFileNames.add(((RollingFileAppender) appender).getFileName());
+            } else if (appender instanceof MemoryMappedFileAppender) {
+                outputFileNames.add(((MemoryMappedFileAppender) appender).getFileName());
+            } else if (appender instanceof RollingRandomAccessFileAppender) {
+                outputFileNames.add(((RollingRandomAccessFileAppender) appender).getFileName());
             }
         }
 

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/LoggingConfigController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/LoggingConfigController.java
@@ -90,7 +90,6 @@ public class LoggingConfigController {
         final Collection<String> outputFileNames = new HashSet<>();
         final Collection<Appender> loggerAppenders = this.loggerContext.getConfiguration().getAppenders().values();
         for (final Appender appender : loggerAppenders) {
-            final Appender appender = config.getAppenders().get(key);
             if (appender instanceof FileAppender) {
                 outputFileNames.add(((FileAppender) appender).getFileName());
             } else if (appender instanceof RandomAccessFileAppender) {


### PR DESCRIPTION
Ensure that you include the following:

- [X] Brief description of changes applied: Use all File appenders of `log4j2.xml` for Logging Dashboard, as default `CasAppender` is not handled in `LoggingConfigController`.
- [X] Any documentation on how to configure, test: nothing new to test
- [X] Any possible limitations, side effects, etc: Its possible that any unused file appenders are observed
- [X] Reference any other pull requests that might be related: none

<!--
Thanks for your contribution. 
-->

Default `log4j2.xml` file makes use of `CasAppender` to sanitize logs. `CasAppender` can not be handled in `registerLogFileTailThreads`. As `CasAppender` just refs another FileAppender we can safely `registerLogFileTailThreads` on all file appenders referenced in `log4j2.xml`