### PR TITLE
drop service deletion from mgmt webapp controller

### DIFF
--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/RegisteredServiceSimpleFormController.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/RegisteredServiceSimpleFormController.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.mgmt.services.web;
 
 import com.google.common.base.Throwables;
-import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.mgmt.services.web.beans.RegisteredServiceEditBean;
 import org.apereo.cas.mgmt.services.web.factory.RegisteredServiceFactory;
 import org.apereo.cas.services.RegisteredService;

--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/RegisteredServiceSimpleFormController.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/services/web/RegisteredServiceSimpleFormController.java
@@ -60,13 +60,6 @@ public class RegisteredServiceSimpleFormController extends AbstractManagementCon
                             @RequestBody final RegisteredServiceEditBean.ServiceData service,
                             final BindingResult result) {
         try {
-            if (StringUtils.isNotBlank(service.getAssignedId())) {
-                final RegisteredService svc = this.servicesManager.findServiceBy(Long.parseLong(service.getAssignedId()));
-                if (svc != null) {
-                    this.servicesManager.delete(svc.getId());
-                }
-            }
-            
             final RegisteredService svcToUse = this.registeredServiceFactory.createRegisteredService(service);
             final RegisteredService newSvc = this.servicesManager.save(svcToUse);
             LOGGER.info("Saved changes to service [{}]", svcToUse.getId());


### PR DESCRIPTION
This is in response to issue [2572](https://github.com/apereo/cas/issues/2572). 

Drops the deletion statement in the mgmt webapp controller as in this former [pull request](https://github.com/apereo/cas/pull/1264). I checked back couchbase, dynamo and mongo and believe that mongodb should be the only one expecting a deleted service when saving. This might require some extra work. There are no test cases for the collaboration of mgmt webapp and each ServiceRegistryDAO though.

The DAO tests from the old pull request don't fit into the current design of test cases, so I left them out.