### PR TITLE
Fix for acceptable use to handle case where user mustAccept

### DIFF
--- a/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/AcceptableUsagePolicyFormAction.java
+++ b/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/AcceptableUsagePolicyFormAction.java
@@ -21,7 +21,7 @@ public class AcceptableUsagePolicyFormAction extends AbstractAction {
     /**
      * Event id to signal the policy needs to be accepted.
      **/
-    private static final String EVENT_ID_MUST_ACCEPT = "mustAccept";
+    protected static final String EVENT_ID_MUST_ACCEPT = "mustAccept";
 
     private final AcceptableUsagePolicyRepository repository;
 

--- a/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/AcceptableUsagePolicyWebflowConfigurer.java
+++ b/support/cas-server-support-actions-aup-webflow/src/main/java/org/apereo/cas/web/flow/AcceptableUsagePolicyWebflowConfigurer.java
@@ -64,6 +64,7 @@ public class AcceptableUsagePolicyWebflowConfigurer extends AbstractCasWebflowCo
         final ActionState actionState = createActionState(flow, STATE_ID_AUP_CHECK, createAcceptableUsagePolicyAction("verify"));
         actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
                 CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
-        createStateDefaultTransition(actionState, CasWebflowConstants.STATE_ID_INIT_LOGIN_FORM);
+        actionState.getTransitionSet().add(createTransition(AcceptableUsagePolicyFormAction.EVENT_ID_MUST_ACCEPT, 
+                ACCEPTABLE_USAGE_POLICY_VIEW));
     }
 }


### PR DESCRIPTION
Closes #2464

It turns out that acceptable use wasn't working at all in 5.1, as far as I could tell, just using the default repository (none). It didn't have to do with using it in combination with x509. If you needed to accept the flow was just sending you back to the login page. 

Should I be trying to share the "mustAccept" string constant across the two classes where it is used? I added a new transition for "mustAccept" but should I have just changed the default transition? 

I would still like to have the option of acceptable use popping-up when users are doing x509 authentication but I can open another issue for that since that is more of a new feature.  

