### PR TITLE
Fix type mismatch during YAML properties decrypting

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/config/CasCoreBootstrapStandaloneConfiguration.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/config/CasCoreBootstrapStandaloneConfiguration.java
@@ -80,7 +80,7 @@ public class CasCoreBootstrapStandaloneConfiguration implements PropertySourceLo
         return new PropertiesPropertySource("standaloneCasConfigService", props);
     }
 
-    private Map decryptProperties(final Map properties) {
+    private Map<Object, Object> decryptProperties(final Map<Object, Object> properties) {
         return this.configurationJasyptDecryptor.decrypt(properties);
     }
 
@@ -93,7 +93,7 @@ public class CasCoreBootstrapStandaloneConfiguration implements PropertySourceLo
         configFiles.forEach(Unchecked.consumer(f -> {
             LOGGER.debug("Loading configuration file [{}]", f);
             if (f.getName().toLowerCase().endsWith("yml")) {
-                final Map pp = loadYamlProperties(new FileSystemResource(f));
+                final Map<Object, Object> pp = loadYamlProperties(new FileSystemResource(f));
                 LOGGER.debug("Found settings [{}] in YAML file [{}]", pp.keySet(), f);
                 props.putAll(decryptProperties(pp));
             } else {
@@ -130,7 +130,7 @@ public class CasCoreBootstrapStandaloneConfiguration implements PropertySourceLo
         return profiles;
     }
 
-    private Map loadYamlProperties(final Resource... resource) {
+    private Map<Object, Object> loadYamlProperties(final Resource... resource) {
         final YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
         factory.setResolutionMethod(YamlProcessor.ResolutionMethod.OVERRIDE);
         factory.setResources(resource);

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptDecryptor.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptDecryptor.java
@@ -120,7 +120,7 @@ public class CasConfigurationJasyptDecryptor {
      * @param propertyValue The property value to cast
      * @return A {@link String} representing the property value or {@code null} if it is not a {@link String}
      */
-    private String getStringPropertyValue(Object propertyValue) {
+    private String getStringPropertyValue(final Object propertyValue) {
         return propertyValue instanceof String ? (String) propertyValue : null;
     }
 }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptDecryptor.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptDecryptor.java
@@ -89,18 +89,18 @@ public class CasConfigurationJasyptDecryptor {
      * @param settings the settings
      * @return the map
      */
-    public Map<String, String> decrypt(final Map<String, String> settings) {
-        final Map<String, String> decrypted = new HashMap();
+    public Map<Object, Object> decrypt(final Map<Object, Object> settings) {
+        final Map<Object, Object> decrypted = new HashMap<>();
         settings.entrySet()
-                .stream()
                 .forEach(entry -> {
-                    if (entry.getValue().startsWith(ENCRYPTED_VALUE_PREFIX)) {
+                    String stringValue = getStringPropertyValue(entry.getValue());
+                    if (stringValue != null && stringValue.startsWith(ENCRYPTED_VALUE_PREFIX)) {
                         try {
                             if (!this.decryptor.isInitialized()) {
                                 this.decryptor.initialize();
                             }
-                            
-                            final String encValue = entry.getValue().substring(ENCRYPTED_VALUE_PREFIX.length());
+
+                            final String encValue = stringValue.substring(ENCRYPTED_VALUE_PREFIX.length());
                             LOGGER.debug("Decrypting property [{}]...", entry.getKey());
                             final String value = this.decryptor.decrypt(encValue);
                             decrypted.put(entry.getKey(), value);
@@ -112,5 +112,15 @@ public class CasConfigurationJasyptDecryptor {
                     }
                 });
         return decrypted;
+    }
+
+    /**
+     * Retrieves the {@link String} of an {@link Object}
+     *
+     * @param propertyValue The property value to cast
+     * @return A {@link String} representing the property value or {@code null} if it is not a {@link String}
+     */
+    private String getStringPropertyValue(Object propertyValue) {
+        return propertyValue instanceof String ? (String) propertyValue : null;
     }
 }


### PR DESCRIPTION
Closes #2471

* make methods `decryptProperties` and `loadYamlProperties` use a typed map in `CasCoreBootstrapStandaloneConfiguration`
* handle map with objects in `CasConfigurationJasyptDecryptor#decrypt` and check for decryption only if the property value is of type `String`
