### PR TITLE
Using streams in Hazelcast, MongoDb and Redis ticket registries

### DIFF
--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -107,7 +107,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements C
                 .map(this::getTicketMapInstanceByMetadata)
                 .filter(Objects::nonNull)
                 .mapToInt(instance -> {
-                    int size = instance.size();
+                    final int size = instance.size();
                     instance.evictAll();
                     instance.clear();
                     return size;

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -29,8 +29,10 @@ import java.util.stream.Collectors;
  * @since 5.1.0
  */
 public class MongoDbTicketRegistry extends AbstractTicketRegistry {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbTicketRegistry.class);
     private static final String FIELD_NAME_EXPIRE_AFTER_SECONDS = "expireAfterSeconds";
+    private static final Query SELECT_ALL_NAMES_QUERY = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).regex(".+"));
 
     private final boolean dropCollection;
     private final TicketCatalog ticketCatalog;
@@ -187,9 +189,8 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
                 .map(this::getTicketCollectionInstanceByMetadata)
                 .filter(StringUtils::isNotBlank)
                 .mapToLong(collectionName -> {
-                    final Query query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).regex(".+"));
-                    final long countTickets = this.mongoTemplate.count(query, collectionName);
-                    mongoTemplate.remove(query, collectionName);
+                    final long countTickets = this.mongoTemplate.count(SELECT_ALL_NAMES_QUERY, collectionName);
+                    mongoTemplate.remove(SELECT_ALL_NAMES_QUERY, collectionName);
                     return countTickets;
                 })
                 .sum();

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -187,10 +187,10 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
                 .map(this::getTicketCollectionInstanceByMetadata)
                 .filter(StringUtils::isNotBlank)
                 .mapToLong(collectionName -> {
-                        final Query query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).regex(".+"));
-                        final long countTickets = this.mongoTemplate.count(query, collectionName);
-                        mongoTemplate.remove(query, collectionName);
-                        return countTickets;
+                    final Query query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).regex(".+"));
+                    final long countTickets = this.mongoTemplate.count(query, collectionName);
+                    mongoTemplate.remove(query, collectionName);
+                    return countTickets;
                 })
                 .sum();
     }
@@ -201,7 +201,7 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
      */
     private static Date getExpireAt(final Ticket ticket) {
         final int ttl = ticket.getExpirationPolicy().getTimeToLive().intValue();
-        
+
         // expiration policy can specify not to delete automatically
         if (ttl < 1) {
             return null;

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -183,16 +183,16 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public long deleteAll() {
-        return ticketCatalog.findAll().stream()
+        return this.ticketCatalog.findAll().stream()
                 .map(this::getTicketCollectionInstanceByMetadata)
                 .filter(StringUtils::isNotBlank)
-                .mapToInt(collectionName -> mongoTemplate.remove(getMatchingAllNamesQuery(), collectionName).getN())
+                .mapToLong(collectionName -> {
+                        final Query query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).regex(".+"));
+                        final long countTickets = this.mongoTemplate.count(query, collectionName);
+                        mongoTemplate.remove(query, collectionName);
+                        return countTickets;
+                })
                 .sum();
-    }
-
-    private static Query getMatchingAllNamesQuery() {
-        // TODO: Could this Query be converted to an static field?
-        return new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).regex(".+"));
     }
 
     /**


### PR DESCRIPTION
Closes no issues

Following the discussion in #2779, I have migrated this 3 registries to use streams.

Iin the MongoDb one, please review the ToDo annotation and also, previously tickets were being decoded twice
