### PR TITLE
Fix Hazelcast ticket deletion when ticket encryption is enabled for 5.0.x

### DIFF
--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -87,7 +87,8 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
 
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
-        return this.registry.remove(ticketId) != null;
+        final String encTicketId = encodeTicketId(ticketId);
+        return this.registry.remove(encTicketId) != null;
     }
 
     @Override


### PR DESCRIPTION
Closes #2528 for 5.0.x

Tickets are stored with encrypted ticket ID as key, so we also need to encrypt the ticket id when deleting.