### PR TITLE
Using streams in EhCache, Ignite and Jpa ticket registries. Using the…

### DIFF
--- a/support/cas-server-support-couchbase-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistry.java
+++ b/support/cas-server-support-couchbase-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistry.java
@@ -20,9 +20,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PreDestroy;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -145,7 +145,7 @@ public class CouchbaseTicketRegistry extends AbstractTicketRegistry {
     @Override
     public Collection<Ticket> getTickets() {
         LOGGER.debug("getTickets() isn't supported. Returning empty list");
-        return Collections.emptyList();
+        return new ArrayList<>(0);
     }
 
     @Override

--- a/support/cas-server-support-couchbase-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistry.java
+++ b/support/cas-server-support-couchbase-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistry.java
@@ -20,16 +20,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PreDestroy;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import java.util.function.Consumer;
 
 /**
  * A Ticket Registry storage backend which uses the memcached protocol.
@@ -54,7 +51,6 @@ public class CouchbaseTicketRegistry extends AbstractTicketRegistry {
             VIEW_NAME_ALL_TICKETS,
             "function(d,m) {emit(m.id);}",
             "_count");
-
 
     /**
      * Views available.
@@ -149,7 +145,7 @@ public class CouchbaseTicketRegistry extends AbstractTicketRegistry {
     @Override
     public Collection<Ticket> getTickets() {
         LOGGER.debug("getTickets() isn't supported. Returning empty list");
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     @Override
@@ -192,26 +188,15 @@ public class CouchbaseTicketRegistry extends AbstractTicketRegistry {
                 + getViewRowCountFromViewResultIterator(oauthcodeIt)
                 + getViewRowCountFromViewResultIterator(refreshTokenIt);
 
-        Stream<ViewRow> tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(grantingTicketsIt, Spliterator.ORDERED), true);
-        tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
+        final Consumer<? super ViewRow> remove = t -> this.couchbase.getBucket().remove(t.document());
 
-        tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(serviceTicketsIt, Spliterator.ORDERED), true);
-        tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
-
-        tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(proxyTicketsIt, Spliterator.ORDERED), true);
-        tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
-
-        tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(proxyGrantingTicketsIt, Spliterator.ORDERED), true);
-        tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
-
-        tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(accessTokenIt, Spliterator.ORDERED), true);
-        tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
-
-        tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(oauthcodeIt, Spliterator.ORDERED), true);
-        tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
-
-        tickets = StreamSupport.stream(Spliterators.spliteratorUnknownSize(refreshTokenIt, Spliterator.ORDERED), true);
-        tickets.forEach(t -> this.couchbase.getBucket().remove(t.document()));
+        grantingTicketsIt.forEachRemaining(remove);
+        serviceTicketsIt.forEachRemaining(remove);
+        proxyTicketsIt.forEachRemaining(remove);
+        proxyGrantingTicketsIt.forEachRemaining(remove);
+        accessTokenIt.forEachRemaining(remove);
+        oauthcodeIt.forEachRemaining(remove);
+        refreshTokenIt.forEachRemaining(remove);
 
         return count;
     }

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
@@ -69,5 +69,4 @@ public class DynamoDbTicketRegistry extends AbstractTicketRegistry {
         final String ticketId = encodeTicketId(ticketIdToDelete);
         return this.dbTableService.delete(ticketId);
     }
-
 }

--- a/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistry.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistry.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -177,7 +177,7 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
             return map.getAll(map.getKeysWithExpiryCheck());
         } catch (final Exception e) {
             LOGGER.warn(e.getMessage(), e);
-            return Collections.emptyMap();
+            return new HashMap<>(0);
         }
     }
 }

--- a/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistry.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistry.java
@@ -13,8 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -101,16 +102,14 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public long deleteAll() {
-        final AtomicLong count = new AtomicLong();
-        final Collection<TicketDefinition> metadata = this.ticketCatalog.findAll();
-        metadata.forEach(r -> {
-            final Ehcache instance = getTicketCacheFor(r);
-            if (instance != null) {
-                count.addAndGet(instance.getSize());
-                instance.removeAll();
-            }
-        });
-        return count.get();
+        return ticketCatalog.findAll().stream()
+                .map(this::getTicketCacheFor)
+                .filter(Objects::nonNull)
+                .mapToLong(instance -> {
+                    final int size = instance.getSize();
+                    instance.removeAll();
+                    return size;
+                }).sum();
     }
 
     @Override
@@ -153,18 +152,12 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public Collection<Ticket> getTickets() {
-        final Collection<Element> tickets = new HashSet<>();
-        try {
-            final Collection<TicketDefinition> metadata = this.ticketCatalog.findAll();
-            metadata.forEach(t -> {
-                final Ehcache map = getTicketCacheFor(t);
-                final Collection<Element> cacheTickets = map.getAll(map.getKeysWithExpiryCheck()).values();
-                tickets.addAll(cacheTickets);
-            });
-        } catch (final Exception e) {
-            LOGGER.warn(e.getMessage(), e);
-        }
-        return decodeTickets(tickets.stream().map(e -> (Ticket) e.getObjectValue()).collect(Collectors.toList()));
+        return this.ticketCatalog.findAll().stream()
+                .map(this::getTicketCacheFor)
+                .flatMap(map -> getAllExpired(map).values().stream())
+                .map(e -> (Ticket) e.getObjectValue())
+                .map(this::decodeTicket)
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -177,5 +170,14 @@ public class EhCacheTicketRegistry extends AbstractTicketRegistry {
         final String mapName = metadata.getProperties().getStorageName();
         LOGGER.debug("Locating cache name [{}] for ticket definition [{}]", mapName, metadata);
         return this.cacheManager.getCache(mapName);
+    }
+
+    private Map<Object, Element> getAllExpired(final Ehcache map) {
+        try {
+            return map.getAll(map.getKeysWithExpiryCheck());
+        } catch (final Exception e) {
+            LOGGER.warn(e.getMessage(), e);
+            return Collections.emptyMap();
+        }
     }
 }

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
@@ -7,8 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 import javax.annotation.PreDestroy;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 
 /**
  * Key-value ticket registry implementation that stores tickets in memcached keyed on the ticket ID.
@@ -120,7 +120,7 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
     @Override
     public Collection<Ticket> getTickets() {
         LOGGER.debug("getTickets() isn't supported. Returning empty list");
-        return Collections.emptyList();
+        return new ArrayList<>(0);
     }
 
     /**

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemCacheTicketRegistry.java
@@ -7,8 +7,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 import javax.annotation.PreDestroy;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Key-value ticket registry implementation that stores tickets in memcached keyed on the ticket ID.
@@ -120,7 +120,7 @@ public class MemCacheTicketRegistry extends AbstractTicketRegistry {
     @Override
     public Collection<Ticket> getTickets() {
         LOGGER.debug("getTickets() isn't supported. Returning empty list");
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     /**


### PR DESCRIPTION
… new Iterator.forEachRemaining method

Closes no issues

Following the discussion in #2779, I have migrated this 3 registries to use streams and used the new ```Iterator.forEachRemaining``` method in CouchBase
