### PR TITLE
Fix deletion of encoded tickets in ticket registries

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -32,7 +32,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
     private static final String MESSAGE = "Ticket encryption is not enabled. Falling back to default behavior";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTicketRegistry.class);
-    
+
     /**
      * The cipher executor for ticket objects.
      */
@@ -154,16 +154,6 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
         }
 
         return count.intValue();
-    }
-
-    /**
-     * Delete a single ticket instance from the store.
-     *
-     * @param ticketId the ticket id
-     * @return true/false
-     */
-    public boolean deleteSingleTicket(final Ticket ticketId) {
-        return deleteSingleTicket(ticketId.getId());
     }
 
     /**

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.CipherExecutor;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
@@ -8,11 +9,19 @@ import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
+import org.apereo.cas.util.cipher.DefaultTicketCipherExecutor;
+import org.apereo.cas.util.cipher.NoOpCipherExecutor;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.util.AopTestUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -22,17 +31,39 @@ import static org.junit.Assert.*;
  */
 public abstract class AbstractTicketRegistryTests {
 
+    @ClassRule
+    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+
     private static final int TICKETS_IN_REGISTRY = 10;
     private static final String EXCEPTION_CAUGHT_NONE_EXPECTED = "Exception caught.  None expected.";
     private static final String CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED = "Caught an exception. But no exception should have been thrown: ";
 
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+
+    private final boolean useEncryption;
     private TicketRegistry ticketRegistry;
+
+    public AbstractTicketRegistryTests(final boolean useEncryption) {
+        this.useEncryption = useEncryption;
+    }
 
     @Before
     public void setUp() throws Exception {
         this.ticketRegistry = this.getNewTicketRegistry();
         if (ticketRegistry != null) {
             this.ticketRegistry.deleteAll();
+            setUpEncryption();
+        }
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private void setUpEncryption() {
+        final AbstractTicketRegistry registry = (AbstractTicketRegistry) AopTestUtils.getTargetObject(this.ticketRegistry);
+        if (this.useEncryption) {
+            registry.setCipherExecutor(new DefaultTicketCipherExecutor(null, null, "AES", 512, 16));
+        } else {
+            registry.setCipherExecutor((CipherExecutor) NoOpCipherExecutor.getInstance());
         }
     }
 
@@ -134,6 +165,29 @@ public abstract class AbstractTicketRegistryTests {
     }
 
     @Test
+    public void verifyAddAndUpdateTicket() {
+        try {
+            TicketGrantingTicket tgt = new TicketGrantingTicketImpl(
+                    TicketGrantingTicket.PREFIX,
+                    CoreAuthenticationTestUtils.getAuthentication(),
+                    new NeverExpiresExpirationPolicy());
+            this.ticketRegistry.addTicket(tgt);
+
+            tgt = this.ticketRegistry.getTicket(tgt.getId(), TicketGrantingTicket.class);
+            assertTrue(tgt.getServices().isEmpty());
+
+            tgt.grantServiceTicket("ST1", RegisteredServiceTestUtils.getService("TGT_UPDATE_TEST"),
+                    new NeverExpiresExpirationPolicy(), false, false);
+            this.ticketRegistry.updateTicket(tgt);
+
+            tgt = this.ticketRegistry.getTicket(tgt.getId(), TicketGrantingTicket.class);
+            assertEquals(Collections.singleton("ST1"), tgt.getServices().keySet());
+        } catch (final Exception e) {
+            fail(CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED + e.getMessage());
+        }
+    }
+
+    @Test
     public void verifyDeleteAllExistingTickets() {
         try {
             for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
@@ -154,6 +208,7 @@ public abstract class AbstractTicketRegistryTests {
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
             assertSame(1, this.ticketRegistry.deleteTicket(TicketGrantingTicket.PREFIX));
+            assertNull(this.ticketRegistry.getTicket(TicketGrantingTicket.PREFIX));
         } catch (final Exception e) {
             fail(CAUGHT_AN_EXCEPTION_BUT_WAS_NOT_EXPECTED + e.getMessage());
         }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/AbstractTicketRegistryTests.java
@@ -11,6 +11,7 @@ import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.apereo.cas.util.cipher.DefaultTicketCipherExecutor;
 import org.apereo.cas.util.cipher.NoOpCipherExecutor;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -75,6 +76,13 @@ public abstract class AbstractTicketRegistryTests {
      * @throws Exception the exception
      */
     public abstract TicketRegistry getNewTicketRegistry() throws Exception;
+
+    /**
+     * Determine whether the tested registry is able to iterate its tickets.
+     */
+    protected boolean isIterableRegistry() {
+        return true;
+    }
 
     /**
      * Method to add a TicketGrantingTicket to the ticket cache. This should add
@@ -189,6 +197,7 @@ public abstract class AbstractTicketRegistryTests {
 
     @Test
     public void verifyDeleteAllExistingTickets() {
+        Assume.assumeTrue(isIterableRegistry());
         try {
             for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
                 this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX + i,
@@ -220,7 +229,7 @@ public abstract class AbstractTicketRegistryTests {
             this.ticketRegistry.addTicket(new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX,
                     CoreAuthenticationTestUtils.getAuthentication(),
                     new NeverExpiresExpirationPolicy()));
-            assertSame(0, this.ticketRegistry.deleteTicket(TicketGrantingTicket.PREFIX + "1"));
+            assertSame(0, this.ticketRegistry.deleteTicket(TicketGrantingTicket.PREFIX + "NON-EXISTING-SUFFIX"));
         } catch (final Exception e) {
             fail(EXCEPTION_CAUGHT_NONE_EXPECTED);
         }
@@ -249,6 +258,7 @@ public abstract class AbstractTicketRegistryTests {
 
     @Test
     public void verifyGetTicketsFromRegistryEqualToTicketsAdded() {
+        Assume.assumeTrue(isIterableRegistry());
         final Collection<Ticket> tickets = new ArrayList<>();
 
         for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryTests.java
@@ -2,8 +2,13 @@ package org.apereo.cas.ticket.registry;
 
 import org.apereo.cas.util.cipher.NoOpCipherExecutor;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Test case to test the DefaultTicketRegistry based on test cases to test all
@@ -12,7 +17,17 @@ import static org.junit.Assert.*;
  * @author Scott Battaglia
  * @since 3.0.0
  */
+@RunWith(Parameterized.class)
 public class DefaultTicketRegistryTests extends AbstractTicketRegistryTests {
+
+    public DefaultTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        return Arrays.asList(false, true);
+    }
 
     @Override
     public TicketRegistry getNewTicketRegistry() throws Exception {

--- a/support/cas-server-support-couchbase-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistry.java
+++ b/support/cas-server-support-couchbase-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistry.java
@@ -67,7 +67,7 @@ public class CouchbaseTicketRegistry extends AbstractTicketRegistry {
     public static final String UTIL_DOCUMENT = "statistics";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CouchbaseTicketRegistry.class);
-    
+
     private static final long MAX_EXP_TIME_IN_DAYS = 30;
     private static final String END_TOKEN = "\u02ad";
 
@@ -163,7 +163,8 @@ public class CouchbaseTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public boolean deleteSingleTicket(final String ticketId) {
+    public boolean deleteSingleTicket(final String ticketIdToDelete) {
+        final String ticketId = encodeTicketId(ticketIdToDelete);
         LOGGER.debug("Deleting ticket [{}]", ticketId);
         try {
             return this.couchbase.getBucket().remove(ticketId) != null;
@@ -211,7 +212,7 @@ public class CouchbaseTicketRegistry extends AbstractTicketRegistry {
 
         tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(refreshTokenIt, Spliterator.ORDERED), true);
         tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
-        
+
         return count;
     }
 

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
@@ -65,7 +65,8 @@ public class DynamoDbTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public boolean deleteSingleTicket(final String ticketId) {
+    public boolean deleteSingleTicket(final String ticketIdToDelete) {
+        final String ticketId = encodeTicketId(ticketIdToDelete);
         return this.dbTableService.delete(ticketId);
     }
 

--- a/support/cas-server-support-dynamodb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryTests.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryTests.java
@@ -1,5 +1,8 @@
 package org.apereo.cas.ticket.registry;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -17,13 +20,13 @@ import org.apereo.cas.config.DynamoDbTicketRegistryConfiguration;
 import org.apereo.cas.config.DynamoDbTicketRegistryTicketCatalogConfiguration;
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * This is {@link DynamoDbTicketRegistryTests}.
@@ -32,7 +35,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @since 5.1.0
  */
 @IfProfileValue(name = "dynamoDbEnabled", value = "true")
-@RunWith(SpringRunner.class)
+@RunWith(Parameterized.class)
 @SpringBootTest(classes = {DynamoDbTicketRegistryConfiguration.class,
         DynamoDbTicketRegistryTicketCatalogConfiguration.class,
         CasCoreTicketsConfiguration.class,
@@ -59,6 +62,15 @@ public class DynamoDbTicketRegistryTests extends AbstractTicketRegistryTests {
     @Autowired
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
+
+    public DynamoDbTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        return Arrays.asList(false, true);
+    }
 
     @Override
     public TicketRegistry getNewTicketRegistry() throws Exception {

--- a/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistry.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistry.java
@@ -25,9 +25,9 @@ import java.util.stream.Collectors;
  */
 public class EhCacheTicketRegistry extends AbstractTicketRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(EhCacheTicketRegistry.class);
-    
+
     private Cache ehcacheTicketsCache;
-    
+
     /**
      * Instantiates a new EhCache ticket registry.
      *
@@ -58,7 +58,7 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
     public void addTicket(final Ticket ticketToAdd) {
         final Ticket ticket = encodeTicket(ticketToAdd);
         final Element element = new Element(ticket.getId(), ticket);
-        
+
         int idleValue = ticketToAdd.getExpirationPolicy().getTimeToIdle().intValue();
         if (idleValue <= 0) {
             idleValue = ticketToAdd.getExpirationPolicy().getTimeToLive().intValue();
@@ -93,7 +93,7 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
             return true;
         }
 
-        if (this.ehcacheTicketsCache.remove(ticket.getId())) {
+        if (this.ehcacheTicketsCache.remove(encodeTicketId(ticket.getId()))) {
             LOGGER.debug("Ticket [{}] is removed", ticket.getId());
         }
         return true;
@@ -123,14 +123,14 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
         final CacheConfiguration config = new CacheConfiguration();
         config.setTimeToIdleSeconds(ticket.getExpirationPolicy().getTimeToIdle());
         config.setTimeToLiveSeconds(ticket.getExpirationPolicy().getTimeToLive());
-        
+
         if (element.isExpired(config) || ticket.isExpired()) {
             LOGGER.debug("Ticket [{}] has expired", ticket.getId());
             this.ehcacheTicketsCache.evictExpiredElements();
             this.ehcacheTicketsCache.flush();
             return null;
         }
-        
+
         return ticket;
     }
 
@@ -146,7 +146,7 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
         addTicket(ticket);
         return ticket;
     }
-    
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)

--- a/support/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -1,13 +1,16 @@
 package org.apereo.cas.ticket.registry;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apereo.cas.config.EhcacheTicketRegistryConfiguration;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Unit test for {@link EhCacheTicketRegistry}.
@@ -15,7 +18,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Scott Battaglia
  * @since 3.0.0
  */
-@RunWith(SpringRunner.class)
+@RunWith(Parameterized.class)
 @SpringBootTest(classes = {EhcacheTicketRegistryConfiguration.class, RefreshAutoConfiguration.class})
 @ContextConfiguration(locations = "classpath:ticketRegistry.xml")
 public class EhCacheTicketRegistryTests extends AbstractTicketRegistryTests {
@@ -23,7 +26,16 @@ public class EhCacheTicketRegistryTests extends AbstractTicketRegistryTests {
     @Autowired
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
-    
+
+    public EhCacheTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        return Arrays.asList(false, true);
+    }
+
     @Override
     public TicketRegistry getNewTicketRegistry() throws Exception {
         return ticketRegistry;

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -127,7 +127,6 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
                 final IMap<String, Ticket> map = getTicketMapInstanceByMetadata(t);
                 tickets.addAll(map.values().stream().limit(this.pageSize).collect(Collectors.toList()));
             });
-            return tickets;
         } catch (final Exception e) {
             LOGGER.warn(e.getMessage(), e);
         }

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -1,5 +1,8 @@
 package org.apereo.cas.ticket.registry;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -18,12 +21,12 @@ import org.apereo.cas.config.HazelcastTicketRegistryConfiguration;
 import org.apereo.cas.config.HazelcastTicketRegistryTicketCatalogConfiguration;
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Unit tests for {@link HazelcastTicketRegistry}.
@@ -31,7 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Dmitriy Kopylenko
  * @since 4.1.0
  */
-@RunWith(SpringRunner.class)
+@RunWith(Parameterized.class)
 @SpringBootTest(classes = {
         HazelcastTicketRegistryConfiguration.class,
         CasCoreTicketsConfiguration.class,
@@ -55,9 +58,19 @@ import org.springframework.test.context.junit4.SpringRunner;
 })
 @TestPropertySource(properties = {"cas.ticket.registry.hazelcast.cluster.instanceName=testlocalhostinstance"})
 public class HazelcastTicketRegistryTests extends AbstractTicketRegistryTests {
+
     @Autowired
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
+
+    public HazelcastTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        return Arrays.asList(false, true);
+    }
 
     @Override
     public TicketRegistry getNewTicketRegistry() throws Exception {

--- a/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/IgniteTicketRegistry.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/IgniteTicketRegistry.java
@@ -42,14 +42,14 @@ import static java.util.stream.Collectors.toList;
  */
 public class IgniteTicketRegistry extends AbstractTicketRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(IgniteTicketRegistry.class);
-    
+
     private final IgniteConfiguration igniteConfiguration;
     private final IgniteProperties properties;
 
     private IgniteCache<String, Ticket> ticketIgniteCache;
 
     private Ignite ignite;
-    
+
     private boolean supportRegistryState = true;
 
     /**
@@ -64,8 +64,8 @@ public class IgniteTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public void addTicket(final Ticket ticketToAdd) {
-        final Ticket ticket = encodeTicket(ticketToAdd);
+    public void addTicket(final Ticket ticket) {
+        final Ticket encodedTicket = encodeTicket(ticket);
         LOGGER.debug("Adding ticket [{}] to the cache [{}]", ticket.getId(), this.ticketIgniteCache.getName());
         this.ticketIgniteCache.withExpiryPolicy(new ExpiryPolicy() {
             @Override
@@ -85,7 +85,7 @@ public class IgniteTicketRegistry extends AbstractTicketRegistry {
             public Duration getExpiryForUpdate() {
                 return new Duration(TimeUnit.SECONDS, ticket.getExpirationPolicy().getTimeToLive());
             }
-        }).put(ticket.getId(), ticket);
+        }).put(encodedTicket.getId(), encodedTicket);
     }
 
     @Override
@@ -94,12 +94,12 @@ public class IgniteTicketRegistry extends AbstractTicketRegistry {
         this.ticketIgniteCache.removeAll();
         return size;
     }
-    
+
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
         final Ticket ticket = getTicket(ticketId);
         if (ticket != null) {
-            return this.ticketIgniteCache.remove(ticket.getId());
+            return this.ticketIgniteCache.remove(encodeTicketId(ticket.getId()));
         }
         return true;
     }

--- a/support/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -1,13 +1,16 @@
 package org.apereo.cas.ticket.registry;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apereo.cas.config.IgniteTicketRegistryConfiguration;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Unit test for {@link IgniteTicketRegistry}.
@@ -16,7 +19,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Timur Duehr timur.duehr@nccgroup.trust
  * @since 3.0.0
  */
-@RunWith(SpringRunner.class)
+@RunWith(Parameterized.class)
 @SpringBootTest(classes = {RefreshAutoConfiguration.class, IgniteTicketRegistryConfiguration.class})
 @TestPropertySource(locations={"classpath:/igniteregistry.properties"})
 public class IgniteTicketRegistryTests extends AbstractTicketRegistryTests {
@@ -24,6 +27,16 @@ public class IgniteTicketRegistryTests extends AbstractTicketRegistryTests {
     @Autowired
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
+
+    public IgniteTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        // FIXME Encryption in Ignite registry is broken
+        return Arrays.asList(false/*, true */);
+    }
 
     @Override
     public TicketRegistry getNewTicketRegistry() throws Exception {

--- a/support/cas-server-support-infinispan-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistry.java
+++ b/support/cas-server-support-infinispan-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistry.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class InfinispanTicketRegistry extends AbstractTicketRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanTicketRegistry.class);
-    
+
     private final Cache<String, Ticket> cache;
 
     /**
@@ -65,7 +65,7 @@ public class InfinispanTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public boolean deleteSingleTicket(final String ticketId) {
-        this.cache.remove(ticketId);
+        this.cache.remove(encodeTicketId(ticketId));
         return getTicket(ticketId) == null;
     }
 
@@ -75,7 +75,7 @@ public class InfinispanTicketRegistry extends AbstractTicketRegistry {
         this.cache.clear();
         return size;
     }
-    
+
     /**
      * Retrieve all tickets from the registry.
      * <p>

--- a/support/cas-server-support-infinispan-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistry.java
+++ b/support/cas-server-support-infinispan-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistry.java
@@ -34,7 +34,8 @@ public class InfinispanTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public Ticket updateTicket(final Ticket ticket) {
-        this.cache.put(ticket.getId(), ticket);
+        final Ticket encodedTicket = encodeTicket(ticket);
+        this.cache.put(encodedTicket.getId(), encodedTicket);
         return ticket;
     }
 
@@ -42,15 +43,15 @@ public class InfinispanTicketRegistry extends AbstractTicketRegistry {
     public void addTicket(final Ticket ticketToAdd) {
         final Ticket ticket = encodeTicket(ticketToAdd);
 
-        final long idleTime = ticket.getExpirationPolicy().getTimeToIdle() <= 0
-                ? ticket.getExpirationPolicy().getTimeToLive()
-                : ticket.getExpirationPolicy().getTimeToIdle();
+        final long idleTime = ticketToAdd.getExpirationPolicy().getTimeToIdle() <= 0
+                ? ticketToAdd.getExpirationPolicy().getTimeToLive()
+                : ticketToAdd.getExpirationPolicy().getTimeToIdle();
 
         LOGGER.debug("Adding ticket [{}] to cache store to live [{}] seconds and stay idle for [{}]",
-                ticket.getId(), ticket.getExpirationPolicy().getTimeToLive(), idleTime);
+                ticketToAdd.getId(), ticketToAdd.getExpirationPolicy().getTimeToLive(), idleTime);
 
         this.cache.put(ticket.getId(), ticket,
-                ticket.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS,
+                ticketToAdd.getExpirationPolicy().getTimeToLive(), TimeUnit.SECONDS,
                 idleTime, TimeUnit.SECONDS);
     }
 
@@ -60,7 +61,7 @@ public class InfinispanTicketRegistry extends AbstractTicketRegistry {
         if (ticketId == null) {
             return null;
         }
-        return Ticket.class.cast(cache.get(encTicketId));
+        return decodeTicket(Ticket.class.cast(cache.get(encTicketId)));
     }
 
     @Override

--- a/support/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
+++ b/support/cas-server-support-infinispan-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/InfinispanTicketRegistryTests.java
@@ -1,25 +1,37 @@
 package org.apereo.cas.ticket.registry;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apereo.cas.ticket.registry.config.InfinispanTicketRegistryConfiguration;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * This is {@link InfinispanTicketRegistryTests}.
  *
  * @since 4.2.0
  */
-@RunWith(SpringRunner.class)
+@RunWith(Parameterized.class)
 @SpringBootTest(classes = {RefreshAutoConfiguration.class, InfinispanTicketRegistryConfiguration.class})
 public class InfinispanTicketRegistryTests extends AbstractTicketRegistryTests {
 
     @Autowired
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
+
+    public InfinispanTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        return Arrays.asList(false, true);
+    }
 
     @Override
     public TicketRegistry getNewTicketRegistry() throws Exception {

--- a/support/cas-server-support-memcached-monitor/src/test/java/org/apereo/cas/monitor/MemcachedMonitorTests.java
+++ b/support/cas-server-support-memcached-monitor/src/test/java/org/apereo/cas/monitor/MemcachedMonitorTests.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.monitor;
 
-import org.apereo.cas.AbstractMemcachedTests;
 import org.apereo.cas.monitor.config.MemcachedMonitorConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,7 +19,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {RefreshAutoConfiguration.class, MemcachedMonitorConfiguration.class})
 @ContextConfiguration(locations = "/monitor-test.xml")
-public class MemcachedMonitorTests extends AbstractMemcachedTests {
+public class MemcachedMonitorTests {
 
     @Autowired
     @Qualifier("memcachedMonitor")

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
@@ -86,8 +86,9 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public boolean deleteSingleTicket(final String ticketId) {
+    public boolean deleteSingleTicket(final String ticketIdToDelete) {
         Assert.notNull(this.client, NO_MEMCACHED_CLIENT_IS_DEFINED);
+        final String ticketId = encodeTicketId(ticketIdToDelete);
         try {
             if (this.client.delete(ticketId).get()) {
                 LOGGER.debug("Removed ticket [{}] from the cache", ticketId);

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
@@ -63,7 +63,7 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
             final Ticket ticket = encodeTicket(ticketToAdd);
             LOGGER.debug("Adding ticket [{}]", ticket);
             final int timeout = getTimeout(ticketToAdd);
-            if (!this.client.add(ticket.getId(), getTimeout(ticketToAdd), ticket).get()) {
+            if (!this.client.set(ticket.getId(), getTimeout(ticketToAdd), ticket).get()) {
                 LOGGER.error("Failed to add [{}] without timeout [{}]", ticketToAdd, timeout);
             }
             // Sanity check to ensure ticket can retrieved

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/MemCacheTestUtils.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/MemCacheTestUtils.java
@@ -17,17 +17,20 @@ import java.net.Socket;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
- * This is {@link AbstractMemcachedTests}.
+ * This is {@link MemCacheTestUtils}.
  *
  * @author Misagh Moayyed
  * @since 4.2.0
  */
-public abstract class AbstractMemcachedTests {
+public final class MemCacheTestUtils {
 
     private static final int PORT = 14938;
 
     private static MemcachedExecutable MEMCACHED_EXECUTABLE;
     private static MemcachedProcess MEMCACHED;
+
+    private MemCacheTestUtils() {
+    }
 
     public static void bootstrap() {
         try {
@@ -36,7 +39,7 @@ public abstract class AbstractMemcachedTests {
             MEMCACHED_EXECUTABLE = runtime.prepare(new MemcachedConfig(Version.V1_4_22, PORT));
             MEMCACHED = MEMCACHED_EXECUTABLE.start();
         } catch (final Exception e) {
-            getLogger(AbstractMemcachedTests.class).warn("Aborting since no memcached server could be started.", e);
+            getLogger(MemCacheTestUtils.class).warn("Aborting since no memcached server could be started.", e);
         }
     }
 
@@ -49,7 +52,7 @@ public abstract class AbstractMemcachedTests {
         }
     }
 
-    public boolean isMemcachedListening() {
+    public static boolean isMemcachedListening() {
         try (Socket socket = new Socket("memcached-14938.c10.us-east-1-3.ec2.cloud.redislabs.com", PORT)) {
             return true;
         } catch (final Exception e) {

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
  */
 public class MongoDbTicketRegistry extends AbstractTicketRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbTicketRegistry.class);
-    
+
     private final String collectionName;
 
     private final boolean dropCollection;
@@ -126,7 +126,8 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
-    public boolean deleteSingleTicket(final String ticketId) {
+    public boolean deleteSingleTicket(final String ticketIdToDelete) {
+        final String ticketId = encodeTicketId(ticketIdToDelete);
         LOGGER.debug("Deleting ticket [{}]", ticketId);
         try {
             this.mongoTemplate.remove(new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).is(ticketId)), this.collectionName);

--- a/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
@@ -1,5 +1,8 @@
 package org.apereo.cas.ticket.registry;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -18,6 +21,7 @@ import org.apereo.cas.config.MongoDbTicketRegistryConfiguration;
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
@@ -26,7 +30,6 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * This is {@link MongoDbTicketRegistryTests}.
@@ -34,7 +37,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Misagh Moayyed
  * @since 5.1.0
  */
-@RunWith(SpringRunner.class)
+@RunWith(Parameterized.class)
 @SpringBootTest(classes = {RefreshAutoConfiguration.class,
         CasCoreUtilConfiguration.class,
         AopAutoConfiguration.class,
@@ -62,11 +65,21 @@ public class MongoDbTicketRegistryTests extends AbstractTicketRegistryTests {
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
 
+    public MongoDbTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        // FIXME Encryption in MongoDb registry is missing / broken
+        return Arrays.asList(false/*, true */);
+    }
+
     @Before
     public void before() {
         ticketRegistry.getTickets().forEach(t -> this.ticketRegistry.deleteTicket(t.getId()));
     }
-    
+
     @Override
     public TicketRegistry getNewTicketRegistry() throws Exception {
         return this.ticketRegistry;

--- a/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisTicketRegistryTests.java
+++ b/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisTicketRegistryTests.java
@@ -1,15 +1,18 @@
 package org.apereo.cas.ticket.registry;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apereo.cas.config.RedisTicketRegistryConfiguration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import redis.embedded.RedisServer;
 
 /**
@@ -18,7 +21,7 @@ import redis.embedded.RedisServer;
  * @author Scott Battaglia
  * @since 3.0.0
  */
-@RunWith(SpringRunner.class)
+@RunWith(Parameterized.class)
 @SpringBootTest(classes = {RedisTicketRegistryConfiguration.class, RefreshAutoConfiguration.class})
 @TestPropertySource(locations={"classpath:/redis.properties"})
 public class RedisTicketRegistryTests extends AbstractTicketRegistryTests {
@@ -28,6 +31,15 @@ public class RedisTicketRegistryTests extends AbstractTicketRegistryTests {
     @Autowired
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
+
+    public RedisTicketRegistryTests(final boolean useEncryption) {
+        super(useEncryption);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object> getTestParameters() throws Exception {
+        return Arrays.asList(false, true);
+    }
 
     @BeforeClass
     public static void startRedis() throws Exception {


### PR DESCRIPTION
Lots of `TicketRegistry` implementations were not encoding `ticketId` when deleting tickets. This lead to issues like the one described in #2660.

Commit description:

* I have added ticket ID encoding where it seem it was missing (some registries had encoding already in place or were fetching encoded tickets and using their id instead).
* I have also deleted one ambiguous method on `AbstractTicketRegistry`. This method was unused and did not state whether the provided ticket was supposed to be `EncodedTicket` or not.

Additional comments:

* It would be nice to have unit tests for encoded registry behavior, but writing such tests is too complex for me.
* `TicketRegistry` implementations don't have single naming / style convention when comes to encoded values. Possible future improvement: refactor registries so that every time encoded ticket or ID is expected, the variable can use `enc` prefix or something like that.
* It is also not clear, whether the log statements should log original ticket ID or the encoded one. Where one registry logs `Removing ticket [{ENCODED ID}]`, other might be logging `Removing ticket [{ORIGINAL ID}]`.
