### PR TITLE
correct typo

### DIFF
--- a/webapp/cas-server-webapp-config-security/src/main/java/org/apereo/cas/config/CasWebApplicationSecurityConfiguration.java
+++ b/webapp/cas-server-webapp-config-security/src/main/java/org/apereo/cas/config/CasWebApplicationSecurityConfiguration.java
@@ -50,6 +50,6 @@ public class CasWebApplicationSecurityConfiguration extends GlobalAuthentication
         final LdapAuthorizationProperties authZ = ldap.getLdapAuthz();
         return StringUtils.isNotBlank(ldap.getBaseDn()) && StringUtils.isNotBlank(ldap.getLdapUrl())
                 && StringUtils.isNotBlank(ldap.getUserFilter())
-                && (StringUtils.isNotBlank(authZ.getRoleAttribute()) || StringUtils.isNotBlank(authZ.getRoleAttribute()));
+                && (StringUtils.isNotBlank(authZ.getRoleAttribute()) || StringUtils.isNotBlank(authZ.getGroupAttribute()));
     }
 }


### PR DESCRIPTION
Fixes a typo in CasWebApplicationSecurityConfiguration

role || role -> role || group