### PR TITLE
Make possible to use BCRypt encoder without "secret".

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
@@ -254,16 +254,16 @@ public final class Beans {
                 LOGGER.debug("Creating standard password encoder with the secret defined in the configuration");
                 return new StandardPasswordEncoder(properties.getSecret());
             case BCRYPT:
-			LOGGER.debug("Creating BCRYPT password encoder given the strength [{}] and secret in the configuration",
-			        properties.getStrength());
-			if (properties.getSecret() == null || properties.getSecret().isEmpty()) {
-				LOGGER.debug("BCRYPT without secret word");
-				return new BCryptPasswordEncoder(properties.getStrength());
-			} else {
-				LOGGER.debug("BCRYPT uses secret word");
-				return new BCryptPasswordEncoder(properties.getStrength(),
-						new SecureRandom(properties.getSecret().getBytes(StandardCharsets.UTF_8)));
-			}
+            LOGGER.debug("Creating BCRYPT password encoder given the strength [{}] and secret in the configuration",
+                    properties.getStrength());
+            if (properties.getSecret() == null || properties.getSecret().isEmpty()) {
+                LOGGER.debug("BCRYPT without secret word");
+	            return new BCryptPasswordEncoder(properties.getStrength());
+	        } else {
+	            LOGGER.debug("BCRYPT uses secret word");
+	            return new BCryptPasswordEncoder(properties.getStrength(),
+	                    new SecureRandom(properties.getSecret().getBytes(StandardCharsets.UTF_8)));
+	       }
             case NONE:
             default:
                 LOGGER.debug("No password encoder shall be created");

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
@@ -254,10 +254,16 @@ public final class Beans {
                 LOGGER.debug("Creating standard password encoder with the secret defined in the configuration");
                 return new StandardPasswordEncoder(properties.getSecret());
             case BCRYPT:
-                LOGGER.debug("Creating BCRYPT password encoder given the strength [{}] and secret in the configuration",
-                        properties.getStrength());
-                return new BCryptPasswordEncoder(properties.getStrength(),
-                        new SecureRandom(properties.getSecret().getBytes(StandardCharsets.UTF_8)));
+			LOGGER.debug("Creating BCRYPT password encoder given the strength [{}] and secret in the configuration",
+			        properties.getStrength());
+			if (properties.getSecret() == null || properties.getSecret().isEmpty()) {
+				LOGGER.debug("BCRYPT without secret word");
+				return new BCryptPasswordEncoder(properties.getStrength());
+			} else {
+				LOGGER.debug("BCRYPT uses secret word");
+				return new BCryptPasswordEncoder(properties.getStrength(),
+						new SecureRandom(properties.getSecret().getBytes(StandardCharsets.UTF_8)));
+			}
             case NONE:
             default:
                 LOGGER.debug("No password encoder shall be created");


### PR DESCRIPTION
When we have tried to use BCRYPT password encoder without any passwordEncoder.secret, than we got null pointer exception, however, Springs BcryptPasswordEncoder makes it possible to create an object without secure random. 

This change checks if any secret is set, and only tries to create secure random from the secret, if that exists.