### PR TITLE
Update SamlIdPMetadataUIAction.java

### DIFF
--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/flow/SamlIdPMetadataUIAction.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/flow/SamlIdPMetadataUIAction.java
@@ -39,7 +39,7 @@ public class SamlIdPMetadataUIAction extends AbstractAction {
     @Override
     protected Event doExecute(final RequestContext requestContext) throws Exception {
         Service service = WebUtils.getService(requestContext);
-        if (service != null) {
+        if (service != null && serviceSelectionStrategy.supports(service)) {
             service = serviceSelectionStrategy.resolveServiceFrom(service);
             final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
             RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);


### PR DESCRIPTION
avoid error when accessing a non-SamlRegisteredService
```
Caused by: java.util.NoSuchElementException: No value present
        at java.util.Optional.get(Optional.java:135) ~[?:1.8.0_92]
        at org.apereo.cas.support.saml.services.SamlIdPEntityIdAuthenticationRequestServiceSelectionStrategy.resolveServiceFrom(SamlIdPEntityIdAuthenticationRequestServiceSelectionStrategy.java:28) ~[cas-server-support-saml-idp-5.1.0-20161208.024739-99.jar:5.1.0-SNAPSHOT]
        at org.apereo.cas.support.saml.web.flow.SamlIdPMetadataUIAction.doExecute(SamlIdPMetadataUIAction.java:43) ~[classes/:5.1.0-SNAPSHOT]
        at org.springframework.webflow.action.AbstractAction.execute(AbstractAction.java:188) ~[spring-webflow-2.4.4.RELEASE.jar:2.4.4.RELEASE]
        at org.springframework.webflow.execution.ActionExecutor.execute(ActionExecutor.java:51) ~[spring-webflow-2.4.4.RELEASE.jar:2.4.4.RELEASE]
        ... 158 more
```