### PR TITLE
Removing refresh token generation when using grant type 'refresh_token'.

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
@@ -52,7 +52,16 @@ public class AccessTokenAuthorizationCodeGrantRequestExtractor extends BaseAcces
         if (token == null) {
             throw new InvalidTicketException(getOAuthParameter());
         }
-        return new AccessTokenRequestDataHolder(token, registeredService, getGrantType());
+        return new AccessTokenRequestDataHolder(token, registeredService, getGrantType(), isAllowedToGenerateRefreshToken());
+    }
+    
+    /**
+     * Is allowed to generate refresh token ?
+     *
+     * @return the boolean
+     */
+    protected boolean isAllowedToGenerateRefreshToken() {
+        return true;
     }
 
     protected String getOAuthParameterName() {

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenRefreshTokenGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenRefreshTokenGrantRequestExtractor.java
@@ -34,6 +34,11 @@ public class AccessTokenRefreshTokenGrantRequestExtractor extends AccessTokenAut
     protected String getOAuthParameterName() {
         return OAuth20Constants.REFRESH_TOKEN;
     }
+    
+    @Override
+    protected boolean isAllowedToGenerateRefreshToken() {
+        return false;
+    }
 
     @Override
     public boolean supports(final HttpServletRequest context) {

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenRequestDataHolder.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenRequestDataHolder.java
@@ -29,35 +29,38 @@ public class AccessTokenRequestDataHolder {
 
     public AccessTokenRequestDataHolder(final OAuthToken token,
                                         final OAuthRegisteredService registeredService,
-                                        final OAuth20GrantTypes grantType) {
-        this(token.getService(), token.getAuthentication(), token, registeredService, grantType);
+                                        final OAuth20GrantTypes grantType,
+                                        final boolean isAllowedToGenerateRefreshToken) {
+        this(token.getService(), token.getAuthentication(), token, registeredService, grantType, isAllowedToGenerateRefreshToken);
     }
 
     public AccessTokenRequestDataHolder(final Service service, final Authentication authentication,
                                         final OAuthToken token,
                                         final OAuthRegisteredService registeredService,
-                                        final OAuth20GrantTypes grantType) {
-        this(service, authentication, registeredService, token, null, grantType);
+                                        final OAuth20GrantTypes grantType,
+                                        final boolean isAllowedToGenerateRefreshToken) {
+        this(service, authentication, registeredService, token, null, grantType, isAllowedToGenerateRefreshToken);
     }
 
     public AccessTokenRequestDataHolder(final Service service, final Authentication authentication,
                                         final OAuthRegisteredService registeredService,
                                         final TicketGrantingTicket ticketGrantingTicket,
                                         final OAuth20GrantTypes grantType) {
-        this(service, authentication, registeredService, null, ticketGrantingTicket, grantType);
+        this(service, authentication, registeredService, null, ticketGrantingTicket, grantType, true);
     }
 
     private AccessTokenRequestDataHolder(final Service service, final Authentication authentication,
                                         final OAuthRegisteredService registeredService,
                                         final OAuthToken token,
                                         final TicketGrantingTicket ticketGrantingTicket,
-                                        final OAuth20GrantTypes grantType) {
+                                        final OAuth20GrantTypes grantType,
+                                        final boolean isAllowedToGenerateRefreshToken) {
         this.service = service;
         this.authentication = authentication;
         this.registeredService = registeredService;
         this.ticketGrantingTicket = token != null ? token.getGrantingTicket() : ticketGrantingTicket;
         this.token = token;
-        this.generateRefreshToken = registeredService != null && registeredService.isGenerateRefreshToken();
+        this.generateRefreshToken = isAllowedToGenerateRefreshToken ? (registeredService != null && registeredService.isGenerateRefreshToken()) : false;
         this.grantType = grantType;
     }
 

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -684,7 +684,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         final AccessToken accessToken = this.ticketRegistry.getTicket(accessTokenId, AccessToken.class);
         assertEquals(principal, accessToken.getAuthentication().getPrincipal());
 
-        final int timeLeft = getTimeLeft(body, service.isGenerateRefreshToken(), json);
+        final int timeLeft = getTimeLeft(body, false, json);
         assertTrue(timeLeft >= TIMEOUT - 10 - DELTA);
     }
 

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -670,17 +670,13 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         if (json) {
             assertEquals("application/json", mockResponse.getContentType());
             assertTrue(body.contains('"' + OAuth20Constants.ACCESS_TOKEN + "\":\"AT-"));
-            if (service.isGenerateRefreshToken()) {
-                assertTrue(body.contains('"' + OAuth20Constants.REFRESH_TOKEN + "\":\"RT-"));
-            }
+            assertFalse(body.contains('"' + OAuth20Constants.REFRESH_TOKEN + "\":\"RT-"));
             assertTrue(body.contains('"' + OAuth20Constants.EXPIRES_IN + "\":"));
             accessTokenId = StringUtils.substringBetween(body, OAuth20Constants.ACCESS_TOKEN + "\":\"", "\",\"");
         } else {
             assertEquals("text/plain", mockResponse.getContentType());
             assertTrue(body.contains(OAuth20Constants.ACCESS_TOKEN + '='));
-            if (service.isGenerateRefreshToken()) {
-                assertTrue(body.contains(OAuth20Constants.REFRESH_TOKEN + '='));
-            }
+            assertFalse(body.contains(OAuth20Constants.REFRESH_TOKEN + '='));
             assertTrue(body.contains(OAuth20Constants.EXPIRES_IN + '='));
             accessTokenId = StringUtils.substringBetween(body, OAuth20Constants.ACCESS_TOKEN + '=', "&");
         }


### PR DESCRIPTION
Fix for #2731 commited in rev. cf38394 introduced a new bug. After the fix refresh token is generated for all grant types, including refresh_token grant type, which is wrong.
This fix removes refresh token generation for "refresh_token" grant type.