### PR TITLE
Stop CacheStatus from printing Map info multiple times

### DIFF
--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/CacheStatus.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/CacheStatus.java
@@ -68,10 +68,7 @@ public class CacheStatus extends Status {
         }
         return Stream.of(statistics)
                 .filter(Objects::nonNull)
-                .map(s -> {
-                    s.toString(sb);
-                    return sb.toString();
-                })
+                .map(s -> s.toString())
                 .collect(Collectors.joining("|",
                         sb.toString() + "Cache statistics: [", "]"));
     }


### PR DESCRIPTION
Passing StringBuilder sb to each CacheStatistics objects causes the maps in the first few entries to be printed to the screen multiple times.
