### PR TITLE
Handle missing service

### DIFF
--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/services/SamlIdPEntityIdAuthenticationServiceSelectionStrategy.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/services/SamlIdPEntityIdAuthenticationServiceSelectionStrategy.java
@@ -38,7 +38,7 @@ public class SamlIdPEntityIdAuthenticationServiceSelectionStrategy implements Au
 
     @Override
     public boolean supports(final Service service) {
-        return getEntityIdAsParameter(service).isPresent();
+        return service != null && getEntityIdAsParameter(service).isPresent();
     }
 
     /**

--- a/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/authentication/WSFederationAuthenticationServiceSelectionStrategy.java
+++ b/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/authentication/WSFederationAuthenticationServiceSelectionStrategy.java
@@ -41,7 +41,7 @@ public class WSFederationAuthenticationServiceSelectionStrategy implements Authe
 
     @Override
     public boolean supports(final Service service) {
-        return getRealmAsParameter(service).isPresent() && getReplyAsParameter(service).isPresent();
+        return service != null && getRealmAsParameter(service).isPresent() && getReplyAsParameter(service).isPresent();
     }
 
     private static Optional<NameValuePair> getRealmAsParameter(final Service service) {


### PR DESCRIPTION
Closes #2472

* `SamlIdPEntityIdAuthenticationServiceSelectionStrategy` and `WSFederationAuthenticationServiceSelectionStrategy`
   don't support `null` services anymore
* make sure `RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed()` is not called with `null` service in `SamlIdPMetadataUIAction`


