### PR TITLE
Incorrect password submission is not detected via throttling

### DIFF
--- a/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.execution.RequestContext;
 
 import javax.servlet.http.HttpServletRequest;
@@ -85,8 +86,8 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
             return;
         }
 
-        // User successfully authenticated
-        if (SUCCESSFUL_AUTHENTICATION_EVENT.equals(context.getCurrentEvent().getId())) {
+        MutableAttributeMap<Object> flowScope = context.getFlowScope();
+        if (flowScope != null && "success".equals(flowScope.get("authenticationResult"))) {
             return;
         }
 

--- a/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -88,7 +88,7 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
             return;
         }
 
-        MutableAttributeMap<Object> flowScope = context.getFlowScope();
+        final MutableAttributeMap<Object> flowScope = context.getFlowScope();
         if (flowScope != null && SUCCESSFUL_AUTHENTICATION_EVENT.equals(flowScope.get(AUTHENTICATION_RESULT))) {
             return;
         }

--- a/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/cas-server-webapp-throttle/src/main/java/org/jasig/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -33,6 +33,8 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
 
     private static final String SUCCESSFUL_AUTHENTICATION_EVENT = "success";
 
+    private static final String AUTHENTICATION_RESULT = "authenticationResult";
+
     /** Logger object. **/
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -87,7 +89,7 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter exten
         }
 
         MutableAttributeMap<Object> flowScope = context.getFlowScope();
-        if (flowScope != null && "success".equals(flowScope.get("authenticationResult"))) {
+        if (flowScope != null && SUCCESSFUL_AUTHENTICATION_EVENT.equals(flowScope.get(AUTHENTICATION_RESULT))) {
             return;
         }
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -79,7 +79,8 @@
 
     <action-state id="realSubmit">
         <evaluate
-                expression="authenticationViaFormAction.submit(flowRequestContext, flowScope.credential, messageContext)"/>
+                expression="authenticationViaFormAction.submit(flowRequestContext, flowScope.credential, messageContext)"
+                result="flowScope.authenticationResult"/>
         <transition on="warn" to="warn"/>
         <!--
         To enable AUP workflows, replace the 'success' transition with the following:


### PR DESCRIPTION
Closes #2149

The result of the password submission is stored in the flowScope to be reused in the throttle submission handler.