### PR TITLE
jwt authentication should accept base64 encoded keys

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -109,7 +109,7 @@ reflectionsVersion=0.9.11
 guavaVersion=22.0
 
 pac4jSpringWebmvcVersion=2.0.0
-pac4jVersion=2.0.0
+pac4jVersion=2.1.0-SNAPSHOT
 
 dropwizardMetricsSpringVersion=3.1.3
 amazonSdkVersion=1.11.155

--- a/support/cas-server-support-token-core/src/main/java/org/apereo/cas/token/TokenConstants.java
+++ b/support/cas-server-support-token-core/src/main/java/org/apereo/cas/token/TokenConstants.java
@@ -41,5 +41,12 @@ public interface TokenConstants {
      * Jwt encryption secret method defined for a given service.
      **/
     String PROPERTY_NAME_TOKEN_SECRET_ENCRYPTION_METHOD = "jwtEncryptionSecretMethod";
+
+
+    /**
+     * Secrets are Base64 encoded.
+     **/
+    String PROPERTY_NAME_TOKEN_SECRETS_ARE_BASE64_ENCODED = "jwtSecretsAreBase64Encoded";
+
 }
 


### PR DESCRIPTION
See https://github.com/pac4j/pac4j/issues/946 for details


Added new service property  "jwtSecretsAreBase64Encoded" as boolean value. Default or missing value is *false*. Property set to *true* implies the secrets are Base64 encoded just like proposed by key generator tool. The modification expects newer version >=2.1.0-SNAPSHOT of pac4j-jwt 

See also https://github.com/pac4j/pac4j/pull/951 for even more details

Usage:

```json
  "jwtSecretsAreBase64Encoded": {
            "@class": "org.apereo.cas.services.DefaultRegisteredServiceProperty",
            "values": [
                "java.util.HashSet",
                [
                    "true"
                ]
            ]
        }
```

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
