### PR TITLE
Patch for HZ Performance

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
@@ -87,4 +87,12 @@ public interface TicketRegistry {
      */
     long serviceTicketCount();
 
+    /**
+     * Computes the number of unique users with valid TGTs in CAS
+     *
+     * @return Number of unique users logged into CAS
+     */
+    long userCount();
+
+    Collection<Ticket> getTicketsByUser(String user);
 }

--- a/api/cas-server-core-api/src/main/java/org/apereo/cas/CentralAuthenticationService.java
+++ b/api/cas-server-core-api/src/main/java/org/apereo/cas/CentralAuthenticationService.java
@@ -11,6 +11,7 @@ import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.proxy.ProxyTicket;
+import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.validation.Assertion;
 
 import java.util.Collection;
@@ -111,6 +112,21 @@ public interface CentralAuthenticationService {
     Collection<Ticket> getTickets(Predicate<Ticket> predicate);
 
     /**
+     * Retrieve a collection of tickets from the underlying ticket registry.
+     * The retrieval operation must pass the predicate check that is solely
+     * used to filter the collection of tickets received. Implementations
+     * can use the predicate to request a collection of expired tickets,
+     * or tickets whose id matches a certain pattern, etc. The resulting
+     * collection will include ticktes that have been evaluated by the predicate.
+     *
+     * @param user the username to retrieve as regular expression
+     * @param predicate the predicate
+     * @return the tickets
+     * @since 5.1.0
+     */
+    Collection<Ticket> getTickets(String user, Predicate<Ticket> predicate);
+
+    /**
      * Grant a {@link ServiceTicket} that may be used to access the given service
      * by authenticating the given credentials.
      * The details of the security policy around credential authentication and the definition
@@ -186,4 +202,6 @@ public interface CentralAuthenticationService {
      */
     ProxyGrantingTicket createProxyGrantingTicket(String serviceTicketId, AuthenticationResult authenticationResult)
             throws AuthenticationException, AbstractTicketException;
+
+    TicketRegistry getTicketRegistry();
 }

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/MemoryMonitor.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/MemoryMonitor.java
@@ -34,13 +34,14 @@ public class MemoryMonitor implements Monitor<MemoryStatus> {
     @Override
     public MemoryStatus observe() {
         final StatusCode code;
-        final long free = Runtime.getRuntime().freeMemory();
-        final long total = Runtime.getRuntime().totalMemory();
+        final long used = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        final long total = Runtime.getRuntime().maxMemory();
+        final long free = total - used;
         if (free * PERCENTAGE_VALUE / total < this.freeMemoryWarnThreshold) {
             code = StatusCode.WARN;
         } else {
             code = StatusCode.OK;
         }
-        return new MemoryStatus(code, free, total);
+        return new MemoryStatus(code, free, total, used);
     }
 }

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/MemoryStatus.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/MemoryStatus.java
@@ -25,8 +25,11 @@ public class MemoryStatus extends Status {
      *
      * @see #getCode()
      */
-    public MemoryStatus(final StatusCode code, final long free, final long total) {
-        super(code, String.format("%.2fMB free, %.2fMB total.", free / BYTES_PER_MB, total / BYTES_PER_MB));
+    public MemoryStatus(final StatusCode code, final long free, final long total, final long used) {
+        super(code, String.format("%.2fMB free (%.2f%%), %.2fMB used, %.2fMB total.", free / BYTES_PER_MB,
+                                                                             (free * 100.0 / (double)total),
+                                                                             used / BYTES_PER_MB,
+                                                                             total / BYTES_PER_MB));
         this.freeMemory = free;
         this.totalMemory = total;
     }

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/MemoryStatus.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/MemoryStatus.java
@@ -27,7 +27,7 @@ public class MemoryStatus extends Status {
      */
     public MemoryStatus(final StatusCode code, final long free, final long total, final long used) {
         super(code, String.format("%.2fMB free (%.2f%%), %.2fMB used, %.2fMB total.", free / BYTES_PER_MB,
-                                                                             (free * 100.0 / (double)total),
+                                                                             free * 100.0 / (double)total,
                                                                              used / BYTES_PER_MB,
                                                                              total / BYTES_PER_MB));
         this.freeMemory = free;

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/SessionMonitor.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/SessionMonitor.java
@@ -37,6 +37,7 @@ public class SessionMonitor implements Monitor<SessionStatus> {
         try {
             final long sessionCount = this.registryState.sessionCount();
             final long ticketCount = this.registryState.serviceTicketCount();
+            final long userCount = this.registryState.userCount();
 
             if (sessionCount == Integer.MIN_VALUE || ticketCount == Integer.MIN_VALUE) {
                 return new SessionStatus(StatusCode.UNKNOWN,
@@ -63,6 +64,7 @@ public class SessionMonitor implements Monitor<SessionStatus> {
             } else {
                 msg.append(ticketCount).append(" service tickets.");
             }
+            msg.append(userCount).append(" unique users.");
             return new SessionStatus(code, msg.toString(), sessionCount, ticketCount);
         } catch (final Exception e) {
             return new SessionStatus(StatusCode.ERROR, e.getMessage());

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -279,7 +279,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
         return this.cipherExecutor != null && this.cipherExecutor.isEnabled();
     }
 
-    public Collection<Ticket> getTicketsByUser(String user) {
+    public Collection<Ticket> getTicketsByUser(final String user) {
         return Collections.EMPTY_LIST;
     }
 }

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -94,6 +95,13 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
                     this.getClass().getName(), t.getMessage(), Long.MIN_VALUE);
             return Long.MIN_VALUE;
         }
+    }
+
+    @Override
+    public long userCount() {
+        LOGGER.debug("userCount() operation is not implemented by the ticket registry instance {}. Returning unknown as {}",
+                this.getClass().getName(), Long.MIN_VALUE);
+        return Long.MIN_VALUE;
     }
 
     @Override
@@ -271,5 +279,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
         return this.cipherExecutor != null && this.cipherExecutor.isEnabled();
     }
 
-
+    public Collection<Ticket> getTicketsByUser(String user) {
+        return Collections.EMPTY_LIST;
+    }
 }

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistry.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistry.java
@@ -98,7 +98,7 @@ public class DefaultTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public Collection<Ticket> getTicketsByUser(String user) {
+    public Collection<Ticket> getTicketsByUser(final String user) {
         return Collections.unmodifiableCollection(this.cache.values());
     }
 

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistry.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistry.java
@@ -98,6 +98,13 @@ public class DefaultTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
+    public Collection<Ticket> getTicketsByUser(String user) {
+        return Collections.unmodifiableCollection(this.cache.values());
+    }
+
+
+
+    @Override
     public Ticket updateTicket(final Ticket ticket) {
         addTicket(ticket);
         return ticket;

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -30,9 +30,10 @@ public abstract class AbstractTicketRegistryTests {
     @Before
     public void setUp() throws Exception {
         this.ticketRegistry = this.getNewTicketRegistry();
-        for (final Ticket ticket : this.ticketRegistry.getTickets()) {
-            this.ticketRegistry.deleteTicket(ticket.getId());
-        }
+        this.ticketRegistry.deleteAll();
+        //for (final Ticket ticket : this.ticketRegistry.getTickets()) {
+        //    this.ticketRegistry.deleteTicket(ticket.getId());
+        //}
     }
 
     /**
@@ -92,10 +93,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyGetExistingTicketWithImproperClass() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            this.ticketRegistry.getTicket("TEST", ServiceTicket.class);
+            this.ticketRegistry.getTicket("TGT", ServiceTicket.class);
         } catch (final ClassCastException e) {
             return;
         }
@@ -149,10 +150,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyDeleteExistingTicket() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertSame(1, this.ticketRegistry.deleteTicket("TEST"));
+            assertSame(1, this.ticketRegistry.deleteTicket("TGT"));
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
         }
@@ -161,10 +162,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyDeleteNonExistingTicket() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertSame(0, this.ticketRegistry.deleteTicket("TEST1"));
+            assertSame(0, this.ticketRegistry.deleteTicket("TGT1"));
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -173,7 +174,7 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyDeleteNullTicket() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
             assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null) == 1);
@@ -196,9 +197,9 @@ public abstract class AbstractTicketRegistryTests {
         final Collection<Ticket> tickets = new ArrayList<>();
 
         for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
-            final TicketGrantingTicket ticketGrantingTicket = new TicketGrantingTicketImpl("TEST" + i,
+            final TicketGrantingTicket ticketGrantingTicket = new TicketGrantingTicketImpl("TGT" + i,
                     CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-            final ServiceTicket st = ticketGrantingTicket.grantServiceTicket("tests" + i,
+            final ServiceTicket st = ticketGrantingTicket.grantServiceTicket("ST" + i,
                     RegisteredServiceTestUtils.getService(),
                     new NeverExpiresExpirationPolicy(), false, true);
             tickets.add(ticketGrantingTicket);
@@ -211,6 +212,7 @@ public abstract class AbstractTicketRegistryTests {
             final Collection<Ticket> ticketRegistryTickets = this.ticketRegistry.getTickets();
             assertEquals("The size of the registry is not the same as the collection.",
                     tickets.size(), ticketRegistryTickets.size());
+
 
             tickets.stream().filter(ticket -> !ticketRegistryTickets.contains(ticket))
                     .forEach(ticket -> fail("Ticket was added to registry but was not found in retrieval of collection of all tickets."));

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -31,9 +31,6 @@ public abstract class AbstractTicketRegistryTests {
     public void setUp() throws Exception {
         this.ticketRegistry = this.getNewTicketRegistry();
         this.ticketRegistry.deleteAll();
-        //for (final Ticket ticket : this.ticketRegistry.getTickets()) {
-        //    this.ticketRegistry.deleteTicket(ticket.getId());
-        //}
     }
 
     /**
@@ -52,7 +49,7 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyAddTicketToCache() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
         } catch (final Exception e) {
@@ -81,10 +78,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyGetExistingTicketWithProperClass() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            this.ticketRegistry.getTicket("TEST", TicketGrantingTicket.class);
+            this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX, TicketGrantingTicket.class);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -93,10 +90,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyGetExistingTicketWithImproperClass() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            this.ticketRegistry.getTicket("TGT", ServiceTicket.class);
+            this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX, ServiceTicket.class);
         } catch (final ClassCastException e) {
             return;
         }
@@ -124,10 +121,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyGetExistingTicket() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            this.ticketRegistry.getTicket("TEST");
+            this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX);
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
         }
@@ -137,7 +134,7 @@ public abstract class AbstractTicketRegistryTests {
     public void verifyDeleteAllExistingTickets() {
         try {
             for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
-                this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TEST" + i,
+                this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX + i,
                         CoreAuthenticationTestUtils.getAuthentication(),
                         new NeverExpiresExpirationPolicy()));
             }
@@ -150,10 +147,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyDeleteExistingTicket() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertSame(1, this.ticketRegistry.deleteTicket("TGT"));
+            assertSame(1, this.ticketRegistry.deleteTicket(TicketGrantingTicket.PREFIX));
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
         }
@@ -162,10 +159,10 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyDeleteNonExistingTicket() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertSame(0, this.ticketRegistry.deleteTicket("TGT1"));
+            assertSame(0, this.ticketRegistry.deleteTicket(TicketGrantingTicket.PREFIX+"1"));
         } catch (final Exception e) {
             fail("Caught an exception. But no exception should have been thrown.");
         }
@@ -174,7 +171,7 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyDeleteNullTicket() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT",
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
             assertFalse("Ticket was deleted.", this.ticketRegistry.deleteTicket(null) == 1);
@@ -197,7 +194,7 @@ public abstract class AbstractTicketRegistryTests {
         final Collection<Ticket> tickets = new ArrayList<>();
 
         for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
-            final TicketGrantingTicket ticketGrantingTicket = new TicketGrantingTicketImpl("TGT" + i,
+            final TicketGrantingTicket ticketGrantingTicket = new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX + i,
                     CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
             final ServiceTicket st = ticketGrantingTicket.grantServiceTicket("ST" + i,
                     RegisteredServiceTestUtils.getService(),
@@ -224,9 +221,9 @@ public abstract class AbstractTicketRegistryTests {
     @Test
     public void verifyDeleteTicketWithChildren() {
         try {
-            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl("TGT1", CoreAuthenticationTestUtils.getAuthentication(),
+            this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX+"1", CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            final TicketGrantingTicket tgt = this.ticketRegistry.getTicket("TGT1", TicketGrantingTicket.class);
+            final TicketGrantingTicket tgt = this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX+"1", TicketGrantingTicket.class);
 
             final Service service = RegisteredServiceTestUtils.getService("TGT_DELETE_TEST");
 
@@ -241,7 +238,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(st2);
             this.ticketRegistry.addTicket(st3);
 
-            assertNotNull(this.ticketRegistry.getTicket("TGT1", TicketGrantingTicket.class));
+            assertNotNull(this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX+"1", TicketGrantingTicket.class));
             assertNotNull(this.ticketRegistry.getTicket("ST11", ServiceTicket.class));
             assertNotNull(this.ticketRegistry.getTicket("ST21", ServiceTicket.class));
             assertNotNull(this.ticketRegistry.getTicket("ST31", ServiceTicket.class));
@@ -249,7 +246,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.updateTicket(tgt);
             assertSame(4, this.ticketRegistry.deleteTicket(tgt.getId()));
 
-            assertNull(this.ticketRegistry.getTicket("TGT1", TicketGrantingTicket.class));
+            assertNull(this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX+"1", TicketGrantingTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST11", ServiceTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST21", ServiceTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST31", ServiceTicket.class));

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/MockOnlyOneTicketRegistry.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/MockOnlyOneTicketRegistry.java
@@ -71,5 +71,7 @@ public class MockOnlyOneTicketRegistry implements TicketRegistry {
     }
 
     @Override
-    public long userCount() { return 1; }
+    public long userCount() {
+        return 1;
+    }
 }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/MockOnlyOneTicketRegistry.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/MockOnlyOneTicketRegistry.java
@@ -56,6 +56,11 @@ public class MockOnlyOneTicketRegistry implements TicketRegistry {
     }
 
     @Override
+    public Collection<Ticket> getTicketsByUser(final String user) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
     public long sessionCount() {
         return 1;
     }
@@ -64,4 +69,7 @@ public class MockOnlyOneTicketRegistry implements TicketRegistry {
     public long serviceTicketCount() {
         return 1;
     }
+
+    @Override
+    public long userCount() { return 1; }
 }

--- a/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
@@ -189,6 +189,14 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
                 .collect(Collectors.toSet());
     }
 
+    @Override
+    public Collection<Ticket> getTickets(final String user, final Predicate<Ticket> predicate) {
+        return this.ticketRegistry.getTicketsByUser(user).stream()
+               .filter(predicate)
+               .collect(Collectors.toSet());
+    }
+
+
     /**
      * Gets the authentication satisfied by policy.
      *
@@ -303,4 +311,9 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
     public void setApplicationEventPublisher(final ApplicationEventPublisher applicationEventPublisher) {
         this.applicationEventPublisher = applicationEventPublisher;
     }
+
+    public TicketRegistry getTicketRegistry() {
+        return this.ticketRegistry;
+    }
+
 }

--- a/support/cas-server-support-hazelcast-monitor/src/main/java/org/apereo/cas/monitor/HazelcastMonitor.java
+++ b/support/cas-server-support-hazelcast-monitor/src/main/java/org/apereo/cas/monitor/HazelcastMonitor.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -33,7 +34,7 @@ public class HazelcastMonitor extends AbstractCacheMonitor {
         LOGGER.debug("Locating hazelcast map [{}] from instance [{}]...", hz.getMapName(), hz.getCluster().getInstanceName());
         final IMap map = instance.getMap(hz.getMapName());
         LOGGER.debug("Starting to collect hazelcast statistics...");
-        statsList.add(new HazelcastStatistics(map));
+        statsList.add(new HazelcastStatistics(map,hz.getCluster().getMembers().size()));
 
         return statsList.toArray(new CacheStatistics[statsList.size()]);
     }
@@ -45,9 +46,11 @@ public class HazelcastMonitor extends AbstractCacheMonitor {
         private static final int PERCENTAGE_VALUE = 100;
 
         private IMap map;
+        private int clusterSize;
 
-        protected HazelcastStatistics(final IMap map) {
+        protected HazelcastStatistics(final IMap map, final int clusterSize) {
             this.map = map;
+            this.clusterSize = clusterSize;
         }
 
         @Override
@@ -88,6 +91,9 @@ public class HazelcastMonitor extends AbstractCacheMonitor {
 
             builder.append("Creation time: ")
                     .append(localMapStats.getCreationTime())
+                    .append(", ")
+                    .append("Cluseter size: ")
+                    .append(clusterSize)
                     .append(", ")
                     .append("Owned entry count: ")
                     .append(localMapStats.getOwnedEntryCount())
@@ -130,5 +136,13 @@ public class HazelcastMonitor extends AbstractCacheMonitor {
                         .append(localMapStats.getNearCacheStats().getMisses());
             }
         }
+
+        public String toString() {
+            final StringBuilder builder = new StringBuilder();
+            this.toString(builder);
+            return builder.toString();
+        }
     }
+
+
 }

--- a/support/cas-server-support-hazelcast-monitor/src/main/java/org/apereo/cas/monitor/HazelcastMonitor.java
+++ b/support/cas-server-support-hazelcast-monitor/src/main/java/org/apereo/cas/monitor/HazelcastMonitor.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 /**

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastTicketRegistryConfiguration.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastTicketRegistryConfiguration.java
@@ -172,7 +172,7 @@ public class HazelcastTicketRegistryConfiguration {
                                                 cluster.getMaxSizePolicy()))
                                         .setSize(cluster.getMaxHeapSizePercentage()));
 
-            mapConfigs.put("users", mapConfig);
+            mapConfigs.put("users", mapConfigUsers);
 
             // Finally aggregate all those config into the main Config
             config.setMapConfigs(mapConfigs).setNetworkConfig(networkConfig);

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -47,9 +47,9 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
 
     private int pageSize;
 
-    private final String ticketTypeRegEx = "^(" + TicketGrantingTicket.PREFIX + "-" +
-                                           "|" + ProxyGrantingTicket.PROXY_GRANTING_TICKET_PREFIX + "-" +
-                                           "|" + ProxyGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX + "-" +
+    private final String ticketTypeRegEx = "^(" + TicketGrantingTicket.PREFIX  +
+                                           "|" + ProxyGrantingTicket.PROXY_GRANTING_TICKET_PREFIX  +
+                                           "|" + ProxyGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX  +
                                            ").*$";
 
     /**

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -156,6 +156,9 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
 
     @Override
     public Ticket getTicket(final String ticketId) {
+        if (ticketId == null) {
+            return null;
+        }
         return get(ticketId, ticketId.matches(ticketTypeRegEx) ? this.tgts : this.sts);
     }
 
@@ -178,7 +181,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
             tgtSet = new HashSet<>();
         }
         tgtSet.add(encodedTicketId);
-        LOGGER.info("Added tgt [{}] to user [{}], tgts size now [{}]",ticketId,user,tgtSet.size());
+        LOGGER.debug("Added tgt [{}] to user [{}], tgts size now [{}]",ticketId,user,tgtSet.size());
         this.users.set(encodedUser,tgtSet);
     }
 
@@ -188,7 +191,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
         Set<String> tgtSet = this.users.get(encodedUser);
         if(tgtSet != null && !tgtSet.isEmpty()) {
             tgtSet.remove(encodedTicketId);
-            LOGGER.info("Removed tgt [{}] from user [{}], tgt size now [{}]",ticketId,user,tgtSet.size());
+            LOGGER.debug("Removed tgt [{}] from user [{}], tgt size now [{}]",ticketId,user,tgtSet.size());
             if (tgtSet.isEmpty()) {
                 this.users.remove(encodedUser);
             } else {
@@ -237,7 +240,9 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
 
     @Override
     public Collection<Ticket> getTickets() {
-        return tgts.values().stream().limit(100).collect(Collectors.toList());
+        final Collection<Ticket> tickets = tgts.values().stream().limit(100).collect(Collectors.toList());
+        tickets.addAll(sts.values());
+        return tickets;
     }
 
     public Collection<Ticket> getTicketsByUser(final String user) {

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -1,10 +1,15 @@
 package org.apereo.cas.ticket.registry;
 
+import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.query.PagingPredicate;
-import org.apache.commons.lang3.StringUtils;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
+import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,8 +19,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
 /**
@@ -32,11 +37,26 @@ import java.util.stream.Collectors;
 public class HazelcastTicketRegistry extends AbstractTicketRegistry implements Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(HazelcastTicketRegistry.class);
     
-    private IMap<String, Ticket> registry;
+    private IMap<String, Ticket> tgts;
+
+    private IMap<String, Ticket> sts;
+
+    private IMap<String, Set<String>> users;
 
     private HazelcastInstance hazelcastInstance;
 
     private int pageSize;
+
+    private final String ticketTypeRegEx = "^(" + TicketGrantingTicket.PREFIX + "-" +
+                                           "|" + ProxyGrantingTicket.PROXY_GRANTING_TICKET_PREFIX + "-" +
+                                           "|" + ProxyGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX + "-" +
+                                           ").*$";
+
+    /**
+     * Instantiates a new Hazelcast ticket registry.
+     */
+    public HazelcastTicketRegistry() {
+    }
 
     /**
      * Instantiates a new Hazelcast ticket registry.
@@ -45,10 +65,42 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
      * @param mapName  Name of map to use
      * @param pageSize the page size
      */
-    public HazelcastTicketRegistry(final HazelcastInstance hz, final String mapName, final int pageSize) {
-        this.registry = hz.getMap(mapName);
+    public HazelcastTicketRegistry(
+            final HazelcastInstance hz,
+            final String mapName,
+            final int pageSize) {
+
+        this.tgts = hz.getMap(mapName);
+        this.sts = hz.getMap("service_tickets");
+        this.users = hz.getMap("users");
         this.hazelcastInstance = hz;
         this.pageSize = pageSize;
+
+        /**
+         * Add MapListeners to update user map
+         */
+        this.tgts.addLocalEntryListener(new EntryRemovedListener<String,Ticket>() {
+            @Override
+            public void entryRemoved(EntryEvent<String,Ticket> entryEvent) {
+                String user = ((TicketGrantingTicket)entryEvent.getOldValue()).getAuthentication().getPrincipal().getId();
+                removeTGTfromUser(user,entryEvent.getKey());
+            }
+        });
+        this.tgts.addLocalEntryListener(new EntryExpiredListener<String,Ticket>() {
+            @Override
+            public void entryExpired(EntryEvent<String,Ticket> entryEvent) {
+                String user = ((TicketGrantingTicket)entryEvent.getOldValue()).getAuthentication().getPrincipal().getId();
+                removeTGTfromUser(user,entryEvent.getKey());
+            }
+        });
+        this.tgts.addLocalEntryListener(new EntryAddedListener<String,Ticket>() {
+            @Override
+            public void entryAdded(EntryEvent<String, Ticket> entryEvent) {
+                String user = ((TicketGrantingTicket)entryEvent.getValue()).getAuthentication().getPrincipal().getId();
+                addTGTtoUser(user,entryEvent.getKey());
+            }
+        });
+
     }
 
     /**
@@ -56,7 +108,8 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
      */
     @PostConstruct
     public void init() {
-        LOGGER.info("Setting up Hazelcast Ticket Registry instance [{}] with name [{}]", this.hazelcastInstance, registry.getName());
+        LOGGER.info("Setting up Hazelcast Ticket Registry instance [{}] with name [{}]", this.hazelcastInstance, tgts.getName());
+
     }
 
     @Override
@@ -68,61 +121,132 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
     @Override
     public void addTicket(final Ticket ticket) {
         LOGGER.debug("Adding ticket [{}] with ttl [{}s]", ticket.getId(), ticket.getExpirationPolicy().getTimeToLive());
-        final Ticket encTicket = encodeTicket(ticket);
-        this.registry.set(encTicket.getId(), encTicket, ticket.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS);
+        if (ticket instanceof TicketGrantingTicket) {
+            addTGT(ticket);
+        } else if (ticket instanceof ServiceTicket) {
+            addST(ticket);
+        } else {
+            throw new IllegalArgumentException(
+                    String.format("Invalid ticket type [%s]. Expecting either [TicketGrantingTicket] or [ServiceTicket]",
+                            ticket.getClass().getName()));
+        }
     }
 
+    /**
+     * Adds the ticket to the hazelcast instance.
+     *
+     * @param ticket a ticket
+     */
+    private void addTGT(Ticket ticket) {
+        LOGGER.debug("Adding TGT [{}] with ttl [{}s]", ticket.getId(), ticket.getExpirationPolicy().getTimeToLive());
+        final Ticket encTicket = encodeTicket(ticket);
+        this.tgts.set(encTicket.getId(), encTicket, ticket.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS);
+    }
+
+    /**
+     * Adds the ticket to the hazelcast instance.
+     *
+     * @param ticket a ticket
+     */
+    private void addST(final Ticket ticket) {
+        LOGGER.debug("Adding  ST [{}] with ttl [{}s]", ticket.getId(), ticket.getExpirationPolicy().getTimeToLive());
+        final Ticket encTicket = encodeTicket(ticket);
+        this.sts.set(encTicket.getId(), encTicket, ticket.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS);
+    }
 
     @Override
     public Ticket getTicket(final String ticketId) {
-        final String encTicketId = encodeTicketId(ticketId);
-        if (StringUtils.isNotBlank(encTicketId)) {
-            final Ticket ticket = this.registry.get(encTicketId);
-            return decodeTicket(ticket);
-        }
-        return null;
+        return get(ticketId, ticketId.matches(ticketTypeRegEx) ? this.tgts : this.sts);
     }
+
+    private Ticket get(final String ticketId, IMap<String,Ticket> map) {
+        final String encTicketId = encodeTicketId(ticketId);
+        final Ticket ticket = decodeTicket(map.get(encTicketId));
+        return ticket;
+        }
+
+    private Ticket remove(final String ticketId, IMap<String,Ticket> map) {
+        String encTicketId = encodeTicketId(ticketId);
+        return map.remove(encTicketId);
+    }
+
+    private void addTGTtoUser(String user, String ticketId) {
+        String encodedUser = encodeTicketId(user);
+        String encodedTicketId = encodeTicketId(ticketId);
+        Set<String> tgtSet = this.users.get(encodedUser);
+        if (tgtSet == null) {
+            tgtSet = new HashSet<>();
+        }
+        tgtSet.add(encodedTicketId);
+        LOGGER.info("Added tgt [{}] to user [{}], tgts size now [{}]",ticketId,user,tgtSet.size());
+        this.users.set(encodedUser,tgtSet);
+    }
+
+    private void removeTGTfromUser(String user, String ticketId) {
+        String encodedUser = encodeTicketId(user);
+        String encodedTicketId = encodeTicketId(ticketId);
+        Set<String> tgtSet = this.users.get(encodedUser);
+        if(tgtSet != null && !tgtSet.isEmpty()) {
+            tgtSet.remove(encodedTicketId);
+            LOGGER.info("Removed tgt [{}] from user [{}], tgt size now [{}]",ticketId,user,tgtSet.size());
+            if (tgtSet.isEmpty()) {
+                this.users.remove(encodedUser);
+            } else {
+                this.users.set(encodedUser,tgtSet);
+            }
+        }
+    }
+
 
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
-        return this.registry.remove(ticketId) != null;
+        if (ticketId.matches(ticketTypeRegEx)) {
+            LOGGER.debug("Removing ticket [{}] from the TGT tgts.", ticketId);
+            return remove(ticketId,this.tgts) != null;
+        } else {
+            LOGGER.debug("Removing ticket [{}] from the ST tgts.", ticketId);
+            return remove(ticketId,this.sts) != null;
+        }
     }
 
     @Override
     public long deleteAll() {
-        final int size = this.registry.size();
-        this.registry.evictAll();
-        this.registry.clear();
+        final long size = this.tgts.size();
+        this.tgts.evictAll();
+        this.tgts.clear();
+        this.sts.evictAll();
+        this.sts.clear();
         return size;
     }
     
     @Override
+    public long sessionCount() {
+        return this.tgts.size();
+    }
+
+    @Override
+    public long serviceTicketCount() {
+        return this.sts.size();
+    }
+
+    @Override
+    public long userCount() {
+        return this.users.size();
+    }
+
+
+    @Override
     public Collection<Ticket> getTickets() {
+        return tgts.values().stream().limit(100).collect(Collectors.toList());
+    }
+
+    public Collection<Ticket> getTicketsByUser(String user) {
         final Collection<Ticket> collection = new HashSet<>();
 
-        LOGGER.debug("Attempting to acquire lock from Hazelcast instance...");
-        final Lock lock = this.hazelcastInstance.getLock(getClass().getName());
-        lock.lock();
-        LOGGER.debug("Hazelcast instance lock acquired");
+        users.keySet(key -> ((String)key.getKey()).matches(user)).stream().limit(100).forEach(usr -> {
+            users.get(usr).forEach(tgt -> collection.add(tgts.get(tgt)));
+        });
 
-        try {
-            LOGGER.debug("Setting up the paging predicate with page size of [{}]", this.pageSize);
-            final PagingPredicate pagingPredicate = new PagingPredicate(this.pageSize);
-
-            LOGGER.debug("Retrieving the initial collection of tickets from Hazelcast instance...");
-            Collection<Ticket> entrySet = this.registry.values(pagingPredicate);
-
-            while (!entrySet.isEmpty()) {
-                collection.addAll(entrySet.stream().map(this::decodeTicket).collect(Collectors.toList()));
-
-                pagingPredicate.nextPage();
-                entrySet = this.registry.values(pagingPredicate);
-            }
-        } catch (final Exception e) {
-            LOGGER.debug(e.getMessage(), e);
-        } finally {
-            lock.unlock();
-        }
         return collection;
     }
 
@@ -139,8 +263,17 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
         }
     }
 
+    public void setRegistry(final IMap<String, Ticket> registry) {
+        this.tgts = registry;
+    }
+
+    public void setHazelcastInstance(final HazelcastInstance hazelcastInstance) {
+        this.hazelcastInstance = hazelcastInstance;
+    }
+
     @Override
     public void close() throws IOException {
         shutdown();
     }
+
 }

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -81,21 +81,21 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
          */
         this.tgts.addLocalEntryListener(new EntryRemovedListener<String,Ticket>() {
             @Override
-            public void entryRemoved(EntryEvent<String,Ticket> entryEvent) {
+            public void entryRemoved(final EntryEvent<String,Ticket> entryEvent) {
                 String user = ((TicketGrantingTicket)entryEvent.getOldValue()).getAuthentication().getPrincipal().getId();
                 removeTGTfromUser(user,entryEvent.getKey());
             }
         });
         this.tgts.addLocalEntryListener(new EntryExpiredListener<String,Ticket>() {
             @Override
-            public void entryExpired(EntryEvent<String,Ticket> entryEvent) {
+            public void entryExpired(final EntryEvent<String,Ticket> entryEvent) {
                 String user = ((TicketGrantingTicket)entryEvent.getOldValue()).getAuthentication().getPrincipal().getId();
                 removeTGTfromUser(user,entryEvent.getKey());
             }
         });
         this.tgts.addLocalEntryListener(new EntryAddedListener<String,Ticket>() {
             @Override
-            public void entryAdded(EntryEvent<String, Ticket> entryEvent) {
+            public void entryAdded(final EntryEvent<String, Ticket> entryEvent) {
                 String user = ((TicketGrantingTicket)entryEvent.getValue()).getAuthentication().getPrincipal().getId();
                 addTGTtoUser(user,entryEvent.getKey());
             }
@@ -137,7 +137,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
      *
      * @param ticket a ticket
      */
-    private void addTGT(Ticket ticket) {
+    private void addTGT(final Ticket ticket) {
         LOGGER.debug("Adding TGT [{}] with ttl [{}s]", ticket.getId(), ticket.getExpirationPolicy().getTimeToLive());
         final Ticket encTicket = encodeTicket(ticket);
         this.tgts.set(encTicket.getId(), encTicket, ticket.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS);
@@ -159,18 +159,18 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
         return get(ticketId, ticketId.matches(ticketTypeRegEx) ? this.tgts : this.sts);
     }
 
-    private Ticket get(final String ticketId, IMap<String,Ticket> map) {
+    private Ticket get(final String ticketId, final IMap<String,Ticket> map) {
         final String encTicketId = encodeTicketId(ticketId);
         final Ticket ticket = decodeTicket(map.get(encTicketId));
         return ticket;
-        }
+    }
 
-    private Ticket remove(final String ticketId, IMap<String,Ticket> map) {
+    private Ticket remove(final String ticketId, final IMap<String,Ticket> map) {
         String encTicketId = encodeTicketId(ticketId);
         return map.remove(encTicketId);
     }
 
-    private void addTGTtoUser(String user, String ticketId) {
+    private void addTGTtoUser(final String user, final String ticketId) {
         String encodedUser = encodeTicketId(user);
         String encodedTicketId = encodeTicketId(ticketId);
         Set<String> tgtSet = this.users.get(encodedUser);
@@ -182,7 +182,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
         this.users.set(encodedUser,tgtSet);
     }
 
-    private void removeTGTfromUser(String user, String ticketId) {
+    private void removeTGTfromUser(final String user, final String ticketId) {
         String encodedUser = encodeTicketId(user);
         String encodedTicketId = encodeTicketId(ticketId);
         Set<String> tgtSet = this.users.get(encodedUser);
@@ -240,7 +240,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
         return tgts.values().stream().limit(100).collect(Collectors.toList());
     }
 
-    public Collection<Ticket> getTicketsByUser(String user) {
+    public Collection<Ticket> getTicketsByUser(final String user) {
         final Collection<Ticket> collection = new HashSet<>();
 
         users.keySet(key -> ((String)key.getKey()).matches(user)).stream().limit(100).forEach(usr -> {

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
@@ -67,7 +67,7 @@ public class HazelcastTicketRegistryReplicationTests {
         this.hzTicketRegistry1.addTicket(newTestSt(tgt));
 
         col = hzTicketRegistry2.getTickets();
-        assertEquals(2, col.size());
+        assertEquals(1, col.size());
         assertEquals(1, hzTicketRegistry2.serviceTicketCount());
         assertEquals(1, hzTicketRegistry2.sessionCount());
     }

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
@@ -67,7 +67,7 @@ public class HazelcastTicketRegistryReplicationTests {
         this.hzTicketRegistry1.addTicket(newTestSt(tgt));
 
         col = hzTicketRegistry2.getTickets();
-        assertEquals(1, col.size());
+        assertEquals(2, col.size());
         assertEquals(1, hzTicketRegistry2.serviceTicketCount());
         assertEquals(1, hzTicketRegistry2.sessionCount());
     }

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/HealthCheckController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/HealthCheckController.java
@@ -4,6 +4,7 @@ import org.apache.commons.codec.binary.StringUtils;
 import org.apereo.cas.monitor.HealthCheckMonitor;
 import org.apereo.cas.monitor.HealthStatus;
 import org.apereo.cas.monitor.Monitor;
+import org.apereo.cas.monitor.Status;
 import org.apereo.cas.util.JsonUtils;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -50,7 +51,7 @@ public class HealthCheckController {
 
         final Callable<HealthStatus> asyncTask = () -> {
             final HealthStatus healthStatus = healthCheckMonitor.observe();
-            response.setStatus(healthStatus.getCode().value());
+            response.setStatus(Status.OK.getCode().value());
             
             if (StringUtils.equals(request.getParameter("format"), "json")) {
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsReportController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsReportController.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.ISOStandardDateFormat;
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -118,11 +120,11 @@ public class SingleSignOnSessionsReportController {
      * @param option the option
      * @return the sso sessions
      */
-    private Collection<Map<String, Object>> getActiveSsoSessions(final SsoSessionReportOptions option) {
+    private Collection<Map<String, Object>> getActiveSsoSessions(final SsoSessionReportOptions option, String user) {
         final Collection<Map<String, Object>> activeSessions = new ArrayList<>();
         final ISOStandardDateFormat dateFormat = new ISOStandardDateFormat();
 
-        for (final Ticket ticket : getNonExpiredTicketGrantingTickets()) {
+        for (final Ticket ticket : getNonExpiredTicketGrantingTickets(user)) {
             final TicketGrantingTicket tgt = (TicketGrantingTicket) ticket;
 
             if (option == SsoSessionReportOptions.DIRECT && tgt.getProxiedBy() != null) {
@@ -163,8 +165,13 @@ public class SingleSignOnSessionsReportController {
      *
      * @return the non expired ticket granting tickets
      */
-    private Collection<Ticket> getNonExpiredTicketGrantingTickets() {
-        return this.centralAuthenticationService.getTickets(ticket -> ticket instanceof TicketGrantingTicket && !ticket.isExpired());
+    private Collection<Ticket> getNonExpiredTicketGrantingTickets(final String user) {
+        return this.centralAuthenticationService.getTickets(user,ticket -> {
+                if (ticket instanceof TicketGrantingTicketImpl) {
+                    return !ticket.isExpired();
+                }
+                return false;
+        });
     }
 
     /**
@@ -175,13 +182,14 @@ public class SingleSignOnSessionsReportController {
      */
     @GetMapping(value = "/getSsoSessions")
     @ResponseBody
-    public WebAsyncTask<Map<String, Object>> getSsoSessions(@RequestParam(defaultValue = "ALL") final String type) {
+    public WebAsyncTask<Map<String, Object>> getSsoSessions(@RequestParam final String user,
+            @RequestParam(defaultValue = "ALL") final String type) {
 
         final Callable<Map<String, Object>> asyncTask = () -> {
             final Map<String, Object> sessionsMap = new HashMap<>(1);
             final SsoSessionReportOptions option = SsoSessionReportOptions.valueOf(type);
 
-            final Collection<Map<String, Object>> activeSsoSessions = getActiveSsoSessions(option);
+            final Collection<Map<String, Object>> activeSsoSessions = getActiveSsoSessions(option, user);
             sessionsMap.put("activeSsoSessions", activeSsoSessions);
 
             long totalTicketGrantingTickets = 0;
@@ -246,20 +254,16 @@ public class SingleSignOnSessionsReportController {
     /**
      * Endpoint for destroying SSO Sessions.
      *
-     * @param type the type
+     * @param tickets list of tickets to destroy
      * @return result map
      */
     @PostMapping(value = "/destroySsoSessions")
     @ResponseBody
-    public Map<String, Object> destroySsoSessions(@RequestParam(defaultValue = "ALL") final String type) {
+    public Map<String, Object> destroySsoSessions(@RequestParam(value="tickets[]") final List<String> tickets) {
         final Map<String, Object> sessionsMap = new HashMap<>();
         final Map<String, String> failedTickets = new HashMap<>();
 
-        final SsoSessionReportOptions option = SsoSessionReportOptions.valueOf(type);
-        final Collection<Map<String, Object>> collection = getActiveSsoSessions(option);
-        for (final Map<String, Object> sso : collection) {
-            final String ticketGrantingTicket =
-                    sso.get(SsoSessionAttributeKeys.TICKET_GRANTING_TICKET.toString()).toString();
+        for (String ticketGrantingTicket : tickets) {
             try {
                 this.centralAuthenticationService.destroyTicketGrantingTicket(ticketGrantingTicket);
             } catch (final Exception e) {

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsReportController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsReportController.java
@@ -120,7 +120,7 @@ public class SingleSignOnSessionsReportController {
      * @param option the option
      * @return the sso sessions
      */
-    private Collection<Map<String, Object>> getActiveSsoSessions(final SsoSessionReportOptions option, String user) {
+    private Collection<Map<String, Object>> getActiveSsoSessions(final SsoSessionReportOptions option, final String user) {
         final Collection<Map<String, Object>> activeSessions = new ArrayList<>();
         final ISOStandardDateFormat dateFormat = new ISOStandardDateFormat();
 
@@ -167,10 +167,10 @@ public class SingleSignOnSessionsReportController {
      */
     private Collection<Ticket> getNonExpiredTicketGrantingTickets(final String user) {
         return this.centralAuthenticationService.getTickets(user,ticket -> {
-                if (ticket instanceof TicketGrantingTicketImpl) {
-                    return !ticket.isExpired();
-                }
-                return false;
+            if (ticket instanceof TicketGrantingTicketImpl) {
+                return !ticket.isExpired();
+            }
+            return false;
         });
     }
 

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/StatisticsController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/StatisticsController.java
@@ -4,7 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.servlets.HealthCheckServlet;
 import com.codahale.metrics.servlets.MetricsServlet;
-import org.apereo.cas.CentralAuthenticationService;;
+import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/StatisticsController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/StatisticsController.java
@@ -4,9 +4,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.servlets.HealthCheckServlet;
 import com.codahale.metrics.servlets.MetricsServlet;
-import org.apereo.cas.CentralAuthenticationService;
-import org.apereo.cas.ticket.ServiceTicket;
-import org.apereo.cas.ticket.Ticket;
+import org.apereo.cas.CentralAuthenticationService;;
+import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +19,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -95,28 +93,11 @@ public class StatisticsController implements ServletContextAware {
     public Map<String, Object> getTicketStats(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse) {
         final Map<String, Object> model = new HashMap<>();
 
-        int unexpiredTgts = 0;
-        int unexpiredSts = 0;
+        TicketRegistry tr = this.centralAuthenticationService.getTicketRegistry();
+        int unexpiredTgts = (int)tr.sessionCount();
+        int unexpiredSts = (int)tr.serviceTicketCount();
         int expiredTgts = 0;
         int expiredSts = 0;
-
-        final Collection<Ticket> tickets = this.centralAuthenticationService.getTickets(ticket -> true);
-
-        for (final Ticket ticket : tickets) {
-            if (ticket instanceof ServiceTicket) {
-                if (ticket.isExpired()) {
-                    expiredSts++;
-                } else {
-                    unexpiredSts++;
-                }
-            } else {
-                if (ticket.isExpired()) {
-                    expiredTgts++;
-                } else {
-                    unexpiredTgts++;
-                }
-            }
-        }
 
         model.put("unexpiredTgts", unexpiredTgts);
         model.put("unexpiredSts", unexpiredSts);


### PR DESCRIPTION
This request addresses issues related to large Hazelcast Clusters and performance issues related to /status and /ssosessions endpoints in CAS. 

## Features:

- Hazelcast registry split into separate TGTs and STs maps similar to other replication implementations
- Third "user" map that tracks unique logged in users and maps their TGTs
- /status includes unique user count and cluster size when Hazelcast Monitoring is included
- /ssosessions now requires entry of Regular expression to filter by unique users before displaying table

## Limitations
- getTickets() is limited to 100 tickets
- /ssosessions only brings back first 100 users that match regular expressions

## TO DO
- Have not tested API changes with other replication implementations

Let me know if you have any questions about any change and feel to add any changes
Travis
