### PR TITLE
Correct ldap urls parsing

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
@@ -428,7 +428,7 @@ public final class Beans {
         LOGGER.debug("Creating LDAP connection configuration for [{}]", l.getLdapUrl());
         final ConnectionConfig cc = new ConnectionConfig();
 
-        final String urls = Arrays.stream(l.getLdapUrl().split(",")).collect(Collectors.joining(" "));
+        final String urls = l.getLdapUrl().contains(" ") ? l.getLdapUrl() : Arrays.stream(l.getLdapUrl().split(",")).collect(Collectors.joining(" "));
         LOGGER.debug("Transformed LDAP urls from [{}] to [{}]", l.getLdapUrl(), urls);
         cc.setLdapUrl(urls);
 


### PR DESCRIPTION
Ldap url may contain a comma.