### PR TITLE
Disable HazelcastTicketRegistry configuration reload

### DIFF
--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastInstanceConfiguration.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastInstanceConfiguration.java
@@ -51,7 +51,6 @@ public class HazelcastInstanceConfiguration {
     private CasConfigurationProperties casProperties;
         
     @Bean(name = {"hazelcastTicketRegistry", "ticketRegistry"})
-    @RefreshScope
     public TicketRegistry hazelcastTicketRegistry() {
         final HazelcastTicketRegistry r = new HazelcastTicketRegistry(hazelcast(),
                 casProperties.getTicket().getRegistry().getHazelcast().getMapName(),


### PR DESCRIPTION
Remove `@RefreshScope` anotation from `org.apereo.cas.config.HazelcastInstanceConfiguration.hazelcastTicketRegistry` to avoid issues on configuration reload.

Closes #2539