### PR TITLE
Slf4j prints entire Map contents

### DIFF
--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -155,7 +155,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
     private IMap<String, Ticket> getTicketMapInstance(final String mapName) {
         try {
             final IMap<String, Ticket> inst = hazelcastInstance.getMap(mapName);
-            LOGGER.debug("Located Hazelcast map instance [{}] for [{}]", inst, mapName);
+            LOGGER.debug("Located Hazelcast map instance [{}]", mapName);
             return inst;
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
Found this in 5.1.x load testing.  

The Sf4j Logger will iterate collections calling toSting() on each entry in a map.  This causes severe degradation once the map reaches even a trivial size.  

Changed the debug statement to just echo the mapName and not pass instance to the LOGGER.debug().
