### PR TITLE
Call matches() for supporting non-idempotent password encoding in FileAuthenticationHandler

### DIFF
--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/FileAuthenticationHandler.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/FileAuthenticationHandler.java
@@ -44,22 +44,25 @@ public class FileAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     }
 
     @Override
-    protected HandlerResult authenticateUsernamePasswordInternal(final UsernamePasswordCredential credential)
+    protected final HandlerResult authenticateUsernamePasswordInternal(final UsernamePasswordCredential credential)
             throws GeneralSecurityException, PreventedException {
+        throw new AssertionError();
+    }
 
+    @Override
+    protected HandlerResult authenticateUsernamePasswordInternal(UsernamePasswordCredential transformedCredential, String originalPassword)
+            throws GeneralSecurityException, PreventedException {
         try {
             if (this.fileName == null) {
                 throw new FileNotFoundException("Filename does not exist");
             }
-
-            final String username = credential.getUsername();
+            final String username = transformedCredential.getUsername();
             final String passwordOnRecord = getPasswordOnRecord(username);
             if (StringUtils.isBlank(passwordOnRecord)) {
                 throw new AccountNotFoundException(username + " not found in backing file.");
             }
-            final String password = credential.getPassword();
-            if (StringUtils.equals(password, passwordOnRecord)) {
-                return createHandlerResult(credential, this.principalFactory.createPrincipal(username), null);
+            if (matches(originalPassword, passwordOnRecord)) {
+                return createHandlerResult(transformedCredential, this.principalFactory.createPrincipal(username), null);
             }
         } catch (final IOException e) {
             throw new PreventedException("IO error reading backing file", e);


### PR DESCRIPTION
Related to https://github.com/joemccall86/cas/commit/711dced9f7eb1888e4145ebc3c3600bfb59b0cd7 and https://github.com/apereo/cas/pull/1579
