### PR TITLE
Fix Hazelcast ticket deletion when ticket encryption is enabled

### DIFF
--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -89,9 +89,10 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
 
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
+        final String encTicketId = encodeTicketId(ticketId);
         final TicketDefinition metadata = this.ticketCatalog.find(ticketId);
         final IMap<String, Ticket> map = getTicketMapInstanceByMetadata(metadata);
-        return map.remove(ticketId) != null;
+        return map.remove(encTicketId) != null;
     }
 
     @Override


### PR DESCRIPTION
Closes #2528 for master.

Tickets are stored with encrypted ticket ID as key, so we also need to encrypt the ticket id when deleting.

