### PR TITLE
Don't enable the RADIUS auth handler if it has no server address

### DIFF
--- a/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
+++ b/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.config;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.adaptors.radius.JRadiusServerImpl;
 import org.apereo.cas.adaptors.radius.RadiusClientFactory;
 import org.apereo.cas.adaptors.radius.RadiusProtocol;
@@ -119,7 +120,9 @@ public class RadiusConfiguration {
 
     @PostConstruct
     protected void initializeRootApplicationContext() {
-        authenticationHandlersResolvers.put(radiusAuthenticationHandler(), null);
+        if (StringUtils.isNotBlank(casProperties.getAuthn().getRadius().getClient().getInetAddress())) {
+            authenticationHandlersResolvers.put(radiusAuthenticationHandler(), null);
+        }
     }
 }
 


### PR DESCRIPTION
Currently in 5.0.x there's no way to include cas-server-support-radius while leaving it disabled. If the properties aren't configured, this makes login hang indefinitely because the handler gets set up with a default address of localhost and 0 timeout (unless there just happens to be a RADIUS server listening there with the same secret).

Even if I specify cas.authn.radius.client.inetAddress= (no value), it eventually gets passed to a getAllByName method that interprets an empty value as a special case and returns a loopback address.

This change follows the pattern I see in several other handler configuration classes, where the handler isn't added to the handler map if some crucial value (here, the RADIUS server address) is blank.

I haven't changed the RadiusProperties class that sets the default address to localhost, so this change only makes a difference if the property cas.authn.radius.client.inetAddress is specified somewhere and set to be empty. Let me know if you think I should go further and remove that default value as well? Maybe better to save that for 5.1.x?

Test cases I've run through, with cas-server-support-radius built in:
cas.authn.radius.client.inetAddress not present in properties -> No change, will try to reach RADIUS server on localhost indefinitely
cas.authn.radius.client.inetAddress present and set to empty, before this change -> Also tries to reach localhost indefnitely
cas.authn.radius.client.inetAddress present and set to empty, after this change -> Doesn't attempt RADIUS auth
cas.authn.radius.client.inetAddress present and set non-empty -> No change, tries that server

I'm submitting for 5.0.x because I could really use this fix in 5.0.3. If this gets accepted I can port to master.