### PR TITLE
Name is missing

### DIFF
--- a/docs/cas-server-documentation/installation/Configuring-Multifactor-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-Multifactor-Authentication.md
@@ -133,6 +133,7 @@ value can be an arbitrary regex pattern. See below to learn about how to configu
 {
   "@class" : "org.apereo.cas.services.RegexRegisteredService",
   "serviceId" : "^(https|imaps)://.*",
+  "name": "test",
   "id" : 100,
   "multifactorPolicy" : {
     "@class" : "org.apereo.cas.services.DefaultRegisteredServiceMultifactorPolicy",
@@ -175,6 +176,7 @@ functionality, if that provider cannot respond.
 {
   "@class" : "org.apereo.cas.services.RegexRegisteredService",
   "serviceId" : "^(https|imaps)://.*",
+  "name": "test",
   "id" : 100,
   "multifactorPolicy" : {
     "@class" : "org.apereo.cas.services.DefaultRegisteredServiceMultifactorPolicy",


### PR DESCRIPTION
If name is missing, when user accesses the page and service, page displays "the state 'null' of flow 'login' -- action execution attributes were 'map[[empty]]'"
