### PR TITLE
Add LinkedIn delegated authN support for CAS 5.0.x

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -23,6 +23,7 @@ public class Pac4jProperties {
     private Yahoo yahoo = new Yahoo();
     private Foursquare foursquare = new Foursquare();
     private WindowsLive windowsLive = new WindowsLive();
+    private LinkedIn linkedIn = new LinkedIn();
 
     public WindowsLive getWindowsLive() {
         return windowsLive;
@@ -100,6 +101,10 @@ public class Pac4jProperties {
         this.cas = cas;
     }
 
+    public void setLinkedIn(LinkedIn linkedIn) {
+        this.linkedIn = linkedIn;
+    }
+
     public Cas getCas() {
         return this.cas;
     }
@@ -118,6 +123,10 @@ public class Pac4jProperties {
 
     public Twitter getTwitter() {
         return this.twitter;
+    }
+
+    public LinkedIn getLinkedIn() {
+        return linkedIn;
     }
 
     public static class Facebook {
@@ -492,6 +501,45 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+    }
+    
+    public static class LinkedIn {
+        private String id;
+        private String secret;
+        private String scope;
+        private String fields;
+
+        public String getId() {
+            return this.id;
+        }
+
+        public void setId(final String id) {
+            this.id = id;
+        }
+
+        public String getSecret() {
+            return this.secret;
+        }
+
+        public void setSecret(final String secret) {
+            this.secret = secret;
+        }
+
+        public String getScope() {
+            return this.scope;
+        }
+
+        public void setScope(final String scope) {
+            this.scope = scope;
+        }
+
+        public String getFields() {
+            return this.fields;
+        }
+
+        public void setFields(final String fields) {
+            this.fields = fields;
         }
     }
 }

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1853,6 +1853,17 @@ Delegate authentication to Google.
 # cas.authn.pac4j.google.scope=
 ```
 
+### LinkedIn
+
+Delegate authentication to LinkedIn.
+
+```properties
+# cas.authn.pac4j.linkedIn.id=
+# cas.authn.pac4j.linkedIn.secret=
+# cas.authn.pac4j.linkedIn.fields=
+# cas.authn.pac4j.linkedIn.scope=
+```
+
 ## OAuth2
 
 Allows CAS to act as an OAuth2 provider. Here you can control how

--- a/gradle.properties
+++ b/gradle.properties
@@ -90,7 +90,7 @@ guavaVersion=19.0
 groovyVersion=2.4.7
 
 springWebmvcPac4jVersion=1.1.4
-pac4jVersion=1.9.4
+pac4jVersion=1.9.6-SNAPSHOT
 dropwizardMetricsVersion=3.1.2
 dropwizardMetricsSpringVersion=3.1.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -90,7 +90,7 @@ guavaVersion=19.0
 groovyVersion=2.4.7
 
 springWebmvcPac4jVersion=1.1.4
-pac4jVersion=1.9.6-SNAPSHOT
+pac4jVersion=1.9.6
 dropwizardMetricsVersion=3.1.2
 dropwizardMetricsSpringVersion=3.1.3
 

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
@@ -196,6 +196,13 @@ public class Pac4jConfiguration {
         properties.put(PropertiesConfigFactory.OIDC_USE_NONCE, casProperties.getAuthn().getPac4j().getOidc().getUseNonce());
     }
 
+    private void configureLinkedInClient(final Map<String, String> properties) {
+        properties.put(PropertiesConfigFactory.LINKEDIN_ID, casProperties.getAuthn().getPac4j().getLinkedIn().getId());
+        properties.put(PropertiesConfigFactory.LINKEDIN_SECRET, casProperties.getAuthn().getPac4j().getLinkedIn().getSecret());
+        properties.put(PropertiesConfigFactory.LINKEDIN_SCOPE, casProperties.getAuthn().getPac4j().getLinkedIn().getScope());
+        properties.put(PropertiesConfigFactory.LINKEDIN_FIELDS, casProperties.getAuthn().getPac4j().getLinkedIn().getFields());
+    }
+
     /**
      * Returning the built clients.
      *
@@ -220,6 +227,7 @@ public class Pac4jConfiguration {
         configureGoogleClient(properties);
         configureWindowsLiveClient(properties);
         configureYahooClient(properties);
+        configureLinkedInClient(properties);
 
         // add the new clients found via properties first
         final ConfigFactory configFactory = new PropertiesConfigFactory(properties);

--- a/webapp/cas-server-webapp/src/main/resources/templates/fragments/loginProviders.html
+++ b/webapp/cas-server-webapp/src/main/resources/templates/fragments/loginProviders.html
@@ -20,6 +20,7 @@
                     <span th:case="facebook" class="fa fa-facebook-square"></span>
                     <span th:case="oidc" class="fa fa-openid"></span>
                     <span th:case="saml2" class="fa fa-lock"></span>
+                    <span th:case="linkedin2" class="fa fa-linkedin-square"></span>
                     <span th:case="*" class="fa fa-sign-in"></span>
 
                     [[${entry.name}]]
@@ -44,6 +45,7 @@
                 <span th:case="facebook" class="fa fa-facebook-square"></span>
                 <span th:case="oidc" class="fa fa-openid"></span>
                 <span th:case="saml2" class="fa fa-lock"></span>
+                <span th:case="linkedin2" class="fa fa-linkedin-square"></span>
                 <span th:case="*" class="fa fa-sign-in"></span>
             </a>
         </div>


### PR DESCRIPTION
Closes #2101 

Ensure that you include the following:

**Description**
add LinkedIn support for CAS 5.0.x.

**Configuration**
To enable, add following config to application.properites
`cas.authn.pac4j.linkedIn.id=`
`cas.authn.pac4j.linkedIn.secret=`
`cas.authn.pac4j.linkedIn.fields=`
`cas.authn.pac4j.linkedIn.scope=` 




