### PR TITLE
Throttling - HTTP Status 302 should not be reported as failure [branch 5.1.x]

### DIFF
--- a/support/cas-server-support-throttle/src/main/java/org/apereo/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
+++ b/support/cas-server-support-throttle/src/main/java/org/apereo/cas/web/support/AbstractThrottledSubmissionHandlerInterceptorAdapter.java
@@ -72,7 +72,8 @@ public abstract class AbstractThrottledSubmissionHandlerInterceptorAdapter
         }
 
         final boolean recordEvent = response.getStatus() != HttpStatus.SC_CREATED
-                                 && response.getStatus() != HttpStatus.SC_OK;
+                                 && response.getStatus() != HttpStatus.SC_OK
+                                 && response.getStatus() != HttpStatus.SC_MOVED_TEMPORARILY;
 
         if (recordEvent) {
             LOGGER.debug("Recording submission failure for [{}]", request.getRequestURI());


### PR DESCRIPTION
This is the same pull request as
https://github.com/apereo/cas/pull/2683
but for branch 5.1.x.