### PR TITLE
OpenID yadis.xml should have MIME type application/xrds+xml

### DIFF
--- a/support/cas-server-support-openid/src/main/java/org/apereo/cas/support/openid/web/mvc/YadisController.java
+++ b/support/cas-server-support-openid/src/main/java/org/apereo/cas/support/openid/web/mvc/YadisController.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -45,7 +44,7 @@ public class YadisController {
         try (StringWriter writer = new StringWriter()) {
             IOUtils.copy(template.getInputStream(), writer, StandardCharsets.UTF_8);
             final String yadis = writer.toString().replace("$casLoginUrl", casProperties.getServer().getLoginUrl());
-            response.setContentType(MediaType.TEXT_XML_VALUE);
+            response.setContentType("application/xrds+xml");
             final Writer respWriter = response.getWriter();
             respWriter.write(yadis);
             respWriter.flush();


### PR DESCRIPTION
As noted in #2570, OpenID 2.0 specification states that yadis.xml should have MIME type application/xrds+xml