### PR TITLE
Support container provided datasource lookup for all JPA sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ reports
 
 *.asc
 *.css
+/.nb-gradle/

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
@@ -161,13 +161,13 @@ public class CasPersonDirectoryConfiguration {
                 if (jdbc.isSingleRow()) {
                     LOGGER.debug("Configured single-row JDBC attribute repository for [{}]", jdbc.getUrl());
                     jdbcDao = new SingleRowJdbcPersonAttributeDao(
-                            Beans.newHickariDataSource(jdbc),
+                            Beans.newDataSource(jdbc),
                             jdbc.getSql()
                     );
                 } else {
                     LOGGER.debug("Configured multi-row JDBC attribute repository for [{}]", jdbc.getUrl());
                     jdbcDao = new MultiRowJdbcPersonAttributeDao(
-                            Beans.newHickariDataSource(jdbc),
+                            Beans.newDataSource(jdbc),
                             jdbc.getSql()
                     );
                     LOGGER.debug("Configured multi-row JDBC column mappings for [{}] are [{}]", jdbc.getUrl(), jdbc.getColumnMappings());

--- a/core/cas-server-core-configuration-cloud-jdbc/src/main/java/org/apereo/cas/config/JdbcCloudConfigBootstrapConfiguration.java
+++ b/core/cas-server-core-configuration-cloud-jdbc/src/main/java/org/apereo/cas/config/JdbcCloudConfigBootstrapConfiguration.java
@@ -33,7 +33,7 @@ public class JdbcCloudConfigBootstrapConfiguration implements PropertySourceLoca
 
         try {
             final JdbcCloudConnection connection = new JdbcCloudConnection(environment);
-            final DataSource dataSource = Beans.newHickariDataSource(connection);
+            final DataSource dataSource = Beans.newDataSource(connection);
             final JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
             final List<Map<String, Object>> rows = jdbcTemplate.queryForList(connection.getSql());
             for (final Map row : rows) {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
@@ -22,6 +22,7 @@ public abstract class AbstractJpaProperties {
     private String defaultSchema;
     private String healthQuery = StringUtils.EMPTY;
     private String idleTimeout = "PT10M";
+    private String dataSourceName;
 
     private ConnectionPoolingProperties pool = new ConnectionPoolingProperties();
 
@@ -158,5 +159,13 @@ public abstract class AbstractJpaProperties {
 
     public void setAutocommit(final boolean autocommit) {
         this.autocommit = autocommit;
+    }
+
+    public String getDataSourceName() {
+        return dataSourceName;
+    }
+
+    public void setDataSourceName(final String dataSourceName) {
+        this.dataSourceName = dataSourceName;
     }
 }

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -132,6 +132,83 @@ connections and queries.
 # cas.jdbc.genDdl=true
 ```
 
+### Container-based JDBC Connections <a name="dataSourceName"></a>
+
+If you are planning to use a container-managed JDBC connection with CAS (i.e. JPA Ticket/Service Registry, etc)
+then you can set the dataSourceName property on any of the configuration items that require a database
+connection. When using a container configured data source, many of the pool related parameters will not be used.
+If dataSourceName is specified but the JNDI lookup fails, a data source will be created with the configured 
+(or default) CAS pool parameters.
+
+The dataSourceName property can be either a JNDI name for the datasource or a resource name prefixed with 
+java:/comp/env/. If it is a resource name then you need an entry in a web.xml that you can add to your
+CAS overlay. It should contain an entry like this:
+
+```
+    <resource-ref>
+        <res-ref-name>jdbc/casDataSource</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+    </resource-ref>
+```
+
+In Tomcat a container datasource can be defined like this in the context.xml:
+```
+    <Resource name="jdbc/casDataSource"
+       auth="Container"
+       type="javax.sql.DataSource"
+       driverClassName="org.postgresql.Driver"
+       url="jdbc:postgresql://casdb.example.com:5432/xyz_db"
+       username="cas"
+       password="xyz"
+       testWhileIdle="true"
+       testOnBorrow="true"
+       testOnReturn="false"
+       validationQuery="select 1"
+       validationInterval="30000"
+       timeBetweenEvictionRunsMillis="30000"
+       factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
+       minIdle="0"
+       maxIdle="5"
+       initialSize="0"
+       maxActive="20"
+       maxWait="10000" />
+```
+
+Or in a Jetty a pool can be put in JNDI with a jetty.xml or jetty-env.xml file like this:
+
+```
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+<New id="datasource.cas" class="org.eclipse.jetty.plus.jndi.Resource">
+    <Arg></Arg> <!-- empty scope arg is JVM scope -->
+    <Arg>jdbc/casDataSource</Arg> <!-- name that matches resource in web.xml-->
+    <Arg>
+        <New class="org.apache.commons.dbcp.BasicDataSource">
+            <Set name="driverClassName">oracle.jdbc.OracleDriver</Set>
+            <Set name="url">jdbc:oracle:thin:@//casdb.example.com:1521/ntrs"</Set>
+            <Set name="username">cas</Set>
+            <Set name="password">xyz</Set>
+            <Set name="validationQuery">select dummy from dual</Set>
+            <Set name="testOnBorrow">true</Set>
+            <Set name="testOnReturn">false</Set>
+            <Set name="testWhileIdle">false</Set>
+            <Set name="defaultAutoCommit">false</Set>
+            <Set name="initialSize">0</Set>
+            <Set name="maxActive">15</Set>
+            <Set name="minIdle">0</Set>
+            <Set name="maxIdle">5</Set>
+            <Set name="maxWait">2000</Set>
+        </New>
+    </Arg>
+</New>
+</Configure>
+
+```
+
+
 ### Signing & Encryption
 
 A number of components in CAS accept signing and encryption keys. In most scenarios if keys are not provided, CAS will auto-generate them. The following instructions apply if you wish to 
@@ -665,6 +742,7 @@ security.basic.realm=CAS
 # cas.adminPagesSecurity.jdbc.autocommit=false
 # cas.adminPagesSecurity.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.adminPagesSecurity.jdbc.idleTimeout=5000
+# cas.adminPagesSecurity.jdbc.[dataSourceName](#dataSourceName)=
 ```
 
 #### LDAP Authentication
@@ -998,6 +1076,7 @@ the following settings are then relevant:
 # cas.authn.attributeRepository.jdbc[0].pool.minSize=6
 # cas.authn.attributeRepository.jdbc[0].pool.maxSize=18
 # cas.authn.attributeRepository.jdbc[0].pool.maxWait=2000
+# cas.authn.attributeRepository.jdbc[0].[dataSourceName](#dataSourceName)=
 ```
 
 ### Grouper
@@ -1152,6 +1231,7 @@ same IP address.
 # cas.authn.throttle.jdbc.pool.minSize=6
 # cas.authn.throttle.jdbc.pool.maxSize=18
 # cas.authn.throttle.jdbc.pool.maxWait=2000
+# cas.authn.throttle.jdbc.[dataSourceName](#dataSourceName)=
 ```
 
 ## Adaptive Authentication
@@ -1413,6 +1493,7 @@ against the password on record determined by a configurable database query.
 # cas.authn.jdbc.query[0].credentialCriteria=
 # cas.authn.jdbc.query[0].name=
 # cas.authn.jdbc.query[0].order=0
+# cas.authn.jdbc.query[0].[dataSourceName](#dataSourceName)=
 
 # cas.authn.jdbc.query[0].fieldPassword=password
 # cas.authn.jdbc.query[0].fieldExpired=
@@ -1457,6 +1538,7 @@ Searches for a user record by querying against a username and password; the user
 # cas.authn.jdbc.search[0].credentialCriteria=
 # cas.authn.jdbc.search[0].name=
 # cas.authn.jdbc.search[0].order=0
+# cas.authn.jdbc.search[0].[dataSourceName](#dataSourceName)=
 
 # cas.authn.jdbc.search[0].passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.jdbc.search[0].passwordEncoder.characterEncoding=
@@ -1493,7 +1575,7 @@ Authenticates a user by attempting to create a database connection using the use
 # cas.authn.jdbc.bind[0].credentialCriteria=
 # cas.authn.jdbc.bind[0].name=
 # cas.authn.jdbc.bind[0].order=0
-
+# cas.authn.jdbc.bind[0].[dataSourceName](#dataSourceName)=
 # cas.authn.jdbc.bind[0].passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.jdbc.bind[0].passwordEncoder.characterEncoding=
 # cas.authn.jdbc.bind[0].passwordEncoder.encodingAlgorithm=
@@ -1544,7 +1626,7 @@ is converted to hex before comparing it to the database value.
 # cas.authn.jdbc.encode[0].credentialCriteria=
 # cas.authn.jdbc.encode[0].name=
 # cas.authn.jdbc.encode[0].order=0
-
+# cas.authn.jdbc.encode[0].[dataSourceName](#dataSourceName)=
 # cas.authn.jdbc.encode[0].passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.jdbc.encode[0].passwordEncoder.characterEncoding=
 # cas.authn.jdbc.encode[0].passwordEncoder.encodingAlgorithm=
@@ -2284,6 +2366,7 @@ The encryption algorithm is set to `AES_128_CBC_HMAC_SHA_256`.
 # cas.authn.mfa.trusted.jpa.autocommit=false
 # cas.authn.mfa.trusted.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.authn.mfa.trusted.jpa.idleTimeout=5000
+# cas.authn.mfa.trusted.jpa.[dataSourceName](#dataSourceName)=
 
 # cas.authn.mfa.trusted.jpa.pool.suspension=false
 # cas.authn.mfa.trusted.jpa.pool.minSize=6
@@ -2381,6 +2464,7 @@ To learn more about this topic, [please review this guide](GoogleAuthenticator-A
 # cas.authn.mfa.gauth.jpa.database.autocommit=false
 # cas.authn.mfa.gauth.jpa.database.driverClass=org.hsqldb.jdbcDriver
 # cas.authn.mfa.gauth.jpa.database.idleTimeout=5000
+# cas.authn.mfa.gauth.jpa.database.[dataSourceName](#dataSourceName)=
 
 # cas.authn.mfa.gauth.jpa.database.pool.suspension=false
 # cas.authn.mfa.gauth.jpa.database.pool.minSize=6
@@ -3285,6 +3369,7 @@ Store audit logs inside a database.
 # cas.audit.jdbc.autocommit=false
 # cas.audit.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.audit.jdbc.idleTimeout=5000
+# cas.audit.jdbc.[dataSourceName](#dataSourceName)=
 
 # cas.audit.jdbc.pool.suspension=false
 # cas.audit.jdbc.pool.minSize=6
@@ -3359,6 +3444,7 @@ for authentication or attribute retrieval.
 # cas.monitor.jdbc.autocommit=false
 # cas.monitor.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.monitor.jdbc.idleTimeout=5000
+# cas.monitor.jdbc.[dataSourceName](#dataSourceName)=
 ```
 
 ### LDAP Connection Pool
@@ -3464,6 +3550,7 @@ Decide how CAS should store authentication events inside a database instance.
 # cas.events.jpa.autocommit=false
 # cas.events.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.events.jpa.idleTimeout=5000
+# cas.events.jpa.[dataSourceName](#dataSourceName)=
 
 # cas.events.jpa.pool.suspension=false
 # cas.events.jpa.pool.minSize=6
@@ -3702,6 +3789,7 @@ To learn more about this topic, [please review this guide](JPA-Service-Managemen
 # cas.serviceRegistry.jpa.autocommit=false
 # cas.serviceRegistry.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.serviceRegistry.jpa.idleTimeout=5000
+# cas.serviceRegistry.jpa.[dataSourceName](#dataSourceName)=
 
 # cas.serviceRegistry.jpa.pool.suspension=false
 # cas.serviceRegistry.jpa.pool.minSize=6
@@ -3754,6 +3842,7 @@ To learn more about this topic, [please review this guide](JPA-Ticket-Registry.h
 # cas.ticket.registry.jpa.autocommit=false
 # cas.ticket.registry.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.ticket.registry.jpa.idleTimeout=5000
+# cas.ticket.registry.jpa.[dataSourceName](#dataSourceName)=
 
 # cas.ticket.registry.jpa.pool.suspension=false
 # cas.ticket.registry.jpa.pool.minSize=6
@@ -4508,6 +4597,7 @@ The following LDAP types are supported:
 # cas.authn.pm.jdbc.autocommit=false
 # cas.authn.pm.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.authn.pm.jdbc.idleTimeout=5000
+# cas.authn.pm.jdbc.[dataSourceName](#dataSourceName)=
 
 # cas.authn.pm.jdbc.passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.pm.jdbc.passwordEncoder.characterEncoding=
@@ -4523,3 +4613,5 @@ The following LDAP types are supported:
 # cas.authn.pm.rest.endpointUrlSecurityQuestions=
 # cas.authn.pm.rest.endpointUrlChange=
 ```
+
+

--- a/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/audit/config/CasSupportJdbcAuditConfiguration.java
+++ b/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/audit/config/CasSupportJdbcAuditConfiguration.java
@@ -84,7 +84,7 @@ public class CasSupportJdbcAuditConfiguration {
     @Bean
     @RefreshScope
     public DataSource inspektrAuditTrailDataSource() {
-        return Beans.newHickariDataSource(casProperties.getAudit().getJdbc());
+        return Beans.newDataSource(casProperties.getAudit().getJdbc());
     }
 
     @Bean

--- a/support/cas-server-support-events-jpa/src/main/java/org/apereo/cas/config/JpaEventsConfiguration.java
+++ b/support/cas-server-support-events-jpa/src/main/java/org/apereo/cas/config/JpaEventsConfiguration.java
@@ -46,7 +46,7 @@ public class JpaEventsConfiguration {
     @RefreshScope
     @Bean
     public DataSource dataSourceEvent() {
-        return Beans.newHickariDataSource(casProperties.getEvents().getJpa());
+        return Beans.newDataSource(casProperties.getEvents().getJpa());
     }
     
     public String[] jpaEventPackagesToScan() {

--- a/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/config/GoogleAuthenticatorJpaConfiguration.java
+++ b/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/config/GoogleAuthenticatorJpaConfiguration.java
@@ -53,7 +53,7 @@ public class GoogleAuthenticatorJpaConfiguration {
     @RefreshScope
     @Bean
     public DataSource dataSourceGoogleAuthenticator() {
-        return Beans.newHickariDataSource(casProperties.getAuthn().getMfa().getGauth().getJpa().getDatabase());
+        return Beans.newDataSource(casProperties.getAuthn().getMfa().getGauth().getJpa().getDatabase());
     }
 
     @Bean

--- a/support/cas-server-support-jdbc-monitor/src/main/java/org/apereo/cas/monitor/config/CasJdbcMonitorConfiguration.java
+++ b/support/cas-server-support-jdbc-monitor/src/main/java/org/apereo/cas/monitor/config/CasJdbcMonitorConfiguration.java
@@ -49,6 +49,6 @@ public class CasJdbcMonitorConfiguration {
     @Bean
     @RefreshScope
     public DataSource monitorDataSource() {
-        return Beans.newHickariDataSource(casProperties.getMonitor().getJdbc());
+        return Beans.newDataSource(casProperties.getMonitor().getJdbc());
     }
 }

--- a/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
+++ b/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
@@ -80,7 +80,7 @@ public class CasJdbcAuthenticationConfiguration {
 
     private AuthenticationHandler bindModeSearchDatabaseAuthenticationHandler(final JdbcAuthenticationProperties.Bind b) {
         final BindModeSearchDatabaseAuthenticationHandler h = new BindModeSearchDatabaseAuthenticationHandler(b.getName(), servicesManager,
-                jdbcPrincipalFactory(), b.getOrder(), Beans.newHickariDataSource(b));
+                jdbcPrincipalFactory(), b.getOrder(), Beans.newDataSource(b));
         h.setPasswordEncoder(Beans.newPasswordEncoder(b.getPasswordEncoder()));
         h.setPrincipalNameTransformer(Beans.newPrincipalNameTransformer(b.getPrincipalTransformation()));
 
@@ -100,7 +100,7 @@ public class CasJdbcAuthenticationConfiguration {
 
     private AuthenticationHandler queryAndEncodeDatabaseAuthenticationHandler(final JdbcAuthenticationProperties.Encode b) {
         final QueryAndEncodeDatabaseAuthenticationHandler h = new QueryAndEncodeDatabaseAuthenticationHandler(b.getName(), servicesManager,
-                jdbcPrincipalFactory(), b.getOrder(), Beans.newHickariDataSource(b), b.getAlgorithmName(), b.getSql(), b.getPasswordFieldName(),
+                jdbcPrincipalFactory(), b.getOrder(), Beans.newDataSource(b), b.getAlgorithmName(), b.getSql(), b.getPasswordFieldName(),
                 b.getSaltFieldName(), b.getExpiredFieldName(), b.getDisabledFieldName(), b.getNumberOfIterationsFieldName(), b.getNumberOfIterations(),
                 b.getStaticSalt());
 
@@ -127,7 +127,7 @@ public class CasJdbcAuthenticationConfiguration {
 
         final QueryDatabaseAuthenticationHandler h = new QueryDatabaseAuthenticationHandler(b.getName(), servicesManager,
                 jdbcPrincipalFactory(), b.getOrder(),
-                Beans.newHickariDataSource(b), b.getSql(), b.getFieldPassword(),
+                Beans.newDataSource(b), b.getSql(), b.getFieldPassword(),
                 b.getFieldExpired(), b.getFieldDisabled(), attributes);
 
         h.setPasswordEncoder(Beans.newPasswordEncoder(b.getPasswordEncoder()));
@@ -149,7 +149,7 @@ public class CasJdbcAuthenticationConfiguration {
 
     private AuthenticationHandler searchModeSearchDatabaseAuthenticationHandler(final JdbcAuthenticationProperties.Search b) {
         final SearchModeSearchDatabaseAuthenticationHandler h = new SearchModeSearchDatabaseAuthenticationHandler(b.getName(), servicesManager,
-                jdbcPrincipalFactory(), b.getOrder(), Beans.newHickariDataSource(b), b.getFieldUser(), b.getFieldPassword(), b.getTableUsers());
+                jdbcPrincipalFactory(), b.getOrder(), Beans.newDataSource(b), b.getFieldUser(), b.getFieldPassword(), b.getTableUsers());
 
         h.setPasswordEncoder(Beans.newPasswordEncoder(b.getPasswordEncoder()));
         h.setPrincipalNameTransformer(Beans.newPrincipalNameTransformer(b.getPrincipalTransformation()));

--- a/support/cas-server-support-jpa-service-registry/src/main/java/org/apereo/cas/config/JpaServiceRegistryConfiguration.java
+++ b/support/cas-server-support-jpa-service-registry/src/main/java/org/apereo/cas/config/JpaServiceRegistryConfiguration.java
@@ -22,7 +22,7 @@ import javax.sql.DataSource;
 
 import static org.apereo.cas.configuration.support.Beans.newHibernateEntityManagerFactoryBean;
 import static org.apereo.cas.configuration.support.Beans.newHibernateJpaVendorAdapter;
-import static org.apereo.cas.configuration.support.Beans.newHickariDataSource;
+import static org.apereo.cas.configuration.support.Beans.newDataSource;
 
 /**
  * This this {@link JpaServiceRegistryConfiguration}.
@@ -78,7 +78,7 @@ public class JpaServiceRegistryConfiguration {
     @RefreshScope
     @Bean
     public DataSource dataSourceService() {
-        return newHickariDataSource(casProperties.getServiceRegistry().getJpa());
+        return newDataSource(casProperties.getServiceRegistry().getJpa());
     }
 
     @Bean

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
@@ -71,7 +71,7 @@ public class JpaTicketRegistryConfiguration {
     @RefreshScope
     @Bean
     public DataSource dataSourceTicket() {
-        return Beans.newHickariDataSource(casProperties.getTicket().getRegistry().getJpa());
+        return Beans.newDataSource(casProperties.getTicket().getRegistry().getJpa());
     }
 
     @Bean

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/config/PasswordManagementConfiguration.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/config/PasswordManagementConfiguration.java
@@ -140,7 +140,7 @@ public class PasswordManagementConfiguration {
                 return new JdbcPasswordManagementService(passwordManagementCipherExecutor(),
                         casProperties.getServer().getPrefix(),
                         casProperties.getAuthn().getPm(),
-                        Beans.newHickariDataSource(casProperties.getAuthn().getPm().getJdbc()));
+                        Beans.newDataSource(casProperties.getAuthn().getPm().getJdbc()));
             }
 
             if (StringUtils.isNotBlank(pm.getRest().getEndpointUrlChange())

--- a/support/cas-server-support-throttle-jdbc/src/main/java/org/apereo/cas/web/support/config/CasJdbcThrottlingConfiguration.java
+++ b/support/cas-server-support-throttle-jdbc/src/main/java/org/apereo/cas/web/support/config/CasJdbcThrottlingConfiguration.java
@@ -30,7 +30,7 @@ public class CasJdbcThrottlingConfiguration {
 
     @Bean
     public DataSource inspektrAuditTrailDataSource() {
-        return Beans.newHickariDataSource(casProperties.getAuthn().getThrottle().getJdbc());
+        return Beans.newDataSource(casProperties.getAuthn().getThrottle().getJdbc());
     }
 
     @Autowired

--- a/support/cas-server-support-trusted-mfa-jdbc/src/main/java/org/apereo/cas/trusted/config/JdbcMultifactorAuthnTrustConfiguration.java
+++ b/support/cas-server-support-trusted-mfa-jdbc/src/main/java/org/apereo/cas/trusted/config/JdbcMultifactorAuthnTrustConfiguration.java
@@ -48,7 +48,7 @@ public class JdbcMultifactorAuthnTrustConfiguration {
     @RefreshScope
     @Bean
     public DataSource dataSourceMfaTrustedAuthn() {
-        return Beans.newHickariDataSource(casProperties.getAuthn().getMfa().getTrusted().getJpa());
+        return Beans.newDataSource(casProperties.getAuthn().getMfa().getTrusted().getJpa());
     }
 
     @Bean

--- a/webapp/cas-server-webapp-config-security/src/main/java/org/apereo/cas/web/security/CasJdbcUserDetailsManagerConfigurer.java
+++ b/webapp/cas-server-webapp-config-security/src/main/java/org/apereo/cas/web/security/CasJdbcUserDetailsManagerConfigurer.java
@@ -22,7 +22,7 @@ public class CasJdbcUserDetailsManagerConfigurer extends JdbcUserDetailsManagerC
     public void configure(final AuthenticationManagerBuilder auth) throws Exception {
         usersByUsernameQuery(adminPagesSecurityProperties.getJdbc().getQuery());
         rolePrefix(adminPagesSecurityProperties.getJdbc().getRolePrefix());
-        dataSource(Beans.newHickariDataSource(adminPagesSecurityProperties.getJdbc()));
+        dataSource(Beans.newDataSource(adminPagesSecurityProperties.getJdbc()));
         passwordEncoder(Beans.newPasswordEncoder(adminPagesSecurityProperties.getJdbc().getPasswordEncoder()));
         super.configure(auth);
     }


### PR DESCRIPTION
This isn't ready to merge yet because I haven't tested it (at all) or updated the documentation. I just wanted to see if you thought it was worthwhile before I spent any time on it. 

I am planning to deploy CAS to a set of Tomcat servers that store datasources outside the applications and I think it would be nice if the configuration for CAS's datasource was in the same place as all the other applications' datasource configs. 

This would add "dataSourceName" to all JPA modules and if it was set, then it would be used to lookup a datasource via resource reference or jndi name instead of using the hickari datasource. If dataSourceName was set but lookup failed then it would fall back hickari. Not sure if that behavior makes sense or not, but I can see running with hickari when testing locally (and using spring boot) but then using a tomcat datasource in other environments. 

If this looks OK then I will update documentation and test it out on JPA ticket registry. I wouldn't be able to test all JPA modules but once one works I suspect they all would. 