### PR TITLE
Proper failure mode override/default handling

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceMultifactorPolicy.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceMultifactorPolicy.java
@@ -35,7 +35,12 @@ public interface RegisteredServiceMultifactorPolicy extends Serializable {
         /**
          * Do not check for failure at all.
          */
-        NONE
+        NONE,
+
+        /**
+         * The default one indicating that no failure mode is set at all.
+         */
+        NOT_SET
     }
 
     /**

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/services/AbstractMultifactorAuthenticationProvider.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/services/AbstractMultifactorAuthenticationProvider.java
@@ -11,6 +11,9 @@ import org.springframework.webflow.execution.Event;
 
 import java.io.Serializable;
 
+import static org.apereo.cas.services.RegisteredServiceMultifactorPolicy.FailureModes.CLOSED;
+import static org.apereo.cas.services.RegisteredServiceMultifactorPolicy.FailureModes.NOT_SET;
+
 /**
  * The {@link AbstractMultifactorAuthenticationProvider} is responsible for
  * as the parent of all providers.
@@ -89,14 +92,14 @@ public abstract class AbstractMultifactorAuthenticationProvider implements Multi
 
     @Override
     public boolean isAvailable(final RegisteredService service) throws AuthenticationException {
-        RegisteredServiceMultifactorPolicy.FailureModes failureMode = RegisteredServiceMultifactorPolicy.FailureModes.CLOSED;
+        RegisteredServiceMultifactorPolicy.FailureModes failureMode = CLOSED;
         final RegisteredServiceMultifactorPolicy policy = service.getMultifactorPolicy();
-        if (policy != null) {
+        if (policy.getFailureMode() != NOT_SET) {
             failureMode = policy.getFailureMode();
-            LOGGER.debug("Multifactor failure mode for [{}] is defined as [{}]", service.getServiceId(), failureMode);
+            LOGGER.debug("Multi-factor failure mode for [{}] is defined as [{}]", service.getServiceId(), failureMode);
         } else if (StringUtils.isNotBlank(this.globalFailureMode)) {
             failureMode = RegisteredServiceMultifactorPolicy.FailureModes.valueOf(this.globalFailureMode);
-            LOGGER.debug("Using global multifactor failure mode for [{}] defined as [{}]", service.getServiceId(), failureMode);
+            LOGGER.debug("Using global multi-factor failure mode for [{}] defined as [{}]", service.getServiceId(), failureMode);
         }
 
         if (failureMode != RegisteredServiceMultifactorPolicy.FailureModes.NONE) {

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceMultifactorPolicy.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceMultifactorPolicy.java
@@ -18,9 +18,13 @@ public class DefaultRegisteredServiceMultifactorPolicy implements RegisteredServ
     private static final long serialVersionUID = -3068390754996358337L;
 
     private Set<String> multifactorAuthenticationProviders = new LinkedHashSet<>();
-    private FailureModes failureMode = FailureModes.CLOSED;
+
+    private FailureModes failureMode = FailureModes.NOT_SET;
+
     private String principalAttributeNameTrigger;
+
     private String principalAttributeValueToMatch;
+
     private boolean bypassEnabled;
 
     /**


### PR DESCRIPTION
... as currently the registered service mode is instantiated with default of `CLOSED`: https://github.com/apereo/cas/blob/master/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractRegisteredService.java#L99 no `global` failure mode branch could ever be reached.

This commit fixes that by introducing the default mode of `NOT_SET` and checking this value to make sure that the global mode could take effect.