### PR TITLE
information how to enable sha512 password encoder

### DIFF
--- a/cas-server-documentation/installation/MongoDb-Authentication.md
+++ b/cas-server-documentation/installation/MongoDb-Authentication.md
@@ -9,6 +9,16 @@ Verify and authenticate credentials against a [MongoDb](https://www.mongodb.org/
 ```xml
 <alias name="mongoAuthenticationHandler" alias="primaryAuthenticationHandler" />
 ```
+Default password encoder is NopPasswordEncoder (plain text).
+
+To enable SHA512 and salt add:
+```xml
+<bean id="mongoPac4jPasswordEncoder"
+ 		class="org.pac4j.http.credentials.password.BasicSaltedSha512PasswordEncoder">
+ 		<property name="salt"
+ 			value="salt_value" />
+ 	</bean>
+```
 
 Support is enabled by including the following dependency in the Maven WAR overlay:
 


### PR DESCRIPTION
Additional info how to add sha512 password encoder from pac4j to mongoAuthenticationHandler.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
