### PR TITLE
Closes #2549 Allow container datasource to be used directly or proxied

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
@@ -32,6 +32,7 @@ public abstract class AbstractJpaProperties {
     private boolean failFast = true;
     private boolean isolateInternalQueries;
     private boolean autocommit;
+    private boolean dataSourceProxy;
 
     public String getDefaultCatalog() {
         return defaultCatalog;
@@ -167,5 +168,13 @@ public abstract class AbstractJpaProperties {
 
     public void setDataSourceName(final String dataSourceName) {
         this.dataSourceName = dataSourceName;
+    }
+
+    public boolean isDataSourceProxy() {
+        return dataSourceProxy;
+    }
+
+    public void setDataSourceProxy(final boolean dataSourceProxy) {
+        this.dataSourceProxy = dataSourceProxy;
     }
 }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
@@ -7,7 +7,6 @@ import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
-import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import groovy.lang.GroovyClassLoader;
 import org.apache.commons.io.IOUtils;
@@ -154,10 +153,7 @@ public final class Beans {
      * Since the datasource beans are RefreshScope, they will be a proxied by Spring
      * and on some application servers there have been classloading issues. A workaround
      * for this is to use the dataSourceProxy parameter and then the dataSource will be
-     * wrapped in a Hikari pool. If that is an issue, don't do it. If container datasource
-     * doesn't work and you don't want to use Hikari for whatever reason, another option
-     * is to override the various DataSource Spring beans, but those bean names are not
-     * guaranteed to stay the same from release to release.
+     * wrapped in an application level class. If that is an issue, don't do it. 
      *
      * @param jpaProperties the jpa properties
      * @return the data source
@@ -179,10 +175,7 @@ public final class Beans {
                 if (!proxyDataSource) {
                     return containerDataSource;
                 } else {
-                    // wrapping datasource in hikari pool b/c of classloading issues on some appservers
-                    final HikariConfig config = new HikariConfig(new Properties());
-                    config.setDataSource(containerDataSource);
-                    return new HikariDataSource(config);
+                    return new DataSourceProxy(containerDataSource);
                 }
             } catch (final DataSourceLookupFailureException e) {
                 LOGGER.warn("Lookup of datasource [{}] failed due to {} "

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/DataSourceProxy.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/DataSourceProxy.java
@@ -1,0 +1,44 @@
+package org.apereo.cas.configuration.support;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.datasource.AbstractDataSource;
+
+/**
+ * This purpose of this class is to fix a class loading issue that occurs
+ * in some application servers when using a datasource/pool from the
+ * container ClassLoader. By having this class at the app level,
+ * proxying that occurs (e.g. RefreshScope annotation) doesn't encounter
+ * problems if another proxying library somewhere else uses the container
+ * class loader and encounters other proxying classes in the application. 
+ *
+ * Extends AbstractDataSource  but it could probably
+ * just delegate all methods to the wrapped datasource if anything
+ * that AbstractDataSource is doing causes a problem.
+ *
+ * @author Hal Deadman
+ * @since 5.1
+ */
+public class DataSourceProxy extends AbstractDataSource {
+
+    private DataSource dataSource;
+    
+    public DataSourceProxy(final DataSource dataSource) {
+        super();
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    @Override
+    public Connection getConnection(final String username, final String password) throws SQLException {
+        return dataSource.getConnection(username, password);
+    }
+
+}

--- a/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
@@ -132,6 +132,10 @@ connection. When using a container configured data source, many of the pool rela
 If `dataSourceName` is specified but the JNDI lookup fails, a data source will be created with the configured 
 (or default) CAS pool parameters.
 
+If you experience classloading errors while trying to use a container datasource, you can try 
+setting the `dataSourceProxy` setting to true which will wrap the container datasource in
+a way that may resolve the error.
+
 The `dataSourceName` property can be either a JNDI name for the datasource or a resource name prefixed with 
 `java:/comp/env/`. If it is a resource name then you need an entry in a `web.xml` that you can add to your
 CAS overlay. It should contain an entry like this:

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -550,6 +550,7 @@ security.basic.realm=CAS
 # cas.adminPagesSecurity.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.adminPagesSecurity.jdbc.idleTimeout=5000
 # cas.adminPagesSecurity.jdbc.dataSourceName=
+# cas.adminPagesSecurity.jdbc.dataSourceProxy=false
 ```
 
 #### LDAP Authentication
@@ -884,6 +885,7 @@ the following settings are then relevant:
 # cas.authn.attributeRepository.jdbc[0].pool.maxSize=18
 # cas.authn.attributeRepository.jdbc[0].pool.maxWait=2000
 # cas.authn.attributeRepository.jdbc[0].dataSourceName=
+# cas.authn.attributeRepository.jdbc[0].dataSourceProxy=false
 ```
 
 ### Grouper
@@ -1046,6 +1048,7 @@ same IP address.
 # cas.authn.throttle.jdbc.pool.maxSize=18
 # cas.authn.throttle.jdbc.pool.maxWait=2000
 # cas.authn.throttle.jdbc.dataSourceName=
+# cas.authn.throttle.jdbc.dataSourceProxy=false
 ```
 
 ## Adaptive Authentication
@@ -1308,6 +1311,7 @@ against the password on record determined by a configurable database query.
 # cas.authn.jdbc.query[0].name=
 # cas.authn.jdbc.query[0].order=0
 # cas.authn.jdbc.query[0].dataSourceName=
+# cas.authn.jdbc.query[0].dataSourceProxy=false
 
 # cas.authn.jdbc.query[0].fieldPassword=password
 # cas.authn.jdbc.query[0].fieldExpired=
@@ -1353,6 +1357,7 @@ Searches for a user record by querying against a username and password; the user
 # cas.authn.jdbc.search[0].name=
 # cas.authn.jdbc.search[0].order=0
 # cas.authn.jdbc.search[0].dataSourceName=
+# cas.authn.jdbc.search[0].dataSourceProxy=false
 
 # cas.authn.jdbc.search[0].passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.jdbc.search[0].passwordEncoder.characterEncoding=
@@ -1390,6 +1395,7 @@ Authenticates a user by attempting to create a database connection using the use
 # cas.authn.jdbc.bind[0].name=
 # cas.authn.jdbc.bind[0].order=0
 # cas.authn.jdbc.bind[0].dataSourceName=
+# cas.authn.jdbc.bind[0].dataSourceProxy=false
 # cas.authn.jdbc.bind[0].passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.jdbc.bind[0].passwordEncoder.characterEncoding=
 # cas.authn.jdbc.bind[0].passwordEncoder.encodingAlgorithm=
@@ -1441,6 +1447,7 @@ is converted to hex before comparing it to the database value.
 # cas.authn.jdbc.encode[0].name=
 # cas.authn.jdbc.encode[0].order=0
 # cas.authn.jdbc.encode[0].dataSourceName=
+# cas.authn.jdbc.encode[0].dataSourceProxy=false
 # cas.authn.jdbc.encode[0].passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.jdbc.encode[0].passwordEncoder.characterEncoding=
 # cas.authn.jdbc.encode[0].passwordEncoder.encodingAlgorithm=
@@ -2181,6 +2188,7 @@ The encryption algorithm is set to `AES_128_CBC_HMAC_SHA_256`.
 # cas.authn.mfa.trusted.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.authn.mfa.trusted.jpa.idleTimeout=5000
 # cas.authn.mfa.trusted.jpa.dataSourceName=
+# cas.authn.mfa.trusted.jpa.dataSourceProxy=false
 
 # cas.authn.mfa.trusted.jpa.pool.suspension=false
 # cas.authn.mfa.trusted.jpa.pool.minSize=6
@@ -2279,6 +2287,7 @@ To learn more about this topic, [please review this guide](GoogleAuthenticator-A
 # cas.authn.mfa.gauth.jpa.database.driverClass=org.hsqldb.jdbcDriver
 # cas.authn.mfa.gauth.jpa.database.idleTimeout=5000
 # cas.authn.mfa.gauth.jpa.database.dataSourceName=
+# cas.authn.mfa.gauth.jpa.database.dataSourceProxy=false
 
 # cas.authn.mfa.gauth.jpa.database.pool.suspension=false
 # cas.authn.mfa.gauth.jpa.database.pool.minSize=6
@@ -3193,6 +3202,7 @@ Store audit logs inside a database.
 # cas.audit.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.audit.jdbc.idleTimeout=5000
 # cas.audit.jdbc.dataSourceName=
+# cas.audit.jdbc.dataSourceProxy=false
 
 # cas.audit.jdbc.pool.suspension=false
 # cas.audit.jdbc.pool.minSize=6
@@ -3268,6 +3278,7 @@ for authentication or attribute retrieval.
 # cas.monitor.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.monitor.jdbc.idleTimeout=5000
 # cas.monitor.jdbc.dataSourceName=
+# cas.monitor.jdbc.dataSourceProxy=false
 ```
 
 ### LDAP Connection Pool
@@ -3374,6 +3385,7 @@ Decide how CAS should store authentication events inside a database instance.
 # cas.events.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.events.jpa.idleTimeout=5000
 # cas.events.jpa.dataSourceName=
+# cas.events.jpa.dataSourceProxy=false
 
 # cas.events.jpa.pool.suspension=false
 # cas.events.jpa.pool.minSize=6
@@ -3613,6 +3625,7 @@ To learn more about this topic, [please review this guide](JPA-Service-Managemen
 # cas.serviceRegistry.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.serviceRegistry.jpa.idleTimeout=5000
 # cas.serviceRegistry.jpa.dataSourceName=
+# cas.serviceRegistry.jpa.dataSourceProxy=false
 
 # cas.serviceRegistry.jpa.pool.suspension=false
 # cas.serviceRegistry.jpa.pool.minSize=6
@@ -3666,6 +3679,7 @@ To learn more about this topic, [please review this guide](JPA-Ticket-Registry.h
 # cas.ticket.registry.jpa.driverClass=org.hsqldb.jdbcDriver
 # cas.ticket.registry.jpa.idleTimeout=5000
 # cas.ticket.registry.jpa.dataSourceName=
+# cas.ticket.registry.jpa.dataSourceProxy=false
 
 # cas.ticket.registry.jpa.pool.suspension=false
 # cas.ticket.registry.jpa.pool.minSize=6
@@ -4423,6 +4437,7 @@ The following LDAP types are supported:
 # cas.authn.pm.jdbc.driverClass=org.hsqldb.jdbcDriver
 # cas.authn.pm.jdbc.idleTimeout=5000
 # cas.authn.pm.jdbc.dataSourceName=
+# cas.authn.pm.jdbc.dataSourceProxy=false
 
 # cas.authn.pm.jdbc.passwordEncoder.type=NONE|DEFAULT|STANDARD|BCRYPT|SCRYPT|PBKDF2|com.example.CustomPasswordEncoder
 # cas.authn.pm.jdbc.passwordEncoder.characterEncoding=


### PR DESCRIPTION
Closes #2549

By proxying the datasource with a class loaded by the app classloader, it resolves some classloading issues, but now by default it won't proxy the datasource. Tomcat currently requires the proxy option to be turned on. 

This may be tricking Hikari into thinking it is delegating to an existing Hikari datasource but it is really a non-Hikari datasource. Might be better to just add a small datasource proxy class rather than using Hikari in a way it probably doesn't intend for people to use it. Since I am creating the datasource with a HikariConfig object, the HikariDataSource sets a fastPathPool instance variable and when getConnection is called it just delegates to that (the non-hikari container datasource). 

I didn't document this yet, but it adds one new configuration property that is false by default. You can wait to merge until later.


When I actually tried to set properties on the Hikari pool, making it a pool of a pool, I got an error like this:
```
Caused by: org.postgresql.util.PSQLException: Cannot change transaction read-only property in the middle of a transaction.
	at org.postgresql.jdbc2.AbstractJdbc2Connection.setReadOnly(AbstractJdbc2Connection.java:749) ~[postgresql-9.4-1203-jdbc42.jar:9.4]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_111]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_111]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_111]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_111]
	at org.apache.tomcat.jdbc.pool.ProxyConnection.invoke(ProxyConnection.java:126) ~[tomcat-jdbc.jar:?]
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:108) ~[tomcat-jdbc.jar:?]
	at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:81) ~[tomcat-jdbc.jar:?]
	at com.sun.proxy.$Proxy110.setReadOnly(Unknown Source) ~[?:?]
	at com.zaxxer.hikari.pool.PoolBase.setupConnection(PoolBase.java:400) ~[HikariCP-2.6.1.jar:?]
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:361) ~[HikariCP-2.6.1.jar:?]
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:199) ~[HikariCP-2.6.1.jar:?]
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:444) ~[HikariCP-2.6.1.jar:?]
	at com.zaxxer.hikari.pool.HikariPool.access$200(HikariPool.java:71) ~[HikariCP-2.6.1.jar:?]
	at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:631) ~[HikariCP-2.6.1.jar:?]
	at com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:617) ~[HikariCP-2.6.1.jar:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_111]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_111]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_111]
	... 1 more
```