### PR TITLE
Principal Serial Number Radix feature

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/PersonDirPrincipalResolverProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/PersonDirPrincipalResolverProperties.java
@@ -13,9 +13,6 @@ public class PersonDirPrincipalResolverProperties {
     private boolean returnNull;
     private boolean principalResolutionFailureFatal;
 
-    private int radix;
-    private boolean hexZeroPadding;
-
     public boolean isPrincipalResolutionFailureFatal() {
         return principalResolutionFailureFatal;
     }
@@ -38,21 +35,5 @@ public class PersonDirPrincipalResolverProperties {
 
     public void setReturnNull(final boolean returnNull) {
         this.returnNull = returnNull;
-    }
-
-    public int getRadix() {
-        return radix;
-    }
-
-    public void setRadix(int radix) {
-        this.radix = radix;
-    }
-
-    public boolean isHexZeroPadding() {
-        return hexZeroPadding;
-    }
-
-    public void setHexZeroPadding(boolean hexZeroPadding) {
-        this.hexZeroPadding = hexZeroPadding;
     }
 }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/PersonDirPrincipalResolverProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/PersonDirPrincipalResolverProperties.java
@@ -13,6 +13,9 @@ public class PersonDirPrincipalResolverProperties {
     private boolean returnNull;
     private boolean principalResolutionFailureFatal;
 
+    private int radix;
+    private boolean hexZeroPadding;
+
     public boolean isPrincipalResolutionFailureFatal() {
         return principalResolutionFailureFatal;
     }
@@ -35,5 +38,21 @@ public class PersonDirPrincipalResolverProperties {
 
     public void setReturnNull(final boolean returnNull) {
         this.returnNull = returnNull;
+    }
+
+    public int getRadix() {
+        return radix;
+    }
+
+    public void setRadix(int radix) {
+        this.radix = radix;
+    }
+
+    public boolean isHexZeroPadding() {
+        return hexZeroPadding;
+    }
+
+    public void setHexZeroPadding(boolean hexZeroPadding) {
+        this.hexZeroPadding = hexZeroPadding;
     }
 }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/x509/X509Properties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/x509/X509Properties.java
@@ -86,6 +86,9 @@ public class X509Properties {
     private String crlResourceExpiredPolicy = DENY;
     private String crlUnavailablePolicy = DENY;
     private String crlExpiredPolicy = DENY;
+
+    private int principalSNRadix;
+    private boolean principalHexSNZeroPadding;
     
     @NestedConfigurationProperty
     private PersonDirPrincipalResolverProperties principal = new PersonDirPrincipalResolverProperties();
@@ -374,6 +377,22 @@ public class X509Properties {
 
     public void setCrlExpiredPolicy(final String crlExpiredPolicy) {
         this.crlExpiredPolicy = crlExpiredPolicy;
+    }
+
+    public int getPrincipalSNRadix() {
+        return principalSNRadix;
+    }
+
+    public void setPrincipalSNRadix(final int principalSNRadix) {
+        this.principalSNRadix = principalSNRadix;
+    }
+
+    public boolean isPrincipalHexSNZeroPadding() {
+        return principalHexSNZeroPadding;
+    }
+
+    public void setPrincipalHexSNZeroPadding(final boolean principalHexSNZeroPadding) {
+        this.principalHexSNZeroPadding = principalHexSNZeroPadding;
     }
 
     public static class Ldap extends AbstractLdapProperties {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1798,6 +1798,12 @@ prior to production rollouts.</p></div>
 
 To learn more about this topic, [please review this guide](X509-Authentication.html).
 
+### Principal Resolution
+
+X509SerialNumberPrincipalResolver can provide Serial Number with configurable <strong>radix</strong>. Which could be in
+range from 2 to 36. If <strong>radix</strong> is <strong>16</strong> Serial Number could be filled with <strong>leading 0</strong> to even
+number of digits.
+
 ### CRL Fetching / Revocation
 
 CAS provides a flexible policy engine for certificate revocation checking. This facility arose due to lack of configurability
@@ -1853,6 +1859,8 @@ To fetch CRLs, the following options are available:
 
 # cas.authn.x509.name=
 # cas.authn.x509.principalDescriptor=
+# cas.authn.x509.principalSNRadix=10
+# cas.authn.x509.principalHexSNZeroPadding=false
 # cas.authn.x509.maxPathLength=1
 # cas.authn.x509.throwOnFetchFailure=false
 # cas.authn.x509.valueDelimiter=,

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolver.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolver.java
@@ -17,7 +17,7 @@ public class X509SerialNumberPrincipalResolver extends AbstractX509PrincipalReso
      */
     private int radix = 10;
 
-    private boolean zeroPadding = false;
+    private boolean zeroPadding;
 
     public X509SerialNumberPrincipalResolver() {
     }

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolver.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolver.java
@@ -12,9 +12,28 @@ import java.security.cert.X509Certificate;
  */
 public class X509SerialNumberPrincipalResolver extends AbstractX509PrincipalResolver {
 
+    /**
+     * Radix to use in <code>toString</code> method.
+     */
+    private int radix = 10;
+
+    private boolean zeroPadding = false;
+
+    public X509SerialNumberPrincipalResolver() {
+    }
+
+    public X509SerialNumberPrincipalResolver(final int radix, final boolean zeroPadding) {
+        this.radix = radix;
+        this.zeroPadding = zeroPadding;
+    }
+
     @Override
     protected String resolvePrincipalInternal(final X509Certificate certificate) {
-        return certificate.getSerialNumber().toString();
+        final String principal = certificate.getSerialNumber().toString(radix);
+        if (zeroPadding && principal.length() % 2 == 1) {
+            return "0" + principal;
+        }
+        return principal;
     }
 
     @Override

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -5,7 +5,11 @@ import org.apereo.cas.adaptors.x509.authentication.CRLFetcher;
 import org.apereo.cas.adaptors.x509.authentication.ResourceCRLFetcher;
 import org.apereo.cas.adaptors.x509.authentication.handler.support.X509CredentialsAuthenticationHandler;
 import org.apereo.cas.adaptors.x509.authentication.ldap.LdaptiveResourceCRLFetcher;
-import org.apereo.cas.adaptors.x509.authentication.principal.*;
+import org.apereo.cas.adaptors.x509.authentication.principal.X509SerialNumberPrincipalResolver;
+import org.apereo.cas.adaptors.x509.authentication.principal.X509SubjectAlternativeNameUPNPrincipalResolver;
+import org.apereo.cas.adaptors.x509.authentication.principal.X509SubjectDNPrincipalResolver;
+import org.apereo.cas.adaptors.x509.authentication.principal.X509SubjectPrincipalResolver;
+import org.apereo.cas.adaptors.x509.authentication.principal.X509SerialNumberAndIssuerDNPrincipalResolver;
 import org.apereo.cas.adaptors.x509.authentication.revocation.checker.CRLDistributionPointRevocationChecker;
 import org.apereo.cas.adaptors.x509.authentication.revocation.checker.NoOpRevocationChecker;
 import org.apereo.cas.adaptors.x509.authentication.revocation.checker.ResourceCRLRevocationChecker;
@@ -51,6 +55,8 @@ import net.sf.ehcache.Cache;
 @Configuration("x509AuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class X509AuthenticationConfiguration {
+
+    private static final int HEX = 16;
 
     @Autowired
     private ResourceLoader resourceLoader;
@@ -234,10 +240,10 @@ public class X509AuthenticationConfiguration {
     public PrincipalResolver x509SerialNumberPrincipalResolver() {
         final X509Properties x509 = casProperties.getAuthn().getX509();
         final X509SerialNumberPrincipalResolver r;
-        final int radix = x509.getPrincipal().getRadix();
-        if (radix > 0) {
-            if (radix == 16) {
-                r = new X509SerialNumberPrincipalResolver(radix, x509.getPrincipal().isHexZeroPadding());
+        final int radix = x509.getPrincipalSNRadix();
+        if (Character.MAX_RADIX <= radix && radix >= Character.MIN_RADIX) {
+            if (radix == HEX) {
+                r = new X509SerialNumberPrincipalResolver(radix, x509.isPrincipalHexSNZeroPadding());
             } else {
                 r = new X509SerialNumberPrincipalResolver(radix, false);
             }

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -241,7 +241,7 @@ public class X509AuthenticationConfiguration {
         final X509Properties x509 = casProperties.getAuthn().getX509();
         final X509SerialNumberPrincipalResolver r;
         final int radix = x509.getPrincipalSNRadix();
-        if (Character.MAX_RADIX <= radix && radix >= Character.MIN_RADIX) {
+        if (Character.MIN_RADIX <= radix && radix <= Character.MAX_RADIX) {
             if (radix == HEX) {
                 r = new X509SerialNumberPrincipalResolver(radix, x509.isPrincipalHexSNZeroPadding());
             } else {

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
@@ -1,13 +1,18 @@
 package org.apereo.cas.adaptors.x509.authentication.principal;
 
-import static org.junit.Assert.*;
-
-import java.security.cert.X509Certificate;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.UsernamePasswordCredential;
 import org.apereo.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler;
 import org.junit.Test;
+
+import java.math.BigInteger;
+import java.security.cert.X509Certificate;
 
 /**
  * @author Scott Battaglia
@@ -40,4 +45,23 @@ public class X509SerialNumberPrincipalResolverTests extends AbstractX509Certific
         assertFalse(this.resolver.supports(new UsernamePasswordCredential()));
     }
 
+    @Test
+    public void verifyHexPrincipalOdd() {
+        final X509SerialNumberPrincipalResolver r = new X509SerialNumberPrincipalResolver(16, true);
+        X509Certificate mockCert = mock(X509Certificate.class);
+        when(mockCert.getSerialNumber()).thenReturn(BigInteger.valueOf(300l));
+
+        final String principal = r.resolvePrincipalInternal(mockCert);
+        assertEquals("012c", principal);
+    }
+
+    @Test
+    public void verifyHexPrincipalEven() {
+        final X509SerialNumberPrincipalResolver r = new X509SerialNumberPrincipalResolver(16, true);
+        X509Certificate mockCert = mock(X509Certificate.class);
+        when(mockCert.getSerialNumber()).thenReturn(BigInteger.valueOf(60300l));
+
+        final String principal = r.resolvePrincipalInternal(mockCert);
+        assertEquals("eb8c", principal);
+    }
 }

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
@@ -1,10 +1,7 @@
 package org.apereo.cas.adaptors.x509.authentication.principal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.UsernamePasswordCredential;

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
@@ -48,18 +48,28 @@ public class X509SerialNumberPrincipalResolverTests extends AbstractX509Certific
     @Test
     public void verifyHexPrincipalOdd() {
         final X509SerialNumberPrincipalResolver r = new X509SerialNumberPrincipalResolver(16, true);
-        X509Certificate mockCert = mock(X509Certificate.class);
-        when(mockCert.getSerialNumber()).thenReturn(BigInteger.valueOf(300l));
+        final X509Certificate mockCert = mock(X509Certificate.class);
+        when(mockCert.getSerialNumber()).thenReturn(BigInteger.valueOf(300L));
 
         final String principal = r.resolvePrincipalInternal(mockCert);
         assertEquals("012c", principal);
     }
 
     @Test
+    public void verifyHexPrincipalOddFalse() {
+        final X509SerialNumberPrincipalResolver r = new X509SerialNumberPrincipalResolver(16, false);
+        final X509Certificate mockCert = mock(X509Certificate.class);
+        when(mockCert.getSerialNumber()).thenReturn(BigInteger.valueOf(300L));
+
+        final String principal = r.resolvePrincipalInternal(mockCert);
+        assertEquals("12c", principal);
+    }
+
+    @Test
     public void verifyHexPrincipalEven() {
         final X509SerialNumberPrincipalResolver r = new X509SerialNumberPrincipalResolver(16, true);
-        X509Certificate mockCert = mock(X509Certificate.class);
-        when(mockCert.getSerialNumber()).thenReturn(BigInteger.valueOf(60300l));
+        final X509Certificate mockCert = mock(X509Certificate.class);
+        when(mockCert.getSerialNumber()).thenReturn(BigInteger.valueOf(60300L));
 
         final String principal = r.resolvePrincipalInternal(mockCert);
         assertEquals("eb8c", principal);


### PR DESCRIPTION
Closes #2469 

Ensure that you include the following:

- [] X509SerialNumberPrincipalResolver extended to support HEX and other configurable radixes.
- [] cas.authn.x509.principal.radix=16
cas.authn.x509.principal.hexZeroPadding=true
- [] Character.MIN_RADIX <= radix <= Character.MAX_RADIX
- [] N/A.
