### PR TITLE
Fix RestPasswordManagementService to use 'urlChange' endpoint

### DIFF
--- a/support/cas-server-support-pm-rest/src/main/java/org/apereo/cas/pm/rest/RestPasswordManagementService.java
+++ b/support/cas-server-support-pm-rest/src/main/java/org/apereo/cas/pm/rest/RestPasswordManagementService.java
@@ -53,7 +53,7 @@ public class RestPasswordManagementService extends BasePasswordManagementService
         headers.put("oldPassword", Arrays.asList(upc.getPassword()));
 
         final HttpEntity<String> entity = new HttpEntity<>(headers);
-        final ResponseEntity<Boolean> result = restTemplate.exchange(rest.getEndpointUrlEmail(), HttpMethod.POST, entity, Boolean.class);
+        final ResponseEntity<Boolean> result = restTemplate.exchange(rest.getEndpointUrlChange(), HttpMethod.POST, entity, Boolean.class);
         if (result.getStatusCodeValue() == HttpStatus.OK.value()) {
             return result.getBody();
         }


### PR DESCRIPTION
Fix 'change' method in RestPasswordManagementService to use the correct endpoint. It was using the 'endpointUrlEmail' property instead of the 'endpointUrlChange' one.