### PR TITLE
Make creationTime CasEvent's property

### DIFF
--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/CasEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/CasEvent.java
@@ -41,6 +41,9 @@ public class CasEvent {
     @Column(length = 255, updatable = true, insertable = true, nullable = false)
     private String principalId;
 
+    @Column(length = 255, updatable = true, insertable = true, nullable = false)
+    private String creationTime;
+
     @ElementCollection
     @MapKeyColumn(name = "name")
     @Column(name = "value")
@@ -59,8 +62,34 @@ public class CasEvent {
         return this.type;
     }
 
+    /**
+     * Gets creation time. Attempts to parse the value
+     * as a {@link ZonedDateTime}. Otherwise, assumes a
+     * {@link LocalDateTime} and converts it based on system's
+     * default zone.
+     *
+     * @return the creation time
+     */
+    public ZonedDateTime getCreationTime() {
+        final ZonedDateTime dt = DateTimeUtils.zonedDateTimeOf(this.creationTime);
+        if (dt != null) {
+            return dt;
+        }
+        final LocalDateTime lt = DateTimeUtils.localDateTimeOf(this.creationTime);
+        return DateTimeUtils.zonedDateTimeOf(lt.atZone(ZoneId.systemDefault()));
+    }
+
     public Map<String, String> getProperties() {
         return this.properties;
+    }
+
+    /**
+     * Set creation time.
+     *
+     * @param time the time
+     */
+    public void setCreationTime(final Object time) {
+        this.creationTime = time.toString();
     }
 
     /**
@@ -70,15 +99,6 @@ public class CasEvent {
      */
     public void putTimestamp(final Long time) {
         put("timestamp", time.toString());
-    }
-
-    /**
-     * Put creation time.
-     *
-     * @param time the time
-     */
-    public void putCreationTime(final Object time) {
-        put("creationTime", time.toString());
     }
 
     /**
@@ -115,23 +135,6 @@ public class CasEvent {
      */
     public void putAgent(final String dev) {
         put("agent", dev);
-    }
-
-    /**
-     * Gets creation time. Attempts to parse the value
-     * as a {@link ZonedDateTime}. Otherwise, assumes a
-     * {@link LocalDateTime} and converts it based on system's
-     * default zone.
-     *
-     * @return the creation time
-     */
-    public ZonedDateTime getCreationTime() {
-        final ZonedDateTime dt = DateTimeUtils.zonedDateTimeOf(get("creationTime"));
-        if (dt != null) {
-            return dt;
-        }
-        final LocalDateTime lt = DateTimeUtils.localDateTimeOf(get("creationTime"));
-        return DateTimeUtils.zonedDateTimeOf(lt.atZone(ZoneId.systemDefault()));
     }
 
     public Long getTimestamp() {

--- a/core/cas-server-core-events/src/main/java/org/apereo/cas/support/events/listener/DefaultCasEventListener.java
+++ b/core/cas-server-core-events/src/main/java/org/apereo/cas/support/events/listener/DefaultCasEventListener.java
@@ -61,7 +61,7 @@ public class DefaultCasEventListener {
     public void handleCasTicketGrantingTicketCreatedEvent(final CasTicketGrantingTicketCreatedEvent event) {
         if (this.casEventRepository != null) {
             final CasEvent dto = prepareCasEvent(event);
-            dto.putCreationTime(event.getTicketGrantingTicket().getCreationTime());
+            dto.setCreationTime(event.getTicketGrantingTicket().getCreationTime());
             dto.putId(TicketIdSanitizationUtils.sanitize(event.getTicketGrantingTicket().getId()));
             dto.setPrincipalId(event.getTicketGrantingTicket().getAuthentication().getPrincipal().getId());
             this.casEventRepository.save(dto);
@@ -117,7 +117,7 @@ public class DefaultCasEventListener {
         final CasEvent dto = new CasEvent();
         dto.setType(event.getClass().getCanonicalName());
         dto.putTimestamp(event.getTimestamp());
-        dto.putCreationTime(DateTimeUtils.zonedDateTimeOf(event.getTimestamp()));
+        dto.setCreationTime(DateTimeUtils.zonedDateTimeOf(event.getTimestamp()));
 
         final ClientInfo clientInfo = ClientInfoHolder.getClientInfo();
         dto.putClientIpAddress(clientInfo.getClientIpAddress());

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/AbstractCasEventRepositoryTests.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/AbstractCasEventRepositoryTests.java
@@ -26,7 +26,7 @@ public abstract class AbstractCasEventRepositoryTests {
         final CasEvent dto = new CasEvent();
         dto.setType(event.getClass().getCanonicalName());
         dto.putTimestamp(event.getTimestamp());
-        dto.putCreationTime(event.getTicketGrantingTicket().getCreationTime());
+        dto.setCreationTime(event.getTicketGrantingTicket().getCreationTime());
         dto.putId(event.getTicketGrantingTicket().getId());
         dto.setPrincipalId(event.getTicketGrantingTicket().getAuthentication().getPrincipal().getId());
 

--- a/support/cas-server-support-electrofence/src/test/java/org/apereo/cas/impl/mock/MockTicketGrantingTicketCreatedEventProducer.java
+++ b/support/cas-server-support-electrofence/src/test/java/org/apereo/cas/impl/mock/MockTicketGrantingTicketCreatedEventProducer.java
@@ -110,7 +110,7 @@ public class MockTicketGrantingTicketCreatedEventProducer {
         dto.setType(CasTicketGrantingTicketCreatedEvent.class.getName());
         dto.putTimestamp(new Date().getTime());
         final int days = ThreadLocalRandom.current().nextInt(0, 30);
-        dto.putCreationTime(ZonedDateTime.now().minusDays(days).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        dto.setCreationTime(ZonedDateTime.now().minusDays(days).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
         dto.putId(TicketIdSanitizationUtils.sanitize("TGT-" + i + "-" + RandomStringUtils.randomAlphanumeric(16)));
         dto.setPrincipalId("casuser");
         dto.putClientIpAddress(getMockClientIpAddress());


### PR DESCRIPTION
creationTime should be CasEvent's property (as in AbstractCasEventRepository)
or else an IllegalArgumentException is thrown
(InitialAuthenticationAttemptWebflowEventResolver).

```
2017-06-26 15:23:13,982 TRACE [org.apereo.cas.audit.spi.ThreadLocalPrincipalResolver] - <Resolving principal at audit point [execution(AuthenticationRiskScore org.apereo.cas.impl.engine.DefaultAuthe
nticationRiskEvaluator.eval(Authentication,RegisteredService,HttpServletRequest))] with thrown exception [java.lang.IllegalArgumentException: org.hibernate.QueryException: could not resolve property
: creationTime of: org.apereo.cas.support.events.dao.CasEvent [SELECT r from org.apereo.cas.support.events.dao.CasEvent r where r.type = :type and r.creationTime >= :creationTime and r.principalId =
 :principalId]]>
2017-06-26 15:23:13,986 WARN [org.apereo.cas.web.flow.resolver.impl.InitialAuthenticationAttemptWebflowEventResolver] - <org.hibernate.QueryException: could not resolve property: creationTime of: or
g.apereo.cas.support.events.dao.CasEvent [SELECT r from org.apereo.cas.support.events.dao.CasEvent r where r.type = :type and r.creationTime >= :creationTime and r.principalId = :principalId]>
java.lang.IllegalArgumentException: org.hibernate.QueryException: could not resolve property: creationTime of: org.apereo.cas.support.events.dao.CasEvent [SELECT r from org.apereo.cas.support.events
.dao.CasEvent r where r.type = :type and r.creationTime >= :creationTime and r.principalId = :principalId]
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:131) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:155) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:162) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:663) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:679) ~[hibernate-core-5.2.10.Final.jar:5.2.
...
...
...
        at org.apereo.cas.impl.calcs.BaseAuthenticationRequestRiskCalculator.getCasTicketGrantingTicketCreatedEventsFor(BaseAuthenticationRequestRiskCalculator.java:84) ~[cas-server-support-electrofence-5.1.1.jar:5.1.1]
        at org.apereo.cas.impl.calcs.BaseAuthenticationRequestRiskCalculator.calculate(BaseAuthenticationRequestRiskCalculator.java:47) ~[cas-server-support-electrofence-5.1.1.jar:5.1.1]
...
...
...
Caused by: org.hibernate.QueryException: could not resolve property: creationTime of: org.apereo.cas.support.events.dao.CasEvent [SELECT r from org.apereo.cas.support.events.dao.CasEvent r where r.type = :type and r.creationTime >= :creationTime and r.principalId = :principalId]
        at org.hibernate.QueryException.generateQueryException(QueryException.java:120) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.QueryException.wrapWithQueryString(QueryException.java:103) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.hql.internal.ast.QueryTranslatorImpl.doCompile(QueryTranslatorImpl.java:217) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.hql.internal.ast.QueryTranslatorImpl.compile(QueryTranslatorImpl.java:141) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.engine.query.spi.HQLQueryPlan.<init>(HQLQueryPlan.java:115) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.engine.query.spi.HQLQueryPlan.<init>(HQLQueryPlan.java:77) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.engine.query.spi.QueryPlanCache.getHQLQueryPlan(QueryPlanCache.java:153) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.internal.AbstractSharedSessionContract.getQueryPlan(AbstractSharedSessionContract.java:546) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:655) ~[hibernate-core-5.2.10.Final.jar:5.2.10.Final]
        ... 459 more
```