### PR TITLE
Add ability for deployers to name pac4j SAML clients

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -503,13 +503,13 @@ public class Pac4jProperties {
             this.serviceProviderMetadataPath = serviceProviderMetadataPath;
         }
 
-		public String getClientName() {
-			return clientName;
-		}
+	public String getClientName() {
+		return clientName;
+	}
 
-		public void setClientName(String clientName) {
-			this.clientName = clientName;
-		}
+	public void setClientName(final String clientName) {
+		this.clientName = clientName;
+	}
     }
 
     public static class Cas {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -445,7 +445,7 @@ public class Pac4jProperties {
         private int maximumAuthenticationLifetime = 600;
         private String serviceProviderEntityId;
         private String serviceProviderMetadataPath;
-        private String clientName = null;
+        private String clientName;
 
         public String getKeystorePassword() {
             return this.keystorePassword;

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -445,6 +445,7 @@ public class Pac4jProperties {
         private int maximumAuthenticationLifetime = 600;
         private String serviceProviderEntityId;
         private String serviceProviderMetadataPath;
+        private String clientName = null;
 
         public String getKeystorePassword() {
             return this.keystorePassword;
@@ -501,6 +502,14 @@ public class Pac4jProperties {
         public void setServiceProviderMetadataPath(final String serviceProviderMetadataPath) {
             this.serviceProviderMetadataPath = serviceProviderMetadataPath;
         }
+
+		public String getClientName() {
+			return clientName;
+		}
+
+		public void setClientName(String clientName) {
+			this.clientName = clientName;
+		}
     }
 
     public static class Cas {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -503,13 +503,13 @@ public class Pac4jProperties {
             this.serviceProviderMetadataPath = serviceProviderMetadataPath;
         }
 
-	    public String getClientName() {
-	        return clientName;
-	    }
+        public String getClientName() {
+            return clientName;
+        }
 
-	    public void setClientName(final String clientName) {
-		    this.clientName = clientName;
-	    }
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
+        }
     }
 
     public static class Cas {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -503,13 +503,13 @@ public class Pac4jProperties {
             this.serviceProviderMetadataPath = serviceProviderMetadataPath;
         }
 
-	public String getClientName() {
-		return clientName;
-	}
+	    public String getClientName() {
+	        return clientName;
+	    }
 
-	public void setClientName(final String clientName) {
-		this.clientName = clientName;
-	}
+	    public void setClientName(final String clientName) {
+		    this.clientName = clientName;
+	    }
     }
 
     public static class Cas {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3191,6 +3191,9 @@ prefixes for the `keystorePath` or `identityProviderMetadataPath` property).
 
 # Path/URL to delegated IdP metadata
 # cas.authn.pac4j.saml[0].identityProviderMetadataPath=
+
+# (Optional) Friendly name for IdP, e.g. "This Organization" or "That Organization"
+# cas.authn.pac4j.saml[0].clientName=
 ```
 
 Examine the generated metadata after accessing the CAS login screen to ensure all ports and endpoints are correctly adjusted.  

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -237,7 +237,7 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
                     
                     final int count = index.intValue();
 
-                    if(saml.getClientName() != null) {
+                    if (saml.getClientName() != null) {
                         client.setName(saml.getClientName());
                     } else if (count > 0) {
                         client.setName(client.getClass().getSimpleName() + count);

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -239,8 +239,7 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
 
                     if(saml.getClientName() != null) {
                         client.setName(saml.getClientName());
-                    }
-                    else if (count > 0) {
+                    } else if (count > 0) {
                         client.setName(client.getClass().getSimpleName() + count);
                     }
 

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -236,9 +236,14 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
                     final SAML2Client client = new SAML2Client(cfg);
                     
                     final int count = index.intValue();
-                    if (count > 0) {
+
+                    if(saml.getClientName() != null) {
+                        client.setName(saml.getClientName());
+                    }
+                    else if (count > 0) {
                         client.setName(client.getClass().getSimpleName() + count);
                     }
+
                     index.incrementAndGet();
                     LOGGER.debug("Created client [{}]", client);
                     properties.add(client);


### PR DESCRIPTION
Closes #2647

Add additional "clientName" property to Pac4jProperties, have
Pac4jAuthenticationEventExecutionPlanConfiguration use it to
configure the underlying pac4j SAML2Client.
