### PR TITLE
Replace RequestMapping with the equivalent Spring annotation

### DIFF
--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/adaptors/gauth/web/flow/rest/GoogleAuthenticatorQRGeneratorController.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/adaptors/gauth/web/flow/rest/GoogleAuthenticatorQRGeneratorController.java
@@ -6,14 +6,13 @@ import com.google.zxing.EncodeHintType;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.QRCodeWriter;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.awt.Color;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -36,7 +35,7 @@ public class GoogleAuthenticatorQRGeneratorController {
      * @param request  the request
      * @throws Exception the exception
      */
-    @RequestMapping(path= { "/gauth/qrgen" })
+    @GetMapping(path= { "/gauth/qrgen" })
     public void generate(final HttpServletResponse response, final HttpServletRequest request) throws Exception {
         response.setContentType("image/png");
         final String key = request.getParameter("key");

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20AuthorizeController.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20AuthorizeController.java
@@ -29,7 +29,7 @@ import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.CommonHelper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -76,7 +76,7 @@ public class OAuth20AuthorizeController extends BaseOAuthWrapperController {
      * @return the model and view
      * @throws Exception the exception
      */
-    @RequestMapping(path = OAuthConstants.BASE_OAUTH20_URL + '/' + OAuthConstants.AUTHORIZE_URL)
+    @GetMapping(path = OAuthConstants.BASE_OAUTH20_URL + '/' + OAuthConstants.AUTHORIZE_URL)
     public ModelAndView handleRequestInternal(final HttpServletRequest request, final HttpServletResponse response) throws Exception {
 
         final J2EContext context = new J2EContext(request, response);

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20ProfileController.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20ProfileController.java
@@ -18,7 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -55,7 +55,7 @@ public class OAuth20ProfileController extends BaseOAuthWrapperController {
      * @return the response entity
      * @throws Exception the exception
      */
-    @RequestMapping(path = OAuthConstants.BASE_OAUTH20_URL + '/' + OAuthConstants.PROFILE_URL, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(path = OAuthConstants.BASE_OAUTH20_URL + '/' + OAuthConstants.PROFILE_URL, produces = MediaType.APPLICATION_JSON_VALUE)
     protected ResponseEntity<String> handleRequestInternal(final HttpServletRequest request, final HttpServletResponse response) throws Exception {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         String accessToken = request.getParameter(OAuthConstants.ACCESS_TOKEN);

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/DashboardController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/DashboardController.java
@@ -10,7 +10,7 @@ import org.springframework.cloud.context.restart.RestartEndpoint;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -60,7 +60,7 @@ public class DashboardController {
      * @return the model and view
      * @throws Exception the exception
      */
-    @RequestMapping("/status/dashboard")
+    @GetMapping("/status/dashboard")
     protected ModelAndView handleRequestInternal(final HttpServletRequest request, final HttpServletResponse response)
             throws Exception {
         final Map<String, Object> model = new HashMap<>();


### PR DESCRIPTION
Closes #2189 

Changes:
- Replace ```@RequestMapping``` with the equivalent GET/POST Spring annotation

Note that the remaining ```@RequestMapping``` are used at class scope and can not be replaced.