### PR TITLE
Documentation fix and addition related to webjars

### DIFF
--- a/docs/cas-server-documentation/installation/User-Interface-Customization-CSSJS.md
+++ b/docs/cas-server-documentation/installation/User-Interface-Customization-CSSJS.md
@@ -39,7 +39,7 @@ The following Javascript libraries are utilized by CAS automatically:
 
 ## Asynchronous Script Loading
 CAS will attempt load the aforementioned script libraries asynchronously so as to not block the page rendering functionality.
-The loading of script files is handled by the [`head.js` library](http://headjs.com) and is the responsibility of `cas.js` file.
+The loading of script files is handled by the [`head.js` library](http://headjs.com) and is the responsibility of some javascript in the `bottom.html` template fragment which calls some methods in the `cas.js` file.
 
 The only script that is loaded synchronously is the `head.js` library itself.
 
@@ -96,3 +96,24 @@ function prepareSubmit(form) {
 <form method="post" id="fm1" th:object="${credential}">
         onsubmit="return prepareSubmit(this);">
 ```
+
+### Use Webjars for 3rd Party Static Resources
+The CAS application uses 3rd party static resources packaged in jar files and served up via the Servlet 3.0 feature 
+that merges any folders under META-INF/resources in web applications jarss with the application web root.
+
+For developers modifying CAS, if adding or modifying a 3rd party library, the steps are:
+
+1. Add webjar dependency to dependencies.gradle in the ext.library.webjars section
+1. Add dependency version to gradle.properties (and use it in dependency.gradle)
+1. Add entry to /cas-server-core-web/src/main/resources/cas_common_messages.properties for each resource (e.g. js or css). Reference the version from gradle.properties in the URL (it will be filtered in at build time)
+1. Reference the entry from cas_common_messages.properties in the Thyme template with HTML like following, where the entry is `webjars.zxcvbn.js`:
+```html
+<script type="text/javascript" th:src="@{#{webjars.zxcvbn.js}}"></script>
+```
+1. You can search for webjars at: http://webjars.org
+1. There are three flavors of webjars that you can read about on http://webjars.org but the NPM and Bower types can be created automatically for any version (if they don't already exist) as long as there exists an NPM or Bower package for the web resources you want to use. Click the "Add a webjar" button on http://webjars.org.
+
+If customizing the UI in an overlay, the deployer can add webjars as dependencies to their overlay project and reference the URLs of the resource either directly in an html file or via adding an entry to a `common_messages.properties` file in the overlay project's src\main\resources folder. See the cas.messageBundle.commonNames configuration property. 
+
+
+

--- a/webapp/gradle/webapp.gradle
+++ b/webapp/gradle/webapp.gradle
@@ -121,6 +121,6 @@ dependencies {
     implementation libraries.cassecurityfilter
     implementation libraries.metrics
     implementation libraries.bouncycastle
-    implementation libraries.webjars
+    runtime libraries.webjars
     compile libraries.springcloudconfigclient
 }

--- a/webapp/resources/static/sass/components/_cas.scss
+++ b/webapp/resources/static/sass/components/_cas.scss
@@ -1,8 +1,4 @@
 
-
-/*@import url(https://fonts.googleapis.com/css?family=Lato);*/
-@import url(https://fonts.googleapis.com/css?family=Lato:700,400,300,100|Signika:400,700|Courgette);
-
 * {
   box-sizing: border-box;
   //-webkit-transition: all 0.2s ease;

--- a/webapp/resources/static/sass/partials/_fonts.scss
+++ b/webapp/resources/static/sass/partials/_fonts.scss
@@ -1,4 +1,3 @@
-@import url(https://fonts.googleapis.com/css?family=Lato:700,400,300,100);
 
 .huge {
   font-size: 30pt;

--- a/webapp/resources/static/themes/apereo/css/cas.css
+++ b/webapp/resources/static/themes/apereo/css/cas.css
@@ -1,5 +1,3 @@
-/*@import url(https://fonts.googleapis.com/css?family=Lato);*/
-@import url(https://fonts.googleapis.com/css?family=Lato:700,400,300,100);
 * {
   box-sizing: border-box; }
 

--- a/webapp/resources/templates/casAzureAuthenticatorLoginView.html
+++ b/webapp/resources/templates/casAzureAuthenticatorLoginView.html
@@ -4,7 +4,6 @@
 <head>
     <title th:text="#{cas.mfa.azure.pagetitle}"></title>
     <style>
-        @import url(https://fonts.googleapis.com/css?family=Lato:700,400,300,100|Signika:400,700|Courgette);
         textarea {
             border: 2pt;
             font-family: "Courier New";


### PR DESCRIPTION
This fixes some documentation about head.js (since usage moved from cas.js to bottom.html) and it adds some how-to for CAS developers regarding webjars. 