### PR TITLE
Avoid NPE when using Acceptable Use Policy without repository

### DIFF
--- a/support/cas-server-support-actions-aup-ldap/src/main/java/org/apereo/cas/web/config/CasSupportActionsAcceptableUsagePolicyLdapConfiguration.java
+++ b/support/cas-server-support-actions-aup-ldap/src/main/java/org/apereo/cas/web/config/CasSupportActionsAcceptableUsagePolicyLdapConfiguration.java
@@ -36,9 +36,9 @@ public class CasSupportActionsAcceptableUsagePolicyLdapConfiguration {
     public AcceptableUsagePolicyRepository acceptableUsagePolicyRepository() {
         final AcceptableUsagePolicyProperties.Ldap ldap = casProperties.getAcceptableUsagePolicy().getLdap();
         final ConnectionFactory connectionFactory = Beans.newLdaptivePooledConnectionFactory(ldap);
-        final LdapAcceptableUsagePolicyRepository r = new LdapAcceptableUsagePolicyRepository(connectionFactory, ldap.getUserFilter(), ldap.getBaseDn());
+        final LdapAcceptableUsagePolicyRepository r = new LdapAcceptableUsagePolicyRepository(ticketRegistrySupport, 
+                connectionFactory, ldap.getUserFilter(), ldap.getBaseDn());
         r.setAupAttributeName(casProperties.getAcceptableUsagePolicy().getAupAttributeName());
-        r.setTicketRegistrySupport(ticketRegistrySupport);
         return r;
     }
 }

--- a/support/cas-server-support-actions-aup-ldap/src/main/java/org/apereo/cas/web/flow/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-actions-aup-ldap/src/main/java/org/apereo/cas/web/flow/LdapAcceptableUsagePolicyRepository.java
@@ -3,6 +3,7 @@ package org.apereo.cas.web.flow;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.configuration.support.Beans;
+import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.LdapUtils;
 import org.ldaptive.ConnectionFactory;
 import org.ldaptive.LdapException;
@@ -35,7 +36,9 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
     private String searchFilter;
     private String baseDn;
 
-    public LdapAcceptableUsagePolicyRepository(final ConnectionFactory connectionFactory, final String searchFilter, final String baseDn) {
+    public LdapAcceptableUsagePolicyRepository(final TicketRegistrySupport ticketRegistrySupport, 
+            final ConnectionFactory connectionFactory, final String searchFilter, final String baseDn) {
+        super(ticketRegistrySupport);
         this.connectionFactory = connectionFactory;
         this.searchFilter = searchFilter;
         this.baseDn = baseDn;

--- a/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/config/CasSupportActionsAcceptableUsagePolicyConfiguration.java
+++ b/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/config/CasSupportActionsAcceptableUsagePolicyConfiguration.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.config;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.web.flow.AcceptableUsagePolicyFormAction;
 import org.apereo.cas.web.flow.AcceptableUsagePolicyRepository;
 import org.apereo.cas.web.flow.AcceptableUsagePolicyWebflowConfigurer;
@@ -34,6 +35,10 @@ public class CasSupportActionsAcceptableUsagePolicyConfiguration {
     private FlowBuilderServices flowBuilderServices;
 
     @Autowired
+    @Qualifier("defaultTicketRegistrySupport")
+    private TicketRegistrySupport ticketRegistrySupport;
+
+    @Autowired
     @Bean
     public Action acceptableUsagePolicyFormAction(@Qualifier("acceptableUsagePolicyRepository")
                                                   final AcceptableUsagePolicyRepository repository) {
@@ -49,6 +54,6 @@ public class CasSupportActionsAcceptableUsagePolicyConfiguration {
     @ConditionalOnMissingBean(name = "acceptableUsagePolicyRepository")
     @Bean
     public AcceptableUsagePolicyRepository acceptableUsagePolicyRepository() {
-        return new DefaultAcceptableUsagePolicyRepository();
+        return new DefaultAcceptableUsagePolicyRepository(ticketRegistrySupport);
     }
 }

--- a/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/AbstractPrincipalAttributeAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/AbstractPrincipalAttributeAcceptableUsagePolicyRepository.java
@@ -33,6 +33,10 @@ public abstract class AbstractPrincipalAttributeAcceptableUsagePolicyRepository 
      */
     protected TicketRegistrySupport ticketRegistrySupport;
 
+    public AbstractPrincipalAttributeAcceptableUsagePolicyRepository(final TicketRegistrySupport ticketRegistrySupport) {
+        this.ticketRegistrySupport = ticketRegistrySupport;
+    }
+
     @Override
     public Pair<Boolean, Principal> verify(final RequestContext requestContext, final Credential credential) {
         final Principal principal = WebUtils.getPrincipalFromRequestContext(requestContext, this.ticketRegistrySupport);

--- a/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/DefaultAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/DefaultAcceptableUsagePolicyRepository.java
@@ -3,6 +3,7 @@ package org.apereo.cas.web.flow;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.web.support.WebUtils;
 import org.springframework.webflow.execution.RequestContext;
 
@@ -16,9 +17,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 4.2
  */
 public class DefaultAcceptableUsagePolicyRepository extends AbstractPrincipalAttributeAcceptableUsagePolicyRepository {
+
     private static final long serialVersionUID = -3059445754626980894L;
 
     private final Map<String, Boolean> policyMap = new ConcurrentHashMap<>();
+
+    public DefaultAcceptableUsagePolicyRepository(final TicketRegistrySupport ticketRegistrySupport) {
+        super(ticketRegistrySupport);
+    }
 
     @Override
     public Pair<Boolean, Principal> verify(final RequestContext requestContext, final Credential credential) {


### PR DESCRIPTION
Closes #2442 

I haven't actually tested this yet, it's taking forever to run gradlew.bat install so I can test it in my overlay project. Is there a faster way to compile and get jars in local maven repo? Seems to spend lots of time doing compileKotlin but is there any kotlin code?

Let me know if you don't want the new constructors and I can just use the setter. 