### PR TITLE
Rework how service pattern matching is conditionally handled

### DIFF
--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicy.java
@@ -32,8 +32,8 @@ public class ReturnMappedAttributeReleasePolicy extends AbstractRegisteredServic
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReturnMappedAttributeReleasePolicy.class);
 
-    private static final Pattern INLINE_GROOVY_PATTERN = RegexUtils.createPattern("groovy\\s*\\{(.+)\\}").get();
-    private static final Pattern FILE_GROOVY_PATTERN = RegexUtils.createPattern("file:(.+\\.groovy)").get();
+    private static final Pattern INLINE_GROOVY_PATTERN = RegexUtils.createPattern("groovy\\s*\\{(.+)\\}");
+    private static final Pattern FILE_GROOVY_PATTERN = RegexUtils.createPattern("file:(.+\\.groovy)");
 
     private Map<String, String> allowedAttributes;
 

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceAccessStrategy.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceAccessStrategy.java
@@ -256,7 +256,7 @@ public class DefaultRegisteredServiceAccessStrategy implements RegisteredService
 
             final Set<?> differenceInValues;
             final Pattern pattern = RegexUtils.concatenate(requiredValues, this.caseInsensitive);
-            if (pattern != null) {
+            if (pattern != RegexUtils.MATCH_NOTHING_PATTERN) {
                 final Predicate<String> patternPredicate = pattern.asPredicate();
                 differenceInValues = availableValues.stream().filter(patternPredicate).collect(Collectors.toSet());
             } else {
@@ -300,7 +300,7 @@ public class DefaultRegisteredServiceAccessStrategy implements RegisteredService
 
             final Set<?> differenceInValues;
             final Pattern pattern = RegexUtils.concatenate(rejectedValues, this.caseInsensitive);
-            if (pattern != null) {
+            if (pattern != RegexUtils.MATCH_NOTHING_PATTERN) {
                 final Predicate<String> patternPredicate = pattern.asPredicate();
                 differenceInValues = availableValues.stream().filter(patternPredicate).collect(Collectors.toSet());
             } else {

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/RegexRegisteredService.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/RegexRegisteredService.java
@@ -1,12 +1,10 @@
 package org.apereo.cas.services;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.util.RegexUtils;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
@@ -42,18 +40,13 @@ public class RegexRegisteredService extends AbstractRegisteredService {
     @Override
     public boolean matches(final String serviceId) {
         if (this.servicePattern == null) {
-            final Optional<Pattern> parsedPattern = RegexUtils.createPattern(this.serviceId);
-            if (parsedPattern.isPresent()) {
-                this.servicePattern = parsedPattern.get();
-            }
+            this.servicePattern = RegexUtils.createPattern(this.serviceId);
         }
-        return StringUtils.isNotBlank(serviceId) && this.servicePattern != null
-                && this.servicePattern.matcher(serviceId).matches();
+        return this.servicePattern.matcher(serviceId).matches();
     }
 
     @Override
     protected AbstractRegisteredService newInstance() {
         return new RegexRegisteredService();
     }
-    
 }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractRegisteredServiceTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractRegisteredServiceTests.java
@@ -178,4 +178,14 @@ public class AbstractRegisteredServiceTests {
         final RegisteredService svc2 = svc1.clone();
         assertEquals(svc1, svc2);
     }
+
+    @Test
+    public void verifyServiceWithInvalidIdStillHasTheSameIdAfterCallingMatches() throws Exception {
+        final String invalidId = "***";
+        final AbstractRegisteredService service = RegisteredServiceTestUtils.getRegisteredService(invalidId);
+
+        service.matches("notRelevant");
+
+        assertEquals(service.getServiceId(), invalidId);
+    }
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
@@ -45,7 +45,8 @@ public final class RegexUtils {
      * case insensitive.
      *
      * @param pattern the pattern, may not be null.
-     * @return the pattern or empty.
+     * @return the pattern or or {@link RegexUtils#MATCH_NOTHING_PATTERN}
+     * if pattern is null or invalid.
      */
     public static Pattern createPattern(final String pattern) {
         return createPattern(pattern, Pattern.CASE_INSENSITIVE);
@@ -63,13 +64,22 @@ public final class RegexUtils {
         return createPattern(pattern, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
     }
 
+    /**
+     * Creates the pattern with the given flags.
+     *
+     * @param pattern the pattern, may be null.
+     * @return the compiled pattern or {@link RegexUtils#MATCH_NOTHING_PATTERN}
+     * if pattern is null or invalid.
+     */
     private static Pattern createPattern(final String pattern, final int flags) {
         if (pattern == null) {
+            LOGGER.debug("Pattern {} can't be null", pattern);
             return MATCH_NOTHING_PATTERN;
         }
         try {
             return Pattern.compile(pattern, flags);
         } catch (final PatternSyntaxException exception) {
+            LOGGER.debug("Pattern {} is not a valid regex.", pattern);
             return MATCH_NOTHING_PATTERN;
         }
     }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
@@ -1,8 +1,5 @@
 package org.apereo.cas.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collection;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -15,7 +12,6 @@ import java.util.stream.Collectors;
  * @since 5.0.0
  */
 public final class RegexUtils {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RegexUtils.class);
 
     private RegexUtils() {}
 
@@ -26,16 +22,7 @@ public final class RegexUtils {
      * @return whether this is a valid regex or not
      */
     public static boolean isValidRegex(final String pattern) {
-        try {
-            if (pattern == null) {
-                throw new IllegalArgumentException("Pattern cannot be null");
-            }
-            LOGGER.debug("Pattern {} is a valid regex.", Pattern.compile(pattern).pattern());
-            return true;
-        } catch (final Exception exception) {
-            LOGGER.debug("Pattern {} is not a valid regex.", pattern);
-        }
-        return false;
+        return pattern != null;
     }
 
     /**
@@ -49,7 +36,6 @@ public final class RegexUtils {
         if (RegexUtils.isValidRegex(pattern)) {
             return Optional.of(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
         }
-
         return Optional.empty();
     }
     

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
@@ -1,7 +1,11 @@
 package org.apereo.cas.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 /**
@@ -12,6 +16,7 @@ import java.util.stream.Collectors;
  */
 public final class RegexUtils {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegexUtils.class);
     private static final Pattern MATCH_NOTHING_PATTERN = Pattern.compile("a^");
 
     private RegexUtils() {}
@@ -23,7 +28,15 @@ public final class RegexUtils {
      * @return whether this is a valid regex or not
      */
     public static boolean isValidRegex(final String pattern) {
-        return pattern != null;
+        try {
+            if (pattern != null) {
+                Pattern.compile(pattern).pattern();
+                return true;
+            }
+        } catch (final PatternSyntaxException exception) {
+            LOGGER.debug("Pattern {} is not a valid regex.", pattern);
+        }
+        return false;
     }
 
     /**

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
@@ -16,8 +16,9 @@ import java.util.stream.Collectors;
  */
 public final class RegexUtils {
 
+    public static final Pattern MATCH_NOTHING_PATTERN = Pattern.compile("a^");
+
     private static final Logger LOGGER = LoggerFactory.getLogger(RegexUtils.class);
-    private static final Pattern MATCH_NOTHING_PATTERN = Pattern.compile("a^");
 
     private RegexUtils() {}
 
@@ -30,7 +31,7 @@ public final class RegexUtils {
     public static boolean isValidRegex(final String pattern) {
         try {
             if (pattern != null) {
-                Pattern.compile(pattern).pattern();
+                Pattern.compile(pattern);
                 return true;
             }
         } catch (final PatternSyntaxException exception) {
@@ -47,10 +48,7 @@ public final class RegexUtils {
      * @return the pattern or empty.
      */
     public static Pattern createPattern(final String pattern) {
-        if (RegexUtils.isValidRegex(pattern)) {
-            return Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
-        }
-        return MATCH_NOTHING_PATTERN;
+        return createPattern(pattern, Pattern.CASE_INSENSITIVE);
     }
     
     /**
@@ -62,9 +60,17 @@ public final class RegexUtils {
      */
     public static Pattern concatenate(final Collection<String> requiredValues, final boolean caseInsensitive) {
         final String pattern = requiredValues.stream().collect(Collectors.joining("|", "(", ")"));
-        if (isValidRegex(pattern)) {
-            return Pattern.compile(pattern, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
+        return createPattern(pattern, caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
+    }
+
+    private static Pattern createPattern(final String pattern, final int flags) {
+        if (pattern == null) {
+            return MATCH_NOTHING_PATTERN;
         }
-        return null;
+        try {
+            return Pattern.compile(pattern, flags);
+        } catch (final PatternSyntaxException exception) {
+            return MATCH_NOTHING_PATTERN;
+        }
     }
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RegexUtils.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.util;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -12,6 +11,8 @@ import java.util.stream.Collectors;
  * @since 5.0.0
  */
 public final class RegexUtils {
+
+    private static final Pattern MATCH_NOTHING_PATTERN = Pattern.compile("a^");
 
     private RegexUtils() {}
 
@@ -30,13 +31,13 @@ public final class RegexUtils {
      * case insensitive.
      *
      * @param pattern the pattern, may not be null.
-     * @return the pattern or empty. 
+     * @return the pattern or empty.
      */
-    public static Optional<Pattern> createPattern(final String pattern) {
+    public static Pattern createPattern(final String pattern) {
         if (RegexUtils.isValidRegex(pattern)) {
-            return Optional.of(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
+            return Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
         }
-        return Optional.empty();
+        return MATCH_NOTHING_PATTERN;
     }
     
     /**

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTest.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTest.java
@@ -8,8 +8,15 @@ public class RegexUtilsTest {
 
     @Test
     public void verifyNotValidRegex() throws Exception {
-        String notValidRegex = "$$$$";
+        String notValidRegex = "***";
 
         assertFalse(RegexUtils.isValidRegex(notValidRegex));
+    }
+
+    @Test
+    public void verifyNullRegex() throws Exception {
+        String nullRegex = null;
+
+        assertFalse(RegexUtils.isValidRegex(nullRegex));
     }
 }

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTest.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTest.java
@@ -1,0 +1,15 @@
+package org.apereo.cas.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RegexUtilsTest {
+
+    @Test
+    public void verifyNotValidRegex() throws Exception {
+        String notValidRegex = "$$$$";
+
+        assertFalse(RegexUtils.isValidRegex(notValidRegex));
+    }
+}

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTests.java
@@ -4,18 +4,24 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class RegexUtilsTest {
+/**
+ * Tests for {@link RegexUtils}
+ *
+ * @author David Rodriguez
+ * @since 5.0.0
+ */
+public class RegexUtilsTests {
 
     @Test
     public void verifyNotValidRegex() throws Exception {
-        String notValidRegex = "***";
+        final String notValidRegex = "***";
 
         assertFalse(RegexUtils.isValidRegex(notValidRegex));
     }
 
     @Test
     public void verifyNullRegex() throws Exception {
-        String nullRegex = null;
+        final String nullRegex = null;
 
         assertFalse(RegexUtils.isValidRegex(nullRegex));
     }

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTests.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.*;
  * Tests for {@link RegexUtils}
  *
  * @author David Rodriguez
- * @since 5.0.0
+ * @since 5.1.0
  */
 public class RegexUtilsTests {
 


### PR DESCRIPTION
This PR doesn't close any issue, it's just an improvement

- Return a pattern that matches nothing instead of an empty optional, so the rest of checks are not needed (null/present, blank serviceId, ...)
- Remove useless code, as it was just checking for null. Method maintained for future additions