### PR TITLE
consolidate search authenticator logic

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapAuthenticationProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapAuthenticationProperties.java
@@ -70,11 +70,7 @@ public abstract class AbstractLdapAuthenticationProperties extends AbstractLdapP
         /**
          * Anonymous Search.
          */
-        ANONYMOUS,
-        /**
-         * SASL bind search.
-         */
-        SASL
+        ANONYMOUS
     }
 
     private AuthenticationTypes type;

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
@@ -954,40 +954,20 @@ public final class Beans {
      * @return the authenticator
      */
     public static Authenticator newLdaptiveAuthenticator(final AbstractLdapAuthenticationProperties l) {
-        if (l.getType() == AbstractLdapAuthenticationProperties.AuthenticationTypes.AD) {
-            LOGGER.debug("Creating active directory authenticator for [{}]", l.getLdapUrl());
-            return getActiveDirectoryAuthenticator(l);
+        switch (l.getType()) {
+            case AD:
+                LOGGER.debug("Creating active directory authenticator for [{}]", l.getLdapUrl());
+                return getActiveDirectoryAuthenticator(l);
+            case DIRECT:
+                LOGGER.debug("Creating direct-bind authenticator for [{}]", l.getLdapUrl());
+                return getDirectBindAuthenticator(l);
+            case AUTHENTICATED:
+                LOGGER.debug("Creating authenticated authenticator for [{}]", l.getLdapUrl());
+                return getAuthenticatedOrAnonSearchAuthenticator(l);
+            default:
+                LOGGER.debug("Creating anonymous authenticator for [{}]", l.getLdapUrl());
+                return getAuthenticatedOrAnonSearchAuthenticator(l);
         }
-        if (l.getType() == AbstractLdapAuthenticationProperties.AuthenticationTypes.DIRECT) {
-            LOGGER.debug("Creating direct-bind authenticator for [{}]", l.getLdapUrl());
-            return getDirectBindAuthenticator(l);
-        }
-        if (l.getType() == AbstractLdapAuthenticationProperties.AuthenticationTypes.SASL) {
-            LOGGER.debug("Creating SASL authenticator for [{}]", l.getLdapUrl());
-            return getSaslAuthenticator(l);
-        }
-        if (l.getType() == AbstractLdapAuthenticationProperties.AuthenticationTypes.AUTHENTICATED) {
-            LOGGER.debug("Creating authenticated authenticator for [{}]", l.getLdapUrl());
-            return getAuthenticatedOrAnonSearchAuthenticator(l);
-        }
-
-        LOGGER.debug("Creating anonymous authenticator for [{}]", l.getLdapUrl());
-        return getAuthenticatedOrAnonSearchAuthenticator(l);
-    }
-
-    private static Authenticator getSaslAuthenticator(final AbstractLdapAuthenticationProperties l) {
-        if (StringUtils.isBlank(l.getUserFilter())) {
-            throw new IllegalArgumentException("User filter cannot be empty/blank for sasl authentication");
-        }
-
-        final PooledConnectionFactory connectionFactoryForSearch = Beans.newLdaptivePooledConnectionFactory(l);
-        final PooledSearchDnResolver resolver = new PooledSearchDnResolver();
-        resolver.setBaseDn(l.getBaseDn());
-        resolver.setSubtreeSearch(l.isSubtreeSearch());
-        resolver.setAllowMultipleDns(l.isAllowMultipleDns());
-        resolver.setConnectionFactory(connectionFactoryForSearch);
-        resolver.setUserFilter(l.getUserFilter());
-        return new Authenticator(resolver, getPooledBindAuthenticationHandler(l, Beans.newLdaptivePooledConnectionFactory(l)));
     }
 
     private static Authenticator getAuthenticatedOrAnonSearchAuthenticator(final AbstractLdapAuthenticationProperties l) {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -588,7 +588,7 @@ security.basic.realm=CAS
 #### LDAP Authentication
 
 ```properties
-# cas.adminPagesSecurity.ldap.type=AD|AUTHENTICATED|DIRECT|ANONYMOUS|SASL
+# cas.adminPagesSecurity.ldap.type=AD|AUTHENTICATED|DIRECT|ANONYMOUS
 
 # cas.adminPagesSecurity.ldap.ldapUrl=ldaps://ldap1.example.edu ldaps://ldap2.example.edu
 # cas.adminPagesSecurity.ldap.connectionStrategy=
@@ -1479,10 +1479,9 @@ The following authentication types are supported:
 | Type                    | Description                            
 |-------------------------|----------------------------------------------------------------------------------------------------
 | `AD`                    | Acive Directory - Users authenticate with `sAMAccountName` typically using a DN format.     
-| `AUTHENTICATED`         | Manager bind/search type of authentication. If `principalAttributePassword` is empty then a user simple bind is done to validate credentials. Otherwise the given attribute is compared with the given `principalAttributePassword` using the `SHA` encrypted value of it.
+| `AUTHENTICATED`         | Manager bind/search or SASL type of authentication. If `principalAttributePassword` is empty then a user simple bind is done to validate credentials. Otherwise the given attribute is compared with the given `principalAttributePassword` using the `SHA` encrypted value of it.
 | `DIRECT`                | Compute user DN from a format string and perform simple bind. This is relevant when no search is required to compute the DN needed for a bind operation. This option is useful when all users are under a single branch in the directory, e.g. `ou=Users,dc=example,dc=org`, or the username provided on the CAS login form is part of the DN, e.g. `uid=%s,ou=Users,dc=exmaple,dc=org`
 | `ANONYMOUS`             | Similar semantics as `AUTHENTICATED` except no `bindDn` and `bindCredential` may be specified to initialize the connection. If `principalAttributePassword` is empty then a user simple bind is done to validate credentials. Otherwise the given attribute is compared with the given `principalAttributePassword` using the `SHA` encrypted value of it.
-| `SASL`                  | Similar semantics as `AUTHENTICATED` except you can specify the SASL mechanism.
 
 ### Connection Strategies
 
@@ -1534,7 +1533,7 @@ You may receive unexpected LDAP failures, when CAS is configured to authenticate
 
 
 ```properties
-# cas.authn.ldap[0].type=AD|AUTHENTICATED|DIRECT|ANONYMOUS|SASL
+# cas.authn.ldap[0].type=AD|AUTHENTICATED|DIRECT|ANONYMOUS
 
 # cas.authn.ldap[0].ldapUrl=ldaps://ldap1.example.edu ldaps://ldap2.example.edu
 # cas.authn.ldap[0].connectionStrategy=


### PR DESCRIPTION
Consolidates startup logic. Removes need for separate `SASL` authentication type option, folding it neatly into `AUTHENTICATED`