### PR TITLE
Throttling - HTTP Status 302 should not be reported as failure

### DIFF
--- a/support/cas-server-support-throttle/src/main/java/org/apereo/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/support/cas-server-support-throttle/src/main/java/org/apereo/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -70,7 +70,8 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter
         }
 
         final boolean recordEvent = response.getStatus() != HttpStatus.SC_CREATED
-                                 && response.getStatus() != HttpStatus.SC_OK;
+                                 && response.getStatus() != HttpStatus.SC_OK
+                                 && response.getStatus() != HttpStatus.SC_MOVED_TEMPORARILY;
 
         if (recordEvent) {
             logger.debug("Recording submission failure for {}", request.getRequestURI());


### PR DESCRIPTION
Dear CAS developers,

I have noticed that the CAS throttling subsystem reports successful authentications as failed, if the 'service' parameter is specified and a redirect to the service URL follows the successful authentication. I think this should not happen and HTTP status code 302 should be handled in the same way like 200 or 201.

There is some ongoing discussion here, although not completely about this change: https://groups.google.com/a/apereo.org/forum/#!topic/cas-dev/7yhZDm0Az0k

If this change looks OK, I can also prepare a merge request for 5.1.x and master.

Thank you!

Jarda