### PR TITLE
Replace IllegalStateException with log messages.

### DIFF
--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authorization/LdapUserAttributesToRolesAuthorizationGenerator.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/authorization/LdapUserAttributesToRolesAuthorizationGenerator.java
@@ -52,16 +52,16 @@ public class LdapUserAttributesToRolesAuthorizationGenerator extends BaseUseAttr
 
     @Override
     protected CommonProfile generateAuthorizationForLdapEntry(final CommonProfile profile, final LdapEntry userEntry) {
-        if (userEntry.getAttributes().isEmpty()) {
-            throw new IllegalStateException("No attributes are retrieved for this user.");
+        if (!userEntry.getAttributes().isEmpty()) {
+            final LdapAttribute attribute = userEntry.getAttribute(this.roleAttribute);
+            if (attribute != null) {
+                addProfileRoles(userEntry, profile, attribute, this.rolePrefix);
+            } else {
+                LOGGER.warn("Configured role attribute cannot be found for this user");
+            }
+        } else {
+            LOGGER.warn("No attributes are retrieved for this user.");
         }
-
-        final LdapAttribute attribute = userEntry.getAttribute(this.roleAttribute);
-        if (attribute == null) {
-            throw new IllegalStateException("Configured role attribute cannot be found for this user");
-        }
-
-        addProfileRoles(userEntry, profile, attribute, this.rolePrefix);
         return profile;
     }
 }


### PR DESCRIPTION
When no attributes are returned for the user or
when configured role attribute can not be found,
instead of throwing IllegalStateException, log the
appropriate message and return the (unmodified) profile.

(That's, also, how generateAuthorizationForLdapEntry in
LdapUserGroupsToRolesAuthorizationGenerator handles
similar cases.)
With this change, cas-management shows correctly the
authorizationFailure view instead of throwing

> The CAS management webapp is unavailable.
