### PR TITLE
Replacing Guava with java collections

### DIFF
--- a/support/cas-server-support-trusted-mfa-jdbc/src/main/java/org/apereo/cas/trusted/authentication/storage/JpaMultifactorAuthenticationTrustStorage.java
+++ b/support/cas-server-support-trusted-mfa-jdbc/src/main/java/org/apereo/cas/trusted/authentication/storage/JpaMultifactorAuthenticationTrustStorage.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.trusted.authentication.storage;
 
-import com.google.common.collect.Sets;
 import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustRecord;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +8,8 @@ import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -58,11 +59,11 @@ public class JpaMultifactorAuthenticationTrustStorage extends BaseMultifactorAut
             final List<MultifactorAuthenticationTrustRecord> results =
                     this.entityManager.createQuery("SELECT r FROM " + TABLE_NAME + " r where r.date >= :date",
                             MultifactorAuthenticationTrustRecord.class).setParameter("date", onOrAfterDate).getResultList();
-            return Sets.newHashSet(results);
+            return new HashSet<>(results);
         } catch (final NoResultException e) {
             logger.info("No trusted authentication records could be found for {}", onOrAfterDate);
         }
-        return Sets.newHashSet();
+        return Collections.emptySet();
     }
 
     @Override
@@ -71,11 +72,11 @@ public class JpaMultifactorAuthenticationTrustStorage extends BaseMultifactorAut
             final List<MultifactorAuthenticationTrustRecord> results =
                     this.entityManager.createQuery("SELECT r FROM " + TABLE_NAME + " r where r.principal = :principal",
                             MultifactorAuthenticationTrustRecord.class).setParameter("principal", principal).getResultList();
-            return Sets.newHashSet(results);
+            return new HashSet<>(results);
         } catch (final NoResultException e) {
             logger.info("No trusted authentication records could be found for {}", principal);
         }
-        return Sets.newHashSet();
+        return Collections.emptySet();
     }
 
     @Override

--- a/support/cas-server-support-trusted-mfa-mongo/src/main/java/org/apereo/cas/trusted/authentication/storage/MongoDbMultifactorAuthenticationTrustStorage.java
+++ b/support/cas-server-support-trusted-mfa-mongo/src/main/java/org/apereo/cas/trusted/authentication/storage/MongoDbMultifactorAuthenticationTrustStorage.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.trusted.authentication.storage;
 
-import com.google.common.collect.Sets;
 import com.mongodb.WriteResult;
 import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustRecord;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -11,6 +10,7 @@ import org.springframework.util.Assert;
 import javax.annotation.PostConstruct;
 import javax.persistence.NoResultException;
 import java.time.LocalDate;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -92,7 +92,7 @@ public class MongoDbMultifactorAuthenticationTrustStorage extends BaseMultifacto
         query.addCriteria(Criteria.where("date").gte(onOrAfterDate));
         final List<MultifactorAuthenticationTrustRecord> results =
                 this.mongoTemplate.find(query, MultifactorAuthenticationTrustRecord.class, this.collectionName);
-        return Sets.newHashSet(results);
+        return new HashSet<>(results);
     }
 
     @Override
@@ -101,7 +101,7 @@ public class MongoDbMultifactorAuthenticationTrustStorage extends BaseMultifacto
         query.addCriteria(Criteria.where("principal").is(principal));
         final List<MultifactorAuthenticationTrustRecord> results =
                 this.mongoTemplate.find(query, MultifactorAuthenticationTrustRecord.class, this.collectionName);
-        return Sets.newHashSet(results);
+        return new HashSet<>(results);
     }
 
     @Override

--- a/support/cas-server-support-trusted-mfa-rest/src/main/java/org/apereo/cas/trusted/authentication/storage/RestMultifactorAuthenticationTrustStorage.java
+++ b/support/cas-server-support-trusted-mfa-rest/src/main/java/org/apereo/cas/trusted/authentication/storage/RestMultifactorAuthenticationTrustStorage.java
@@ -1,13 +1,15 @@
 package org.apereo.cas.trusted.authentication.storage;
 
-import com.google.common.collect.Sets;
 import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustRecord;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This is {@link RestMultifactorAuthenticationTrustStorage}.
@@ -63,9 +65,9 @@ public class RestMultifactorAuthenticationTrustStorage extends BaseMultifactorAu
                 restTemplate.getForEntity(url, MultifactorAuthenticationTrustRecord[].class);
         if (responseEntity.getStatusCode() == HttpStatus.OK) {
             final MultifactorAuthenticationTrustRecord[] results = responseEntity.getBody();
-            return Sets.newHashSet(results);
+            return Stream.of(results).collect(Collectors.toSet());
         }
 
-        return Sets.newHashSet();
+        return Collections.emptySet();
     }
 }


### PR DESCRIPTION
Part of #2212

replacing Guava in  modules:
- Cas-server-support-trusted-mfa-jdbc
- Cas-server-support-trusted-mfa-mongo
- Cas-server-support-trusted-mfa-rest
