### PR TITLE
Fix typo in Attribute-Resolution.md

### DIFF
--- a/docs/cas-server-documentation/integration/Attribute-Resolution.md
+++ b/docs/cas-server-documentation/integration/Attribute-Resolution.md
@@ -7,7 +7,7 @@ title: CAS - Attribute Resolution
 
 Attribute resolution strategies are controlled by
 the [Person Directory project](https://github.com/apereo/person-directory).
-The Person Directory dependency is automatically bundled with the CAS server. Therefor,
+The Person Directory dependency is automatically bundled with the CAS server. Therefore,
 declaring an additional dependency will not be required.
 This Person Directory project supports both LDAP and JDBC attribute resolution,
 caching, attribute aggregation from multiple attribute sources, etc.


### PR DESCRIPTION

Add missing "e" to the end of "Therefor" in first paragraph.