### PR TITLE
Passing wrong property for SSOStatus endpoint

### DIFF
--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/DashboardController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/DashboardController.java
@@ -114,7 +114,7 @@ public class DashboardController extends BaseCasMvcEndpoint {
         model.put("statisticsEndpointEnabled",
                 isEndpointCapable(casProperties.getMonitor().getEndpoints().getStatistics(), casProperties));
         model.put("singleSignOnStatusEndpointEnabled",
-                isEndpointCapable(casProperties.getMonitor().getEndpoints().getSingleSignOnReport(), casProperties));
+                isEndpointCapable(casProperties.getMonitor().getEndpoints().getSingleSignOnStatus(), casProperties));
         model.put("springWebflowEndpointEnabled",
                 isEndpointCapable(casProperties.getMonitor().getEndpoints().getSpringWebflowReport(), casProperties));
         model.put("auditLogEndpointEnabled",


### PR DESCRIPTION
DashboardController.java is passing th SSOReport endpoint flag for the SSOStatus endpoint.  This causes the SSOStatus link to show on the cas/status/dashboard, but when the link is clicked it reports 404 error.  

This pull changes the file to pass the correct endpoint flag

