### PR TITLE
Prevent extracting expired TGT authentication.

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistrySupport.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistrySupport.java
@@ -26,7 +26,7 @@ public class DefaultTicketRegistrySupport implements TicketRegistrySupport {
     @Override
     public Authentication getAuthenticationFrom(final String ticketGrantingTicketId) throws RuntimeException {
         final TicketGrantingTicket tgt = this.ticketRegistry.getTicket(ticketGrantingTicketId, TicketGrantingTicket.class);
-        return tgt == null ? null : tgt.getAuthentication();
+        return tgt == null || tgt.isExpired() ? null : tgt.getAuthentication();
     }
 
     @Override


### PR DESCRIPTION
As I understand the internals of CAS there is no guarantee that a ticket registry does not have expired tickets. Hence ticket expiration needs to be checked when trying to obtain a *valid* authentication.

PR adds TGT expiration check to `DefaultTicketRegistrySupport` so that call to `getAuthenticationFrom` won't return authentication of an expired ticket. This fulfils contract defined in JavaDoc:

> @return valid Authentication OR NULL if there is no valid SSO session present identified by the provided TGT id SSO token

The scenario this PR solves is following:

* Once user goes to login flow with TGC referencing expired TGT, this TGT is being picked by `InitialFlowSetupAction#configureWebflowContext`.
* Later after a succesful authentication a new TGT should be ideally issued, but that is prevented by `AbstractCasWebflowEventResolver#shouldIssueTicketGrantingTicket`, which *blindly* reuses expired TGT from flow context.

Not sure if the issue should be solved in a different way (maybe the expired TGT is supposed to be purged from the registry at some point), however the change is minimalistic and seems as a legit modification.