### PR TITLE
Updated Documentation to match Spring Cloud Native profile behavior

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Management.md
+++ b/docs/cas-server-documentation/installation/Configuration-Management.md
@@ -98,17 +98,20 @@ By default, all CAS settings and configuration is controlled via the embedded `a
 
 ### Native
 
-CAS is also configured to load `*.properties` or `*.yml` files from an external location that is `/etc/cas/config`. 
+CAS is also configured to load a `cas.properties` or `cas.yml` file from an external location that is `/etc/cas/config`. 
 This location is constantly monitored by CAS to detect external changes. Note that this location simply needs to 
-exist, and does not require any special permissions
-or structure. The names of the configuration files that go inside this directory also do
- not matter, and there can be many. 
+exist, and does not require any special permissions or structure. The name of the configuration file that goes inside 
+this directory needs to match the `spring.application.name` (i.e. cas.properties). If you want to use additional configuration 
+files they need to have the form application-\<profile\>.properties or  application-\<profile\>.yml. A file named 
+application.properties or application.yml will be included by default. The profile specific files can be activated by 
+using the `spring.profiles.include` configuration option.
 
 The configuration of this behavior is controlled via the `src/main/resources/bootstrap.properties` file:
 
 ```properties
 spring.profiles.active=native
 spring.cloud.config.server.native.searchLocations=file:///etc/cas/config
+spring.profiles.include=profile1,profile2
 ```
 
 An example of an external `.properties` file hosted by an external location follows:


### PR DESCRIPTION
Duplicate of #2208 for the 5.0.x branch

- [x] Brief description of changes applied

An update to the spring native profile documentation to reflect the actual behavior of spring cloud using that profile
