### PR TITLE
Quotes not escaped for some MessageFormat strings in messages_fr.prop…

### DIFF
--- a/webapp/cas-server-webapp/src/main/resources/messages_fr.properties
+++ b/webapp/cas-server-webapp/src/main/resources/messages_fr.properties
@@ -50,7 +50,7 @@ screen.logout.security=Pour des raisons de sécurité, veuillez fermer votre nav
 screen.logout.redirect=Le service duquel vous arrivez a fourni un <a href="{0}">lien que vous pouvez suivre en cliquant ici</a>.
 
 screen.service.sso.error.header=Une nouvelle authentification est requise pour accéder à ce service.
-screen.service.sso.error.message=Vous avez tenté d'accéder à un service qui requiert une nouvelle authentification sans vous authentifier à nouveau.  Veuillez <a href="{0}">vous authentifier de nouveau</a>.
+screen.service.sso.error.message=Vous avez tenté d''accéder à un service qui requiert une nouvelle authentification sans vous authentifier à nouveau.  Veuillez <a href="{0}">vous authentifier de nouveau</a>.
 screen.service.required.message=Vous avez tenté de vous authentifier sans préciser d'application cible. Merci de vérifier votre requête et de recommencer.
 
 
@@ -100,7 +100,7 @@ screen.badworkstation.message=Merci de contacter votre administrateur système p
 
 # OAuth
 screen.oauth.confirm.header=Autorisation
-screen.oauth.confirm.message=Voulez-vous donner l'accès de votre profil complet à "{0}" ?
+screen.oauth.confirm.message=Voulez-vous donner l''accès de votre profil complet à "{0}" ?
 screen.oauth.confirm.allow=Autoriser
 
 # Unavailable


### PR DESCRIPTION
Some French MessageFormat strings had quotes not escaped. Example:

![selection_001](https://cloud.githubusercontent.com/assets/1698090/22783681/247fb43a-eecd-11e6-8981-2201343be813.png)


