### PR TITLE
Mapped Regex attribute filter docs update

### DIFF
--- a/docs/cas-server-documentation/integration/Attribute-Value-Release-Policies.md
+++ b/docs/cas-server-documentation/integration/Attribute-Value-Release-Policies.md
@@ -96,6 +96,7 @@ For example, the below example only allows release of `memberOf` if it contains 
     "attributeFilter" : {
       "@class": "org.apereo.cas.services.support.RegisteredServiceMappedRegexAttributeFilter",
       "patterns": {
+          "@class" : "java.util.HashMap",
           "memberOf": "^\\w{3}$"
       },
       "excludeUnmappedAttributes": false,


### PR DESCRIPTION
The `property` map of the Mapped Regex attribute filter requires an explicit `"@class": "java.util.HashMap"` or similar definition for the software to parse and interpret it correctly.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
