### PR TITLE
Fix typo in CasOAuthConfiguration.java

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -381,8 +381,8 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "oauth20ValidationServiceSelectionStrategy")
-    public AuthenticationRequestServiceSelectionStrategy oauth20ValidationServiceSelectionStrategy() {
+    @ConditionalOnMissingBean(name = "oauth20AuthenticationRequestServiceSelectionStrategy")
+    public AuthenticationRequestServiceSelectionStrategy oauth20AuthenticationRequestServiceSelectionStrategy() {
         final OAuth20AuthenticationRequestServiceSelectionStrategy s = new OAuth20AuthenticationRequestServiceSelectionStrategy();
         s.setServicesManager(servicesManager);
         s.setWebApplicationServiceFactory(webApplicationServiceFactory);

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -422,6 +422,6 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
             servicesManager.load();
         }
 
-        this.authenticationRequestServiceSelectionStrategies.add(0, oauth20ValidationServiceSelectionStrategy());
+        this.authenticationRequestServiceSelectionStrategies.add(0, oauth20AuthenticationRequestServiceSelectionStrategy());
     }
 }


### PR DESCRIPTION
Ensure that you include the following:

- [X] Brief description of changes applied: fixed typo
- [X] Any documentation on how to configure, test: nothing to test
- [X] Any possible limitations, side effects, etc: none
<!--
Thanks for your contribution. 
-->

Seems like a typo, which will throw `No qualifying bean of type 'org.apereo.cas.validation.AuthenticationRequestServiceSelectionStrategy' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true), @org.springframework.beans.factory.annotation.Qualifier(value=oauth20AuthenticationRequestServiceSelectionStrategy)}` without context xml, which is used in tests-