### PR TITLE
make TicketGrantingTicketImpl.getRoot method "recursive" and clearer

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/TicketGrantingTicketImpl.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/TicketGrantingTicketImpl.java
@@ -254,13 +254,11 @@ public class TicketGrantingTicketImpl extends AbstractTicket implements TicketGr
     @JsonIgnore
     @Override
     public TicketGrantingTicket getRoot() {
-        TicketGrantingTicket current = this;
-        TicketGrantingTicket parent = current.getGrantingTicket();
-        while (parent != null) {
-            current = parent;
-            parent = current.getGrantingTicket();
+        final TicketGrantingTicket parent = getGrantingTicket();
+        if (parent == null) {
+            return this;
         }
-        return current;
+        return parent.getRoot();
     }
 
     /**

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/TicketGrantingTicketImplTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/TicketGrantingTicketImplTests.java
@@ -113,6 +113,21 @@ public class TicketGrantingTicketImplTests {
     }
 
     @Test
+    public void verifyproperRootIsReturned() {
+        final TicketGrantingTicketImpl t1 = new TicketGrantingTicketImpl(TGT_ID, null, null,
+                CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
+        final TicketGrantingTicket t2 = new TicketGrantingTicketImpl(TGT_ID,
+                CoreAuthenticationTestUtils.getService("gantor"), t1,
+                CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
+
+        final TicketGrantingTicket t3 = new TicketGrantingTicketImpl(TGT_ID,
+                CoreAuthenticationTestUtils.getService("gantor"), t2,
+                CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
+
+        assertSame(t1, t3.getRoot());
+    }
+
+    @Test
     public void verifyGetChainedPrincipalsWithOne() {
         final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication();
         final List<Authentication> principals = new ArrayList<>();
@@ -158,7 +173,7 @@ public class TicketGrantingTicketImplTests {
     public void verifyServiceTicketAsFromInitialCredentials() {
         final TicketGrantingTicket t = new TicketGrantingTicketImpl(TGT_ID, null, null,
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        final ServiceTicket s = t.grantServiceTicket(this.ID_GENERATOR
+        final ServiceTicket s = t.grantServiceTicket(ID_GENERATOR
             .getNewTicketId(ServiceTicket.PREFIX), RegisteredServiceTestUtils.getService(),
             new NeverExpiresExpirationPolicy(), false, true);
 
@@ -171,13 +186,13 @@ public class TicketGrantingTicketImplTests {
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService(),
                 new NeverExpiresExpirationPolicy(),
                 false,
                 true);
         final ServiceTicket s = t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService(),
                 new NeverExpiresExpirationPolicy(),
                 false,
@@ -191,7 +206,7 @@ public class TicketGrantingTicketImplTests {
         final MockService testService = new MockService(TGT_ID);
         final TicketGrantingTicket t = new TicketGrantingTicketImpl(TGT_ID, null, null,
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        t.grantServiceTicket(this.ID_GENERATOR
+        t.grantServiceTicket(ID_GENERATOR
             .getNewTicketId(ServiceTicket.PREFIX), testService,
             new NeverExpiresExpirationPolicy(), false, true);
         Map<String, Service> services = t.getServices();
@@ -208,7 +223,7 @@ public class TicketGrantingTicketImplTests {
         final MockService testService = new MockService(TGT_ID);
         final TicketGrantingTicket t = new TicketGrantingTicketImpl(TGT_ID, null, null,
             CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
-        t.grantServiceTicket(this.ID_GENERATOR
+        t.grantServiceTicket(ID_GENERATOR
                         .getNewTicketId(ServiceTicket.PREFIX), testService,
                 new NeverExpiresExpirationPolicy(), false, true);
         assertFalse(t.isExpired());
@@ -222,13 +237,13 @@ public class TicketGrantingTicketImplTests {
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService(),
                 new NeverExpiresExpirationPolicy(),
                 false,
                 true);
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService(),
                 new NeverExpiresExpirationPolicy(),
                 false,
@@ -243,13 +258,13 @@ public class TicketGrantingTicketImplTests {
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService("http://host.com?test"),
                 new NeverExpiresExpirationPolicy(),
                 false,
                 true);
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService("http://host.com;JSESSIONID=xxx"),
                 new NeverExpiresExpirationPolicy(),
                 false,
@@ -264,13 +279,13 @@ public class TicketGrantingTicketImplTests {
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService("http://host.com/webapp1"),
                 new NeverExpiresExpirationPolicy(),
                 false,
                 true);
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService("http://host.com/webapp1?test=true"),
                 new NeverExpiresExpirationPolicy(),
                 false,
@@ -285,13 +300,13 @@ public class TicketGrantingTicketImplTests {
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService(),
                 new NeverExpiresExpirationPolicy(),
                 false,
                 true);
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService(),
                 new NeverExpiresExpirationPolicy(),
                 false,
@@ -306,13 +321,13 @@ public class TicketGrantingTicketImplTests {
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService(),
                 new NeverExpiresExpirationPolicy(),
                 false,
                 true);
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService2(),
                 new NeverExpiresExpirationPolicy(),
                 false,
@@ -327,13 +342,13 @@ public class TicketGrantingTicketImplTests {
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
 
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService("http://host.com/webapp1"),
                 new NeverExpiresExpirationPolicy(),
                 false,
                 true);
         t.grantServiceTicket(
-                this.ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
+                ID_GENERATOR.getNewTicketId(ServiceTicket.PREFIX),
                 RegisteredServiceTestUtils.getService("http://host.com/webapp2"),
                 new NeverExpiresExpirationPolicy(),
                 false,

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/TicketGrantingTicketImplTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/TicketGrantingTicketImplTests.java
@@ -113,7 +113,7 @@ public class TicketGrantingTicketImplTests {
     }
 
     @Test
-    public void verifyproperRootIsReturned() {
+    public void verifyProperRootIsReturned() {
         final TicketGrantingTicketImpl t1 = new TicketGrantingTicketImpl(TGT_ID, null, null,
                 CoreAuthenticationTestUtils.getAuthentication(), new NeverExpiresExpirationPolicy());
         final TicketGrantingTicket t2 = new TicketGrantingTicketImpl(TGT_ID,


### PR DESCRIPTION
Closes #2445 

Changes:
- make TicketGrantingTicketImpl.getRoot method "recursive" and clearer
- add test to verify the correct root is returned