### PR TITLE
add user facing translations for 5.0.x version

### DIFF
--- a/webapp/cas-server-webapp/src/main/resources/messages_sk.properties
+++ b/webapp/cas-server-webapp/src/main/resources/messages_sk.properties
@@ -8,12 +8,18 @@ screen.welcome.label.password.accesskey=h
 screen.welcome.label.publicstation=Som na verejnej pracovnej stanici.
 screen.welcome.label.warn=<span class\="accesskey">V</span>arovať pred prihlásením do iných služieb.
 screen.welcome.label.warn.accesskey=v
+screen.welcome.label.warnremove=Neupozornovať opakovane
 screen.welcome.button.login=PRIHLÁSIŤ
+screen.welcome.button.loginwip=Overenie hesla...
 screen.welcome.button.clear=VYMAZAŤ
 
+screen.welcome.label.loginwith=Alebo sa prihláste pomocou:
 screen.cookies.disabled.title=Cookies v prehliadači sú zakázané
 screen.cookies.disabled.message=Váš browser nepodporuje cookies. Single Sign On NEBUDE FUNGOVAŤ.
 
+screen.pm.button.submit=OK
+screen.pm.button.cancel=ZRUŠIŤ
+screen.pm.button.resetPassword=Zmena hesla
 screen.aup.button.accept=PRIJAŤ
 screen.aup.button.cancel=ZRUŠIŤ
 
@@ -22,8 +28,10 @@ screen.nonsecure.message=Pristupujete k serveru CAS cez nezabezpečené spojenie
 
 logo.title=Prechod na domovskú stránku
 copyright=Copyright &copy; 2005&ndash;2015 Apereo, Inc.
-screen.capslock.on = Klávesa CAPSLOCK je zapnutá\!
+screen.capslock.on = Klávesa CAPSLOCK je zapnutá!
 
+screen.button.continue=Pokračovať
+screen.post.response.message=Budete presmerovaní na {0}.
 # Remember-Me Authentication
 screen.rememberme.checkbox.title=Zapamätať si ma
 
@@ -35,6 +43,7 @@ AbstractAccessDecisionManager.accessDenied=Nie ste oprávnený k prístupu k tom
 #Confirmation Screen Messages
 screen.confirmation.message=Kliknite <a href\="{0}">sem</a> pre prístup k aplikácii.
 
+screen.authentication.warning=Prihlásenie sa podarilo s varovaním
 #Generic Success Screen Messages
 screen.success.header=Prihlásenie bolo úspešné
 screen.success.success= {0}, práve ste sa úspešne prihlásili do CAS.
@@ -42,7 +51,7 @@ screen.success.security=Ak ste ukončili prácu, z bezpečnostných dôvodov pro
 
 #Logout Screen Messages
 screen.logout.header=Odhlásenie bolo úspešné
-screen.logout.success=Úspešne ste sa odhlásili zo služby centrálnej autentifikácie.
+screen.logout.success=Úspešne ste sa odhlásili z CAS. Môžete sa <a href="login">prihlásiť</a> znova. 
 screen.logout.security=Z bezpečnostných dôvodov ukončite prácu s prehliadačom.
 screen.logout.redirect=Služba, z ktorej ste prišli poskytla <a href\="{0}">linku, ktorú môžete nasledovať kliknutím sem</a>.
 
@@ -50,10 +59,11 @@ screen.service.sso.error.header=Na prístup k službe je nutná opakovaná auten
 screen.service.sso.error.message=Pokúsili ste sa o prístup k službe, ktorá vyžaduje autentifkáciu bez opätovnej autentifikácie.  Prosím skúste sa <a href\="{0}">autentifikovať znovu</a>.
 screen.service.required.message=Pokúsili ste sa autentifikovať bez zadania cieľovej aplikácie. Prosím preverte požiadavku a skúste znovu.
 
-error.invalid.loginticket=Nie je možné odoslať opakovanú požiadavku na formulár, ktorý už bol odoslaný.
+captchaError=reCAPTCHA kontrola bola neúspešná.
 username.required=Meno používateľa je povinné pole.
 password.required=Heslo je povinné pole.
 
+confirmedPassword.required=Heslo je potrebné zadať znova.
 # Authentication failure messages
 authenticationFailure.AccountDisabledException=Tento používateľský účet bol deaktivovaný.
 authenticationFailure.AccountLockedException=Tento používateľský účet bol uzamknutý.
@@ -62,6 +72,8 @@ authenticationFailure.InvalidLoginLocationException=Z tejto pracovnej stanice ni
 authenticationFailure.InvalidLoginTimeException=Váš účet má v tomto čase zakázaný prístup.
 authenticationFailure.AccountNotFoundException=Nesprávne používateľské meno alebo heslo.
 authenticationFailure.FailedLoginException=Nesprávne používateľské meno alebo heslo.
+authenticationFailure.AccountPasswordMustChangeException=Vaše heslo je už neplatné a musíte ho zmeniť.
+authenticationFailure.UnauthorizedServiceForPrincipalException=Prístup na službu nemáte povolený.
 authenticationFailure.UNKNOWN=Nesprávne používateľské meno alebo heslo.
 
 INVALID_REQUEST_PROXY=Vaša požiadavka je nekorektne formulovaná. Prosím uistite sa že všetky požadované parametre sú v požiadavke a sú správne formátované.
@@ -89,17 +101,25 @@ screen.accountlocked.message=Prosím kontaktujte systémového administrátora n
 screen.expiredpass.heading=Vaše heslo expirovalo.
 screen.expiredpass.message=Prosím <a href\="{0}">zmeňte svoje heslo</a>.
 screen.mustchangepass.heading=Je nutné zmeniť Vaše heslo.
-screen.mustchangepass.message=Prosím <a href\="{0}">zmeňte svoje heslo</a>.
-screen.badhours.heading=Váš používateľský účet je v tomto momente zakázaný.
+screen.mustchangepass.message=Prosím <a href="{0}">zmeňte svoje heslo</a>.
+screen.badhours.heading=Váš účet v tomto čase nemá povolený prístup.
 screen.badhours.message=Prosím skúste znovu neskôr.
+screen.authnblocked.heading=Pokus o prihlásenie bol zamietnutý.
+screen.authnblocked.message=Váš pokus o prihlásenie z aktuálneho zariadenia nie je dôveryhodný a povolený. 
 screen.badworkstation.heading=Nie je možné sa prihlásiť z tejto pracovnej stanice.
 screen.badworkstation.message=Na opätovné získanie prístupu prosím kontaktujte administrátora.
 
+screen.authentication.gauth.register=Vaše konto nie je registrované. Použite nastavenia nižšie pre registráciu zariadenia v CAS.
+screen.authentication.gauth.key=Tajný kód pre registráciu je {0}
 # OAuth
-screen.oauth.confirm.header=Authorizácia
-screen.oauth.confirm.message=Chete povoliť prístup k Vášmu kompletnému profilu pre "{0}" ?
+screen.oauth.confirm.header=Autorizácia
+screen.oauth.confirm.message=Chcete povoliť prístup k Vášmu kompletnému profilu pre "{0}" ?
 screen.oauth.confirm.allow=Povoliť
 
+cas.oauth.confirm.pagetitle=Povoľte prístup
 # Unavailable
-screen.unavailable.heading=CAS je nedostupný
+screen.unavailable.heading=CAS nie je schopný spracovať požiadavku: "{0}:{1}"
 screen.unavailable.message=Pri spracovaní požiadavky nastala chyba. Prosím informujte podporu alebo skúste znovu.
+cas.login.pagetitle=Prihlásenie
+cas.login.resources.header=Odkazy na CAS zdroje
+cas.login.resources.wiki=Dokumentácia


### PR DESCRIPTION
missing translations to Slovak (most of user area) are provided
messages in management area are intentionally left untranslated


