### PR TITLE
This timeout expiration policy is never expiring.  It wasn't looking …

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/support/TimeoutExpirationPolicy.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/support/TimeoutExpirationPolicy.java
@@ -42,9 +42,12 @@ public class TimeoutExpirationPolicy extends AbstractCasExpirationPolicy {
 
     @Override
     public boolean isExpired(final TicketState ticketState) {
+        if (ticketState == null) {
+            return true;
+        }
         final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-        final ZonedDateTime expirationTime = now.plus(this.timeToKillInSeconds, ChronoUnit.SECONDS);
-        return ticketState == null || now.isAfter(expirationTime);
+        final ZonedDateTime expirationTime = ticketState.getLastTimeUsed().plus(this.timeToKillInSeconds, ChronoUnit.SECONDS);
+        return now.isAfter(expirationTime);
     }
 
     @Override


### PR DESCRIPTION
I didn't open an issue but this is an issue I encountered debugging TGT expiration. 

This timeout expiration policy is never expiring the TGT.  It wasn't looking at the ticket state last time used when trying to determine if the ticket expired.

I didn't update the test but if you look at the test it use a negative time to kill which is why either of these version passes.  Negative time to kill is in my opinion an unrealistic use case and might be a good idea to validate that constraint during the construction of TimeoutExpirationPolicy.