### PR TITLE
OidcProfileScopeToAttributesFilter must release all attributes

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/profile/OidcProfileScopeToAttributesFilter.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/profile/OidcProfileScopeToAttributesFilter.java
@@ -11,7 +11,7 @@ import org.apereo.cas.oidc.claims.OidcEmailScopeAttributeReleasePolicy;
 import org.apereo.cas.oidc.claims.OidcPhoneScopeAttributeReleasePolicy;
 import org.apereo.cas.oidc.claims.OidcProfileScopeAttributeReleasePolicy;
 import org.apereo.cas.services.ChainingAttributeReleasePolicy;
-import org.apereo.cas.services.DenyAllAttributeReleasePolicy;
+import org.apereo.cas.services.ReturnAllAttributeReleasePolicy;
 import org.apereo.cas.services.OidcRegisteredService;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServicesManager;
@@ -151,7 +151,7 @@ public class OidcProfileScopeToAttributesFilter extends DefaultOAuth20ProfileSco
         }
 
         if (policy.getPolicies().isEmpty()) {
-            oidc.setAttributeReleasePolicy(new DenyAllAttributeReleasePolicy());
+            oidc.setAttributeReleasePolicy(new ReturnAllAttributeReleasePolicy());
         } else {
             oidc.setAttributeReleasePolicy(policy);
         }


### PR DESCRIPTION
OidcProfileScopeToAttributesFilter must release all attributes first and letting OIDC scope to configure which attributes to be returned. DenyAllAttributeReleasePolicy is unsuitable because no attributes will be released to OIDC scope processing and rendering it totally useless.