### PR TITLE
Fix cas-management default service URL

### DIFF
--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
@@ -274,7 +274,7 @@ public class CasManagementWebAppConfiguration extends WebMvcConfigurerAdapter {
     }
 
     private String getDefaultServiceUrl() {
-        return casProperties.getMgmt().getServerName().concat(serverProperties.getContextPath()).concat("/callback");
+        return casProperties.getMgmt().getServerName().concat(serverProperties.getContextPath()).concat("/manage.html");
     }
 
     @Bean


### PR DESCRIPTION
Without fixing this URL a new installation will have a hard time messing underlying service registry to properly register cas-management