### PR TITLE
Correct Maven snippet in installation guide for Ehcache ticket registry support

### DIFF
--- a/docs/cas-server-documentation/installation/Ehcache-Ticket-Registry.md
+++ b/docs/cas-server-documentation/installation/Ehcache-Ticket-Registry.md
@@ -9,7 +9,7 @@ Ehcache integration is enabled by including the following dependency in the WAR 
 ```xml
 <dependency>
      <groupId>org.apereo.cas</groupId>
-     <artifactId>cas-server-support-ehcache</artifactId>
+     <artifactId>cas-server-support-ehcache-ticket-registry</artifactId>
      <version>${cas.version}</version>
 </dependency>
 ```


### PR DESCRIPTION
Looks like original snippet was copied from one of 4.x branches, but there is no such module in CAS 5.0.x branch so I have corrected the doc to reflect current structure of CAS 5.0.x modules for Ehcache support.