### PR TITLE
Returning correct expires_in value for access token (#2644)

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AccessTokenEndpointController.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AccessTokenEndpointController.java
@@ -158,7 +158,7 @@ public class OAuth20AccessTokenEndpointController extends BaseOAuth20Controller 
                 responseHolder.getRegisteredService(),
                 responseHolder.getService(),
                 accessToken, refreshToken,
-                casProperties.getTicket().getTgt().getTimeToKillInSeconds(), type);
+                casProperties.getAuthn().getOauth().getAccessToken().getMaxTimeToLiveInSeconds(), type);
     }
 
     private static OAuth20ResponseTypes getOAuth20ResponseType(final J2EContext context) {

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -400,7 +400,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
             if (refreshToken) {
                 assertTrue(body.contains('"' + OAuth20Constants.REFRESH_TOKEN + "\":\"RT-"));
             }
-            assertTrue(body.contains('"' + OAuth20Constants.EXPIRES_IN + "\":7"));
+            assertTrue(body.contains('"' + OAuth20Constants.EXPIRES_IN + "\":"));
             accessTokenId = StringUtils.substringBetween(body, OAuth20Constants.ACCESS_TOKEN + "\":\"", "\",\"");
         } else {
             assertEquals(MediaType.TEXT_PLAIN_VALUE, mockResponse.getContentType());
@@ -548,7 +548,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
             if (refreshToken) {
                 assertTrue(body.contains('"' + OAuth20Constants.REFRESH_TOKEN + "\":\"RT-"));
             }
-            assertTrue(body.contains('"' + OAuth20Constants.EXPIRES_IN + "\":7"));
+            assertTrue(body.contains('"' + OAuth20Constants.EXPIRES_IN + "\":"));
             accessTokenId = StringUtils.substringBetween(body, OAuth20Constants.ACCESS_TOKEN + "\":\"", "\",\"");
         } else {
             assertEquals("text/plain", mockResponse.getContentType());
@@ -671,7 +671,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
             assertEquals("application/json", mockResponse.getContentType());
             assertTrue(body.contains('"' + OAuth20Constants.ACCESS_TOKEN + "\":\"AT-"));
             assertFalse(body.contains('"' + OAuth20Constants.REFRESH_TOKEN + "\":\"RT-"));
-            assertTrue(body.contains('"' + OAuth20Constants.EXPIRES_IN + "\":7"));
+            assertTrue(body.contains('"' + OAuth20Constants.EXPIRES_IN + "\":"));
             accessTokenId = StringUtils.substringBetween(body, OAuth20Constants.ACCESS_TOKEN + "\":\"", "\",\"");
         } else {
             assertEquals("text/plain", mockResponse.getContentType());


### PR DESCRIPTION
Closes #2644 in 5.1.x.
Returning correct expires_in value for access token.