### PR TITLE
Fix documentation as result of webjars change, add how-to doc for webjar

### DIFF
--- a/docs/cas-server-documentation/installation/User-Interface-Customization-CSSJS.md
+++ b/docs/cas-server-documentation/installation/User-Interface-Customization-CSSJS.md
@@ -39,7 +39,7 @@ The following Javascript libraries are utilized by CAS automatically:
 
 ## Asynchronous Script Loading
 CAS will attempt load the aforementioned script libraries asynchronously so as to not block the page rendering functionality.
-The loading of script files is handled by the [`head.js` library](http://headjs.com) and is the responsibility of `cas.js` file.
+The loading of script files is handled by the [`head.js` library](http://headjs.com) and is the responsibility of some javascript in the `bottom.html` template fragment which calls some methods in the `cas.js` file.
 
 The only script that is loaded synchronously is the `head.js` library itself.
 
@@ -96,3 +96,25 @@ function prepareSubmit(form) {
 <form method="post" id="fm1" th:object="${credential}">
         onsubmit="return prepareSubmit(this);">
 ```
+
+### Use Webjars for 3rd Party Static Resources
+The CAS application application packages 3rd party static resources inside the CAS webapp rather than referencing CDN links so that CAS may be deployed on networks with limited interent access.
+The 3rd party static resources are packaged in "Webjar" jar files and served up via the Servlet 3.0 feature 
+that merges any folders under META-INF/resources in web application jars with the application's web root.
+
+For developers modifying CAS, if adding or modifying a 3rd party library, the steps are:
+
+1. Add webjar dependency to dependencies.gradle in the ext.library.webjars section
+1. Add dependency version to gradle.properties (and use it in dependency.gradle)
+1. Add entry to /cas-server-core-web/src/main/resources/cas_common_messages.properties for each resource (e.g. js or css). Reference the version from gradle.properties in the URL (it will be filtered in at build time) For example:
+```
+webjars.zxcvbn.js=/webjars/zxcvbn/${zxcvbnVersion}/zxcvbn.js
+```
+1. Reference the entry from cas_common_messages.properties in the Thyme template with HTML like following, where the entry is `webjars.zxcvbn.js`:
+```html
+<script type="text/javascript" th:src="@{#{webjars.zxcvbn.js}}"></script>
+```
+1. You can search for webjars at: http://webjars.org
+1. There are three flavors of webjars that you can read about on http://webjars.org but the NPM and Bower types can be created automatically for any version (if they don't already exist) as long as there exists an NPM or Bower package for the web resources you want to use. Click the "Add a webjar" button on http://webjars.org and follow the instructions.
+
+If customizing the UI in an overlay, the deployer can add webjars as dependencies to their overlay project and reference the URLs of the resource either directly in an html file or via adding an entry to a `common_messages.properties` file in the overlay project's src\main\resources folder. See the cas.messageBundle.commonNames configuration property. 


### PR DESCRIPTION
The first line of this corrects an inaccurate statement now that head.js stuff moved from cas.js to bottom.html. 

The rest is a section about using webjars, mainly for CAS developers. If you think that is unnecessary or too much information, I can delete it. 