### PR TITLE
Explaining how to use Unicode property values

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Management.md
+++ b/docs/cas-server-documentation/installation/Configuration-Management.md
@@ -15,7 +15,10 @@ and leaving all else behind to be handled by the default CAS configuration.
 The following strategies may be used to fully extend the CAS configuration model.
 
 <div class="alert alert-info"><strong>YAML or Properties?</strong><p>CAS configuration allows for both
-YAML and Properties syntax in any of the below strategies used.</p></div>
+YAML and Properties syntax in any of the below strategies used. It generally does not matter which syntax 
+is used, but when working with Unicode strings as properties values it does matter. Spring loads properties
+files using the ISO-8859-1 encoding. YAML files are loaded with UTF-8 encoding. If you are setting Unicode
+values try using a YAML configuration file.</p></div>
 
 ## Overview
 


### PR DESCRIPTION
Adding documentation explaining how to set Unicode properties so implementors know the difference between using .properties files (ISO-8859-1 encoding) and .yml files (UTF-8 encoding).