### PR TITLE
@RefreshScope on ServiceTicketExpirationPolicy causes deserializtion err

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsConfiguration.java
@@ -245,7 +245,6 @@ public class CasCoreTicketsConfiguration implements TransactionManagementConfigu
 
     @ConditionalOnMissingBean(name = "serviceTicketExpirationPolicy")
     @Bean
-    @RefreshScope
     public ExpirationPolicy serviceTicketExpirationPolicy() {
         return new MultiTimeUseOrTimeoutExpirationPolicy.ServiceTicketExpirationPolicy(
                 casProperties.getTicket().getSt().getNumberOfUses(),


### PR DESCRIPTION
Found this testing 5.1.0 release:

When using a distributed ticket registry cache such as Hazelcast, the de-serialization of the ServiceTicketImpl fails when reading the ticket from a different host then what created it.  

Removing @RefreshScope from the ServiceTicketExpirationPolicy bean allows it to be serialized between different hosts.
