### PR TITLE
Fix NPE when password has expired but there are remaining logins.

### DIFF
--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authentication/support/DefaultAccountStateHandler.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authentication/support/DefaultAccountStateHandler.java
@@ -156,7 +156,7 @@ public class DefaultAccountStateHandler implements AccountStateHandler {
             return;
         }
 
-        if(warning.getExpiration()!=null){
+        if (warning.getExpiration()!=null){
             final ZonedDateTime expDate = DateTimeUtils.zonedDateTimeOf(warning.getExpiration());
             final long ttl = ZonedDateTime.now(ZoneOffset.UTC).until(expDate, ChronoUnit.DAYS);
             LOGGER.debug(

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authentication/support/DefaultAccountStateHandler.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authentication/support/DefaultAccountStateHandler.java
@@ -156,14 +156,16 @@ public class DefaultAccountStateHandler implements AccountStateHandler {
             return;
         }
 
-        final ZonedDateTime expDate = DateTimeUtils.zonedDateTimeOf(warning.getExpiration());
-        final long ttl = ZonedDateTime.now(ZoneOffset.UTC).until(expDate, ChronoUnit.DAYS);
-        LOGGER.debug(
+        if(warning.getExpiration()!=null){
+            final ZonedDateTime expDate = DateTimeUtils.zonedDateTimeOf(warning.getExpiration());
+            final long ttl = ZonedDateTime.now(ZoneOffset.UTC).until(expDate, ChronoUnit.DAYS);
+            LOGGER.debug(
                 "Password expires in [{}] days. Expiration warning threshold is [{}] days.",
                 ttl,
                 configuration.getPasswordWarningNumberOfDays());
-        if (configuration.isAlwaysDisplayPasswordExpirationWarning() || ttl < configuration.getPasswordWarningNumberOfDays()) {
-            messages.add(new PasswordExpiringWarningMessageDescriptor("Password expires in {0} days.", ttl));
+            if (configuration.isAlwaysDisplayPasswordExpirationWarning() || ttl < configuration.getPasswordWarningNumberOfDays()) {
+                messages.add(new PasswordExpiringWarningMessageDescriptor("Password expires in {0} days.", ttl));
+            }
         }
         if (warning.getLoginsRemaining() > 0) {
             messages.add(new DefaultMessageDescriptor(


### PR DESCRIPTION
Check that warning.getExpiration() is not null, to avoid NPE.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
