### PR TITLE
FIX unreachable ppolicy views

### DIFF
--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/web/flow/AuthenticationExceptionHandlerAction.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/web/flow/AuthenticationExceptionHandlerAction.java
@@ -231,7 +231,7 @@ public class AuthenticationExceptionHandlerAction extends AbstractAction {
 
     @Override
     protected Event doExecute(final RequestContext requestContext) throws Exception {
-        final String event = handle(requestContext.getAttributes().get("error", Exception.class),
+        final String event = handle(requestContext.getCurrentEvent().getAttributes().get("error", Exception.class),
                 requestContext.getMessageContext());
         return new EventFactorySupport().event(this, event);
     }


### PR DESCRIPTION
getAttributes() should be called on currentEvent() to get the
exception.class.
With this fix ppolicy views are now accessible again.