### PR TITLE
allow hibernate specific properties

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
@@ -1,5 +1,8 @@
 package org.apereo.cas.configuration.model.support.jpa;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.configuration.model.support.ConnectionPoolingProperties;
 import org.apereo.cas.configuration.support.Beans;
@@ -23,6 +26,7 @@ public abstract class AbstractJpaProperties {
     private String healthQuery = StringUtils.EMPTY;
     private String idleTimeout = "PT10M";
     private String dataSourceName;
+    private Map<String, String> properties = new HashMap<String, String>();
 
     private ConnectionPoolingProperties pool = new ConnectionPoolingProperties();
 
@@ -176,5 +180,13 @@ public abstract class AbstractJpaProperties {
 
     public void setDataSourceProxy(final boolean dataSourceProxy) {
         this.dataSourceProxy = dataSourceProxy;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(final Map<String, String> properties) {
+        this.properties = properties;
     }
 }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/support/Beans.java
@@ -265,6 +265,7 @@ public final class Beans {
         if (StringUtils.isNotBlank(jpaProperties.getDefaultSchema())) {
             properties.put("hibernate.default_schema", jpaProperties.getDefaultSchema());
         }
+        properties.putAll(jpaProperties.getProperties());
         bean.setJpaProperties(properties);
         bean.getJpaPropertyMap().put("hibernate.enable_lazy_load_no_trans", Boolean.TRUE);
         return bean;

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3677,6 +3677,8 @@ To learn more about this topic, [please review this guide](JPA-Service-Managemen
 # cas.serviceRegistry.jpa.pool.maxWait=2000
 ```
 
+Database-specific properties can be specified under cas.serviceRegistry.jpa.properties, similar to Spring Boot JPA properties.
+
 ## Ticket Registry
 
 To learn more about this topic, [please review this guide](Configuring-Ticketing-Components.html).
@@ -3736,6 +3738,8 @@ To learn more about this topic, [please review this guide](JPA-Ticket-Registry.h
 # cas.ticket.registry.jpa.crypto.encryption.keySize=16
 # cas.ticket.registry.jpa.crypto.alg=AES
 ```
+
+Database-specific properties can be specified under cas.ticket.registry.jpa.properties, similar to Spring Boot JPA properties.
 
 ### Couchbase Ticket Registry
 


### PR DESCRIPTION
added the ability to specify hibernate-specific properties, similar to standard spring boot jpa settings

Example: cas.serviceRegistry.jpa.properties.hibernate.globally_quoted_identifiers=true

This setting specifically allows the service management overlay to work against a mysql database.  The SamlRegisteredService_AttributeNameFormats object contains a field named 'key', which prevents MySQL from being used.  Instructing hibernate to quote all identifiers allows this to work without any modification to the code.  This could also be useful for any other hibernate-specific settings without the need to add further custom properties and property support.  This also follows existing spring boot conventions for custom hibernate properties.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
