### PR TITLE
Incorrect cookie domain setting

### DIFF
--- a/support/cas-server-support-cookie/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/support/cas-server-support-cookie/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -65,7 +65,7 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
         super();
         super.setCookieName(name);
         super.setCookiePath(path);
-        super.setCookieDomain(domain);
+        this.setCookieDomain(domain);
         super.setCookieMaxAge(maxAge);
         super.setCookieSecure(secure);
         this.casCookieValueManager = casCookieValueManager;


### PR DESCRIPTION
In CookieRetrievingCookieGenerator exists overriden method setCookieDomain, but it is never called. In constructor, super method is called.
SSO mechanism doesn't work because domain is an empty string ("")