### PR TITLE
Makes tickets stored in MongoDb expire automatically

### DIFF
--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -18,6 +18,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -207,8 +208,20 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
         return count.get();
     }
 
-    private static int getTimeToLive(final Ticket ticket) {
-        return ticket.getExpirationPolicy().getTimeToLive().intValue();
+    /**
+     * Calculate the time at which the ticket is eligible for automatic deletion by MongoDb.
+     * Makes the assumption that the CAS server date and the Mongo server date are in sync.
+     */
+    private static Date getExpireAt(final Ticket ticket) {
+        final int ttl = ticket.getExpirationPolicy().getTimeToLive().intValue();
+        
+        // expiration policy can specify not to delete automatically 
+        if (ttl < 1) {
+            return null;
+        }
+        
+        final Date expireAt = new Date(System.currentTimeMillis() + (ttl * 1000));
+        return expireAt;
     }
 
     private static String serializeTicketForMongoDocument(final Ticket ticket) {
@@ -229,8 +242,8 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
         final String json = serializeTicketForMongoDocument(encTicket);
         if (StringUtils.isNotBlank(json)) {
             LOGGER.trace("Serialized ticket into a JSON document as \n [{}]", JsonValue.readJSON(json).toString(Stringify.FORMATTED));
-            final int timeToLive = getTimeToLive(ticket);
-            return new TicketHolder(json, encTicket.getId(), encTicket.getClass().getName(), timeToLive);
+            final Date expireAt = getExpireAt(ticket);
+            return new TicketHolder(json, encTicket.getId(), encTicket.getClass().getName(), expireAt);
         }
         throw new IllegalArgumentException("Ticket " + ticket.getId() + " cannot be serialized to JSON");
     }

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/TicketHolder.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/TicketHolder.java
@@ -1,8 +1,9 @@
 package org.apereo.cas.ticket.registry;
 
-import org.springframework.data.mongodb.core.index.Indexed;
-
 import java.io.Serializable;
+import java.util.Date;
+
+import org.springframework.data.mongodb.core.index.Indexed;
 
 /**
  * This is {@link TicketHolder}.
@@ -29,10 +30,10 @@ public class TicketHolder implements Serializable {
     private final String type;
 
     @Indexed
-    private final long expireAt;
+    private final Date expireAt;
 
     public TicketHolder(final String json, final String ticketId,
-                        final String type, final long expireAt) {
+                        final String type, final Date expireAt) {
         this.json = json;
         this.ticketId = ticketId;
         this.type = type;
@@ -51,7 +52,7 @@ public class TicketHolder implements Serializable {
         return type;
     }
 
-    public long getExpireAt() {
+    public Date getExpireAt() {
         return expireAt;
     }
 


### PR DESCRIPTION
Makes tickets stored in MongoDb expire automatically by setting the expireAt field to be a date type.

Previously it was being set to the ticket's TTL so the Mongo index for auto-deletion had no effect.
This change assumes that the CAS and Mongo server dates are in sync.  If they are not, tickets may be deleted from MongoDb earlier than expected (solution would seem to be to set ticket.getProperties().getStorageTimeout() appropriately).

Closes #2748 
