### PR TITLE
Do not call .value() method when comparing HttpStatus as they are enums

### DIFF
--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -38,24 +38,21 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
             final UsernamePasswordCredential creds = new UsernamePasswordCredential(c.getUsername(), c.getPassword());
             
             final ResponseEntity<SimplePrincipal> authenticationResponse = api.authenticate(creds);
-            if (authenticationResponse.getStatusCode().value() == HttpStatus.OK.value()) {
+            if (authenticationResponse.getStatusCode() == HttpStatus.OK) {
                 final SimplePrincipal principalFromRest = authenticationResponse.getBody();
                 if (principalFromRest == null || StringUtils.isBlank(principalFromRest.getId())) {
-                    throw new FailedLoginException("Could not determine authentication response from rest endpoint for "
-                            + c.getUsername());
+                    throw new FailedLoginException("Could not determine authentication response from rest endpoint for " + c.getUsername());
                 }
-                return createHandlerResult(c,
-                        this.principalFactory.createPrincipal(principalFromRest.getId()),
-                        new ArrayList<>());
+                return createHandlerResult(c, this.principalFactory.createPrincipal(principalFromRest.getId()), new ArrayList<>());
             }
         } catch (final HttpClientErrorException e) {
-            if (e.getStatusCode().value() == HttpStatus.FORBIDDEN.value()) {
+            if (e.getStatusCode() == HttpStatus.FORBIDDEN) {
                 throw new AccountDisabledException("Could not authenticate forbidden account for " + c.getUsername());
             }
-            if (e.getStatusCode().value() == HttpStatus.UNAUTHORIZED.value()) {
+            if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
                 throw new FailedLoginException("Could not authenticate account for " + c.getUsername());
             }
-            if (e.getStatusCode().value() == HttpStatus.NOT_FOUND.value()) {
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
                 throw new AccountNotFoundException("Could not locate account for " + c.getUsername());
             }
             throw new FailedLoginException("Rest endpoint returned an unknown status code "


### PR DESCRIPTION
Closes no issues

Changes:

- Don't call .value() method when comparing HttpStatus as they are enums