### PR TITLE
#2711 support delegation clients redirecting via /delegatedAuthn context path

### DIFF
--- a/support/cas-server-support-audit-jdbc/build.gradle
+++ b/support/cas-server-support-audit-jdbc/build.gradle
@@ -3,8 +3,6 @@ dependencies {
 	compile project(":api:cas-server-core-api")
     implementation libraries.pac4j
     implementation libraries.persondirectory
-    
-
     compile project(":core:cas-server-core-util")
     provided project(":core:cas-server-core-audit")
     testImplementation project(":core:cas-server-core-services")

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/config/DelegatedClientEndpointConfiguration.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/config/DelegatedClientEndpointConfiguration.java
@@ -1,0 +1,27 @@
+package org.apereo.cas.support.pac4j.web.config;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.support.pac4j.web.controllers.DelegatedClientEndpointController;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Endpoint configuration
+ *
+ * @author Ghenadii Batalski
+ * @since 5.2.0
+ */
+@Configuration("delegatedClientEndpointConfiguration")
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class DelegatedClientEndpointConfiguration {
+
+    @RefreshScope
+    @Bean
+    @Lazy
+    public DelegatedClientEndpointController creDelegatedClientEndpointController(){
+         return new DelegatedClientEndpointController();
+    }
+}

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/config/DelegatedClientEndpointConfiguration.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/config/DelegatedClientEndpointConfiguration.java
@@ -21,7 +21,7 @@ public class DelegatedClientEndpointConfiguration {
     @RefreshScope
     @Bean
     @Lazy
-    public DelegatedClientEndpointController creDelegatedClientEndpointController(){
+    public DelegatedClientEndpointController createDelegatedClientEndpointController(){
          return new DelegatedClientEndpointController();
     }
 }

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/controllers/DelegatedClientEndpointController.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/controllers/DelegatedClientEndpointController.java
@@ -1,0 +1,31 @@
+package org.apereo.cas.support.pac4j.web.controllers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ *
+ * Processes delegation response over /delegatedAuthn/ context path
+ * <p>
+ * This controller extracts the client name from the context path, enriches the request by client_name attribute
+ * and forwards it for further processing by the webflow for /login?client_name </p>
+ *
+ * @see org.apereo.cas.support.pac4j.web.flow.DelegatedClientAuthenticationAction
+ *
+ * @author Ghenadii Batalski
+ * @since 5.2.0
+ */
+@Controller
+public class DelegatedClientEndpointController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelegatedClientEndpointController.class);
+
+   @RequestMapping("/delegatedAuthn/{clientType}/{clientName}")
+    public ModelAndView delegateAuthnClient(@PathVariable String clientType, @PathVariable String clientName, ModelMap model) {
+       return new ModelAndView("forward:/login?client_name="+clientName, model);
+    }
+}

--- a/support/cas-server-support-pac4j-core-clients/src/main/resources/META-INF/spring.factories
+++ b/support/cas-server-support-pac4j-core-clients/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.support.pac4j.web.config.DelegatedClientEndpointConfiguration

--- a/support/cas-server-support-token-authentication/build.gradle
+++ b/support/cas-server-support-token-authentication/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation project(":core:cas-server-core")
     testImplementation project(":core:cas-server-core-logout")
     testImplementation project(":support:cas-server-support-cookie")
+    testImplementation project(path: ":core:cas-server-core-services", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-authentication", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-util", configuration: "tests")
 }

--- a/support/cas-server-support-token-authentication/src/test/java/org/apereo/cas/token/authentication/TokenAuthenticationHandlerTests.java
+++ b/support/cas-server-support-token-authentication/src/test/java/org/apereo/cas/token/authentication/TokenAuthenticationHandlerTests.java
@@ -63,8 +63,8 @@ import static org.junit.Assert.*;
         TokenAuthenticationConfiguration.class})
 public class TokenAuthenticationHandlerTests {
 
-    private static final String signingSecret = RandomStringUtils.randomAlphanumeric(256);
-    private static final String encryptionSecret = RandomStringUtils.randomAlphanumeric(48);
+    private static final String SIGNING_SECRET = RandomStringUtils.randomAlphanumeric(256);
+    private static final String ENCRYPTION_SECRET = RandomStringUtils.randomAlphanumeric(48);
 
     @Autowired
     @Qualifier("tokenAuthenticationHandler")
@@ -73,8 +73,8 @@ public class TokenAuthenticationHandlerTests {
     @Test
     public void verifyKeysAreSane() throws Exception {
         final JwtGenerator<CommonProfile> g = new JwtGenerator<>();
-        g.setSignatureConfiguration(new SecretSignatureConfiguration(signingSecret, JWSAlgorithm.HS256));
-        g.setEncryptionConfiguration(new SecretEncryptionConfiguration(encryptionSecret,
+        g.setSignatureConfiguration(new SecretSignatureConfiguration(SIGNING_SECRET, JWSAlgorithm.HS256));
+        g.setEncryptionConfiguration(new SecretEncryptionConfiguration(ENCRYPTION_SECRET,
                 JWEAlgorithm.DIR, EncryptionMethod.A192CBC_HS384));
 
         final CommonProfile profile = new CommonProfile();
@@ -86,7 +86,7 @@ public class TokenAuthenticationHandlerTests {
         assertEquals(result.getPrincipal().getId(), profile.getId());
     }
 
-    @Configuration
+    @Configuration("TokenAuthenticationTests")
     public static class TokenAuthenticationTests {
         @Bean
         public List inMemoryRegisteredServices() {
@@ -94,11 +94,11 @@ public class TokenAuthenticationHandlerTests {
             svc.setAttributeReleasePolicy(new ReturnAllAttributeReleasePolicy());
 
             DefaultRegisteredServiceProperty p = new DefaultRegisteredServiceProperty();
-            p.addValue(signingSecret);
+            p.addValue(SIGNING_SECRET);
             svc.getProperties().put(TokenConstants.PROPERTY_NAME_TOKEN_SECRET_SIGNING, p);
 
             p = new DefaultRegisteredServiceProperty();
-            p.addValue(encryptionSecret);
+            p.addValue(ENCRYPTION_SECRET);
             svc.getProperties().put(TokenConstants.PROPERTY_NAME_TOKEN_SECRET_ENCRYPTION, p);
 
             final List l = new ArrayList();

--- a/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/DefaultTokenRequestExtractor.java
+++ b/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/DefaultTokenRequestExtractor.java
@@ -1,0 +1,23 @@
+package org.apereo.cas.web;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.token.TokenConstants;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This is {@link DefaultTokenRequestExtractor}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.2.0
+ */
+public class DefaultTokenRequestExtractor implements TokenRequestExtractor {
+    @Override
+    public String extract(final HttpServletRequest request) {
+        String authTokenValue = request.getParameter(TokenConstants.PARAMETER_NAME_TOKEN);
+        if (StringUtils.isBlank(authTokenValue)) {
+            authTokenValue = request.getHeader(TokenConstants.PARAMETER_NAME_TOKEN);
+        }
+        return authTokenValue;
+    }
+}

--- a/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/TokenRequestExtractor.java
+++ b/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/TokenRequestExtractor.java
@@ -1,0 +1,21 @@
+package org.apereo.cas.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This is {@link TokenRequestExtractor}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.2.0
+ */
+@FunctionalInterface
+public interface TokenRequestExtractor {
+
+    /**
+     * Extract string.
+     *
+     * @param request the request
+     * @return the string
+     */
+    String extract(HttpServletRequest request);
+}

--- a/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/flow/TokenAuthenticationAction.java
+++ b/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/flow/TokenAuthenticationAction.java
@@ -7,8 +7,8 @@ import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceAccessStrategyUtils;
 import org.apereo.cas.services.ServicesManager;
-import org.apereo.cas.token.TokenConstants;
 import org.apereo.cas.token.authentication.TokenCredential;
+import org.apereo.cas.web.TokenRequestExtractor;
 import org.apereo.cas.web.flow.resolver.CasDelegatingWebflowEventResolver;
 import org.apereo.cas.web.flow.resolver.CasWebflowEventResolver;
 import org.apereo.cas.web.support.WebUtils;
@@ -31,24 +31,23 @@ public class TokenAuthenticationAction extends AbstractNonInteractiveCredentials
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TokenAuthenticationAction.class);
 
+    private final TokenRequestExtractor tokenRequestExtractor;
     private final ServicesManager servicesManager;
 
     public TokenAuthenticationAction(final CasDelegatingWebflowEventResolver initialAuthenticationAttemptWebflowEventResolver,
                                      final CasWebflowEventResolver serviceTicketRequestWebflowEventResolver,
-                                     final AdaptiveAuthenticationPolicy adaptiveAuthenticationPolicy, 
+                                     final AdaptiveAuthenticationPolicy adaptiveAuthenticationPolicy,
+                                     final TokenRequestExtractor tokenRequestExtractor,
                                      final ServicesManager servicesManager) {
         super(initialAuthenticationAttemptWebflowEventResolver, serviceTicketRequestWebflowEventResolver, adaptiveAuthenticationPolicy);
+        this.tokenRequestExtractor = tokenRequestExtractor;
         this.servicesManager = servicesManager;
     }
 
     @Override
     protected Credential constructCredentialsFromRequest(final RequestContext requestContext) {
         final HttpServletRequest request = WebUtils.getHttpServletRequest(requestContext);
-
-        String authTokenValue = request.getParameter(TokenConstants.PARAMETER_NAME_TOKEN);
-        if (StringUtils.isBlank(authTokenValue)) {
-            authTokenValue = request.getHeader(TokenConstants.PARAMETER_NAME_TOKEN);
-        }
+        final String authTokenValue = this.tokenRequestExtractor.extract(request);
         final Service service = WebUtils.getService(requestContext);
 
         if (StringUtils.isNotBlank(authTokenValue) && service != null) {

--- a/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/flow/config/TokenAuthenticationWebflowConfiguration.java
+++ b/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/flow/config/TokenAuthenticationWebflowConfiguration.java
@@ -3,6 +3,8 @@ package org.apereo.cas.web.flow.config;
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.web.DefaultTokenRequestExtractor;
+import org.apereo.cas.web.TokenRequestExtractor;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
 import org.apereo.cas.web.flow.TokenAuthenticationAction;
 import org.apereo.cas.web.flow.TokenWebflowConfigurer;
@@ -57,11 +59,18 @@ public class TokenAuthenticationWebflowConfiguration {
         return new TokenWebflowConfigurer(flowBuilderServices, loginFlowDefinitionRegistry);
     }
 
+    @Bean
+    @ConditionalOnMissingBean(name = "tokenRequestExtractor")
+    public TokenRequestExtractor tokenRequestExtractor() {
+        return new DefaultTokenRequestExtractor();
+    }
 
     @Bean
+    @ConditionalOnMissingBean(name = "tokenAuthenticationAction")
     public Action tokenAuthenticationAction() {
         return new TokenAuthenticationAction(initialAuthenticationAttemptWebflowEventResolver,
                 serviceTicketRequestWebflowEventResolver,
-                adaptiveAuthenticationPolicy, servicesManager);
+                adaptiveAuthenticationPolicy,
+                tokenRequestExtractor(), servicesManager);
     }
 }

--- a/support/cas-server-support-token-webflow/src/test/java/org/apereo/cas/web/DefaultTokenRequestExtractorTests.java
+++ b/support/cas-server-support-token-webflow/src/test/java/org/apereo/cas/web/DefaultTokenRequestExtractorTests.java
@@ -1,0 +1,42 @@
+package org.apereo.cas.web;
+
+import org.apereo.cas.token.TokenConstants;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.Assert.*;
+
+/**
+ * This is {@link DefaultTokenRequestExtractorTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.2.0
+ */
+public class DefaultTokenRequestExtractorTests {
+
+    @Test
+    public void verifyTokenFromParameter() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter(TokenConstants.PARAMETER_NAME_TOKEN, "test");
+        final DefaultTokenRequestExtractor e = new DefaultTokenRequestExtractor();
+        final String token = e.extract(request);
+        assertEquals(token, "test");
+    }
+
+    @Test
+    public void verifyTokenFromHeader() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(TokenConstants.PARAMETER_NAME_TOKEN, "test");
+        final DefaultTokenRequestExtractor e = new DefaultTokenRequestExtractor();
+        final String token = e.extract(request);
+        assertEquals(token, "test");
+    }
+
+    @Test
+    public void verifyTokenNotFound() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final DefaultTokenRequestExtractor e = new DefaultTokenRequestExtractor();
+        final String token = e.extract(request);
+        assertNull(token);
+    }
+}


### PR DESCRIPTION
See https://github.com/apereo/cas/issues/2711 for details

Closes #2711 

This is the counterpart to https://github.com/pac4j/pac4j/pull/956 .

@mmoayyed  please take a look at this. The solution is quite simple: pac4j generates a callback url in form: `/delegatedAuthn/<clientType>/<clientName>` eg. `/delegatedAuthn/oidc/AzureAdClient1`

The newly proposed `DelegatedClientEndpointController` extracts the `clientName` from callback context path and forwards the request to `login` webflow enriching it by `client_name=<clientName>` url parameter  The DelegatedClientAuthenticationAction may complete the work now. It is not the elegant solution, because i'm not familiar with Spring MVC/ Spring Webflow, but the simple, self contained and one successfully tested by me :-)

I could improve the error handling by checking of the correctness of clientType and not emptieness of client_name, but this should be already done by Spring MVC and DelegatedClientAuthenticationAction respectively. Both (Spring MVC and DelegatedClientAuthenticationAction) already do the error handling much better, i think.

Could one please take a look at this proposal and give me a feedback? As i already mentioned, i've successfully testet the solution containing this patch and https://github.com/pac4j/pac4j/pull/956 . 

Regards, Gena
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
