### PR TITLE
Added `dupclient` repository (still required)

### DIFF
--- a/docs/cas-server-documentation/installation/DuoSecurity-Authentication.md
+++ b/docs/cas-server-documentation/installation/DuoSecurity-Authentication.md
@@ -31,6 +31,10 @@ You may need to add the following repositories to the WAR overlay:
     <id>duo</id>
     <url>https://dl.bintray.com/uniconiam/maven</url>
 </repository>
+<repository>
+    <id>dupclient</id>
+    <url>https://jitpack.io</url>
+</repository>
 ```
 
 ## Configuration


### PR DESCRIPTION
Build fails with `Could not find com.github.duosecurity:duo_client_java:${project.'cas.version'}` if this repository is not specified.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
