### PR TITLE
Fix creationTime column - Master

### DIFF
--- a/webapp/resources/static/js/authnEvents.js
+++ b/webapp/resources/static/js/authnEvents.js
@@ -30,7 +30,7 @@ $('#myTabs a').click(function (e) {
             t.row.add([
                 type[type.length - 1],
                 rec.principalId,
-                new Date(rec.properties.creationTime),
+                new Date(rec.creationTime*1000),
                 new Date(rec.timestamp),
                 rec.properties.agent,
                 rec.clientIpAddress,


### PR DESCRIPTION
creationTime does not exist anymore in properties ( #2720  ), as a
consequence, creationTime column displays Invalid Date. Update
authnEvents.js to get creationTime from the right place.
