### PR TITLE
Update HazelcastInstanceConfiguration.java hazelcastTicketRegistry be…

### DIFF
--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastInstanceConfiguration.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastInstanceConfiguration.java
@@ -50,7 +50,7 @@ public class HazelcastInstanceConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;
         
-    @Bean(name = {"hazelcastTicketRegistry", "ticketRegistry"})
+    @Bean(name = {"hazelcastTicketRegistry"})
     @RefreshScope
     public TicketRegistry hazelcastTicketRegistry() {
         final HazelcastTicketRegistry r = new HazelcastTicketRegistry(hazelcast(),


### PR DESCRIPTION
Hazelcast ticket registry prevents CAS 5.0.5 from starting up as referenced in issue 2559.

Updating HazelcastInstanceConfiguration.java to remove "ticketRegistry" from the Bean annotation on the hazelcastTicketRegistry function seems to allow CAS to startup, though not sure if this will cause other issues.

Closes #2559 