### PR TITLE
Move @Controller annotations to superclass of ValidationControllers

### DIFF
--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/web/AbstractDelegateController.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/web/AbstractDelegateController.java
@@ -17,7 +17,6 @@ import javax.servlet.http.HttpServletResponse;
  * @author Frederic Esnault
  * @since 4.2.0
  */
-@Controller
 public abstract class AbstractDelegateController implements ApplicationContextAware {
 
     /** Application context. */

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/web/AbstractDelegateController.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/web/AbstractDelegateController.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -16,6 +17,7 @@ import javax.servlet.http.HttpServletResponse;
  * @author Frederic Esnault
  * @since 4.2.0
  */
+@Controller
 public abstract class AbstractDelegateController implements ApplicationContextAware {
 
     /** Application context. */

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
@@ -58,6 +58,7 @@ import java.util.Optional;
  * @author Misagh Moayyed
  * @since 3.0.0
  */
+@Controller
 public abstract class AbstractServiceValidateController extends AbstractDelegateController {
     
     private ValidationSpecification validationSpecification;

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
@@ -32,6 +32,7 @@ import org.apereo.cas.validation.Assertion;
 import org.apereo.cas.validation.ValidationResponseType;
 import org.apereo.cas.validation.ValidationSpecification;
 import org.apereo.cas.web.support.ArgumentExtractor;
+import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/LegacyValidateController.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/LegacyValidateController.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletResponse;
  * @author Misagh Moayyed
  * @since 4.2
  */
-@Controller("legacyValidateController")
 public class LegacyValidateController extends AbstractServiceValidateController {
 
     /**

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/ProxyValidateController.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/ProxyValidateController.java
@@ -13,7 +13,6 @@ import javax.servlet.http.HttpServletResponse;
  * @author Misagh Moayyed
  * @since 4.2
  */
-@Controller("proxyValidateController")
 public class ProxyValidateController extends AbstractServiceValidateController {
     
     /**

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/ServiceValidateController.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/ServiceValidateController.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletResponse;
  * @author Misagh Moayyed
  * @since 4.2
  */
-@Controller("serviceValidateController")
 public class ServiceValidateController extends AbstractServiceValidateController {
     
     /**

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/v3/V3ProxyValidateController.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/v3/V3ProxyValidateController.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletResponse;
  * @author Misagh Moayyed
  * @since 4.2
  */
-@Controller("v3ProxyValidateController")
 public class V3ProxyValidateController extends V3ServiceValidateController {
     /**
      * Handle model and view.

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/v3/V3ServiceValidateController.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/v3/V3ServiceValidateController.java
@@ -13,7 +13,6 @@ import javax.servlet.http.HttpServletResponse;
  * @author Misagh Moayyed
  * @since 4.2
  */
-@Controller("v3ServiceValidateController")
 public class V3ServiceValidateController extends AbstractServiceValidateController {
     /**
      * Handle model and view.


### PR DESCRIPTION
- Avoid NPE when running as Spring-Boot Application due to @Controller annotations picked up to early during bootstrap of the application. 
- see #2605 

Moved ```@Controller``` to AbstractServiceValidateController, as the child classes of it are the only ones affected by the Spring-Boot wiring issue (AbstractDelegateController is also extended by the SmartOpenIdController, which is not marked ```@Controller```, so I do want to avoid side effects).