### PR TITLE
AuthnContext comparison type is mandatory for AuthnContextClassRef

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -448,7 +448,7 @@ public class Pac4jProperties {
         private String clientName;
         private boolean forceAuth;
         private String authnContextClassRef;
-        private String authnContextComparisonType;
+        private String authnContextComparisonType = "exact";
         private String keystoreAlias;
         private String nameIdPolicyFormat;
         private boolean wantsAssertionsSigned;
@@ -473,6 +473,13 @@ public class Pac4jProperties {
             return authnContextComparisonType;
         }
 
+	/**
+         * Specifies the comparison rule that should be used to evaluate the specified authentication methods.
+         * For example, if “exact” is specified, the authentication method used must match one of the authentication
+         * methods specified by the AuthnContextClassRef elements.
+         *
+         * @param authnContextComparisonType comparison rule (“better” | “exact” | “maximum” | “minimum”).
+         */
         public void setAuthnContextComparisonType(final String authnContextComparisonType) {
             this.authnContextComparisonType = authnContextComparisonType;
         }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -448,6 +448,7 @@ public class Pac4jProperties {
         private String clientName;
         private boolean forceAuth;
         private String authnContextClassRef;
+        private String authnContextComparisonType;
         private String keystoreAlias;
         private String nameIdPolicyFormat;
         private boolean wantsAssertionsSigned;
@@ -466,6 +467,14 @@ public class Pac4jProperties {
 
         public void setAuthnContextClassRef(final String authnContextClassRef) {
             this.authnContextClassRef = authnContextClassRef;
+        }
+
+        public String getAuthnContextComparisonType() {
+            return authnContextComparisonType;
+        }
+
+        public void setAuthnContextComparisonType(final String authnContextComparisonType) {
+            this.authnContextComparisonType = authnContextComparisonType;
         }
 
         public String getKeystoreAlias() {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3401,6 +3401,7 @@ prefixes for the `keystorePath` or `identityProviderMetadataPath` property).
 
 # Control aspects of the authentication request sent to IdP
 # cas.authn.pac4j.saml[0].authnContextClassRef=
+# cas.authn.pac4j.saml[0].authnContextComparisonType=
 # cas.authn.pac4j.saml[0].nameIdPolicyFormat=
 # cas.authn.pac4j.saml[0].forceAuth=false
 

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -56,6 +56,8 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+
 /**
  * This is {@link Pac4jAuthenticationEventExecutionPlanConfiguration}.
  *
@@ -238,6 +240,11 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration {
                     cfg.setForceAuth(saml.isForceAuth());
 
                     if (StringUtils.isNotBlank(saml.getAuthnContextClassRef())) {
+                        final String authContextComparisonType = StringUtils.isNotBlank(saml.
+                                getAuthnContextComparisonType())
+                                        ? AuthnContextComparisonTypeEnumeration.EXACT.toString()
+                                        : saml.getAuthnContextComparisonType();
+                        cfg.setComparisonType(authContextComparisonType);
                         cfg.setAuthnContextClassRef(saml.getAuthnContextClassRef());
                     }
                     if (StringUtils.isNotBlank(saml.getKeystoreAlias())) {

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -56,8 +56,6 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
-
 /**
  * This is {@link Pac4jAuthenticationEventExecutionPlanConfiguration}.
  *
@@ -240,11 +238,11 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration {
                     cfg.setForceAuth(saml.isForceAuth());
 
                     if (StringUtils.isNotBlank(saml.getAuthnContextClassRef())) {
-                        final String authContextComparisonType = StringUtils.isNotBlank(saml.
-                                getAuthnContextComparisonType())
-                                        ? AuthnContextComparisonTypeEnumeration.EXACT.toString()
-                                        : saml.getAuthnContextComparisonType();
-                        cfg.setComparisonType(authContextComparisonType);
+                        /*
+                         * AuthContextClassRef element require comparison rule to be used to evaluate the specified 
+                         * authentication methods. If not explicitly specified "exact" rule will be used by default.
+                         */
+                        cfg.setComparisonType(saml.getAuthnContextComparisonType());
                         cfg.setAuthnContextClassRef(saml.getAuthnContextClassRef());
                     }
                     if (StringUtils.isNotBlank(saml.getKeystoreAlias())) {


### PR DESCRIPTION
This PR introduce a new configuration parameter for AuthnContext comparison type.
This parameter will be used set comparison attribute of the given AuthnContextClassRef. In case of missing value, "exact" comparison type is used.
