### PR TITLE
Move service action responsibilities into the serviceRegistry

### DIFF
--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDao.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDao.java
@@ -115,14 +115,14 @@ public abstract class AbstractResourceBasedServiceRegistryDao extends AbstractSe
             LOGGER.info("Watching service registry directory at [{}]", configDirectory);
 
             final Consumer<File> onCreate = file -> {
-                    final RegisteredService service = load(file);
-                    if (service != null) {
-                        if (findServiceById(service.getId()) != null) {
-                            LOG_SERVICE_DUPLICATE.accept(service);
-                        }
-                        update(service);
-                        publishEvent(new CasRegisteredServicesRefreshEvent(this));
+                final RegisteredService service = load(file);
+                if (service != null) {
+                    if (findServiceById(service.getId()) != null) {
+                        LOG_SERVICE_DUPLICATE.accept(service);
                     }
+                    update(service);
+                    publishEvent(new CasRegisteredServicesRefreshEvent(this));
+                }
             };
             final Consumer<File> onDelete = file -> {
                 load();

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDao.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDao.java
@@ -41,8 +41,9 @@ import java.util.stream.Collectors;
 public abstract class AbstractResourceBasedServiceRegistryDao extends AbstractServiceRegistryDao implements ResourceBasedServiceRegistryDao {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractResourceBasedServiceRegistryDao.class);
-    private static final Consumer<RegisteredService> LOG_SERVICE_DUPLICATE = service -> LOGGER.warn("Found a service definition [{}] with a duplicate id [{}]. This will overwrite previous service definitions and is likely a configuration "
-            + "problem. Make sure all services have a unique id and try again.", service.getServiceId(), service.getId());
+    private static final Consumer<RegisteredService> LOG_SERVICE_DUPLICATE = service -> LOGGER.warn("Found a service definition [{}] with a duplicate id [{}]. "
+            + "This will overwrite previous service definitions and is likely a configuration problem. Make sure all services have a unique id and try again.",
+            service.getServiceId(), service.getId());
     private static final BinaryOperator<RegisteredService> LOG_DUPLICATE_AND_RETURN_FIRST_ONE = (s1, s2) -> {
         LOG_SERVICE_DUPLICATE.accept(s2);
         return s1;
@@ -113,7 +114,7 @@ public abstract class AbstractResourceBasedServiceRegistryDao extends AbstractSe
 
             LOGGER.info("Watching service registry directory at [{}]", configDirectory);
 
-            final Consumer<File> onCreate = file ->  {
+            final Consumer<File> onCreate = file -> {
                     final RegisteredService service = load(file);
                     if (service != null) {
                         if (findServiceById(service.getId()) != null) {
@@ -123,11 +124,11 @@ public abstract class AbstractResourceBasedServiceRegistryDao extends AbstractSe
                         publishEvent(new CasRegisteredServicesRefreshEvent(this));
                     }
             };
-            final Consumer<File> onDelete = file ->  {
+            final Consumer<File> onDelete = file -> {
                 load();
                 publishEvent(new CasRegisteredServicesRefreshEvent(this));
             };
-            final Consumer<File> onModify = file ->  {
+            final Consumer<File> onModify = file -> {
                 final RegisteredService newService = load(file);
                 if (newService != null) {
                     final RegisteredService oldService = findServiceById(newService.getId());

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDao.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractResourceBasedServiceRegistryDao.java
@@ -3,6 +3,7 @@ package org.apereo.cas.services;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.support.events.service.CasRegisteredServiceLoadedEvent;
+import org.apereo.cas.support.events.service.CasRegisteredServicesRefreshEvent;
 import org.apereo.cas.util.ResourceUtils;
 import org.apereo.cas.util.io.LockedOutputStream;
 import org.apereo.cas.util.serialization.StringSerializer;
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -39,9 +41,10 @@ import java.util.stream.Collectors;
 public abstract class AbstractResourceBasedServiceRegistryDao extends AbstractServiceRegistryDao implements ResourceBasedServiceRegistryDao {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractResourceBasedServiceRegistryDao.class);
+    private static final Consumer<RegisteredService> LOG_SERVICE_DUPLICATE = service -> LOGGER.warn("Found a service definition [{}] with a duplicate id [{}]. This will overwrite previous service definitions and is likely a configuration "
+            + "problem. Make sure all services have a unique id and try again.", service.getServiceId(), service.getId());
     private static final BinaryOperator<RegisteredService> LOG_DUPLICATE_AND_RETURN_FIRST_ONE = (s1, s2) -> {
-        LOGGER.warn("Found a service definition [{}] with a duplicate id [{}]. This will overwrite previous service definitions and is likely a configuration "
-                        + "problem. Make sure all services have a unique id and try again.", s2.getServiceId(), s2.getId());
+        LOG_SERVICE_DUPLICATE.accept(s2);
         return s1;
     };
 
@@ -110,7 +113,35 @@ public abstract class AbstractResourceBasedServiceRegistryDao extends AbstractSe
 
             LOGGER.info("Watching service registry directory at [{}]", configDirectory);
 
-            this.serviceRegistryConfigWatcher = new ServiceRegistryConfigWatcher(this, eventPublisher);
+            final Consumer<File> onCreate = file ->  {
+                    final RegisteredService service = load(file);
+                    if (service != null) {
+                        if (findServiceById(service.getId()) != null) {
+                            LOG_SERVICE_DUPLICATE.accept(service);
+                        }
+                        update(service);
+                        publishEvent(new CasRegisteredServicesRefreshEvent(this));
+                    }
+            };
+            final Consumer<File> onDelete = file ->  {
+                load();
+                publishEvent(new CasRegisteredServicesRefreshEvent(this));
+            };
+            final Consumer<File> onModify = file ->  {
+                final RegisteredService newService = load(file);
+                if (newService != null) {
+                    final RegisteredService oldService = findServiceById(newService.getId());
+
+                    if (!newService.equals(oldService)) {
+                        update(newService);
+                        publishEvent(new CasRegisteredServicesRefreshEvent(this));
+                    } else {
+                        LOGGER.debug("Service [{}] loaded from [{}] is identical to the existing entry. Entry may have already been saved "
+                                + "in the event processing pipeline", newService.getId(), file.getName());
+                    }
+                }
+            };
+            this.serviceRegistryConfigWatcher = new ServiceRegistryConfigWatcher(serviceRegistryDirectory, onCreate, onModify, onDelete);
             this.serviceRegistryWatcherThread = new Thread(this.serviceRegistryConfigWatcher);
             this.serviceRegistryWatcherThread.setName(this.getClass().getName());
             this.serviceRegistryWatcherThread.start();

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/ServiceRegistryConfigWatcher.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/ServiceRegistryConfigWatcher.java
@@ -2,15 +2,12 @@ package org.apereo.cas.services;
 
 import com.google.common.base.Throwables;
 import org.apache.commons.io.IOUtils;
-import org.apereo.cas.support.events.service.CasRegisteredServicesRefreshEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationEventPublisher;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
@@ -19,6 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 
 import static java.nio.file.StandardWatchEventKinds.*;
 
@@ -30,33 +28,35 @@ import static java.nio.file.StandardWatchEventKinds.*;
  * @since 4.1.0
  */
 class ServiceRegistryConfigWatcher implements Runnable, Closeable {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceRegistryConfigWatcher.class);
+    private static final WatchEvent.Kind[] KINDS = new WatchEvent.Kind[]{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY};
 
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final Lock readLock = this.lock.readLock();
 
     private final WatchService watcher;
-
-    private final ResourceBasedServiceRegistryDao serviceRegistryDao;
-
-    private ApplicationEventPublisher applicationEventPublisher;
+    private final Consumer<File> onCreate;
+    private final Consumer<File> onModify;
+    private final Consumer<File> onDelete;
 
     /**
      * Instantiates a new Json service registry config watcher.
      *
-     * @param serviceRegistryDao the registry to callback
+     * @param watchablePath path that will be watched
+     * @param onCreate action triggered when a new file is created
+     * @param onModify action triggered when a file is modified
+     * @param onDelete action triggered when a file is deleted
      */
-    ServiceRegistryConfigWatcher(final ResourceBasedServiceRegistryDao serviceRegistryDao,
-                                 final ApplicationEventPublisher eventPublisher) {
+    ServiceRegistryConfigWatcher(final Path watchablePath, final Consumer<File> onCreate, final Consumer<File> onModify, final Consumer<File> onDelete) {
+        this.onCreate = onCreate;
+        this.onModify = onModify;
+        this.onDelete = onDelete;
         try {
-            this.serviceRegistryDao = serviceRegistryDao;
-            this.watcher = FileSystems.getDefault().newWatchService();
-            final WatchEvent.Kind[] kinds = new WatchEvent.Kind[]{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY};
-            LOGGER.debug("Created service registry watcher for events of type [{}]", (Object[]) kinds);
-            this.serviceRegistryDao.getWatchableResource().register(this.watcher, kinds);
-            
-            this.applicationEventPublisher = eventPublisher;
+            this.watcher = watchablePath.getFileSystem().newWatchService();
+            LOGGER.debug("Created service registry watcher for events of type [{}]", (Object[]) KINDS);
+            watchablePath.register(this.watcher, KINDS);
         } catch (final IOException e) {
             throw Throwables.propagate(e);
         }
@@ -97,9 +97,8 @@ class ServiceRegistryConfigWatcher implements Runnable, Closeable {
     private void handleEvent(final WatchKey key) {
         this.readLock.lock();
         try {
-            //The filename is the context of the event.
             key.pollEvents().stream().filter(event -> event.count() <= 1).forEach(event -> {
-                final WatchEvent.Kind kind = event.kind();
+                final String eventName = event.kind().name();
 
                 //The filename is the context of the event.
                 final WatchEvent<Path> ev = (WatchEvent<Path>) event;
@@ -109,13 +108,13 @@ class ServiceRegistryConfigWatcher implements Runnable, Closeable {
                 final Path fullPath = parent.resolve(filename);
                 final File file = fullPath.toFile();
 
-                LOGGER.trace("Detected event [{}] on file [{}]. Loading change...", kind, file);
-                if (kind.name().equals(ENTRY_CREATE.name()) && file.exists()) {
-                    handleCreateEvent(file);
-                } else if (kind.name().equals(ENTRY_DELETE.name())) {
-                    handleDeleteEvent();
-                } else if (kind.name().equals(ENTRY_MODIFY.name()) && file.exists()) {
-                    handleModifyEvent(file);
+                LOGGER.trace("Detected event [{}] on file [{}]. Loading change...", eventName, file);
+                if (eventName.equals(ENTRY_CREATE.name()) && file.exists()) {
+                    onCreate.accept(file);
+                } else if (eventName.equals(ENTRY_DELETE.name())) {
+                    onDelete.accept(file);
+                } else if (eventName.equals(ENTRY_MODIFY.name()) && file.exists()) {
+                    onModify.accept(file);
                 }
             });
         } finally {
@@ -123,65 +122,8 @@ class ServiceRegistryConfigWatcher implements Runnable, Closeable {
         }
     }
 
-    /**
-     * Handle modify event.
-     *
-     * @param file the file
-     */
-    private void handleModifyEvent(final File file) {
-        final RegisteredService newService = this.serviceRegistryDao.load(file);
-        if (newService == null) {
-            LOGGER.warn("New service definition could not be loaded from [{}]", file.getAbsolutePath());
-        } else {
-            final RegisteredService oldService = this.serviceRegistryDao.findServiceById(newService.getId());
-
-            if (!newService.equals(oldService)) {
-                this.serviceRegistryDao.update(newService);
-                this.applicationEventPublisher.publishEvent(new CasRegisteredServicesRefreshEvent(this));
-            } else {
-                LOGGER.debug("Service [{}] loaded from [{}] is identical to the existing entry. Entry may have already been saved "
-                        + "in the event processing pipeline", newService.getId(), file.getName());
-            }
-        }
-    }
-
-    /**
-     * Handle delete event.
-     */
-    private void handleDeleteEvent() {
-        this.serviceRegistryDao.load();
-        this.applicationEventPublisher.publishEvent(new CasRegisteredServicesRefreshEvent(this));
-    }
-
-    /**
-     * Handle create event.
-     *
-     * @param file the file
-     */
-    private void handleCreateEvent(final File file) {
-        //load the entry and add it to the map
-        final RegisteredService service = this.serviceRegistryDao.load(file);
-        if (service == null) {
-            LOGGER.warn("No service definition was loaded from [{}]", file);
-            return;
-        }
-        if (this.serviceRegistryDao.findServiceById(service.getId()) != null) {
-            LOGGER.warn("Found a service definition [{}] with a duplicate id [{}] in [{}]. "
-                            + "This will overwrite previous service definitions and is likely a "
-                            + "configuration problem. Make sure all services have a unique id and try again.",
-                    service.getServiceId(), service.getId(), file.getAbsolutePath());
-
-        }
-        this.serviceRegistryDao.update(service);
-        this.applicationEventPublisher.publishEvent(new CasRegisteredServicesRefreshEvent(this));
-    }
-
     @Override
     public void close() {
         IOUtils.closeQuietly(this.watcher);
-    }
-
-    public void setApplicationEventPublisher(final ApplicationEventPublisher applicationEventPublisher) {
-        this.applicationEventPublisher = applicationEventPublisher;
     }
 }


### PR DESCRIPTION
Closes #2676 

Changes:
- move registeredService logic out of the watcher.

This could be a first step to make the watcher logic agnostic that could be reused for ```ConfigurationDirectoryPathWatchService```