### PR TITLE
Refactor authn event execution plan config

### DIFF
--- a/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/AuthenticationEventExecutionPlanConfigurer.java
+++ b/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/AuthenticationEventExecutionPlanConfigurer.java
@@ -3,16 +3,21 @@ package org.apereo.cas.authentication;
 /**
  * This is {@link AuthenticationEventExecutionPlanConfigurer}.
  * Passes on an authentication execution plan to implementors
- * to register authentication handlers, etc. This class is typically
- * implemented by a configuration class inside a CAS module.
+ * to register authentication handlers, etc.
+ * <p>
+ * Since this interface conforms to a functional interface requirement, typical implementors
+ * are <code>@Conditional</code> beans expressed as compact lambda expressions inside of various CAS modules that
+ * contribute to the overall CAS authentication subsystem.
  * <p>
  * Note: Existing configuration classes that are injected authentication-related functionality
  * such as the transaction manager or the authentication support components need to be refactored
  * to isolate those changes into the configurer. Otherwise, circular dependency issues may appear.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
+@FunctionalInterface
 public interface AuthenticationEventExecutionPlanConfigurer {
 
     /**
@@ -20,6 +25,5 @@ public interface AuthenticationEventExecutionPlanConfigurer {
      *
      * @param plan the plan
      */
-    default void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-    }
+    void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan);
 }

--- a/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/AuthenticationEventExecutionPlanConfigurer.java
+++ b/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/AuthenticationEventExecutionPlanConfigurer.java
@@ -25,5 +25,5 @@ public interface AuthenticationEventExecutionPlanConfigurer {
      *
      * @param plan the plan
      */
-    void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan);
+    void configureAuthenticationExecutionPlan(AuthenticationEventExecutionPlan plan);
 }

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationHandlersConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationHandlersConfiguration.java
@@ -2,7 +2,6 @@ package org.apereo.cas.config;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.AcceptUsersAuthenticationHandler;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.handler.support.HttpBasedServiceCredentialsAuthenticationHandler;

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationHandlersConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationHandlersConfiguration.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
  * This is {@link CasCoreAuthenticationHandlersConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("casCoreAuthenticationHandlersConfiguration")
@@ -119,24 +120,18 @@ public class CasCoreAuthenticationHandlersConfiguration {
         return Collections.emptyMap();
     }
 
-    /**
-     * The type Proxy authentication event execution plan configuration.
-     */
-    @Configuration("proxyAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class ProxyAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandlerWithPrincipalResolver(proxyAuthenticationHandler(), proxyPrincipalResolver());
-        }
+    @ConditionalOnMissingBean(name = "proxyAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer proxyAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(proxyAuthenticationHandler(), proxyPrincipalResolver());
     }
 
     /**
-     * The type Jaas authentication event execution plan configuration.
+     * The Jaas authentication configuration.
      */
-    @Configuration("jaasAuthenticationEventExecutionPlanConfiguration")
+    @Configuration("jaasAuthenticationConfiguration")
     @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class JaasAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+    public class JaasAuthenticationConfiguration {
         @Autowired
         @Qualifier("personDirectoryPrincipalResolver")
         private PrincipalResolver personDirectoryPrincipalResolver;
@@ -167,9 +162,10 @@ public class CasCoreAuthenticationHandlersConfiguration {
                     .collect(Collectors.toList());
         }
 
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandlerWithPrincipalResolvers(jaasAuthenticationHandlers(), personDirectoryPrincipalResolver);
+        @ConditionalOnMissingBean(name = "jaasAuthenticationEventExecutionPlanConfigurer")
+        @Bean
+        public AuthenticationEventExecutionPlanConfigurer jaasAuthenticationEventExecutionPlanConfigurer() {
+            return plan -> plan.registerAuthenticationHandlerWithPrincipalResolvers(jaasAuthenticationHandlers(), personDirectoryPrincipalResolver);
         }
     }
 }

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationMetadataConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationMetadataConfiguration.java
@@ -22,11 +22,12 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link CasCoreAuthenticationMetadataConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("casCoreAuthenticationMetadataConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class CasCoreAuthenticationMetadataConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class CasCoreAuthenticationMetadataConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
@@ -60,15 +61,18 @@ public class CasCoreAuthenticationMetadataConfiguration implements Authenticatio
     }
 
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerMetadataPopulator(successfulHandlerMetaDataPopulator());
-        plan.registerMetadataPopulator(rememberMeAuthenticationMetaDataPopulator());
-        plan.registerMetadataPopulator(authenticationCredentialTypeMetaDataPopulator());
+    @ConditionalOnMissingBean(name = "casCoreAuthenticationMetadataAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer casCoreAuthenticationMetadataAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            plan.registerMetadataPopulator(successfulHandlerMetaDataPopulator());
+            plan.registerMetadataPopulator(rememberMeAuthenticationMetaDataPopulator());
+            plan.registerMetadataPopulator(authenticationCredentialTypeMetaDataPopulator());
 
-        final ClearpassProperties cp = casProperties.getClearpass();
-        if (cp.isCacheCredential()) {
-            plan.registerMetadataPopulator(new CacheCredentialsMetaDataPopulator(cacheCredentialsCipherExecutor()));
-        }
+            final ClearpassProperties cp = casProperties.getClearpass();
+            if (cp.isCacheCredential()) {
+                plan.registerMetadataPopulator(new CacheCredentialsMetaDataPopulator(cacheCredentialsCipherExecutor()));
+            }
+        };
     }
 }

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationMetadataConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationMetadataConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.config;
 
 import org.apereo.cas.CipherExecutor;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.metadata.AuthenticationCredentialTypeMetaDataPopulator;

--- a/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/support/authentication/AuthyAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/support/authentication/AuthyAuthenticationEventExecutionPlanConfiguration.java
@@ -7,7 +7,6 @@ import org.apereo.cas.adaptors.authy.AuthyClientInstance;
 import org.apereo.cas.adaptors.authy.AuthyMultifactorAuthenticationProvider;
 import org.apereo.cas.adaptors.authy.web.flow.AuthyAuthenticationRegistrationWebflowAction;
 import org.apereo.cas.authentication.metadata.AuthenticationContextAttributeMetaDataPopulator;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/support/authentication/AuthyAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/support/authentication/AuthyAuthenticationEventExecutionPlanConfiguration.java
@@ -32,11 +32,12 @@ import org.springframework.webflow.execution.Action;
  * This is {@link AuthyAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("authyAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class AuthyAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class AuthyAuthenticationEventExecutionPlanConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
@@ -108,9 +109,12 @@ public class AuthyAuthenticationEventExecutionPlanConfiguration implements Authe
         return new AuthyAuthenticationRegistrationWebflowAction(authyClientInstance());
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandler(authyAuthenticationHandler());
-        plan.registerMetadataPopulator(authyAuthenticationMetaDataPopulator());
+    @ConditionalOnMissingBean(name = "authyAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer authyAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            plan.registerAuthenticationHandler(authyAuthenticationHandler());
+            plan.registerMetadataPopulator(authyAuthenticationMetaDataPopulator());
+        };
     }
 }

--- a/support/cas-server-support-azure/src/main/java/org/apereo/cas/config/support/authentication/AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-azure/src/main/java/org/apereo/cas/config/support/authentication/AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -6,7 +6,6 @@ import org.apereo.cas.adaptors.azure.AzureAuthenticatorAuthenticationHandler;
 import org.apereo.cas.adaptors.azure.AzureAuthenticatorAuthenticationRequestBuilder;
 import org.apereo.cas.adaptors.azure.AzureAuthenticatorMultifactorAuthenticationProvider;
 import org.apereo.cas.adaptors.azure.web.flow.AzureAuthenticatorGenerateTokenAction;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;

--- a/support/cas-server-support-azure/src/main/java/org/apereo/cas/config/support/authentication/AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-azure/src/main/java/org/apereo/cas/config/support/authentication/AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -36,11 +36,12 @@ import java.io.FileNotFoundException;
  * This is {@link AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("azureAuthenticatorAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
@@ -125,11 +126,14 @@ public class AzureAuthenticatorAuthenticationEventExecutionPlanConfiguration imp
         return new DefaultPrincipalFactory();
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        if (StringUtils.isNotBlank(casProperties.getAuthn().getMfa().getAzure().getConfigDir())) {
-            plan.registerAuthenticationHandler(azureAuthenticatorAuthenticationHandler());
-            plan.registerMetadataPopulator(azureAuthenticatorAuthenticationMetaDataPopulator());
-        }
+    @ConditionalOnMissingBean(name = "azureAuthenticatorAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer azureAuthenticatorAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            if (StringUtils.isNotBlank(casProperties.getAuthn().getMfa().getAzure().getConfigDir())) {
+                plan.registerAuthenticationHandler(azureAuthenticatorAuthenticationHandler());
+                plan.registerMetadataPopulator(azureAuthenticatorAuthenticationMetaDataPopulator());
+            }
+        };
     }
 }

--- a/support/cas-server-support-cassandra-authentication/src/main/java/org/apereo/cas/config/CassandraAuthenticationConfiguration.java
+++ b/support/cas-server-support-cassandra-authentication/src/main/java/org/apereo/cas/config/CassandraAuthenticationConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.config;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.CassandraAuthenticationHandler;

--- a/support/cas-server-support-cassandra-authentication/src/main/java/org/apereo/cas/config/CassandraAuthenticationConfiguration.java
+++ b/support/cas-server-support-cassandra-authentication/src/main/java/org/apereo/cas/config/CassandraAuthenticationConfiguration.java
@@ -16,6 +16,7 @@ import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.services.ServicesManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -25,11 +26,12 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link CassandraAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.2.0
  */
 @Configuration("cassandraAuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class CassandraAuthenticationConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class CassandraAuthenticationConfiguration {
 
     @Autowired
     @Qualifier("cassandraSessionFactory")
@@ -71,8 +73,9 @@ public class CassandraAuthenticationConfiguration implements AuthenticationEvent
         return handler;
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandlerWithPrincipalResolver(cassandraAuthenticationHandler(), personDirectoryPrincipalResolver);
+    @ConditionalOnMissingBean(name = "cassandraAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer cassandraAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(cassandraAuthenticationHandler(), personDirectoryPrincipalResolver);
     }
 }

--- a/support/cas-server-support-cloud-directory-authentication/src/main/java/org/apereo/cas/config/CloudDirectoryAuthenticationConfiguration.java
+++ b/support/cas-server-support-cloud-directory-authentication/src/main/java/org/apereo/cas/config/CloudDirectoryAuthenticationConfiguration.java
@@ -42,7 +42,7 @@ import java.io.File;
  */
 @Configuration("cloudDirectoryAuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class CloudDirectoryAuthenticationConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class CloudDirectoryAuthenticationConfiguration {
 
     @Autowired
     @Qualifier("servicesManager")
@@ -115,8 +115,9 @@ public class CloudDirectoryAuthenticationConfiguration implements Authentication
 
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandlerWithPrincipalResolver(cloudDirectoryAuthenticationHandler(), personDirectoryPrincipalResolver);
+    @ConditionalOnMissingBean(name = "cloudDirectoryAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer cloudDirectoryAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(cloudDirectoryAuthenticationHandler(), personDirectoryPrincipalResolver);
     }
 }

--- a/support/cas-server-support-cloud-directory-authentication/src/main/java/org/apereo/cas/config/CloudDirectoryAuthenticationConfiguration.java
+++ b/support/cas-server-support-cloud-directory-authentication/src/main/java/org/apereo/cas/config/CloudDirectoryAuthenticationConfiguration.java
@@ -9,7 +9,6 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.clouddirectory.AmazonCloudDirectory;
 import com.amazonaws.services.clouddirectory.AmazonCloudDirectoryClientBuilder;
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.CloudDirectoryAuthenticationHandler;

--- a/support/cas-server-support-couchbase-authentication/src/main/java/org/apereo/cas/config/CouchbaseAuthenticationConfiguration.java
+++ b/support/cas-server-support-couchbase-authentication/src/main/java/org/apereo/cas/config/CouchbaseAuthenticationConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.config;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.CouchbaseAuthenticationHandler;

--- a/support/cas-server-support-couchbase-authentication/src/main/java/org/apereo/cas/config/CouchbaseAuthenticationConfiguration.java
+++ b/support/cas-server-support-couchbase-authentication/src/main/java/org/apereo/cas/config/CouchbaseAuthenticationConfiguration.java
@@ -27,11 +27,12 @@ import java.util.Set;
  * This is {@link CouchbaseAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.2.0
  */
 @Configuration("couchbaseAuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class CouchbaseAuthenticationConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class CouchbaseAuthenticationConfiguration {
 
     @Autowired
     @Qualifier("servicesManager")
@@ -72,8 +73,9 @@ public class CouchbaseAuthenticationConfiguration implements AuthenticationEvent
         return handler;
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandlerWithPrincipalResolver(couchbaseAuthenticationHandler(), personDirectoryPrincipalResolver);
+    @ConditionalOnMissingBean(name = "couchbaseAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer couchbaseAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(couchbaseAuthenticationHandler(), personDirectoryPrincipalResolver);
     }
 }

--- a/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/config/support/authentication/DigestAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/config/support/authentication/DigestAuthenticationEventExecutionPlanConfiguration.java
@@ -22,11 +22,12 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link DigestAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("digestAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class DigestAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class DigestAuthenticationEventExecutionPlanConfiguration {
     @Autowired
     @Qualifier("personDirectoryPrincipalResolver")
     private PrincipalResolver personDirectoryPrincipalResolver;
@@ -50,9 +51,10 @@ public class DigestAuthenticationEventExecutionPlanConfiguration implements Auth
         final DigestProperties digest = casProperties.getAuthn().getDigest();
         return new DigestAuthenticationHandler(digest.getName(), servicesManager, digestAuthenticationPrincipalFactory());
     }
-    
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandlerWithPrincipalResolver(digestAuthenticationHandler(), personDirectoryPrincipalResolver);
+
+    @ConditionalOnMissingBean(name = "digestAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer digestAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(digestAuthenticationHandler(), personDirectoryPrincipalResolver);
     }
 }

--- a/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/config/support/authentication/DigestAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/config/support/authentication/DigestAuthenticationEventExecutionPlanConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.digest.config.support.authentication;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-duo/src/main/java/org/apereo/cas/adaptors/duo/config/DuoSecurityAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-duo/src/main/java/org/apereo/cas/adaptors/duo/config/DuoSecurityAuthenticationEventExecutionPlanConfiguration.java
@@ -7,7 +7,6 @@ import org.apereo.cas.adaptors.duo.authn.DuoAuthenticationHandler;
 import org.apereo.cas.adaptors.duo.web.flow.action.PrepareDuoWebLoginFormAction;
 import org.apereo.cas.adaptors.duo.web.flow.config.DuoMultifactorWebflowConfigurer;
 import org.apereo.cas.authentication.metadata.AuthenticationContextAttributeMetaDataPopulator;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-duo/src/main/java/org/apereo/cas/adaptors/duo/config/DuoSecurityAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-duo/src/main/java/org/apereo/cas/adaptors/duo/config/DuoSecurityAuthenticationEventExecutionPlanConfiguration.java
@@ -44,11 +44,13 @@ import java.util.List;
  * This is {@link DuoSecurityAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("duoSecurityAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class DuoSecurityAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class DuoSecurityAuthenticationEventExecutionPlanConfiguration {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DuoSecurityAuthenticationEventExecutionPlanConfiguration.class);
 
     @Autowired
@@ -144,9 +146,12 @@ public class DuoSecurityAuthenticationEventExecutionPlanConfiguration implements
                 duoMultifactorAuthenticationProvider());
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandler(duoAuthenticationHandler());
-        plan.registerMetadataPopulator(duoAuthenticationMetaDataPopulator());
+    @ConditionalOnMissingBean(name = "duoSecurityAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer duoSecurityAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            plan.registerAuthenticationHandler(duoAuthenticationHandler());
+            plan.registerMetadataPopulator(duoAuthenticationMetaDataPopulator());
+        };
     }
 }

--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -47,11 +47,12 @@ import java.util.concurrent.TimeUnit;
  * This is {@link GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("googleAuthenticatorAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
 
     @Lazy
     @Autowired
@@ -162,13 +163,15 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration im
         return new DefaultPrincipalFactory();
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        if (StringUtils.isNotBlank(casProperties.getAuthn().getMfa().getGauth().getIssuer())) {
-            plan.registerAuthenticationHandler(googleAuthenticatorAuthenticationHandler());
-            plan.registerMetadataPopulator(googleAuthenticatorAuthenticationMetaDataPopulator());
-        }
-
+    @ConditionalOnMissingBean(name = "googleAuthenticatorAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer googleAuthenticatorAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            if (StringUtils.isNotBlank(casProperties.getAuthn().getMfa().getGauth().getIssuer())) {
+                plan.registerAuthenticationHandler(googleAuthenticatorAuthenticationHandler());
+                plan.registerMetadataPopulator(googleAuthenticatorAuthenticationMetaDataPopulator());
+            }
+        };
     }
 
     /**

--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -10,7 +10,6 @@ import org.apereo.cas.adaptors.gauth.GoogleAuthenticatorMultifactorAuthenticatio
 import org.apereo.cas.adaptors.gauth.repository.credentials.InMemoryGoogleAuthenticatorTokenCredentialRepository;
 import org.apereo.cas.adaptors.gauth.repository.credentials.JsonGoogleAuthenticatorTokenCredentialRepository;
 import org.apereo.cas.adaptors.gauth.repository.credentials.RestGoogleAuthenticatorTokenCredentialRepository;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;

--- a/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/config/CasRemoteAuthenticationConfiguration.java
+++ b/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/config/CasRemoteAuthenticationConfiguration.java
@@ -2,7 +2,6 @@ package org.apereo.cas.config;
 
 import org.apereo.cas.adaptors.generic.remote.RemoteAddressAuthenticationHandler;
 import org.apereo.cas.adaptors.generic.remote.RemoteAddressNonInteractiveCredentialsAction;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/config/CasRemoteAuthenticationConfiguration.java
+++ b/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/config/CasRemoteAuthenticationConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.webflow.execution.Action;
  * This is {@link CasRemoteAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("casRemoteAuthenticationConfiguration")
@@ -63,6 +64,10 @@ public class CasRemoteAuthenticationConfiguration {
     @Autowired
     private FlowBuilderServices flowBuilderServices;
 
+    @Autowired
+    @Qualifier("personDirectoryPrincipalResolver")
+    private PrincipalResolver personDirectoryPrincipalResolver;
+
     @ConditionalOnMissingBean(name = "remoteAddressWebflowConfigurer")
     @Bean
     public CasWebflowConfigurer remoteAddressWebflowConfigurer() {
@@ -92,19 +97,10 @@ public class CasRemoteAuthenticationConfiguration {
         return new DefaultPrincipalFactory();
     }
 
-    /**
-     * The type Remote address authentication event execution plan configuration.
-     */
-    @Configuration("remoteAddressAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class RemoteAddressAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Autowired
-        @Qualifier("personDirectoryPrincipalResolver")
-        private PrincipalResolver personDirectoryPrincipalResolver;
 
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandlerWithPrincipalResolver(remoteAddressAuthenticationHandler(), personDirectoryPrincipalResolver);
-        }
+    @ConditionalOnMissingBean(name = "remoteAddressAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer remoteAddressAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(remoteAddressAuthenticationHandler(), personDirectoryPrincipalResolver);
     }
 }

--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/FileAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/FileAuthenticationEventExecutionPlanConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.adaptors.generic.config;
 
 import org.apereo.cas.adaptors.generic.FileAuthenticationHandler;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/FileAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/FileAuthenticationEventExecutionPlanConfiguration.java
@@ -21,16 +21,18 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 
 /**
  * This is {@link FileAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("fileAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class FileAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class FileAuthenticationEventExecutionPlanConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileAuthenticationEventExecutionPlanConfiguration.class);
 
     @Autowired(required = false)
@@ -70,14 +72,16 @@ public class FileAuthenticationEventExecutionPlanConfiguration implements Authen
 
         return h;
     }
-    
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        if (casProperties.getAuthn().getFile().getFilename() != null) {
-            LOGGER.debug("Added file-based authentication handler");
-            plan.registerAuthenticationHandlerWithPrincipalResolver(fileAuthenticationHandler(), personDirectoryPrincipalResolver);
-        }
+
+    @ConditionalOnMissingBean(name = "fileAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer fileAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            final Resource file = casProperties.getAuthn().getFile().getFilename();
+            if (file != null) {
+                LOGGER.debug("Added file-based authentication handler for the target file [{}]", file.getDescription());
+                plan.registerAuthenticationHandlerWithPrincipalResolver(fileAuthenticationHandler(), personDirectoryPrincipalResolver);
+            }
+        };
     }
-    
-    
 }

--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/RejectUsersAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/RejectUsersAuthenticationEventExecutionPlanConfiguration.java
@@ -29,11 +29,12 @@ import java.util.Set;
  * This is {@link RejectUsersAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("rejectUsersAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class RejectUsersAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class RejectUsersAuthenticationEventExecutionPlanConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(RejectUsersAuthenticationEventExecutionPlanConfiguration.class);
 
     @Autowired(required = false)
@@ -72,12 +73,16 @@ public class RejectUsersAuthenticationEventExecutionPlanConfiguration implements
         h.setPrincipalNameTransformer(Beans.newPrincipalNameTransformer(rejectProperties.getPrincipalTransformation()));
         return h;
     }
-    
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        if (StringUtils.isNotBlank(casProperties.getAuthn().getReject().getUsers())) {
-            LOGGER.debug("Added rejecting authentication handler");
-            plan.registerAuthenticationHandlerWithPrincipalResolver(rejectUsersAuthenticationHandler(), personDirectoryPrincipalResolver);
-        }
+
+    @ConditionalOnMissingBean(name = "rejectUsersAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer rejectUsersAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            final String users = casProperties.getAuthn().getReject().getUsers();
+            if (StringUtils.isNotBlank(users)) {
+                plan.registerAuthenticationHandlerWithPrincipalResolver(rejectUsersAuthenticationHandler(), personDirectoryPrincipalResolver);
+                LOGGER.debug("Added rejecting authentication handler with the following users [{}]", users);
+            }
+        };
     }
 }

--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/RejectUsersAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/RejectUsersAuthenticationEventExecutionPlanConfiguration.java
@@ -2,7 +2,6 @@ package org.apereo.cas.adaptors.generic.config;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.adaptors.generic.RejectUsersAuthenticationHandler;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/ShiroAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/ShiroAuthenticationEventExecutionPlanConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.adaptors.generic.config;
 
 import org.apereo.cas.adaptors.generic.ShiroAuthenticationHandler;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/ShiroAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/config/ShiroAuthenticationEventExecutionPlanConfiguration.java
@@ -21,16 +21,18 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 
 /**
  * This is {@link ShiroAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("shiroAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class ShiroAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class ShiroAuthenticationEventExecutionPlanConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(ShiroAuthenticationEventExecutionPlanConfiguration.class);
 
     @Autowired(required = false)
@@ -71,11 +73,15 @@ public class ShiroAuthenticationEventExecutionPlanConfiguration implements Authe
         return h;
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        if (casProperties.getAuthn().getShiro().getConfig().getLocation() != null) {
-            LOGGER.debug("Injecting shiro authentication handler");
-            plan.registerAuthenticationHandlerWithPrincipalResolver(shiroAuthenticationHandler(), personDirectoryPrincipalResolver);
-        }
+    @ConditionalOnMissingBean(name = "shiroAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer shiroAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            final Resource shiroConfigFile = casProperties.getAuthn().getShiro().getConfig().getLocation();
+            if (shiroConfigFile != null) {
+                LOGGER.debug("Injecting shiro authentication handler configured at [{}]", shiroConfigFile.getDescription());
+                plan.registerAuthenticationHandlerWithPrincipalResolver(shiroAuthenticationHandler(), personDirectoryPrincipalResolver);
+            }
+        };
     }
 }

--- a/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
+++ b/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
@@ -5,7 +5,6 @@ import org.apereo.cas.adaptors.jdbc.BindModeSearchDatabaseAuthenticationHandler;
 import org.apereo.cas.adaptors.jdbc.QueryAndEncodeDatabaseAuthenticationHandler;
 import org.apereo.cas.adaptors.jdbc.QueryDatabaseAuthenticationHandler;
 import org.apereo.cas.adaptors.jdbc.SearchModeSearchDatabaseAuthenticationHandler;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
+++ b/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
@@ -34,6 +34,7 @@ import java.util.Map;
  * This is {@link CasJdbcAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("CasJdbcAuthenticationConfiguration")
@@ -63,6 +64,10 @@ public class CasJdbcAuthenticationConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
+
+    @Autowired
+    @Qualifier("personDirectoryPrincipalResolver")
+    private PrincipalResolver personDirectoryPrincipalResolver;
 
 
     @ConditionalOnMissingBean(name = "jdbcAuthenticationHandlers")
@@ -174,19 +179,11 @@ public class CasJdbcAuthenticationConfiguration {
         return new DefaultPrincipalFactory();
     }
 
-    /**
-     * The type Jdbc authentication event execution plan configuration.
-     */
-    @Configuration("jdbcAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class JdbcAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Autowired
-        @Qualifier("personDirectoryPrincipalResolver")
-        private PrincipalResolver personDirectoryPrincipalResolver;
-
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
+    @ConditionalOnMissingBean(name = "jdbcAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer jdbcAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
             jdbcAuthenticationHandlers().forEach(h -> plan.registerAuthenticationHandlerWithPrincipalResolver(h, personDirectoryPrincipalResolver));
-        }
+        };
     }
 }

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.config;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.LdapAuthenticationHandler;

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
@@ -45,6 +45,7 @@ import java.util.function.Predicate;
  * relevant authentication handlers for LDAP.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("ldapAuthenticationConfiguration")
@@ -214,20 +215,14 @@ public class LdapAuthenticationConfiguration {
         return cfg;
     }
 
-
-    /**
-     * The type Ldap authentication event execution plan configuration.
-     */
-    @Configuration("ldapAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class LdapAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
+    @ConditionalOnMissingBean(name = "ldapAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer ldapAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
             ldapAuthenticationHandlers().forEach(handler -> {
                 LOGGER.info("Registering LDAP authentication for [{}]", handler.getName());
                 plan.registerAuthenticationHandlerWithPrincipalResolver(handler, personDirectoryPrincipalResolver);
             });
-        }
-
+        };
     }
 }

--- a/support/cas-server-support-mongo/src/main/java/org/apereo/cas/authentication/config/CasMongoAuthenticationConfiguration.java
+++ b/support/cas-server-support-mongo/src/main/java/org/apereo/cas/authentication/config/CasMongoAuthenticationConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.authentication.config;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.MongoAuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-mongo/src/main/java/org/apereo/cas/authentication/config/CasMongoAuthenticationConfiguration.java
+++ b/support/cas-server-support-mongo/src/main/java/org/apereo/cas/authentication/config/CasMongoAuthenticationConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link CasMongoAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("casMongoAuthenticationConfiguration")
@@ -36,6 +37,10 @@ public class CasMongoAuthenticationConfiguration {
     @Autowired
     @Qualifier("servicesManager")
     private ServicesManager servicesManager;
+
+    @Autowired
+    @Qualifier("personDirectoryPrincipalResolver")
+    private PrincipalResolver personDirectoryPrincipalResolver;
     
     @ConditionalOnMissingBean(name = "mongoPrincipalFactory")
     @Bean
@@ -56,19 +61,9 @@ public class CasMongoAuthenticationConfiguration {
         return handler;
     }
 
-    /**
-     * The type Mongo authentication event execution plan configuration.
-     */
-    @Configuration("mongoAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class MongoAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Autowired
-        @Qualifier("personDirectoryPrincipalResolver")
-        private PrincipalResolver personDirectoryPrincipalResolver;
-
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandlerWithPrincipalResolver(mongoAuthenticationHandler(), personDirectoryPrincipalResolver);
-        }
+    @ConditionalOnMissingBean(name = "mongoAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer mongoAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(mongoAuthenticationHandler(), personDirectoryPrincipalResolver);
     }
 }

--- a/support/cas-server-support-openid/src/main/java/org/apereo/cas/config/support/authentication/OpenIdAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-openid/src/main/java/org/apereo/cas/config/support/authentication/OpenIdAuthenticationEventExecutionPlanConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.config.support.authentication;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-openid/src/main/java/org/apereo/cas/config/support/authentication/OpenIdAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-openid/src/main/java/org/apereo/cas/config/support/authentication/OpenIdAuthenticationEventExecutionPlanConfiguration.java
@@ -23,11 +23,12 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link OpenIdAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("openIdAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class OpenIdAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class OpenIdAuthenticationEventExecutionPlanConfiguration {
     @Autowired
     @Qualifier("servicesManager")
     private ServicesManager servicesManager;
@@ -65,8 +66,9 @@ public class OpenIdAuthenticationEventExecutionPlanConfiguration implements Auth
         return new DefaultPrincipalFactory();
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandlerWithPrincipalResolver(openIdCredentialsAuthenticationHandler(), openIdPrincipalResolver());
+    @ConditionalOnMissingBean(name = "openIdAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer openIdAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(openIdCredentialsAuthenticationHandler(), openIdPrincipalResolver());
     }
 }

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -3,7 +3,6 @@ package org.apereo.cas.support.pac4j.config.support.authentication;
 import com.github.scribejava.core.model.Verb;
 import com.nimbusds.jose.JWSAlgorithm;
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/config/support/authentication/RadiusTokenAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/config/support/authentication/RadiusTokenAuthenticationEventExecutionPlanConfiguration.java
@@ -33,11 +33,12 @@ import java.util.List;
  * This is {@link RadiusTokenAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("radiusTokenAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class RadiusTokenAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class RadiusTokenAuthenticationEventExecutionPlanConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
@@ -104,9 +105,12 @@ public class RadiusTokenAuthenticationEventExecutionPlanConfiguration implements
         return new AuthenticationContextAttributeMetaDataPopulator(attribute, radiusTokenAuthenticationHandler(), radiusAuthenticationProvider());
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandler(radiusTokenAuthenticationHandler());
-        plan.registerMetadataPopulator(radiusAuthenticationMetaDataPopulator());
+    @ConditionalOnMissingBean(name = "radiusTokenAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer radiusTokenAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            plan.registerAuthenticationHandler(radiusTokenAuthenticationHandler());
+            plan.registerMetadataPopulator(radiusAuthenticationMetaDataPopulator());
+        };
     }
 }

--- a/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/config/support/authentication/RadiusTokenAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/config/support/authentication/RadiusTokenAuthenticationEventExecutionPlanConfiguration.java
@@ -8,7 +8,6 @@ import org.apereo.cas.adaptors.radius.authentication.RadiusMultifactorAuthentica
 import org.apereo.cas.adaptors.radius.authentication.RadiusTokenAuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.metadata.AuthenticationContextAttributeMetaDataPopulator;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
+++ b/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
@@ -33,6 +33,7 @@ import java.util.List;
  * This this {@link RadiusConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("radiusConfiguration")
@@ -105,19 +106,15 @@ public class RadiusConfiguration {
         return h;
     }
 
-    /**
-     * The type Radius authentication event execution plan configuration.
-     */
-    @Configuration("radiusAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class RadiusAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
+    @ConditionalOnMissingBean(name = "radiusAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer radiusAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
             if (StringUtils.isNotBlank(casProperties.getAuthn().getRadius().getClient().getInetAddress())) {
                 plan.registerAuthenticationHandler(radiusAuthenticationHandler());
             } else {
                 LOGGER.warn("No RADIUS address is defined. RADIUS support will be disabled.");
             }
-        }
+        };
     }
 }

--- a/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
+++ b/support/cas-server-support-radius/src/main/java/org/apereo/cas/config/RadiusConfiguration.java
@@ -6,7 +6,6 @@ import org.apereo.cas.adaptors.radius.RadiusClientFactory;
 import org.apereo.cas.adaptors.radius.RadiusProtocol;
 import org.apereo.cas.adaptors.radius.RadiusServer;
 import org.apereo.cas.adaptors.radius.authentication.handler.support.RadiusAuthenticationHandler;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/config/CasRestAuthenticationConfiguration.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/config/CasRestAuthenticationConfiguration.java
@@ -11,7 +11,6 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.apereo.cas.adaptors.rest.RestAuthenticationApi;
 import org.apereo.cas.adaptors.rest.RestAuthenticationHandler;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/config/CasRestAuthenticationConfiguration.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/config/CasRestAuthenticationConfiguration.java
@@ -36,11 +36,12 @@ import java.net.URI;
  * This is {@link CasRestAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("casRestAuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class CasRestAuthenticationConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class CasRestAuthenticationConfiguration {
 
     @Autowired
     @Qualifier("personDirectoryPrincipalResolver")
@@ -78,11 +79,14 @@ public class CasRestAuthenticationConfiguration implements AuthenticationEventEx
         return r;
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        if (StringUtils.isNotBlank(casProperties.getAuthn().getRest().getUri())) {
-            plan.registerAuthenticationHandlerWithPrincipalResolver(restAuthenticationHandler(), personDirectoryPrincipalResolver);
-        }
+    @ConditionalOnMissingBean(name = "casRestAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer casRestAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            if (StringUtils.isNotBlank(casProperties.getAuthn().getRest().getUri())) {
+                plan.registerAuthenticationHandlerWithPrincipalResolver(restAuthenticationHandler(), personDirectoryPrincipalResolver);
+            }
+        };
     }
 
     private static class HttpComponentsClientHttpRequestFactoryBasicAuth extends HttpComponentsClientHttpRequestFactory {

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/authentication/support/SamlAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/authentication/support/SamlAuthenticationEventExecutionPlanConfiguration.java
@@ -1,10 +1,10 @@
 package org.apereo.cas.config.authentication.support;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.support.saml.authentication.SamlAuthenticationMetaDataPopulator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,19 +13,21 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link SamlAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("samlAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class SamlAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class SamlAuthenticationEventExecutionPlanConfiguration {
 
     @Bean
     public AuthenticationMetaDataPopulator samlAuthenticationMetaDataPopulator() {
         return new SamlAuthenticationMetaDataPopulator();
     }
-    
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerMetadataPopulator(samlAuthenticationMetaDataPopulator());
+
+    @ConditionalOnMissingBean(name = "samlAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer samlAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerMetadataPopulator(samlAuthenticationMetaDataPopulator());
     }
 }

--- a/support/cas-server-support-spnego/src/main/java/org/apereo/cas/config/SpnegoConfiguration.java
+++ b/support/cas-server-support-spnego/src/main/java/org/apereo/cas/config/SpnegoConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.config;
 
 import jcifs.spnego.Authentication;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-spnego/src/main/java/org/apereo/cas/config/SpnegoConfiguration.java
+++ b/support/cas-server-support-spnego/src/main/java/org/apereo/cas/config/SpnegoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link SpnegoConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("spnegoConfiguration")
@@ -121,15 +122,9 @@ public class SpnegoConfiguration {
         return new DefaultPrincipalFactory();
     }
 
-    /**
-     * The type Spnego authentication event execution plan configuration.
-     */
-    @Configuration("spnegoAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class SpnegoAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandlerWithPrincipalResolver(spnegoHandler(), spnegoPrincipalResolver());
-        }
+    @ConditionalOnMissingBean(name = "spnegoAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer spnegoAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(spnegoHandler(), spnegoPrincipalResolver());
     }
 }

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationConfiguration.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationConfiguration.java
@@ -49,12 +49,13 @@ import java.util.Set;
  *
  * @author Misagh Moayyed
  * @author John Gasper
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("surrogateAuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @EnableAspectJAutoProxy
-public class SurrogateAuthenticationConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class SurrogateAuthenticationConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(SurrogateAuthenticationConfiguration.class);
 
     @Autowired

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationConfiguration.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.config;
 
 import org.apereo.cas.audit.spi.PrincipalIdProvider;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.SurrogateAuthenticationAspect;
 import org.apereo.cas.authentication.SurrogatePrincipalResolver;
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationMetadataConfiguration.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationMetadataConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.config;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.SurrogateAuthenticationMetaDataPopulator;
@@ -12,18 +11,21 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link SurrogateAuthenticationMetadataConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("SurrogateAuthenticationMetadataConfiguration")
-public class SurrogateAuthenticationMetadataConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class SurrogateAuthenticationMetadataConfiguration {
+
     @ConditionalOnMissingBean(name = "surrogateAuthenticationMetadataPopulator")
     @Bean
     public AuthenticationMetaDataPopulator surrogateAuthenticationMetadataPopulator() {
         return new SurrogateAuthenticationMetaDataPopulator();
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerMetadataPopulator(surrogateAuthenticationMetadataPopulator());
+    @ConditionalOnMissingBean(name = "surrogateAuthenticationMetadataConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer surrogateAuthenticationMetadataConfigurer() {
+        return plan -> plan.registerMetadataPopulator(surrogateAuthenticationMetadataPopulator());
     }
 }

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateWebflowEventResolutionConfiguration.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateWebflowEventResolutionConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.config;
 
 import org.apereo.cas.CentralAuthenticationService;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.surrogate.SurrogateAuthenticationService;
@@ -28,7 +27,7 @@ import org.springframework.web.util.CookieGenerator;
  */
 @Configuration("SurrogateWebflowEventResolutionConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class SurrogateWebflowEventResolutionConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class SurrogateWebflowEventResolutionConfiguration {
 
     @Autowired
     @Qualifier("servicesManager")

--- a/support/cas-server-support-swivel/src/main/java/org/apereo/cas/config/SwivelAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-swivel/src/main/java/org/apereo/cas/config/SwivelAuthenticationEventExecutionPlanConfiguration.java
@@ -17,6 +17,7 @@ import org.apereo.cas.services.ServicesManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,10 +26,12 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link SwivelAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.2.0
  */
 @Configuration("swivelAuthenticationEventExecutionPlanConfiguration")
-public class SwivelAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class SwivelAuthenticationEventExecutionPlanConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;
 
@@ -76,10 +79,12 @@ public class SwivelAuthenticationEventExecutionPlanConfiguration implements Auth
         return p;
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandler(swivelAuthenticationHandler());
-        plan.registerMetadataPopulator(swivelAuthenticationMetaDataPopulator());
+    @ConditionalOnMissingBean(name = "swivelAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer swivelAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            plan.registerAuthenticationHandler(swivelAuthenticationHandler());
+            plan.registerMetadataPopulator(swivelAuthenticationMetaDataPopulator());
+        };
     }
-
 }

--- a/support/cas-server-support-swivel/src/main/java/org/apereo/cas/config/SwivelAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-swivel/src/main/java/org/apereo/cas/config/SwivelAuthenticationEventExecutionPlanConfiguration.java
@@ -2,7 +2,6 @@ package org.apereo.cas.config;
 
 import org.apereo.cas.adaptors.swivel.SwivelAuthenticationHandler;
 import org.apereo.cas.adaptors.swivel.SwivelMultifactorAuthenticationProvider;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.metadata.AuthenticationContextAttributeMetaDataPopulator;

--- a/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/config/TokenAuthenticationConfiguration.java
+++ b/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/config/TokenAuthenticationConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Configuration;
  * This is {@link TokenAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.2.0
  */
 @Configuration("tokenAuthenticationConfiguration")
@@ -33,6 +34,10 @@ public class TokenAuthenticationConfiguration {
     @Autowired
     @Qualifier("servicesManager")
     private ServicesManager servicesManager;
+
+    @Autowired
+    @Qualifier("personDirectoryPrincipalResolver")
+    private PrincipalResolver personDirectoryPrincipalResolver;
 
 
     @ConditionalOnMissingBean(name = "tokenPrincipalFactory")
@@ -48,19 +53,9 @@ public class TokenAuthenticationConfiguration {
                 Beans.newPrincipalNameTransformer(token.getPrincipalTransformation()));
     }
 
-    /**
-     * The type Token authentication event execution plan configuration.
-     */
-    @Configuration("tokenAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class TokenAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Autowired
-        @Qualifier("personDirectoryPrincipalResolver")
-        private PrincipalResolver personDirectoryPrincipalResolver;
-
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandlerWithPrincipalResolver(tokenAuthenticationHandler(), personDirectoryPrincipalResolver);
-        }
+    @ConditionalOnMissingBean(name = "tokenAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer tokenAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(tokenAuthenticationHandler(), personDirectoryPrincipalResolver);
     }
 }

--- a/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/config/TokenAuthenticationConfiguration.java
+++ b/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/config/TokenAuthenticationConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.config;
 
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-trusted/src/main/java/org/apereo/cas/adaptors/trusted/config/TrustedAuthenticationConfiguration.java
+++ b/support/cas-server-support-trusted/src/main/java/org/apereo/cas/adaptors/trusted/config/TrustedAuthenticationConfiguration.java
@@ -6,7 +6,6 @@ import org.apereo.cas.adaptors.trusted.authentication.principal.RemoteRequestPri
 import org.apereo.cas.adaptors.trusted.authentication.principal.ShibbolethServiceProviderRequestPrincipalAttributesExtractor;
 import org.apereo.cas.adaptors.trusted.web.flow.PrincipalFromRequestRemoteUserNonInteractiveCredentialsAction;
 import org.apereo.cas.adaptors.trusted.web.flow.PrincipalFromRequestUserPrincipalNonInteractiveCredentialsAction;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;

--- a/support/cas-server-support-trusted/src/main/java/org/apereo/cas/adaptors/trusted/config/TrustedAuthenticationConfiguration.java
+++ b/support/cas-server-support-trusted/src/main/java/org/apereo/cas/adaptors/trusted/config/TrustedAuthenticationConfiguration.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
  * This is {@link TrustedAuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("trustedAuthenticationConfiguration")
@@ -118,15 +119,9 @@ public class TrustedAuthenticationConfiguration {
                 trustedPrincipalFactory(), remoteRequestPrincipalAttributesExtractor());
     }
 
-    /**
-     * The type Trusted authentication event execution plan configuration.
-     */
-    @Configuration("trustedAuthenticationEventExecutionPlanConfiguration")
-    @EnableConfigurationProperties(CasConfigurationProperties.class)
-    public class TrustedAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            plan.registerAuthenticationHandlerWithPrincipalResolver(principalBearingCredentialsAuthenticationHandler(), trustedPrincipalResolver());
-        }
+    @ConditionalOnMissingBean(name = "trustedAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer trustedAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(principalBearingCredentialsAuthenticationHandler(), trustedPrincipalResolver());
     }
 }

--- a/support/cas-server-support-u2f/src/main/java/org/apereo/cas/config/support/authentication/U2FAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-u2f/src/main/java/org/apereo/cas/config/support/authentication/U2FAuthenticationEventExecutionPlanConfiguration.java
@@ -3,7 +3,6 @@ package org.apereo.cas.config.support.authentication;
 import org.apereo.cas.adaptors.u2f.U2FAuthenticationHandler;
 import org.apereo.cas.adaptors.u2f.U2FMultifactorAuthenticationProvider;
 import org.apereo.cas.adaptors.u2f.storage.U2FDeviceRepository;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.metadata.AuthenticationContextAttributeMetaDataPopulator;

--- a/support/cas-server-support-u2f/src/main/java/org/apereo/cas/config/support/authentication/U2FAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-u2f/src/main/java/org/apereo/cas/config/support/authentication/U2FAuthenticationEventExecutionPlanConfiguration.java
@@ -18,6 +18,7 @@ import org.apereo.cas.services.ServicesManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,10 +28,12 @@ import org.springframework.context.annotation.Lazy;
  * This is {@link U2FAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("u2fAuthenticationEventExecutionPlanConfiguration")
-public class U2FAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class U2FAuthenticationEventExecutionPlanConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;
 
@@ -82,9 +85,12 @@ public class U2FAuthenticationEventExecutionPlanConfiguration implements Authent
         return p;
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerAuthenticationHandler(u2fAuthenticationHandler());
-        plan.registerMetadataPopulator(u2fAuthenticationMetaDataPopulator());
+    @ConditionalOnMissingBean(name = "u2fAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer u2fAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            plan.registerAuthenticationHandler(u2fAuthenticationHandler());
+            plan.registerMetadataPopulator(u2fAuthenticationMetaDataPopulator());
+        };
     }
 }

--- a/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CoreWsSecuritySecurityTokenServiceConfiguration.java
+++ b/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CoreWsSecuritySecurityTokenServiceConfiguration.java
@@ -25,7 +25,6 @@ import org.apache.cxf.ws.security.sts.provider.operation.IssueOperation;
 import org.apache.cxf.ws.security.sts.provider.operation.ValidateOperation;
 import org.apache.wss4j.dom.validate.Validator;
 import org.apereo.cas.CipherExecutor;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionStrategy;

--- a/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CoreWsSecuritySecurityTokenServiceConfiguration.java
+++ b/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CoreWsSecuritySecurityTokenServiceConfiguration.java
@@ -72,12 +72,13 @@ import java.util.Properties;
  * This is {@link CoreWsSecuritySecurityTokenServiceConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("coreWsSecuritySecurityTokenServiceConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ImportResource(locations = {"classpath:jaxws-realms.xml", "classpath:META-INF/cxf/cxf.xml"})
-public class CoreWsSecuritySecurityTokenServiceConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class CoreWsSecuritySecurityTokenServiceConfiguration {
 
     @Autowired
     @Qualifier("grantingTicketExpirationPolicy")
@@ -323,8 +324,9 @@ public class CoreWsSecuritySecurityTokenServiceConfiguration implements Authenti
         return new DefaultUniqueTicketIdGenerator();
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        plan.registerMetadataPopulator(securityTokenServiceAuthenticationMetaDataPopulator());
+    @ConditionalOnMissingBean(name = "coreWsSecuritySecurityTokenServiceAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer coreWsSecuritySecurityTokenServiceAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> plan.registerMetadataPopulator(securityTokenServiceAuthenticationMetaDataPopulator());
     }
 }

--- a/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/support/wsfederation/config/support/authentication/WsFedAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/support/wsfederation/config/support/authentication/WsFedAuthenticationEventExecutionPlanConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.support.wsfederation.config.support.authentication;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -18,7 +18,6 @@ import org.apereo.cas.adaptors.x509.authentication.revocation.policy.AllowRevoca
 import org.apereo.cas.adaptors.x509.authentication.revocation.policy.DenyRevocationPolicy;
 import org.apereo.cas.adaptors.x509.authentication.revocation.policy.RevocationPolicy;
 import org.apereo.cas.adaptors.x509.authentication.revocation.policy.ThresholdExpiredCRLRevocationPolicy;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -50,6 +50,7 @@ import net.sf.ehcache.Cache;
  * This is {@link X509AuthenticationConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.0.0
  */
 @Configuration("x509AuthenticationConfiguration")
@@ -270,18 +271,11 @@ public class X509AuthenticationConfiguration {
         return new X509SerialNumberAndIssuerDNPrincipalResolver(x509.getSerialNumberPrefix(), x509.getValueDelimiter());
     }
 
-    /**
-     * The type X 509 authentication event execution plan configuration.
-     */
-    @Configuration("x509AuthenticationEventExecutionPlanConfiguration")
-    public class X509AuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
-        @Autowired
-        @Qualifier("personDirectoryPrincipalResolver")
-        private PrincipalResolver personDirectoryPrincipalResolver;
-
-        @Override
-        public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-            PrincipalResolver resolver = personDirectoryPrincipalResolver;
+    @ConditionalOnMissingBean(name = "x509AuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer x509AuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            PrincipalResolver resolver = null;
             if (casProperties.getAuthn().getX509().getPrincipalType() != null) {
                 switch (casProperties.getAuthn().getX509().getPrincipalType()) {
                     case SERIAL_NO:
@@ -301,8 +295,8 @@ public class X509AuthenticationConfiguration {
                         break;
                 }
             }
-            
+
             plan.registerAuthenticationHandlerWithPrincipalResolver(x509CredentialsAuthenticationHandler(), resolver);
-        }
+        };
     }
 }

--- a/support/cas-server-support-yubikey/src/main/java/org/apereo/cas/config/support/authentication/YubiKeyAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-yubikey/src/main/java/org/apereo/cas/config/support/authentication/YubiKeyAuthenticationEventExecutionPlanConfiguration.java
@@ -12,7 +12,6 @@ import org.apereo.cas.adaptors.yubikey.registry.OpenYubiKeyAccountRegistry;
 import org.apereo.cas.adaptors.yubikey.registry.WhitelistYubiKeyAccountRegistry;
 import org.apereo.cas.adaptors.yubikey.web.flow.YubiKeyAccountCheckRegistrationAction;
 import org.apereo.cas.adaptors.yubikey.web.flow.YubiKeyAccountSaveRegistrationAction;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationMetaDataPopulator;

--- a/support/cas-server-support-yubikey/src/main/java/org/apereo/cas/config/support/authentication/YubiKeyAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-yubikey/src/main/java/org/apereo/cas/config/support/authentication/YubiKeyAuthenticationEventExecutionPlanConfiguration.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,10 +41,12 @@ import org.springframework.webflow.execution.Action;
  * This is {@link YubiKeyAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("yubikeyAuthenticationEventExecutionPlanConfiguration")
-public class YubiKeyAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class YubiKeyAuthenticationEventExecutionPlanConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(YubiKeyAuthenticationEventExecutionPlanConfiguration.class);
 
     @Autowired
@@ -164,12 +167,15 @@ public class YubiKeyAuthenticationEventExecutionPlanConfiguration implements Aut
         return p;
     }
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
-        final MultifactorAuthenticationProperties.YubiKey yubi = casProperties.getAuthn().getMfa().getYubikey();
-        if (yubi.getClientId() > 0 && StringUtils.isNotBlank(yubi.getSecretKey())) {
-            plan.registerAuthenticationHandler(yubikeyAuthenticationHandler());
-            plan.registerMetadataPopulator(yubikeyAuthenticationMetaDataPopulator());
-        }
+    @ConditionalOnMissingBean(name = "yubikeyAuthenticationEventExecutionPlanConfigurer")
+    @Bean
+    public AuthenticationEventExecutionPlanConfigurer yubikeyAuthenticationEventExecutionPlanConfigurer() {
+        return plan -> {
+            final MultifactorAuthenticationProperties.YubiKey yubi = casProperties.getAuthn().getMfa().getYubikey();
+            if (yubi.getClientId() > 0 && StringUtils.isNotBlank(yubi.getSecretKey())) {
+                plan.registerAuthenticationHandler(yubikeyAuthenticationHandler());
+                plan.registerMetadataPopulator(yubikeyAuthenticationMetaDataPopulator());
+            }
+        };
     }
 }

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/support/authentication/AcceptUsersAuthenticationEventExecutionPlanConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/support/authentication/AcceptUsersAuthenticationEventExecutionPlanConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.config.support.authentication;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
@@ -40,7 +39,7 @@ public class AcceptUsersAuthenticationEventExecutionPlanConfiguration {
     private AuthenticationHandler acceptUsersAuthenticationHandler;
 
     @ConditionalOnMissingBean(name = "acceptUsersAuthenticationEventExecutionPlanConfigurer")
-    @Bean()
+    @Bean
     public AuthenticationEventExecutionPlanConfigurer acceptUsersAuthenticationEventExecutionPlanConfigurer() {
       return plan -> {
         if (StringUtils.isNotBlank(this.casProperties.getAuthn().getAccept().getUsers())) {

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/support/authentication/AcceptUsersAuthenticationEventExecutionPlanConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/support/authentication/AcceptUsersAuthenticationEventExecutionPlanConfiguration.java
@@ -11,20 +11,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * This is {@link AcceptUsersAuthenticationEventExecutionPlanConfiguration}.
  *
  * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
  * @since 5.1.0
  */
 @Configuration("acceptUsersAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class AcceptUsersAuthenticationEventExecutionPlanConfiguration implements AuthenticationEventExecutionPlanConfigurer {
+public class AcceptUsersAuthenticationEventExecutionPlanConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(AcceptUsersAuthenticationEventExecutionPlanConfiguration.class);
-    
+
     @Autowired
     private CasConfigurationProperties casProperties;
 
@@ -36,16 +39,19 @@ public class AcceptUsersAuthenticationEventExecutionPlanConfiguration implements
     @Qualifier("acceptUsersAuthenticationHandler")
     private AuthenticationHandler acceptUsersAuthenticationHandler;
 
-    @Override
-    public void configureAuthenticationExecutionPlan(final AuthenticationEventExecutionPlan plan) {
+    @ConditionalOnMissingBean(name = "acceptUsersAuthenticationEventExecutionPlanConfigurer")
+    @Bean()
+    public AuthenticationEventExecutionPlanConfigurer acceptUsersAuthenticationEventExecutionPlanConfigurer() {
+      return plan -> {
         if (StringUtils.isNotBlank(this.casProperties.getAuthn().getAccept().getUsers())) {
-            final String header =
-                    "\nCAS is configured to accept a static list of credentials for authentication. "
-                            + "While this is generally useful for demo purposes, it is STRONGLY recommended "
-                            + "that you DISABLE this authentication method (by setting 'cas.authn.accept.users' "
-                            + "to a blank value) and switch to a mode that is more suitable for production.";
-            AsciiArtUtils.printAsciiArtWarning(LOGGER, "STOP!", header);
-            plan.registerAuthenticationHandlerWithPrincipalResolver(acceptUsersAuthenticationHandler, personDirectoryPrincipalResolver);
+          final String header =
+            "\nCAS is configured to accept a static list of credentials for authentication. "
+              + "While this is generally useful for demo purposes, it is STRONGLY recommended "
+              + "that you DISABLE this authentication method (by setting 'cas.authn.accept.users' "
+              + "to a blank value) and switch to a mode that is more suitable for production.";
+          AsciiArtUtils.printAsciiArtWarning(LOGGER, "STOP!", header);
+          plan.registerAuthenticationHandlerWithPrincipalResolver(acceptUsersAuthenticationHandler, personDirectoryPrincipalResolver);
         }
+      };
     }
 }


### PR DESCRIPTION
This refactoring moves `AuthenticationEventExecutionPlanConfigurer`s from `@Configuration` classes implementing it themselves into top level `@Conditional` beans. This enables critical "configuration extension points" for all the modules contributing to CAS' authentication subsystem in cases where custom mappings of `handler -> principal resolver` are desired.