### PR TITLE
Fix JDBC authentication using encoded passwords

### DIFF
--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
@@ -60,7 +60,7 @@ public abstract class AbstractUsernamePasswordAuthenticationHandler extends Abst
         }
 
         userPass.setUsername(transformedUsername);
-        userPass.setPassword(this.passwordEncoder.encode(userPass.getPassword()));
+        userPass.setPassword(transformedPsw);
 
         return authenticateUsernamePasswordInternal(userPass,originalUserPass.getPassword());
     }

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/handler/support/AbstractUsernamePasswordAuthenticationHandler.java
@@ -38,7 +38,8 @@ public abstract class AbstractUsernamePasswordAuthenticationHandler extends Abst
     @Override
     protected HandlerResult doAuthentication(final Credential credential) throws GeneralSecurityException, PreventedException {
 
-        final UsernamePasswordCredential userPass = (UsernamePasswordCredential) credential;
+        final UsernamePasswordCredential originalUserPass = (UsernamePasswordCredential) credential;
+        final UsernamePasswordCredential userPass = new UsernamePasswordCredential(originalUserPass.getUsername(), originalUserPass.getPassword());
 
         if (StringUtils.isBlank(userPass.getUsername())) {
             throw new AccountNotFoundException("Username is null.");
@@ -61,7 +62,7 @@ public abstract class AbstractUsernamePasswordAuthenticationHandler extends Abst
         userPass.setUsername(transformedUsername);
         userPass.setPassword(this.passwordEncoder.encode(userPass.getPassword()));
 
-        return authenticateUsernamePasswordInternal(userPass,((UsernamePasswordCredential) credential).getPassword());
+        return authenticateUsernamePasswordInternal(userPass,originalUserPass.getPassword());
     }
 
     /**


### PR DESCRIPTION
Closes #2229 

Main change: Ensure that each authentication handler copies the incoming credential object, so that the original credentials aren't lost. Required for authenticating bcrypt passwords, and also prevents one authentication handler's encoder from mangling the password that the next handler needs to use.

Also including a small optimization to encode the password only once in the handler. Previous behaviour was to encode the password, check that the encoded form wasn't blank, and encode the original password again. Not a big deal for fast encoders but makes a big difference for slow ones like bcrypt.