### PR TITLE
ConcurrentModificationException thrown resolving AuthenticationServic…

### DIFF
--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationServiceSelectionPlan.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationServiceSelectionPlan.java
@@ -23,16 +23,17 @@ public class DefaultAuthenticationServiceSelectionPlan implements Authentication
 
     public DefaultAuthenticationServiceSelectionPlan(final AuthenticationServiceSelectionStrategy... strategies) {
         this.strategies = Arrays.stream(strategies).collect(Collectors.toList());
+        OrderComparator.sort(this.strategies);
     }
 
     @Override
     public void registerStrategy(final AuthenticationServiceSelectionStrategy strategy) {
         strategies.add(strategy);
+        OrderComparator.sort(this.strategies);
     }
 
     @Override
     public Service resolveService(final Service service) {
-        OrderComparator.sort(this.strategies);
         return this.strategies.stream()
                 .filter(s -> s.supports(service))
                 .findFirst()


### PR DESCRIPTION
…eSelectionStrategy

Found during load testing the 5.1.0 release

OrderComparator.sort() locks the List for access.  This caused a ConcurrentModificationException to be thrown in resolveService() method of DefaultAuthenticationServiceSelectionPlan when searching the list for a supported strategy.  

This fix moves the OrderComparator.sort() call to only when the list is modified and not every time a strategy is resolved.


