### PR TITLE
Revert mismatch ticket registry configuration

### DIFF
--- a/support/cas-server-support-couchbase-ticket-registry/src/main/resources/META-INF/spring.factories
+++ b/support/cas-server-support-couchbase-ticket-registry/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.config.MongoDbTicketRegistryConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.config.CouchbaseTicketRegistryConfiguration


### PR DESCRIPTION
Reverts incorrect ticket registry configuration on `apereo:5.1.x` branch introduced in 6ae24ed.

Closes #2638