### PR TITLE
Fix acceptable use template to use th:value

### DIFF
--- a/webapp/cas-server-webapp/src/main/resources/templates/casAcceptableUsagePolicyView.html
+++ b/webapp/cas-server-webapp/src/main/resources/templates/casAcceptableUsagePolicyView.html
@@ -18,7 +18,7 @@
             </div>
 
             <section class="row btn-row">
-                <input type="hidden" name="execution" value="${flowExecutionKey}" />
+                <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
                 <input type="hidden" name="_eventId" value="submit" />
                 <input class="btn-submit"
                        name="submit"


### PR DESCRIPTION
${flowExecutionKey} wasn't being evaluated and was causing 500 error.

This should probably be merged to 5.0 branch too. 