### PR TITLE
Update AbstractWebApplicationService.java

### DIFF
--- a/cas-server-core-services/src/main/java/org/jasig/cas/authentication/principal/AbstractWebApplicationService.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/authentication/principal/AbstractWebApplicationService.java
@@ -24,7 +24,7 @@ public abstract class AbstractWebApplicationService implements SingleLogoutServi
     private static final Map<String, Object> EMPTY_MAP = Collections.unmodifiableMap(new HashMap<String, Object>());
 
     /** Logger instance. **/
-    protected final transient Logger logger = LoggerFactory.getLogger(this.getClass());
+    protected final transient Logger logger = LoggerFactory.getLogger(AbstractWebApplicationService.getClass());
 
     /** The id of the service. */
     private final String id;

--- a/cas-server-core-services/src/main/java/org/jasig/cas/authentication/principal/AbstractWebApplicationService.java
+++ b/cas-server-core-services/src/main/java/org/jasig/cas/authentication/principal/AbstractWebApplicationService.java
@@ -24,7 +24,7 @@ public abstract class AbstractWebApplicationService implements SingleLogoutServi
     private static final Map<String, Object> EMPTY_MAP = Collections.unmodifiableMap(new HashMap<String, Object>());
 
     /** Logger instance. **/
-    protected final transient Logger logger = LoggerFactory.getLogger(AbstractWebApplicationService.getClass());
+    protected final transient Logger logger = LoggerFactory.getLogger(AbstractWebApplicationService.class);
 
     /** The id of the service. */
     private final String id;


### PR DESCRIPTION
this class throws null point exception when I act CAS server as an openid provider.I've checked the code that (this.getClass()) instance of OpenIdService.getClass() so the logger value gets null.I find 4.1.x and 5.1.x is correct but I dont find any issues or update logs mention this.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
