### PR TITLE
ticketGrantingTicketsCache inherits from abstractTicketCache

### DIFF
--- a/cas-server-integration-ehcache/src/main/resources/META-INF/spring/ehcache-ticket-registry.xml
+++ b/cas-server-integration-ehcache/src/main/resources/META-INF/spring/ehcache-ticket-registry.xml
@@ -46,7 +46,8 @@
         <property name="timeToLive" value="${ehcache.cache.st.timeAlive:300}" />
     </bean>
 
-    <bean id="ticketGrantingTicketsCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean">
+    <bean id="ticketGrantingTicketsCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
+          parent="abstractTicketCache">
         <property name="cacheName" value="${ehcache.cache.tgt.name:org.jasig.cas.ticket.TicketGrantingTicket}" />
         <property name="cacheEventListeners">
             <ref bean="ticketRMIAsynchronousCacheReplicator" />


### PR DESCRIPTION
Closes #2144

When using EhCache as Ticket Registry, ticketGrantingTicketsCache doesn't inherit from abstractTicketCache and the properties such as persitence, eviction policy, max elements hold in memory, etc, are not applied to TGT, resulting on heavy ticketing load server to SSO lifetime issue.
