### PR TITLE
fixes wrong info

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -737,10 +737,10 @@ The following mergeing strategies can be used to resolve conflicts when the same
 Static attributes that need to be mapped to a hardcoded value belong here.
 
 ```properties
-# cas.authn.attributeRepository.stub[0].attributes.uid=uid
-# cas.authn.attributeRepository.stub[0].attributes.displayName=displayName
-# cas.authn.attributeRepository.stub[0].attributes.cn=commonName
-# cas.authn.attributeRepository.stub[0].attributes.affiliation=groupMembership
+# cas.authn.attributeRepository.stub.attributes.uid=uid
+# cas.authn.attributeRepository.stub.attributes.displayName=displayName
+# cas.authn.attributeRepository.stub.attributes.cn=commonName
+# cas.authn.attributeRepository.stub.attributes.affiliation=groupMembership
 ```
 
 ### LDAP


### PR DESCRIPTION
using [0] gives an error because the property is not of array-type (5.1.1)


