### PR TITLE
Disable RADIUS auth handler unless server address is defined

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/radius/RadiusProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/radius/RadiusProperties.java
@@ -169,7 +169,7 @@ public class RadiusProperties {
     }
 
     public static class Client {
-        private String inetAddress = "localhost";
+        private String inetAddress;
         private String sharedSecret = "N0Sh@ar3d$ecReT";
         private int socketTimeout;
         private int authenticationPort = 1812;

--- a/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
+++ b/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.config;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.adaptors.radius.JRadiusServerImpl;
 import org.apereo.cas.adaptors.radius.RadiusClientFactory;
 import org.apereo.cas.adaptors.radius.RadiusProtocol;
@@ -15,6 +16,8 @@ import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.radius.RadiusProperties;
 import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.services.ServicesManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -35,6 +38,7 @@ import java.util.List;
 @Configuration("radiusConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class RadiusConfiguration {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RadiusConfiguration.class);
 
     @Autowired
     private CasConfigurationProperties casProperties;
@@ -113,7 +117,11 @@ public class RadiusConfiguration {
     public class RadiusAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
         @Override
         public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandler(radiusAuthenticationHandler());
+            if (StringUtils.isNotBlank(casProperties.getAuthn().getRadius().getClient().getInetAddress())) {
+                plan.registerAuthenticationHandler(radiusAuthenticationHandler());
+            } else {
+                LOGGER.warn("No RADIUS address is defined. RADIUS support will be disabled.");
+            }
         }
     }
 }


### PR DESCRIPTION
Port of #2336 from 5.0.x into master.

- cas.authn.radius.client.inetAddress is now unset by default instead of trying to authenticate against localhost
- If CAS was built with RADIUS support but inetAddress isn't set, skip enabling the handler and warn:
`WARN [org.apereo.cas.config.RadiusConfiguration] - <No RADIUS address is defined. RADIUS support will be disabled.>`