### PR TITLE
Join with comma separator

### DIFF
--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/RegisteredServiceAuthenticationHandlerResolver.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/RegisteredServiceAuthenticationHandlerResolver.java
@@ -67,7 +67,7 @@ public class RegisteredServiceAuthenticationHandlerResolver implements Authentic
             LOGGER.debug("No specific authentication handlers are required for this transaction");
         }
 
-        final String handlers = candidateHandlers.stream().map(AuthenticationHandler::getName).collect(Collectors.joining());
+        final String handlers = candidateHandlers.stream().map(AuthenticationHandler::getName).collect(Collectors.joining(","));
         LOGGER.debug("Authentication handlers used for this transaction are [{}]", handlers);
         return candidateHandlers;
     }


### PR DESCRIPTION
As currently the default collector returned by no-arg `Collectors#joining` just concatenates the names with no delimiters and it's hard to read in the logs.