### PR TITLE
Cleaning codacy warnings

### DIFF
--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/AcceptUsersAuthenticationHandlerTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/AcceptUsersAuthenticationHandlerTests.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.*;
  */
 public class AcceptUsersAuthenticationHandlerTests {
 
+    private static final String SCOTT = "scott";
+    private static final String RUTGERS = "rutgers";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -28,7 +31,7 @@ public class AcceptUsersAuthenticationHandlerTests {
 
     public AcceptUsersAuthenticationHandlerTests() throws Exception {
         final Map<String, String> users = new HashMap<>();
-        users.put("scott", "rutgers");
+        users.put(SCOTT, RUTGERS);
         users.put("dima", "javarules");
         users.put("bill", "thisisAwesoME");
         users.put("brian", "t�st");
@@ -48,8 +51,8 @@ public class AcceptUsersAuthenticationHandlerTests {
     public void verifySupportsProperUserCredentials() throws Exception {
         final UsernamePasswordCredential c = new UsernamePasswordCredential();
 
-        c.setUsername("scott");
-        c.setPassword("rutgers");
+        c.setUsername(SCOTT);
+        c.setPassword(RUTGERS);
         assertTrue(this.authenticationHandler.supports(c));
     }
 
@@ -68,11 +71,11 @@ public class AcceptUsersAuthenticationHandlerTests {
     public void verifyAuthenticatesUserInMap() throws Exception {
         final UsernamePasswordCredential c = new UsernamePasswordCredential();
 
-        c.setUsername("scott");
-        c.setPassword("rutgers");
+        c.setUsername(SCOTT);
+        c.setPassword(RUTGERS);
 
         try {
-            assertEquals("scott", this.authenticationHandler.authenticate(c).getPrincipal().getId());
+            assertEquals(SCOTT, this.authenticationHandler.authenticate(c).getPrincipal().getId());
         } catch (final GeneralSecurityException e) {
             fail("Authentication exception caught but it should not have been thrown.");
         }
@@ -83,7 +86,7 @@ public class AcceptUsersAuthenticationHandlerTests {
         final UsernamePasswordCredential c = new UsernamePasswordCredential();
 
         c.setUsername("fds");
-        c.setPassword("rutgers");
+        c.setPassword(RUTGERS);
 
         this.thrown.expect(AccountNotFoundException.class);
         this.thrown.expectMessage("fds not found in backing map.");
@@ -121,7 +124,7 @@ public class AcceptUsersAuthenticationHandlerTests {
     public void verifyFailsNullPassword() throws Exception {
         final UsernamePasswordCredential c = new UsernamePasswordCredential();
 
-        c.setUsername("scott");
+        c.setUsername(SCOTT);
         c.setPassword(null);
 
         this.thrown.expect(FailedLoginException.class);

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManagerTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManagerTests.java
@@ -32,6 +32,8 @@ import static org.mockito.Mockito.*;
 @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
 public class PolicyBasedAuthenticationManagerTests {
 
+    private static final String HANDLER_A = "HandlerA";
+    private static final String HANDLER_B = "HandlerB";
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -123,12 +125,11 @@ public class PolicyBasedAuthenticationManagerTests {
     @Test
     public void verifyAuthenticateRequiredHandlerSuccess() throws Exception {
         final Map<AuthenticationHandler, PrincipalResolver> map = new LinkedHashMap<>();
-        map.put(newMockHandler("HandlerA", true), null);
-        map.put(newMockHandler("HandlerB", false), null);
+        map.put(newMockHandler(HANDLER_A, true), null);
+        map.put(newMockHandler(HANDLER_B, false), null);
 
         final PolicyBasedAuthenticationManager manager = new PolicyBasedAuthenticationManager(getAuthenticationExecutionPlan(map), 
-                null,
-                new RequiredHandlerAuthenticationPolicy("HandlerA"));
+                null, new RequiredHandlerAuthenticationPolicy(HANDLER_A));
 
         final Authentication auth = manager.authenticate(transaction);
         assertEquals(1, auth.getSuccesses().size());
@@ -138,12 +139,11 @@ public class PolicyBasedAuthenticationManagerTests {
     @Test
     public void verifyAuthenticateRequiredHandlerFailure() throws Exception {
         final Map<AuthenticationHandler, PrincipalResolver> map = new LinkedHashMap<>();
-        map.put(newMockHandler("HandlerA", true), null);
-        map.put(newMockHandler("HandlerB", false), null);
+        map.put(newMockHandler(HANDLER_A, true), null);
+        map.put(newMockHandler(HANDLER_B, false), null);
 
         final PolicyBasedAuthenticationManager manager = new PolicyBasedAuthenticationManager(getAuthenticationExecutionPlan(map),
-                mockServicesManager(),
-                new RequiredHandlerAuthenticationPolicy("HandlerB"));
+                mockServicesManager(), new RequiredHandlerAuthenticationPolicy(HANDLER_B));
 
         this.thrown.expect(AuthenticationException.class);
         this.thrown.expectMessage("1 errors, 1 successes");
@@ -156,12 +156,11 @@ public class PolicyBasedAuthenticationManagerTests {
     @Test
     public void verifyAuthenticateRequiredHandlerTryAllSuccess() throws Exception {
         final Map<AuthenticationHandler, PrincipalResolver> map = new LinkedHashMap<>();
-        map.put(newMockHandler("HandlerA", true), null);
-        map.put(newMockHandler("HandlerB", false), null);
+        map.put(newMockHandler(HANDLER_A, true), null);
+        map.put(newMockHandler(HANDLER_B, false), null);
 
         final PolicyBasedAuthenticationManager manager = new PolicyBasedAuthenticationManager(getAuthenticationExecutionPlan(map),
-                mockServicesManager(),
-                new RequiredHandlerAuthenticationPolicy("HandlerA", true));
+                mockServicesManager(), new RequiredHandlerAuthenticationPolicy(HANDLER_A, true));
 
         final Authentication auth = manager.authenticate(transaction);
         assertEquals(1, auth.getSuccesses().size());

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/handler/support/JaasAuthenticationHandlerTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/handler/support/JaasAuthenticationHandlerTests.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.*;
  */
 public class JaasAuthenticationHandlerTests {
 
+    private static final String USERNAME = "test";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -45,13 +47,13 @@ public class JaasAuthenticationHandlerTests {
         this.thrown.expect(LoginException.class);
 
         this.handler.setRealm("TEST");
-        this.handler.authenticate(CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword("test", "test1"));
+        this.handler.authenticate(CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword(USERNAME, "test1"));
     }
 
     @Test
     public void verifyWithAlternativeRealmAndValidCredentials() throws Exception {
         this.handler.setRealm("TEST");
-        assertNotNull(this.handler.authenticate(CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword("test", "test")));
+        assertNotNull(this.handler.authenticate(CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword(USERNAME, USERNAME)));
     }
 
     @Test
@@ -63,6 +65,6 @@ public class JaasAuthenticationHandlerTests {
     public void verifyWithInvalidCredentials() throws Exception {
         this.thrown.expect(LoginException.class);
 
-        this.handler.authenticate(CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword("test", "test1"));
+        this.handler.authenticate(CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword(USERNAME, "test1"));
     }
 }

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/principal/DefaultPrincipalFactoryTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/principal/DefaultPrincipalFactoryTests.java
@@ -12,19 +12,22 @@ import static org.junit.Assert.*;
  * @since 4.1
  */
 public class DefaultPrincipalFactoryTests {
+
+    private static final String UID = "uid";
+
     @Test
     public void checkCreatingSimplePrincipal() {
         final PrincipalFactory f = new DefaultPrincipalFactory();
-        final Principal p = f.createPrincipal("uid");
-        assertEquals(p.getId(), "uid");
+        final Principal p = f.createPrincipal(UID);
+        assertEquals(p.getId(), UID);
         assertEquals(p.getAttributes().size(), 0);
     }
 
     @Test
     public void checkCreatingSimplePrincipalWithAttributes() {
         final PrincipalFactory f = new DefaultPrincipalFactory();
-        final Principal p = f.createPrincipal("uid", Collections.singletonMap("mail", "final@example.com"));
-        assertEquals(p.getId(), "uid");
+        final Principal p = f.createPrincipal(UID, Collections.singletonMap("mail", "final@example.com"));
+        assertEquals(p.getId(), UID);
         assertEquals(p.getAttributes().size(), 1);
         assertTrue(p.getAttributes().containsKey("mail"));
     }
@@ -32,8 +35,8 @@ public class DefaultPrincipalFactoryTests {
     @Test
     public void checkCreatingSimplePrincipalWithDefaultRepository() {
         final PrincipalFactory f = new DefaultPrincipalFactory();
-        final Principal p = f.createPrincipal("uid");
-        assertEquals(p.getId(), "uid");
+        final Principal p = f.createPrincipal(UID);
+        assertEquals(p.getId(), UID);
         assertEquals(p.getAttributes().size(), 0);
     }
 

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicyTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicyTests.java
@@ -46,6 +46,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
     private static final String VALUE_1 = "value1";
     private static final String VALUE_2 = "value2";
     private static final String NEW_ATTR_1_VALUE = "newAttr1";
+    private static final String PRINCIPAL_ID = "principalId";
 
     @Test
     public void verifyMappedAttributeFilterMappedAttributesIsCaseInsensitive() {
@@ -58,7 +59,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
         final Map<String, Object> map = new HashMap<>();
         map.put("ATTR1", VALUE_1);
         when(p.getAttributes()).thenReturn(map);
-        when(p.getId()).thenReturn("principalId");
+        when(p.getId()).thenReturn(PRINCIPAL_ID);
 
         final Map<String, Object> attr = policy.getAttributes(p, CoreAuthenticationTestUtils.getRegisteredService());
         assertEquals(attr.size(), 1);
@@ -79,7 +80,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
         map.put("ATTR1", VALUE_1);
         map.put("ATTR2", VALUE_2);
         when(p.getAttributes()).thenReturn(map);
-        when(p.getId()).thenReturn("principalId");
+        when(p.getId()).thenReturn(PRINCIPAL_ID);
 
         final Map<String, Object> attr = policy.getAttributes(p, CoreAuthenticationTestUtils.getRegisteredService());
         assertEquals(attr.size(), 2);
@@ -103,7 +104,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
         map.put(ATTR_3, Arrays.asList("v3", "v4"));
 
         when(p.getAttributes()).thenReturn(map);
-        when(p.getId()).thenReturn("principalId");
+        when(p.getId()).thenReturn(PRINCIPAL_ID);
 
         final Map<String, Object> attr = policy.getAttributes(p, CoreAuthenticationTestUtils.getRegisteredService());
         assertEquals(attr.size(), 1);
@@ -128,7 +129,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
         map.put(ATTR_3, Arrays.asList("v3", "v4"));
 
         when(p.getAttributes()).thenReturn(map);
-        when(p.getId()).thenReturn("principalId");
+        when(p.getId()).thenReturn(PRINCIPAL_ID);
 
         final Map<String, Object> attr = policy.getAttributes(p, CoreAuthenticationTestUtils.getRegisteredService());
         assertEquals(attr.size(), 2);
@@ -150,7 +151,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
         map.put("ATTR1", VALUE_1);
         map.put("ATTR2", VALUE_2);
         when(p.getAttributes()).thenReturn(map);
-        when(p.getId()).thenReturn("principalId");
+        when(p.getId()).thenReturn(PRINCIPAL_ID);
 
         final Map<String, Object> attr = policy.getAttributes(p, CoreAuthenticationTestUtils.getRegisteredService());
         assertEquals(attr.size(), 0);
@@ -167,7 +168,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
         map.put(ATTR_3, Arrays.asList("v3", "v4"));
 
         when(p.getAttributes()).thenReturn(map);
-        when(p.getId()).thenReturn("principalId");
+        when(p.getId()).thenReturn(PRINCIPAL_ID);
 
         final Map<String, Object> attr = policy.getAttributes(p, CoreAuthenticationTestUtils.getRegisteredService());
         assertEquals(attr.size(), map.size());

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/saml/sps/SamlServiceProviderProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/saml/sps/SamlServiceProviderProperties.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
  * @since 5.0.0
  */
 public class SamlServiceProviderProperties {
+    private static final String EMAIL = "email";
+    private static final String PRINCIPAL_NAME = "eduPersonPrincipalName";
     private Dropbox dropbox = new Dropbox();
     private Workday workday = new Workday();
     private SAManage saManage = new SAManage();
@@ -162,7 +164,7 @@ public class SamlServiceProviderProperties {
 
     public static class Box extends AbstractSamlSPProperties {
         public Box() {
-            setAttributes(Arrays.asList("email", "firstName", "lastName"));
+            setAttributes(Arrays.asList(EMAIL, "firstName", "lastName"));
         }
     }
 
@@ -177,13 +179,13 @@ public class SamlServiceProviderProperties {
 
     public static class Salesforce extends AbstractSamlSPProperties {
         public Salesforce() {
-            setAttributes(Arrays.asList("mail", "eduPersonPrincipalName"));
+            setAttributes(Arrays.asList("mail", PRINCIPAL_NAME));
         }
     }
 
     public static class ServiceNow extends AbstractSamlSPProperties {
         public ServiceNow() {
-            setAttributes(Arrays.asList("eduPersonPrincipalName"));
+            setAttributes(Arrays.asList(PRINCIPAL_NAME));
         }
     }
 
@@ -208,7 +210,7 @@ public class SamlServiceProviderProperties {
     
     public static class Webex extends AbstractSamlSPProperties {
         public Webex() {
-            setNameIdAttribute("email");
+            setNameIdAttribute(EMAIL);
             setAttributes(Arrays.asList("firstName,lastName"));
         }
     }
@@ -222,7 +224,7 @@ public class SamlServiceProviderProperties {
     public static class TestShib extends AbstractSamlSPProperties {
         public TestShib() {
             //setMetadata("http://www.testshib.org/metadata/testshib-providers.xml");
-            setAttributes(Arrays.asList("eduPersonPrincipalName"));
+            setAttributes(Arrays.asList(PRINCIPAL_NAME));
         }
     }
 
@@ -237,20 +239,20 @@ public class SamlServiceProviderProperties {
         public InCommon() {
             //setMetadata("http://md.incommon.org/InCommon/InCommon-metadata.xml");
             //setSignatureLocation("/etc/cas/config/certs/inc-md-cert.pem");
-            setAttributes(Arrays.asList("eduPersonPrincipalName"));
+            setAttributes(Arrays.asList(PRINCIPAL_NAME));
         }
     }
     
     public static class Evernote extends AbstractSamlSPProperties {
         public Evernote() {
-            setNameIdAttribute("email");
+            setNameIdAttribute(EMAIL);
             setNameIdFormat("emailAddress");
         }
     }
     
     public static class Asana extends AbstractSamlSPProperties {
         public Asana() {
-            setNameIdAttribute("email");
+            setNameIdAttribute(EMAIL);
             setNameIdFormat("emailAddress");
         }
     }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/x509/X509Properties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/x509/X509Properties.java
@@ -17,6 +17,8 @@ import java.util.concurrent.TimeUnit;
 
 public class X509Properties {
 
+    private static final String DENY = "DENY";
+
     /**
      * The  Principal types.
      */
@@ -80,11 +82,10 @@ public class X509Properties {
     private long cacheTimeToLiveSeconds = TimeUnit.HOURS.toSeconds(4);
     private long cacheTimeToIdleSeconds = TimeUnit.MINUTES.toSeconds(30);
 
-    private String crlResourceUnavailablePolicy = "DENY";
-    private String crlResourceExpiredPolicy = "DENY";
-
-    private String crlUnavailablePolicy = "DENY";
-    private String crlExpiredPolicy = "DENY";
+    private String crlResourceUnavailablePolicy = DENY;
+    private String crlResourceExpiredPolicy = DENY;
+    private String crlUnavailablePolicy = DENY;
+    private String crlExpiredPolicy = DENY;
     
     @NestedConfigurationProperty
     private PersonDirPrincipalResolverProperties principal = new PersonDirPrincipalResolverProperties();

--- a/core/cas-server-core-events/src/main/java/org/apereo/cas/support/events/dao/AbstractCasEventRepository.java
+++ b/core/cas-server-core-events/src/main/java/org/apereo/cas/support/events/dao/AbstractCasEventRepository.java
@@ -15,7 +15,11 @@ import java.util.stream.Collectors;
  * @since 5.0.0
  */
 public abstract class AbstractCasEventRepository implements CasEventRepository {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCasEventRepository.class);
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractCasEventRepository.class);
+    protected static final String TYPE_PARAM = "type";
+    protected static final String CREATION_TIME_PARAM = "creationTime";
+    protected static final String PRINCIPAL_ID_PARAM = "principalId";
 
     @Override
     public Collection<CasEvent> getEventsOfType(final String type) {

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/ResponseTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/ResponseTests.java
@@ -1,12 +1,12 @@
 package org.apereo.cas.authentication.principal;
 
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * @author Scott Battaglia
@@ -14,11 +14,14 @@ import org.junit.Test;
  */
 public class ResponseTests {
 
+    private static final String TICKET_PARAM = "ticket";
+    private static final String TICKET_VALUE = "foobar";
+
     @Test
     public void verifyConstructionWithoutFragmentAndNoQueryString() {
         final String url = "http://localhost:8080/foo";
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("ticket", "foobar");
+        attributes.put(TICKET_PARAM, TICKET_VALUE);
         final Response response = DefaultResponse.getRedirectResponse(url, attributes);
         assertEquals(url + "?ticket=foobar", response.getUrl());
     }
@@ -27,7 +30,7 @@ public class ResponseTests {
     public void verifyConstructionWithoutFragmentButHasQueryString() {
         final String url = "http://localhost:8080/foo?test=boo";
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("ticket", "foobar");
+        attributes.put(TICKET_PARAM, TICKET_VALUE);
         final Response response = DefaultResponse.getRedirectResponse(url, attributes);
         assertEquals(url + "&ticket=foobar", response.getUrl());
     }
@@ -36,7 +39,7 @@ public class ResponseTests {
     public void verifyConstructionWithFragmentAndQueryString() {
         final String url = "http://localhost:8080/foo?test=boo#hello";
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("ticket", "foobar");
+        attributes.put(TICKET_PARAM, TICKET_VALUE);
         final Response response = DefaultResponse.getRedirectResponse(url, attributes);
         assertEquals("http://localhost:8080/foo?test=boo&ticket=foobar#hello", response.getUrl());
     }
@@ -45,7 +48,7 @@ public class ResponseTests {
     public void verifyConstructionWithFragmentAndNoQueryString() {
         final String url = "http://localhost:8080/foo#hello";
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("ticket", "foobar");
+        attributes.put(TICKET_PARAM, TICKET_VALUE);
         final Response response = DefaultResponse.getRedirectResponse(url, attributes);
         assertEquals("http://localhost:8080/foo?ticket=foobar#hello", response.getUrl());
     }
@@ -54,7 +57,7 @@ public class ResponseTests {
     public void verifyUrlSanitization() {
         final String url = "https://www.example.com\r\nLocation: javascript:\r\n\r\n<script>alert(document.cookie)</script>";
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("ticket", "ST-12345");
+        attributes.put(TICKET_PARAM, "ST-12345");
         final Response response = DefaultResponse.getRedirectResponse(url, attributes);
         assertEquals("https://www.example.com Location: javascript: <script>alert(document.cookie)</script>?ticket=ST-12345",
                 response.getUrl());
@@ -64,7 +67,7 @@ public class ResponseTests {
     public void verifyUrlWithUnicode() {
         final String url = "https://www.example.com/πολιτικῶν";
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("ticket", "ST-12345");
+        attributes.put(TICKET_PARAM, "ST-12345");
         final Response response = DefaultResponse.getRedirectResponse(url, attributes);
         assertEquals("https://www.example.com/πολιτικῶν?ticket=ST-12345", response.getUrl());
     }
@@ -73,7 +76,7 @@ public class ResponseTests {
     public void verifyUrlWithUrn() {
         final String url = "urn:applis-cri:java-sso";
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("ticket", "ST-123456");
+        attributes.put(TICKET_PARAM, "ST-123456");
         final Response response = DefaultResponse.getRedirectResponse(url, attributes);
         assertEquals("urn:applis-cri:java-sso?ticket=ST-123456", response.getUrl());
     }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDaoTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDaoTests.java
@@ -42,6 +42,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     private static final String SERVICE_ID = "testId";
     private static final String THEME = "theme";
     private static final String DESCRIPTION = "description";
+    private static final String HTTPS_SERVICE_ID = "^https://.+";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -249,7 +250,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     @Test
     public void verifyServiceType() {
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("testServiceType");
         r.setTheme("testtheme");
         r.setEvaluationOrder(1000);
@@ -261,7 +262,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     @Test
     public void verifyServiceWithInvalidFileName() {
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("hell/o@world:*");
         r.setEvaluationOrder(1000);
 
@@ -275,7 +276,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
         final List<RegisteredService> list = new ArrayList<>(5);
         IntStream.range(1, 5).forEach(i -> {
             final RegexRegisteredService r = new RegexRegisteredService();
-            r.setServiceId("^https://.+");
+            r.setServiceId(HTTPS_SERVICE_ID);
             r.setName("testServiceType");
             r.setTheme("testtheme");
             r.setEvaluationOrder(1000);
@@ -298,7 +299,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     @Test
     public void checkForAuthorizationStrategy() {
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("checkForAuthorizationStrategy");
         r.setId(42);
 
@@ -319,7 +320,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     @Test
     public void verifyAccessStrategyWithStarEndDate() throws Exception {
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("verifyAAccessStrategyWithStarEndDate");
         r.setId(62);
 
@@ -340,7 +341,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     @Test
     public void verifyAccessStrategyWithEndpoint() throws Exception {
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("verifyAccessStrategyWithEndpoint");
         r.setId(62);
 
@@ -362,7 +363,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
                 "classpath:RSA1024Public.key", "RSA");
 
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("serializePublicKeyForServiceAndVerify");
         r.setId(4245);
         r.setPublicKey(publicKey);
@@ -375,7 +376,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     @Test
     public void checkNullabilityOfAccessStrategy() {
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("checkNullabilityOfAccessStrategy");
         r.setId(43210);
         r.setAccessStrategy(null);
@@ -389,7 +390,7 @@ public abstract class AbstractResourceBasedServiceRegistryDaoTests {
     @Test
     public void persistCustomServiceProperties() throws Exception {
         final RegexRegisteredService r = new RegexRegisteredService();
-        r.setServiceId("^https://.+");
+        r.setServiceId(HTTPS_SERVICE_ID);
         r.setName("persistCustomServiceProperties");
         r.setId(4245);
 

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AnonymousRegisteredServiceUsernameAttributeProviderTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AnonymousRegisteredServiceUsernameAttributeProviderTests.java
@@ -21,12 +21,12 @@ public class AnonymousRegisteredServiceUsernameAttributeProviderTests {
 
     private static final File JSON_FILE = new File(FileUtils.getTempDirectoryPath(), "anonymousRegisteredServiceUsernameAttributeProvider.json");
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String CASROX = "casrox";
 
     @Test
     public void verifyPrincipalResolution() {
-        final AnonymousRegisteredServiceUsernameAttributeProvider provider =
-                new AnonymousRegisteredServiceUsernameAttributeProvider(
-                new ShibbolethCompatiblePersistentIdGenerator("casrox"));
+        final AnonymousRegisteredServiceUsernameAttributeProvider provider = new AnonymousRegisteredServiceUsernameAttributeProvider(
+                new ShibbolethCompatiblePersistentIdGenerator(CASROX));
         
         final Service service = mock(Service.class);
         when(service.getId()).thenReturn("id");
@@ -38,22 +38,19 @@ public class AnonymousRegisteredServiceUsernameAttributeProviderTests {
 
     @Test
     public void verifyEquality() {
-        final AnonymousRegisteredServiceUsernameAttributeProvider provider =
-                new AnonymousRegisteredServiceUsernameAttributeProvider(
-                        new ShibbolethCompatiblePersistentIdGenerator("casrox"));
+        final AnonymousRegisteredServiceUsernameAttributeProvider provider = new AnonymousRegisteredServiceUsernameAttributeProvider(
+                        new ShibbolethCompatiblePersistentIdGenerator(CASROX));
 
-        final AnonymousRegisteredServiceUsernameAttributeProvider provider2 =
-                new AnonymousRegisteredServiceUsernameAttributeProvider(
-                        new ShibbolethCompatiblePersistentIdGenerator("casrox"));
+        final AnonymousRegisteredServiceUsernameAttributeProvider provider2 = new AnonymousRegisteredServiceUsernameAttributeProvider(
+                        new ShibbolethCompatiblePersistentIdGenerator(CASROX));
 
         assertEquals(provider, provider2);
     }
 
     @Test
     public void verifySerializeADefaultRegisteredServiceUsernameProviderToJson() throws IOException {
-        final AnonymousRegisteredServiceUsernameAttributeProvider providerWritten =
-                new AnonymousRegisteredServiceUsernameAttributeProvider(
-                        new ShibbolethCompatiblePersistentIdGenerator("casrox"));
+        final AnonymousRegisteredServiceUsernameAttributeProvider providerWritten = new AnonymousRegisteredServiceUsernameAttributeProvider(
+                        new ShibbolethCompatiblePersistentIdGenerator(CASROX));
 
         MAPPER.writeValue(JSON_FILE, providerWritten);
 

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultServicesManagerTests.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
  */
 public class DefaultServicesManagerTests {
 
+    private static final String TEST = "test";
     private ServicesManager defaultServicesManager;
     private ServiceRegistryDao dao;
 
@@ -42,8 +43,8 @@ public class DefaultServicesManagerTests {
     public void verifySaveAndGet() {
         final RegexRegisteredService r = new RegexRegisteredService();
         r.setId(1000);
-        r.setName("test");
-        r.setServiceId("test");
+        r.setName(TEST);
+        r.setServiceId(TEST);
 
         this.defaultServicesManager.save(r);
         assertNotNull(this.defaultServicesManager.findServiceBy(1000));
@@ -73,8 +74,8 @@ public class DefaultServicesManagerTests {
     public void verifySaveWithReturnedPersistedInstance() {
         final RegexRegisteredService r = new RegexRegisteredService();
         r.setId(1000L);
-        r.setName("test");
-        r.setServiceId("test");
+        r.setName(TEST);
+        r.setServiceId(TEST);
 
         final RegisteredService persistedRs = this.defaultServicesManager.save(r);
         assertNotNull(persistedRs);
@@ -85,8 +86,8 @@ public class DefaultServicesManagerTests {
     public void verifyDeleteAndGet() {
         final RegexRegisteredService r = new RegexRegisteredService();
         r.setId(1000);
-        r.setName("test");
-        r.setServiceId("test");
+        r.setName(TEST);
+        r.setServiceId(TEST);
 
         this.defaultServicesManager.save(r);
         assertEquals(r, this.defaultServicesManager.findServiceBy(r.getId()));
@@ -104,10 +105,10 @@ public class DefaultServicesManagerTests {
     public void verifyMatchesExistingService() {
         final RegexRegisteredService r = new RegexRegisteredService();
         r.setId(1000);
-        r.setName("test");
-        r.setServiceId("test");
+        r.setName(TEST);
+        r.setServiceId(TEST);
 
-        final Service service = new SimpleService("test");
+        final Service service = new SimpleService(TEST);
         final Service service2 = new SimpleService("fdfa");
 
         this.defaultServicesManager.save(r);
@@ -121,8 +122,8 @@ public class DefaultServicesManagerTests {
     public void verifyAllService() {
         final RegexRegisteredService r = new RegexRegisteredService();
         r.setId(1000);
-        r.setName("test");
-        r.setServiceId("test");
+        r.setName(TEST);
+        r.setServiceId(TEST);
         r.setEvaluationOrder(2);
 
         this.defaultServicesManager.save(r);
@@ -160,20 +161,20 @@ public class DefaultServicesManagerTests {
     public void verifyEvaluationOrderOfServices() {
         final RegexRegisteredService r = new RegexRegisteredService();
         r.setId(100);
-        r.setName("test");
-        r.setServiceId("test");
+        r.setName(TEST);
+        r.setServiceId(TEST);
         r.setEvaluationOrder(200);
 
         final RegexRegisteredService r2 = new RegexRegisteredService();
         r2.setId(101);
-        r2.setName("test");
-        r2.setServiceId("test");
+        r2.setName(TEST);
+        r2.setServiceId(TEST);
         r2.setEvaluationOrder(80);
 
         final RegexRegisteredService r3 = new RegexRegisteredService();
         r3.setId(102);
         r3.setName("Sample test service");
-        r3.setServiceId("test");
+        r3.setServiceId(TEST);
         r3.setEvaluationOrder(80);
 
         this.defaultServicesManager.save(r);

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/support/RegisteredServiceRegexAttributeFilterTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/support/RegisteredServiceRegexAttributeFilterTests.java
@@ -36,6 +36,7 @@ public class RegisteredServiceRegexAttributeFilterTests {
     private static final String PHONE = "phone";
     private static final String FAMILY_NAME = "familyName";
     private static final String GIVEN_NAME = "givenName";
+    private static final String UID = "uid";
 
     private final RegisteredServiceAttributeFilter filter;
     private final Map<String, Object> givenAttributesMap;
@@ -48,7 +49,7 @@ public class RegisteredServiceRegexAttributeFilterTests {
         this.filter = new RegisteredServiceRegexAttributeFilter("^.{5,}$");
 
         this.givenAttributesMap = new HashMap<>();
-        this.givenAttributesMap.put("uid", "loggedInTestUid");
+        this.givenAttributesMap.put(UID, "loggedInTestUid");
         this.givenAttributesMap.put(PHONE, "1290");
         this.givenAttributesMap.put(FAMILY_NAME, "Smith");
         this.givenAttributesMap.put(GIVEN_NAME, "John");
@@ -58,7 +59,7 @@ public class RegisteredServiceRegexAttributeFilterTests {
         this.givenAttributesMap.put("setAttribute", Stream.of("math", "science", "chemistry").collect(Collectors.toSet()));
 
         final Map<String, String> mapAttributes = new HashMap<>();
-        mapAttributes.put("uid", "loggedInTestUid");
+        mapAttributes.put(UID, "loggedInTestUid");
         mapAttributes.put(PHONE, "890");
         mapAttributes.put(FAMILY_NAME, "Smith");
         this.givenAttributesMap.put("mapAttribute", mapAttributes);
@@ -81,13 +82,13 @@ public class RegisteredServiceRegexAttributeFilterTests {
         assertFalse(attrs.containsKey(PHONE));
         assertFalse(attrs.containsKey(GIVEN_NAME));
 
-        assertTrue(attrs.containsKey("uid"));
+        assertTrue(attrs.containsKey(UID));
         assertTrue(attrs.containsKey("memberOf"));
         assertTrue(attrs.containsKey("mapAttribute"));
 
         @SuppressWarnings("unchecked")
         final Map<String, String> mapAttributes = (Map<String, String>) attrs.get("mapAttribute");
-        assertTrue(mapAttributes.containsKey("uid"));
+        assertTrue(mapAttributes.containsKey(UID));
         assertTrue(mapAttributes.containsKey(FAMILY_NAME));
         assertFalse(mapAttributes.containsKey(PHONE));
 

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/ServiceTicketImplTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/ServiceTicketImplTests.java
@@ -53,8 +53,7 @@ public class ServiceTicketImplTests {
 
     @Test
     public void verifySerializeToJson() throws IOException {
-        final ServiceTicket stWritten = new ServiceTicketImpl(ST_ID, tgt,
-                RegisteredServiceTestUtils.getService(), true, new NeverExpiresExpirationPolicy());
+        final ServiceTicket stWritten = new ServiceTicketImpl(ST_ID, tgt, RegisteredServiceTestUtils.getService(), true, new NeverExpiresExpirationPolicy());
 
         mapper.writeValue(ST_JSON_FILE, stWritten);
         final ServiceTicketImpl stRead = mapper.readValue(ST_JSON_FILE, ServiceTicketImpl.class);
@@ -79,16 +78,14 @@ public class ServiceTicketImplTests {
 
     @Test
     public void verifyIsFromNewLoginTrue() {
-        final ServiceTicket s = new ServiceTicketImpl(ST_ID, tgt,
-                CoreAuthenticationTestUtils.getService(), true, new NeverExpiresExpirationPolicy());
+        final ServiceTicket s = new ServiceTicketImpl(ST_ID, tgt, CoreAuthenticationTestUtils.getService(), true, new NeverExpiresExpirationPolicy());
 
         assertTrue(s.isFromNewLogin());
     }
 
     @Test
     public void verifyIsFromNewLoginFalse() {
-        ServiceTicket s = tgt.grantServiceTicket(ST_ID,
-                CoreAuthenticationTestUtils.getService(), new NeverExpiresExpirationPolicy(), false, false);
+        ServiceTicket s = tgt.grantServiceTicket(ST_ID, CoreAuthenticationTestUtils.getService(), new NeverExpiresExpirationPolicy(), false, false);
         assertTrue(s.isFromNewLogin());
         s = tgt.grantServiceTicket(ST_ID, CoreAuthenticationTestUtils.getService(), new NeverExpiresExpirationPolicy(), false, false);
         assertFalse(s.isFromNewLogin());
@@ -104,15 +101,13 @@ public class ServiceTicketImplTests {
     @Test
     public void verifyGetTicket() {
         final Service simpleService = CoreAuthenticationTestUtils.getService();
-        final ServiceTicket s = new ServiceTicketImpl(ST_ID, tgt, simpleService, false,
-                new NeverExpiresExpirationPolicy());
+        final ServiceTicket s = new ServiceTicketImpl(ST_ID, tgt, simpleService, false, new NeverExpiresExpirationPolicy());
         assertEquals(tgt, s.getGrantingTicket());
     }
 
     @Test
     public void verifyIsExpiredTrueBecauseOfRoot() {
-        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID,
-                CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID, CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
         final ServiceTicket s = t.grantServiceTicket(idGenerator.getNewTicketId(ServiceTicket.PREFIX),
                 CoreAuthenticationTestUtils.getService(), new NeverExpiresExpirationPolicy(), false, true);
 
@@ -123,10 +118,8 @@ public class ServiceTicketImplTests {
 
     @Test
     public void verifyIsExpiredFalse() {
-        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID,
-                CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        final ServiceTicket s = t.grantServiceTicket(idGenerator.getNewTicketId(ServiceTicket.PREFIX),
-                CoreAuthenticationTestUtils.getService(),
+        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID, CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
+        final ServiceTicket s = t.grantServiceTicket(idGenerator.getNewTicketId(ServiceTicket.PREFIX), CoreAuthenticationTestUtils.getService(),
                 new MultiTimeUseOrTimeoutExpirationPolicy(1, 5000), false, true);
 
         assertFalse(s.isExpired());
@@ -135,13 +128,10 @@ public class ServiceTicketImplTests {
     @Test
     public void verifyTicketGrantingTicket() throws AbstractTicketException {
         final Authentication a = CoreAuthenticationTestUtils.getAuthentication();
-        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID,
-                CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        final ServiceTicket s = t.grantServiceTicket(idGenerator.getNewTicketId(ServiceTicket.PREFIX),
-                CoreAuthenticationTestUtils.getService(),
+        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID, CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
+        final ServiceTicket s = t.grantServiceTicket(idGenerator.getNewTicketId(ServiceTicket.PREFIX), CoreAuthenticationTestUtils.getService(),
                 new MultiTimeUseOrTimeoutExpirationPolicy(1, 5000), false, true);
-        final TicketGrantingTicket t1 = s.grantProxyGrantingTicket(
-                idGenerator.getNewTicketId(TicketGrantingTicket.PREFIX), a,
+        final TicketGrantingTicket t1 = s.grantProxyGrantingTicket(idGenerator.getNewTicketId(TicketGrantingTicket.PREFIX), a,
                 new NeverExpiresExpirationPolicy());
 
         assertEquals(a, t1.getAuthentication());
@@ -150,20 +140,13 @@ public class ServiceTicketImplTests {
     @Test
     public void verifyTicketGrantingTicketGrantedTwice() throws AbstractTicketException {
         final Authentication a = CoreAuthenticationTestUtils.getAuthentication();
-        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID,
-                CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        final ServiceTicket s = t.grantServiceTicket(idGenerator.getNewTicketId(ServiceTicket.PREFIX),
-                CoreAuthenticationTestUtils.getService(),
+        final TicketGrantingTicket t = new TicketGrantingTicketImpl(ID, CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
+        final ServiceTicket s = t.grantServiceTicket(idGenerator.getNewTicketId(ServiceTicket.PREFIX), CoreAuthenticationTestUtils.getService(),
                 new MultiTimeUseOrTimeoutExpirationPolicy(1, 5000), false, true);
-        s.grantProxyGrantingTicket(idGenerator.getNewTicketId(TicketGrantingTicket.PREFIX), a,
-                new NeverExpiresExpirationPolicy());
+        s.grantProxyGrantingTicket(idGenerator.getNewTicketId(TicketGrantingTicket.PREFIX), a, new NeverExpiresExpirationPolicy());
 
-        try {
-            s.grantProxyGrantingTicket(idGenerator.getNewTicketId(TicketGrantingTicket.PREFIX), a,
-                    new NeverExpiresExpirationPolicy());
-            fail("Exception expected.");
-        } catch (final Exception e) {
+        this.thrown.expect(Exception.class);
 
-        }
+        s.grantProxyGrantingTicket(idGenerator.getNewTicketId(TicketGrantingTicket.PREFIX), a, new NeverExpiresExpirationPolicy());
     }
 }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -24,7 +24,7 @@ public abstract class AbstractTicketRegistryTests {
 
     private static final int TICKETS_IN_REGISTRY = 10;
     private static final String EXCEPTION_CAUGHT_NONE_EXPECTED = "Exception caught.  None expected.";
-    private static final String CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN = "Caught an exception. But no exception should have been thrown: ";
+    private static final String CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED = "Caught an exception. But no exception should have been thrown: ";
 
     private TicketRegistry ticketRegistry;
 
@@ -129,7 +129,7 @@ public abstract class AbstractTicketRegistryTests {
                     new NeverExpiresExpirationPolicy()));
             this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX);
         } catch (final Exception e) {
-            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED + e.getMessage());
         }
     }
 
@@ -143,7 +143,7 @@ public abstract class AbstractTicketRegistryTests {
             }
             assertEquals(TICKETS_IN_REGISTRY, this.ticketRegistry.deleteAll());
         } catch (final Exception e) {
-            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED + e.getMessage());
         }
     }
 
@@ -155,7 +155,7 @@ public abstract class AbstractTicketRegistryTests {
                     new NeverExpiresExpirationPolicy()));
             assertSame(1, this.ticketRegistry.deleteTicket(TicketGrantingTicket.PREFIX));
         } catch (final Exception e) {
-            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED + e.getMessage());
         }
     }
 
@@ -254,7 +254,7 @@ public abstract class AbstractTicketRegistryTests {
             assertNull(this.ticketRegistry.getTicket("ST21", ServiceTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST31", ServiceTicket.class));
         } catch (final Exception e) {
-            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED + e.getMessage());
         }
     }
 

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -24,6 +24,7 @@ public abstract class AbstractTicketRegistryTests {
 
     private static final int TICKETS_IN_REGISTRY = 10;
     private static final String EXCEPTION_CAUGHT_NONE_EXPECTED = "Exception caught.  None expected.";
+    private static final String CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN = "Caught an exception. But no exception should have been thrown: ";
 
     private TicketRegistry ticketRegistry;
 
@@ -128,7 +129,7 @@ public abstract class AbstractTicketRegistryTests {
                     new NeverExpiresExpirationPolicy()));
             this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX);
         } catch (final Exception e) {
-            fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
         }
     }
 
@@ -142,7 +143,7 @@ public abstract class AbstractTicketRegistryTests {
             }
             assertEquals(TICKETS_IN_REGISTRY, this.ticketRegistry.deleteAll());
         } catch (final Exception e) {
-            fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
         }
     }
 
@@ -154,7 +155,7 @@ public abstract class AbstractTicketRegistryTests {
                     new NeverExpiresExpirationPolicy()));
             assertSame(1, this.ticketRegistry.deleteTicket(TicketGrantingTicket.PREFIX));
         } catch (final Exception e) {
-            fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
         }
     }
 
@@ -253,7 +254,7 @@ public abstract class AbstractTicketRegistryTests {
             assertNull(this.ticketRegistry.getTicket("ST21", ServiceTicket.class));
             assertNull(this.ticketRegistry.getTicket("ST31", ServiceTicket.class));
         } catch (final Exception e) {
-            fail("Caught an exception. But no exception should have been thrown: " + e.getMessage());
+            fail(CAUGHT_AN_EXCEPTION_BUT_NO_EXCEPTION_SHOULD_HAVE_BEEN_THROWN + e.getMessage());
         }
     }
 

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/DefaultMessageDescriptor.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/DefaultMessageDescriptor.java
@@ -83,7 +83,7 @@ public class DefaultMessageDescriptor implements MessageDescriptor {
 
     @Override
     public boolean equals(final Object other) {
-        if (other == null || !(other instanceof DefaultMessageDescriptor)) {
+        if (!(other instanceof DefaultMessageDescriptor)) {
             return false;
         }
         if (other == this) {

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CasVersion.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CasVersion.java
@@ -17,7 +17,8 @@ import java.time.ZonedDateTime;
  * @since 3.0.0
  */
 public class CasVersion {
-    private static Logger LOGGER = LoggerFactory.getLogger(CasVersion.class);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CasVersion.class);
     
     /**
      * Private constructor for CasVersion. You should not be able to instantiate

--- a/support/cas-server-support-events-jpa/src/main/java/org/apereo/cas/support/events/jpa/JpaCasEventRepository.java
+++ b/support/cas-server-support-events-jpa/src/main/java/org/apereo/cas/support/events/jpa/JpaCasEventRepository.java
@@ -43,13 +43,13 @@ public class JpaCasEventRepository extends AbstractCasEventRepository {
     @Override
     public Collection<CasEvent> getEventsForPrincipal(final String id) {
         return this.entityManager.createQuery(SELECT_QUERY.concat("where r.principalId = :principalId"),
-                CasEvent.class).setParameter("principalId", id).getResultList();
+                CasEvent.class).setParameter(PRINCIPAL_ID_PARAM, id).getResultList();
     }
 
     @Override
     public Collection<CasEvent> load(final ZonedDateTime dateTime) {
         return this.entityManager.createQuery(SELECT_QUERY.concat("where r.creationTime >= :creationTime"),
-                CasEvent.class).setParameter("creationTime", dateTime.toString()).getResultList();
+                CasEvent.class).setParameter(CREATION_TIME_PARAM, dateTime.toString()).getResultList();
     }
 
     @Override
@@ -57,9 +57,9 @@ public class JpaCasEventRepository extends AbstractCasEventRepository {
         return this.entityManager.createQuery(
                 SELECT_QUERY.concat("where r.type = :type and r.creationTime >= :creationTime and r.principalId = :principalId"),
                 CasEvent.class)
-                .setParameter("type", type)
-                .setParameter("principalId", principal)
-                .setParameter("creationTime", dateTime.toString())
+                .setParameter(TYPE_PARAM, type)
+                .setParameter(PRINCIPAL_ID_PARAM, principal)
+                .setParameter(CREATION_TIME_PARAM, dateTime.toString())
                 .getResultList();
     }
 
@@ -67,8 +67,8 @@ public class JpaCasEventRepository extends AbstractCasEventRepository {
     public Collection<CasEvent> getEventsOfType(final String type, final ZonedDateTime dateTime) {
         return this.entityManager.createQuery(
                 SELECT_QUERY.concat("where r.type = :type and r.creationTime >= :creationTime"), CasEvent.class)
-                .setParameter("type", type)
-                .setParameter("creationTime", dateTime.toString())
+                .setParameter(TYPE_PARAM, type)
+                .setParameter(CREATION_TIME_PARAM, dateTime.toString())
                 .getResultList();
     }
 
@@ -76,8 +76,8 @@ public class JpaCasEventRepository extends AbstractCasEventRepository {
     public Collection<CasEvent> getEventsForPrincipal(final String id, final ZonedDateTime dateTime) {
         return this.entityManager.createQuery(
                 SELECT_QUERY.concat("where r.principalId = :principalId and r.creationTime >= :creationTime"), CasEvent.class)
-                .setParameter("principalId", id)
-                .setParameter("creationTime", dateTime.toString())
+                .setParameter(PRINCIPAL_ID_PARAM, id)
+                .setParameter(CREATION_TIME_PARAM, dateTime.toString())
                 .getResultList();
     }
 
@@ -85,7 +85,7 @@ public class JpaCasEventRepository extends AbstractCasEventRepository {
     public Collection<CasEvent> getEventsOfType(final String type) {
         return this.entityManager.createQuery(
                 SELECT_QUERY.concat("where r.type = :type"), CasEvent.class)
-                .setParameter("type", type)
+                .setParameter(TYPE_PARAM, type)
                 .getResultList();
     }
 
@@ -94,8 +94,8 @@ public class JpaCasEventRepository extends AbstractCasEventRepository {
         return this.entityManager.createQuery(
                 SELECT_QUERY.concat("where r.type = :type and r.principalId = :principalId"),
                 CasEvent.class)
-                .setParameter("type", type)
-                .setParameter("principalId", principal)
+                .setParameter(TYPE_PARAM, type)
+                .setParameter(PRINCIPAL_ID_PARAM, principal)
                 .getResultList();
     }
 }

--- a/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
+++ b/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
@@ -19,8 +19,9 @@ import java.util.Collection;
  * @since 5.0.0
  */
 public class MongoDbCasEventRepository extends AbstractCasEventRepository {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbCasEventRepository.class);
-    
+
     private final String collectionName;
     private final MongoOperations mongoTemplate;
 
@@ -59,49 +60,49 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
     @Override
     public Collection<CasEvent> getEventsForPrincipal(final String id) {
         final Query query = new Query();
-        query.addCriteria(Criteria.where("principalId").is(id));
+        query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(id));
         return this.mongoTemplate.find(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Collection<CasEvent> getEventsOfType(final String type) {
         final Query query = new Query();
-        query.addCriteria(Criteria.where("type").is(type));
+        query.addCriteria(Criteria.where(TYPE_PARAM).is(type));
         return this.mongoTemplate.find(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Collection<CasEvent> getEventsOfTypeForPrincipal(final String type, final String principal) {
         final Query query = new Query();
-        query.addCriteria(Criteria.where("type").is(type).and("principalId").is(principal));
+        query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(PRINCIPAL_ID_PARAM).is(principal));
         return this.mongoTemplate.find(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Collection<CasEvent> load(final ZonedDateTime dateTime) {
         final Query query = new Query();
-        query.addCriteria(Criteria.where("creationTime").gte(dateTime.toString()));
+        query.addCriteria(Criteria.where(CREATION_TIME_PARAM).gte(dateTime.toString()));
         return this.mongoTemplate.find(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Collection<CasEvent> getEventsOfTypeForPrincipal(final String type, final String principal, final ZonedDateTime dateTime) {
         final Query query = new Query();
-        query.addCriteria(Criteria.where("type").is(type).and("principalId").is(principal).and("creationTime").gte(dateTime.toString()));
+        query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(PRINCIPAL_ID_PARAM).is(principal).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
         return this.mongoTemplate.find(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Collection<CasEvent> getEventsOfType(final String type, final ZonedDateTime dateTime) {
         final Query query = new Query();
-        query.addCriteria(Criteria.where("type").is(type).and("creationTime").gte(dateTime.toString()));
+        query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
         return this.mongoTemplate.find(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Collection<CasEvent> getEventsForPrincipal(final String principal, final ZonedDateTime dateTime) {
         final Query query = new Query();
-        query.addCriteria(Criteria.where("principalId").is(principal).and("creationTime").gte(dateTime.toString()));
+        query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(principal).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
         return this.mongoTemplate.find(query, CasEvent.class, this.collectionName);
     }
 }

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
@@ -64,6 +64,8 @@ import static org.junit.Assert.*;
         CasCoreTicketCatalogConfiguration.class})
 public class HazelcastTicketRegistryReplicationTests {
     private static final String TGT_ID = "TGT";
+    private static final String ST_ID_1 = "ST1";
+    private static final String PGT_ID_1 = "PGT-1";
     @Autowired
     @Qualifier("hzTicketRegistry1")
     private TicketRegistry hzTicketRegistry1;
@@ -129,7 +131,7 @@ public class HazelcastTicketRegistryReplicationTests {
 
         final Service service = RegisteredServiceTestUtils.getService("TGT_DELETE_TEST");
 
-        final ServiceTicket st1 = tgt.grantServiceTicket("ST1", service, new NeverExpiresExpirationPolicy(), false, false);
+        final ServiceTicket st1 = tgt.grantServiceTicket(ST_ID_1, service, new NeverExpiresExpirationPolicy(), false, false);
         final ServiceTicket st2 = tgt.grantServiceTicket("ST2", service, new NeverExpiresExpirationPolicy(), false, false);
         final ServiceTicket st3 = tgt.grantServiceTicket("ST3", service, new NeverExpiresExpirationPolicy(), false, false);
 
@@ -139,14 +141,14 @@ public class HazelcastTicketRegistryReplicationTests {
         this.hzTicketRegistry1.updateTicket(tgt);
 
         assertNotNull(this.hzTicketRegistry1.getTicket(tgt.getId(), TicketGrantingTicket.class));
-        assertNotNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
+        assertNotNull(this.hzTicketRegistry1.getTicket(ST_ID_1, ServiceTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
 
         assertTrue("TGT and children were deleted", this.hzTicketRegistry1.deleteTicket(tgt.getId()) > 0);
 
         assertNull(this.hzTicketRegistry1.getTicket(tgt.getId(), TicketGrantingTicket.class));
-        assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket(ST_ID_1, ServiceTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST2", ServiceTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST3", ServiceTicket.class));
     }
@@ -159,14 +161,14 @@ public class HazelcastTicketRegistryReplicationTests {
 
         final Service service = RegisteredServiceTestUtils.getService("TGT_DELETE_TEST");
 
-        final ServiceTicket st1 = tgt.grantServiceTicket("ST1", service, new NeverExpiresExpirationPolicy(), false, true);
+        final ServiceTicket st1 = tgt.grantServiceTicket(ST_ID_1, service, new NeverExpiresExpirationPolicy(), false, true);
 
         this.hzTicketRegistry1.addTicket(st1);
 
         assertNotNull(this.hzTicketRegistry1.getTicket(TGT_ID, TicketGrantingTicket.class));
-        assertNotNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
+        assertNotNull(this.hzTicketRegistry1.getTicket(ST_ID_1, ServiceTicket.class));
 
-        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
+        final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket(PGT_ID_1, a, new NeverExpiresExpirationPolicy());
         assertEquals(a, pgt.getAuthentication());
 
         this.hzTicketRegistry1.addTicket(pgt);
@@ -174,8 +176,8 @@ public class HazelcastTicketRegistryReplicationTests {
         assertSame(3, this.hzTicketRegistry1.deleteTicket(tgt.getId()));
 
         assertNull(this.hzTicketRegistry1.getTicket(TGT_ID, TicketGrantingTicket.class));
-        assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
-        assertNull(this.hzTicketRegistry1.getTicket("PGT-1", ProxyGrantingTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket(ST_ID_1, ServiceTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket(PGT_ID_1, ProxyGrantingTicket.class));
     }
 
     private static TicketGrantingTicket newTestTgt() {

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryReplicationTests.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.*;
         HazelcastTicketRegistryTicketCatalogConfiguration.class,
         CasCoreTicketCatalogConfiguration.class})
 public class HazelcastTicketRegistryReplicationTests {
+    private static final String TGT_ID = "TGT";
     @Autowired
     @Qualifier("hzTicketRegistry1")
     private TicketRegistry hzTicketRegistry1;
@@ -122,19 +123,15 @@ public class HazelcastTicketRegistryReplicationTests {
 
     @Test
     public void verifyDeleteTicketWithChildren() throws Exception {
-        this.hzTicketRegistry1.addTicket(new TicketGrantingTicketImpl(
-                "TGT", CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy()));
-        final TicketGrantingTicket tgt = this.hzTicketRegistry1.getTicket(
-                "TGT", TicketGrantingTicket.class);
+        this.hzTicketRegistry1.addTicket(new TicketGrantingTicketImpl(TGT_ID, CoreAuthenticationTestUtils.getAuthentication(),
+                new NeverExpiresExpirationPolicy()));
+        final TicketGrantingTicket tgt = this.hzTicketRegistry1.getTicket(TGT_ID, TicketGrantingTicket.class);
 
         final Service service = RegisteredServiceTestUtils.getService("TGT_DELETE_TEST");
 
-        final ServiceTicket st1 = tgt.grantServiceTicket(
-                "ST1", service, new NeverExpiresExpirationPolicy(), false, false);
-        final ServiceTicket st2 = tgt.grantServiceTicket(
-                "ST2", service, new NeverExpiresExpirationPolicy(), false, false);
-        final ServiceTicket st3 = tgt.grantServiceTicket(
-                "ST3", service, new NeverExpiresExpirationPolicy(), false, false);
+        final ServiceTicket st1 = tgt.grantServiceTicket("ST1", service, new NeverExpiresExpirationPolicy(), false, false);
+        final ServiceTicket st2 = tgt.grantServiceTicket("ST2", service, new NeverExpiresExpirationPolicy(), false, false);
+        final ServiceTicket st3 = tgt.grantServiceTicket("ST3", service, new NeverExpiresExpirationPolicy(), false, false);
 
         this.hzTicketRegistry1.addTicket(st1);
         this.hzTicketRegistry1.addTicket(st2);
@@ -157,19 +154,16 @@ public class HazelcastTicketRegistryReplicationTests {
     @Test
     public void verifyDeleteTicketWithPGT() {
         final Authentication a = CoreAuthenticationTestUtils.getAuthentication();
-        this.hzTicketRegistry1.addTicket(new TicketGrantingTicketImpl(
-                "TGT", a, new NeverExpiresExpirationPolicy()));
-        final TicketGrantingTicket tgt = this.hzTicketRegistry1.getTicket(
-                "TGT", TicketGrantingTicket.class);
+        this.hzTicketRegistry1.addTicket(new TicketGrantingTicketImpl(TGT_ID, a, new NeverExpiresExpirationPolicy()));
+        final TicketGrantingTicket tgt = this.hzTicketRegistry1.getTicket(TGT_ID, TicketGrantingTicket.class);
 
         final Service service = RegisteredServiceTestUtils.getService("TGT_DELETE_TEST");
 
-        final ServiceTicket st1 = tgt.grantServiceTicket(
-                "ST1", service, new NeverExpiresExpirationPolicy(), false, true);
+        final ServiceTicket st1 = tgt.grantServiceTicket("ST1", service, new NeverExpiresExpirationPolicy(), false, true);
 
         this.hzTicketRegistry1.addTicket(st1);
 
-        assertNotNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
+        assertNotNull(this.hzTicketRegistry1.getTicket(TGT_ID, TicketGrantingTicket.class));
         assertNotNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
 
         final ProxyGrantingTicket pgt = st1.grantProxyGrantingTicket("PGT-1", a, new NeverExpiresExpirationPolicy());
@@ -179,7 +173,7 @@ public class HazelcastTicketRegistryReplicationTests {
         this.hzTicketRegistry1.updateTicket(tgt);
         assertSame(3, this.hzTicketRegistry1.deleteTicket(tgt.getId()));
 
-        assertNull(this.hzTicketRegistry1.getTicket("TGT", TicketGrantingTicket.class));
+        assertNull(this.hzTicketRegistry1.getTicket(TGT_ID, TicketGrantingTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("ST1", ServiceTicket.class));
         assertNull(this.hzTicketRegistry1.getTicket("PGT-1", ProxyGrantingTicket.class));
     }

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
@@ -19,7 +19,8 @@ import java.util.Collection;
  */
 public class MemCacheTicketRegistry extends AbstractTicketRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(MemCacheTicketRegistry.class);
-    
+    private static final String NO_MEMCACHED_CLIENT_IS_DEFINED = "No memcached client is defined.";
+
     /**
      * Memcached client.
      */
@@ -37,7 +38,7 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public Ticket updateTicket(final Ticket ticketToUpdate) {
-        Assert.notNull(this.client, "No memcached client is defined.");
+        Assert.notNull(this.client, NO_MEMCACHED_CLIENT_IS_DEFINED);
 
         final Ticket ticket = encodeTicket(ticketToUpdate);
         LOGGER.debug("Updating ticket [{}]", ticket);
@@ -57,7 +58,7 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public void addTicket(final Ticket ticketToAdd) {
-        Assert.notNull(this.client, "No memcached client is defined.");
+        Assert.notNull(this.client, NO_MEMCACHED_CLIENT_IS_DEFINED);
         try {
             final Ticket ticket = encodeTicket(ticketToAdd);
             LOGGER.debug("Adding ticket [{}]", ticket);
@@ -86,7 +87,7 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
-        Assert.notNull(this.client, "No memcached client is defined.");
+        Assert.notNull(this.client, NO_MEMCACHED_CLIENT_IS_DEFINED);
         try {
             if (this.client.delete(ticketId).get()) {
                 LOGGER.debug("Removed ticket [{}] from the cache", ticketId);
@@ -101,7 +102,7 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public Ticket getTicket(final String ticketIdToGet) {
-        Assert.notNull(this.client, "No memcached client is defined.");
+        Assert.notNull(this.client, NO_MEMCACHED_CLIENT_IS_DEFINED);
 
         final String ticketId = encodeTicketId(ticketIdToGet);
         try {

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -75,6 +75,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
     private static final String GOOD_PASSWORD = "test";
     private static final int DELTA = 2;
     private static final String GET = "GET";
+    private static final String ERROR_EQUALS = "error=";
 
     @Autowired
     @Qualifier("defaultOAuthCodeFactory")
@@ -116,7 +117,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -134,7 +135,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -152,7 +153,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -171,7 +172,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -189,7 +190,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -208,7 +209,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -227,7 +228,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -246,7 +247,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -265,7 +266,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -298,7 +299,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_GRANT, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_GRANT, mockResponse.getContentAsString());
     }
 
     @Test
@@ -447,7 +448,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -461,7 +462,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -477,7 +478,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -493,7 +494,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -585,7 +586,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_GRANT, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_GRANT, mockResponse.getContentAsString());
     }
 
     @Test
@@ -603,7 +604,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test
@@ -618,7 +619,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
         oAuth20AccessTokenController.handleRequestInternal(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_BAD_REQUEST, mockResponse.getStatus());
-        assertEquals("error=" + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
+        assertEquals(ERROR_EQUALS + OAuthConstants.INVALID_REQUEST, mockResponse.getContentAsString());
     }
 
     @Test

--- a/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/TicketsResourceTests.java
+++ b/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/TicketsResourceTests.java
@@ -131,7 +131,7 @@ public class TicketsResourceTests {
     public void normalCreationOfST() throws Throwable {
         configureCasMockToCreateValidST();
 
-        this.mockMvc.perform(post("/cas/v1/tickets/TGT-1")
+        this.mockMvc.perform(post(TICKETS_RESOURCE_URL + "/TGT-1")
                 .param(SERVICE, CoreAuthenticationTestUtils.getService().getId()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("text/plain;charset=ISO-8859-1"))
@@ -142,7 +142,7 @@ public class TicketsResourceTests {
     public void creationOfSTWithInvalidTicketException() throws Throwable {
         configureCasMockSTCreationToThrow(new InvalidTicketException("TGT-1"));
 
-        this.mockMvc.perform(post("/cas/v1/tickets/TGT-1")
+        this.mockMvc.perform(post(TICKETS_RESOURCE_URL + "/TGT-1")
                 .param(SERVICE, CoreAuthenticationTestUtils.getService().getId()))
                 .andExpect(status().isNotFound())
                 .andExpect(content().string("TicketGrantingTicket could not be found"));
@@ -152,7 +152,7 @@ public class TicketsResourceTests {
     public void creationOfSTWithGeneralException() throws Throwable {
         configureCasMockSTCreationToThrow(new RuntimeException(OTHER_EXCEPTION));
 
-        this.mockMvc.perform(post("/cas/v1/tickets/TGT-1")
+        this.mockMvc.perform(post(TICKETS_RESOURCE_URL + "/TGT-1")
                 .param(SERVICE, CoreAuthenticationTestUtils.getService().getId()))
                 .andExpect(status().is5xxServerError())
                 .andExpect(content().string(OTHER_EXCEPTION));
@@ -160,7 +160,7 @@ public class TicketsResourceTests {
 
     @Test
     public void deletionOfTGT() throws Throwable {
-        this.mockMvc.perform(delete("/cas/v1/tickets/TGT-1"))
+        this.mockMvc.perform(delete(TICKETS_RESOURCE_URL + "/TGT-1"))
                 .andExpect(status().isOk());
     }
 

--- a/support/cas-server-support-saml-core/src/main/java/org/apereo/cas/support/saml/SamlUtils.java
+++ b/support/cas-server-support-saml-core/src/main/java/org/apereo/cas/support/saml/SamlUtils.java
@@ -40,7 +40,8 @@ import java.util.List;
  * @since 5.0.0
  */
 public final class SamlUtils {
-    private static Logger LOGGER = LoggerFactory.getLogger(SamlUtils.class);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SamlUtils.class);
 
     private SamlUtils() {
     }

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
@@ -46,6 +46,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
 
     private static final String TEST_VALUE = "testValue";
     private static final String TEST_ATTRIBUTE = "testAttribute";
+    private static final String PRINCIPAL_ID = "testPrincipal";
     private Saml10SuccessResponseView response;
 
     @Before
@@ -72,7 +73,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
         attributes.put(TEST_ATTRIBUTE, TEST_VALUE);
         attributes.put("testEmptyCollection", Collections.emptyList());
         attributes.put("testAttributeCollection", Arrays.asList("tac1", "tac2"));
-        final Principal principal = new DefaultPrincipalFactory().createPrincipal("testPrincipal", attributes);
+        final Principal principal = new DefaultPrincipalFactory().createPrincipal(PRINCIPAL_ID, attributes);
 
         final Map<String, Object> authAttributes = new HashMap<>();
         authAttributes.put(
@@ -80,8 +81,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
                 SamlAuthenticationMetaDataPopulator.AUTHN_METHOD_SSL_TLS_CLIENT);
         authAttributes.put("testSamlAttribute", "value");
 
-        final Authentication primary =
-                CoreAuthenticationTestUtils.getAuthentication(principal, authAttributes);
+        final Authentication primary = CoreAuthenticationTestUtils.getAuthentication(principal, authAttributes);
         final Assertion assertion = new ImmutableAssertion(
                 primary, Collections.singletonList(primary),
                 CoreAuthenticationTestUtils.getService(), true);
@@ -92,7 +92,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
         this.response.renderMergedOutputModel(model, new MockHttpServletRequest(), servletResponse);
         final String written = servletResponse.getContentAsString();
 
-        assertTrue(written.contains("testPrincipal"));
+        assertTrue(written.contains(PRINCIPAL_ID));
         assertTrue(written.contains(TEST_ATTRIBUTE));
         assertTrue(written.contains(TEST_VALUE));
         assertFalse(written.contains("testEmptyCollection"));
@@ -108,7 +108,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
     public void verifyResponseWithNoAttributes() throws Exception {
         final Map<String, Object> model = new HashMap<>();
 
-        final Principal principal = new DefaultPrincipalFactory().createPrincipal("testPrincipal");
+        final Principal principal = new DefaultPrincipalFactory().createPrincipal(PRINCIPAL_ID);
 
         final Map<String, Object> authAttributes = new HashMap<>();
         authAttributes.put(
@@ -128,7 +128,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
         this.response.renderMergedOutputModel(model, new MockHttpServletRequest(), servletResponse);
         final String written = servletResponse.getContentAsString();
 
-        assertTrue(written.contains("testPrincipal"));
+        assertTrue(written.contains(PRINCIPAL_ID));
         assertTrue(written.contains(SamlAuthenticationMetaDataPopulator.AUTHN_METHOD_SSL_TLS_CLIENT));
         assertTrue(written.contains("AuthenticationMethod="));
     }
@@ -139,15 +139,14 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
 
         final Map<String, Object> attributes = new HashMap<>();
         attributes.put(TEST_ATTRIBUTE, TEST_VALUE);
-        final Principal principal = new DefaultPrincipalFactory().createPrincipal("testPrincipal", attributes);
+        final Principal principal = new DefaultPrincipalFactory().createPrincipal(PRINCIPAL_ID, attributes);
 
         final Map<String, Object> authnAttributes = new HashMap<>();
         authnAttributes.put("authnAttribute1", "authnAttrbuteV1");
         authnAttributes.put("authnAttribute2", "authnAttrbuteV2");
         authnAttributes.put(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, Boolean.TRUE);
 
-        final Authentication primary =
-                CoreAuthenticationTestUtils.getAuthentication(principal, authnAttributes);
+        final Authentication primary = CoreAuthenticationTestUtils.getAuthentication(principal, authnAttributes);
 
         final Assertion assertion = new ImmutableAssertion(
                 primary, Collections.singletonList(primary),
@@ -159,7 +158,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
         this.response.renderMergedOutputModel(model, new MockHttpServletRequest(), servletResponse);
         final String written = servletResponse.getContentAsString();
 
-        assertTrue(written.contains("testPrincipal"));
+        assertTrue(written.contains(PRINCIPAL_ID));
         assertTrue(written.contains(TEST_ATTRIBUTE));
         assertTrue(written.contains(TEST_VALUE));
         assertTrue(written.contains("authnAttribute1"));

--- a/support/cas-server-support-themes/src/test/java/org/apereo/cas/services/web/ServiceThemeResolverTests.java
+++ b/support/cas-server-support-themes/src/test/java/org/apereo/cas/services/web/ServiceThemeResolverTests.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.*;
  */
 public class ServiceThemeResolverTests {
 
+    private static final String MOZILLA = "Mozilla";
+    private static final String DEFAULT_THEME_NAME = "test";
     private ServiceThemeResolver serviceThemeResolver;
     private DefaultServicesManager servicesManager;
     private Map<String, String> mobileBrowsers;
@@ -34,8 +36,8 @@ public class ServiceThemeResolverTests {
         this.servicesManager = new DefaultServicesManager(new InMemoryServiceRegistry());
 
         mobileBrowsers = new HashMap<>();
-        mobileBrowsers.put("Mozilla", "theme");
-        this.serviceThemeResolver = new ServiceThemeResolver("test", servicesManager, mobileBrowsers);
+        mobileBrowsers.put(MOZILLA, "theme");
+        this.serviceThemeResolver = new ServiceThemeResolver(DEFAULT_THEME_NAME, servicesManager, mobileBrowsers);
     }
 
     @Test
@@ -54,24 +56,24 @@ public class ServiceThemeResolverTests {
         scope.put("service", RegisteredServiceTestUtils.getService(r.getServiceId()));
         when(ctx.getFlowScope()).thenReturn(scope);
         RequestContextHolder.setRequestContext(ctx);
-        request.addHeader(WebUtils.USER_AGENT_HEADER, "Mozilla");
-        assertEquals("test", this.serviceThemeResolver.resolveThemeName(request));
+        request.addHeader(WebUtils.USER_AGENT_HEADER, MOZILLA);
+        assertEquals(DEFAULT_THEME_NAME, this.serviceThemeResolver.resolveThemeName(request));
     }
 
     @Test
     public void verifyGetDefaultService() {
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("service", "myServiceId");
-        request.addHeader(WebUtils.USER_AGENT_HEADER, "Mozilla");
-        assertEquals("test", this.serviceThemeResolver.resolveThemeName(request));
+        request.addHeader(WebUtils.USER_AGENT_HEADER, MOZILLA);
+        assertEquals(DEFAULT_THEME_NAME, this.serviceThemeResolver.resolveThemeName(request));
     }
 
     @Test
     public void verifyGetDefaultServiceWithNoServicesManager() {
-        this.serviceThemeResolver = new ServiceThemeResolver("test", null, mobileBrowsers);
+        this.serviceThemeResolver = new ServiceThemeResolver(DEFAULT_THEME_NAME, null, mobileBrowsers);
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("service", "myServiceId");
-        request.addHeader(WebUtils.USER_AGENT_HEADER, "Mozilla");
-        assertEquals("test", this.serviceThemeResolver.resolveThemeName(request));
+        request.addHeader(WebUtils.USER_AGENT_HEADER, MOZILLA);
+        assertEquals(DEFAULT_THEME_NAME, this.serviceThemeResolver.resolveThemeName(request));
     }
 }

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/AbstractServiceValidateControllerTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/AbstractServiceValidateControllerTests.java
@@ -38,8 +38,14 @@ import static org.junit.Assert.*;
  */
 @Import({CasProtocolViewsConfiguration.class, CasValidationConfiguration.class, ThymeleafAutoConfiguration.class})
 public abstract class AbstractServiceValidateControllerTests extends AbstractCentralAuthenticationServiceTests {
+
     private static final Service SERVICE = CoreAuthenticationTestUtils.getService();
     private static final String SUCCESS = "Success";
+    private static final String SERVICE_PARAM = "service";
+    private static final String TICKET_PARAM = "ticket";
+    private static final String GITHUB_URL = "https://www.github.com";
+    private static final String PGT_URL_PARAM = "pgtUrl";
+    private static final String PGT_IOU_PARAM = "pgtIou";
 
     protected AbstractServiceValidateController serviceValidateController;
 
@@ -67,8 +73,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId2 = getCentralAuthenticationService().grantServiceTicket(tId.getId(), SERVICE, null);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId2.getId());
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId2.getId());
         request.addParameter("renew", "true");
 
         return request;
@@ -94,8 +100,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), SERVICE, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId.getId());
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
 
         final ModelAndView mv = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
         assertTrue(mv.getView().toString().contains(SUCCESS));
@@ -132,8 +138,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         getCentralAuthenticationService().destroyTicketGrantingTicket(tId.getId());
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId.getId());
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
 
         assertFalse(this.serviceValidateController.handleRequestInternal(request,
                 new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
@@ -148,9 +154,9 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), SERVICE, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId.getId());
-        request.addParameter("pgtUrl", "https://www.github.com");
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
+        request.addParameter(PGT_URL_PARAM, GITHUB_URL);
 
         assertTrue(this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse())
                 .getView().toString().contains(SUCCESS));
@@ -172,13 +178,13 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), SERVICE, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId.getId());
-        request.addParameter("pgtUrl", "duh");
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
+        request.addParameter(PGT_URL_PARAM, "duh");
 
         final ModelAndView modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
         assertTrue(modelAndView.getView().toString().contains(SUCCESS));
-        assertNull(modelAndView.getModel().get("pgtIou"));
+        assertNull(modelAndView.getModel().get(PGT_IOU_PARAM));
     }
 
     @Test
@@ -189,13 +195,13 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), SERVICE, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId.getId());
-        request.addParameter("pgtUrl", "https://www.github.com");
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
+        request.addParameter(PGT_URL_PARAM, GITHUB_URL);
 
         final ModelAndView modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
         assertTrue(modelAndView.getView().toString().contains(SUCCESS));
-        assertNotNull(modelAndView.getModel().get("pgtIou"));
+        assertNotNull(modelAndView.getModel().get(PGT_IOU_PARAM));
     }
 
     @Test
@@ -206,9 +212,9 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), SERVICE, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId.getId());
-        request.addParameter("pgtUrl", "https://www.github.com");
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
+        request.addParameter(PGT_URL_PARAM, GITHUB_URL);
 
         this.serviceValidateController.setProxyHandler(new ProxyHandler() {
             @Override
@@ -224,7 +230,7 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
 
         final ModelAndView modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
         assertFalse(modelAndView.getView().toString().contains(SUCCESS));
-        assertNull(modelAndView.getModel().get("pgtIou"));
+        assertNull(modelAndView.getModel().get(PGT_IOU_PARAM));
     }
 
     @Test
@@ -241,8 +247,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final String reqSvc = "http://WWW.JASIG.ORG?PARAM=hello%20world";
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", CoreAuthenticationTestUtils.getService(reqSvc).getId());
-        request.addParameter("ticket", sId.getId());
+        request.addParameter(SERVICE_PARAM, CoreAuthenticationTestUtils.getService(reqSvc).getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
 
         assertTrue(this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
     }
@@ -259,8 +265,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
 
         final String reqSvc = "http://www.jasig.org?param=hello%20world";
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", CoreAuthenticationTestUtils.getService(reqSvc).getId());
-        request.addParameter("ticket", sId.getId());
+        request.addParameter(SERVICE_PARAM, CoreAuthenticationTestUtils.getService(reqSvc).getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
 
         assertTrue(this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
     }
@@ -275,13 +281,13 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), svc, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", svc.getId());
-        request.addParameter("ticket", sId.getId());
-        request.addParameter("pgtUrl", "http://www.github.com");
+        request.addParameter(SERVICE_PARAM, svc.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
+        request.addParameter(PGT_URL_PARAM, "http://www.github.com");
 
         final ModelAndView modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
         assertFalse(modelAndView.getView().toString().contains(SUCCESS));
-        assertNull(modelAndView.getModel().get("pgtIou"));
+        assertNull(modelAndView.getModel().get(PGT_IOU_PARAM));
     }
 
     @Test
@@ -293,8 +299,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), svc, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", svc.getId());
-        request.addParameter("ticket", sId.getId());
+        request.addParameter(SERVICE_PARAM, svc.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
         request.addParameter("format", ValidationResponseType.JSON.name());
 
         final ModelAndView modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
@@ -311,8 +317,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), svc, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", svc.getId());
-        request.addParameter("ticket", sId.getId());
+        request.addParameter(SERVICE_PARAM, svc.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
         request.addParameter("format", "NOTHING");
 
         final ModelAndView modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
@@ -325,9 +331,9 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         final ServiceTicket sId = getCentralAuthenticationService().grantServiceTicket(tId.getId(), SERVICE, ctx);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addParameter("service", SERVICE.getId());
-        request.addParameter("ticket", sId.getId());
-        request.addParameter("pgtUrl", "https://www.github.com");
+        request.addParameter(SERVICE_PARAM, SERVICE.getId());
+        request.addParameter(TICKET_PARAM, sId.getId());
+        request.addParameter(PGT_URL_PARAM, GITHUB_URL);
 
         return this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
     }

--- a/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/WsFederationAttributeMutatorTests.java
+++ b/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/WsFederationAttributeMutatorTests.java
@@ -16,21 +16,23 @@ import static org.junit.Assert.*;
  */
 public class WsFederationAttributeMutatorTests extends AbstractWsFederationTests {
 
+    private static final String UPN_PARAM = "upn";
+
     @Test
     public void verifyModifyAttributes() {
         final Map<String, List<Object>> attributes = new HashMap<>();
 
-        final List values = new ArrayList();
+        final List<Object> values = new ArrayList<>();
         values.add("test@example.com");
-        attributes.put("upn", values);
+        attributes.put(UPN_PARAM, values);
         
         final WsFederationAttributeMutator instance = new WsFederationAttributeMutatorImpl();
         instance.modifyAttributes(attributes);
 
         assertTrue(attributes.containsKey("test"));
         assertTrue("newtest".equalsIgnoreCase(attributes.get("test").get(0).toString()));
-        assertTrue(attributes.containsKey("upn"));
-        assertTrue("testing".equalsIgnoreCase(attributes.get("upn").get(0).toString()));
+        assertTrue(attributes.containsKey(UPN_PARAM));
+        assertTrue("testing".equalsIgnoreCase(attributes.get(UPN_PARAM).get(0).toString()));
     }
 
     private static class WsFederationAttributeMutatorImpl implements WsFederationAttributeMutator {
@@ -38,13 +40,13 @@ public class WsFederationAttributeMutatorTests extends AbstractWsFederationTests
 
         @Override
         public void modifyAttributes(final Map<String, List<Object>> attributes) {
-            List values = new ArrayList();
+            List<Object> values = new ArrayList<>();
             values.add("newtest");
             attributes.put("test", values);
 
-            values = new ArrayList();
+            values = new ArrayList<>();
             values.add("testing");
-            attributes.put("upn", values);
+            attributes.put(UPN_PARAM, values);
         }
     }
 }

--- a/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/WsFederationHelperTests.java
+++ b/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/WsFederationHelperTests.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.*;
  * @since 4.2.0
  */
 public class WsFederationHelperTests extends AbstractWsFederationTests {
-    
+
+    private static final String GOOD_TOKEN = "goodToken";
+
     @Autowired
     private WsFederationConfiguration wsFedConfig;
     
@@ -33,14 +35,14 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
 
     @Test
     public void verifyParseTokenString() throws Exception {
-        final String wresult = testTokens.get("goodToken");
+        final String wresult = testTokens.get(GOOD_TOKEN);
         final Assertion result = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         assertNotNull("testParseTokenString() - Not null", result);
     }
 
     @Test
     public void verifyCreateCredentialFromToken() throws Exception {
-        final String wresult = testTokens.get("goodToken");
+        final String wresult = testTokens.get(GOOD_TOKEN);
         final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         
         final WsFederationCredential expResult = new WsFederationCredential();
@@ -72,7 +74,7 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
 
     @Test
     public void verifyValidateSignatureGoodToken() throws Exception {
-        final String wresult = testTokens.get("goodToken");
+        final String wresult = testTokens.get(GOOD_TOKEN);
         final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         final boolean result = wsFederationHelper.validateSignature(assertion, wsFedConfig);
         assertTrue("testValidateSignatureGoodToken() - True", result);
@@ -94,7 +96,7 @@ public class WsFederationHelperTests extends AbstractWsFederationTests {
         cfg.setSigningCertificateResources(ctx.getResource("classpath:bad-signing.crt"));
 
         signingWallet.addAll(cfg.getSigningCertificates());
-        final String wresult = testTokens.get("goodToken");
+        final String wresult = testTokens.get(GOOD_TOKEN);
         final Assertion assertion = wsFederationHelper.parseTokenFromString(wresult, wsFedConfig);
         wsFedConfig.getSigningCertificates().clear();
         wsFedConfig.getSigningCertificates().addAll(signingWallet);

--- a/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/authentication/principal/WsFederationCredentialTests.java
+++ b/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/authentication/principal/WsFederationCredentialTests.java
@@ -16,7 +16,9 @@ import static org.junit.Assert.*;
  * @since 4.2.0
  */
 public class WsFederationCredentialTests extends AbstractWsFederationTests {
-    
+
+    private static final String ISSUER = "http://adfs.example.com/adfs/services/trust";
+    private static final String AUDIENCE = "urn:federation:cas";
     private WsFederationCredential standardCred;
 
     @Before
@@ -25,29 +27,29 @@ public class WsFederationCredentialTests extends AbstractWsFederationTests {
         standardCred.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC));
         standardCred.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).plusHours(1));
         standardCred.setIssuedOn(ZonedDateTime.now(ZoneOffset.UTC));
-        standardCred.setIssuer("http://adfs.example.com/adfs/services/trust");
-        standardCred.setAudience("urn:federation:cas");
+        standardCred.setIssuer(ISSUER);
+        standardCred.setAudience(AUDIENCE);
         standardCred.setId("_6257b2bf-7361-4081-ae1f-ec58d4310f61");
         standardCred.setRetrievedOn(ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(1));
     }
 
     @Test
     public void verifyIsValidAllGood() throws Exception {
-        final boolean result = standardCred.isValid("urn:federation:cas", "http://adfs.example.com/adfs/services/trust", 2000);
+        final boolean result = standardCred.isValid(AUDIENCE, ISSUER, 2000);
         assertTrue("testIsValidAllGood() - True", result);
     }
 
     @Test
     public void verifyIsValidBadAudience() throws Exception {
         standardCred.setAudience("urn:NotUs");
-        final boolean result = standardCred.isValid("urn:federation:cas", "http://adfs.example.com/adfs/services/trust", 2000);
+        final boolean result = standardCred.isValid(AUDIENCE, ISSUER, 2000);
         assertFalse("testIsValidBadAudeience() - False", result);
     }
 
     @Test
     public void verifyIsValidBadIssuer() throws Exception {
         standardCred.setIssuer("urn:NotThem");
-        final boolean result = standardCred.isValid("urn:federation:cas", "http://adfs.example.com/adfs/services/trust", 2000);
+        final boolean result = standardCred.isValid(AUDIENCE, ISSUER, 2000);
         assertFalse("testIsValidBadIssuer() - False", result);
     }
 
@@ -57,7 +59,7 @@ public class WsFederationCredentialTests extends AbstractWsFederationTests {
         standardCred.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).plusHours(1).plusDays(1));
         standardCred.setIssuedOn(ZonedDateTime.now(ZoneOffset.UTC).plusDays(1));
         
-        final boolean result = standardCred.isValid("urn:federation:cas", "http://adfs.example.com/adfs/services/trust", 2000);
+        final boolean result = standardCred.isValid(AUDIENCE, ISSUER, 2000);
         assertFalse("testIsValidEarlyToken() - False", result);
     }
 
@@ -67,7 +69,7 @@ public class WsFederationCredentialTests extends AbstractWsFederationTests {
         standardCred.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).plusHours(1).minusDays(1));
         standardCred.setIssuedOn(ZonedDateTime.now(ZoneOffset.UTC).minusDays(1));
         
-        final boolean result = standardCred.isValid("urn:federation:cas", "http://adfs.example.com/adfs/services/trust", 2000);
+        final boolean result = standardCred.isValid(AUDIENCE, ISSUER, 2000);
         assertFalse("testIsValidOldToken() - False", result);
     }
 
@@ -75,7 +77,7 @@ public class WsFederationCredentialTests extends AbstractWsFederationTests {
     public void verifyIsValidExpiredIssuedOn() throws Exception {
         standardCred.setIssuedOn(ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(3));
         
-        final boolean result = standardCred.isValid("urn:federation:cas", "http://adfs.example.com/adfs/services/trust", 2000);
+        final boolean result = standardCred.isValid(AUDIENCE, ISSUER, 2000);
         assertFalse("testIsValidOldToken() - False", result);
     }
 }

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/handler/support/X509CredentialsAuthenticationHandlerTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/handler/support/X509CredentialsAuthenticationHandlerTests.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.*;
 @RunWith(Parameterized.class)
 public class X509CredentialsAuthenticationHandlerTests {
 
+    private static final String USER_VALID_CRT = "user-valid.crt";
     /**
      * Subject of test.
      */
@@ -67,11 +68,8 @@ public class X509CredentialsAuthenticationHandlerTests {
      * @param supports   Expected result of supports test.
      * @param result     Expected result of authentication test.
      */
-    public X509CredentialsAuthenticationHandlerTests(
-            final X509CredentialsAuthenticationHandler handler,
-            final Credential credential,
-            final boolean supports,
-            final Object result) {
+    public X509CredentialsAuthenticationHandlerTests(final X509CredentialsAuthenticationHandler handler, final Credential credential, final boolean supports,
+                                                     final Object result) {
 
         this.handler = handler;
         this.credential = credential;
@@ -98,7 +96,7 @@ public class X509CredentialsAuthenticationHandlerTests {
 
         // Test case #2:Valid certificate
         handler = new X509CredentialsAuthenticationHandler(RegexUtils.createPattern(".*"));
-        credential = new X509CertificateCredential(createCertificates("user-valid.crt"));
+        credential = new X509CertificateCredential(createCertificates(USER_VALID_CRT));
         params.add(new Object[]{handler, credential, true, new DefaultHandlerResult(handler, credential,
                 new DefaultPrincipalFactory().createPrincipal(credential.getId())),
         });
@@ -134,7 +132,7 @@ public class X509CredentialsAuthenticationHandlerTests {
         // Test case #6: Check key usage on a cert without keyUsage extension
         handler = new X509CredentialsAuthenticationHandler(RegexUtils.createPattern(".*"), 
                 false, true, false);
-        credential = new X509CertificateCredential(createCertificates("user-valid.crt"));
+        credential = new X509CertificateCredential(createCertificates(USER_VALID_CRT));
         params.add(new Object[]{
                 handler,
                 credential,
@@ -147,7 +145,7 @@ public class X509CredentialsAuthenticationHandlerTests {
                 false, true, true);
         params.add(new Object[]{
                 handler,
-                new X509CertificateCredential(createCertificates("user-valid.crt")),
+                new X509CertificateCredential(createCertificates(USER_VALID_CRT)),
                 true, new FailedLoginException(),
         });
 
@@ -182,10 +180,10 @@ public class X509CredentialsAuthenticationHandlerTests {
         checker = new ResourceCRLRevocationChecker(new ClassPathResource("userCA-valid.crl"));
         checker.init();
         handler = new X509CredentialsAuthenticationHandler(RegexUtils.createPattern(".*"), checker);
-        credential = new X509CertificateCredential(createCertificates("user-valid.crt"));
+        credential = new X509CertificateCredential(createCertificates(USER_VALID_CRT));
         params.add(new Object[]{
                 handler,
-                new X509CertificateCredential(createCertificates("user-valid.crt")),
+                new X509CertificateCredential(createCertificates(USER_VALID_CRT)),
                 true,
                 new DefaultHandlerResult(handler, credential, new DefaultPrincipalFactory().createPrincipal(credential.getId())),
         });
@@ -208,7 +206,7 @@ public class X509CredentialsAuthenticationHandlerTests {
         handler = new X509CredentialsAuthenticationHandler(RegexUtils.createPattern(".*"), checker);
         params.add(new Object[]{
                 handler,
-                new X509CertificateCredential(createCertificates("user-valid.crt")),
+                new X509CertificateCredential(createCertificates(USER_VALID_CRT)),
                 true,
                 new ExpiredCRLException(null, ZonedDateTime.now(ZoneOffset.UTC)),
         });


### PR DESCRIPTION
Closes no issue.

Changes include cleaning a bit the following codacy warnings:
- Cleaning some The String literal {0} appears {1} times in this file; the first occurrence is on line {2}
- In JUnit4, use the @Test(expected) annotation to denote tests that should throw exceptions
