### PR TITLE
Source Code cleanup, null checks and collection ordering

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/TicketGrantingTicketImpl.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/TicketGrantingTicketImpl.java
@@ -246,7 +246,6 @@ public class TicketGrantingTicketImpl extends AbstractTicket implements TicketGr
         return this.getGrantingTicket() == null;
     }
 
-
     @Override
     public void markTicketExpired() {
         this.expired = Boolean.TRUE;
@@ -293,7 +292,6 @@ public class TicketGrantingTicketImpl extends AbstractTicket implements TicketGr
     public Service getProxiedBy() {
         return this.proxiedBy;
     }
-
 
     @Override
     public boolean equals(final Object object) {

--- a/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/InitialAuthenticationAttemptWebflowEventResolver.java
+++ b/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/InitialAuthenticationAttemptWebflowEventResolver.java
@@ -112,10 +112,8 @@ public class InitialAuthenticationAttemptWebflowEventResolver extends AbstractCa
      * @param registeredService the registered service
      * @return the set
      */
-    protected Set<Event> resolveCandidateAuthenticationEvents(final RequestContext context,
-                                                              final Service service, final RegisteredService registeredService) {
+    protected Set<Event> resolveCandidateAuthenticationEvents(final RequestContext context, final Service service, final RegisteredService registeredService) {
         return this.orderedResolvers.stream()
-                .filter(Objects::nonNull)
                 .map(resolver -> resolver.resolveSingle(context))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
@@ -123,12 +121,16 @@ public class InitialAuthenticationAttemptWebflowEventResolver extends AbstractCa
 
     @Override
     public void addDelegate(final CasWebflowEventResolver r) {
-        orderedResolvers.add(r);
+        if (r != null) {
+            orderedResolvers.add(r);
+        }
     }
 
     @Override
     public void addDelegate(final CasWebflowEventResolver r, final int index) {
-        orderedResolvers.add(index, r);
+        if (r != null) {
+            orderedResolvers.add(index, r);
+        }
     }
 
     public void setSelectiveResolver(final CasWebflowEventResolver r) {

--- a/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
@@ -127,7 +128,11 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
         this.servicesManager = servicesManager;
         this.logoutManager = logoutManager;
         this.ticketFactory = ticketFactory;
-        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionStrategies.stream().sorted().collect(Collectors.toList());
+        if (authenticationRequestServiceSelectionStrategies != null) {
+            this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionStrategies.stream().sorted().collect(Collectors.toList());
+        } else {
+            this.authenticationRequestServiceSelectionStrategies = new ArrayList<>();
+        }
         this.principalFactory = principalFactory;
         this.serviceContextAuthenticationPolicyFactory = authenticationPolicyFactory;
         this.cipherExecutor = cipherExecutor;

--- a/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
@@ -127,7 +127,7 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
         this.servicesManager = servicesManager;
         this.logoutManager = logoutManager;
         this.ticketFactory = ticketFactory;
-        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionStrategies;
+        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionStrategies.stream().sorted().collect(Collectors.toList());
         this.principalFactory = principalFactory;
         this.serviceContextAuthenticationPolicyFactory = authenticationPolicyFactory;
         this.cipherExecutor = cipherExecutor;
@@ -277,7 +277,6 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
      */
     protected Service resolveServiceFromAuthenticationRequest(final Service service) {
         return this.authenticationRequestServiceSelectionStrategies.stream()
-                .sorted()
                 .filter(s -> s.supports(service))
                 .findFirst()
                 .get()


### PR DESCRIPTION
Closes no issue

Changes:
- Order collection when it's created so it's not needed to sort it on every method call.
- Remove blank lines
- Check for nulls during item insertion instead of doing it when we need to use the collection