### PR TITLE
CAS-2249 Add mapping to handle Active Directory Account Expired Error

### DIFF
--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authentication/support/DefaultAccountStateHandler.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authentication/support/DefaultAccountStateHandler.java
@@ -69,6 +69,7 @@ public class DefaultAccountStateHandler implements AccountStateHandler {
         this.errorMap.put(ActiveDirectoryAccountState.Error.INVALID_WORKSTATION, new InvalidLoginLocationException());
         this.errorMap.put(ActiveDirectoryAccountState.Error.PASSWORD_MUST_CHANGE, new AccountPasswordMustChangeException());
         this.errorMap.put(ActiveDirectoryAccountState.Error.PASSWORD_EXPIRED, new CredentialExpiredException());
+        this.errorMap.put(ActiveDirectoryAccountState.Error.ACCOUNT_EXPIRED, new AccountExpiredException());
         this.errorMap.put(EDirectoryAccountState.Error.ACCOUNT_EXPIRED, new AccountExpiredException());
         this.errorMap.put(EDirectoryAccountState.Error.LOGIN_LOCKOUT, new AccountLockedException());
         this.errorMap.put(EDirectoryAccountState.Error.LOGIN_TIME_LIMITED, new InvalidLoginTimeException());


### PR DESCRIPTION
Issue #2249 

1. Updated support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authentication/support/DefaultAccountStateHandler.java to map ActiveDirectoryAccountState.Error.ACCOUNT_EXPIRED to "new AccountExpiredException()".