### PR TITLE
Fix Password Management webflow state 5.1.x

### DIFF
--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
@@ -55,7 +55,7 @@ public class PasswordManagementWebflowConfigurer extends AbstractCasWebflowConfi
                     CasWebflowConstants.VIEW_ID_INVALID_AUTHENTICATION_HOURS);
             createViewState(flow, CasWebflowConstants.VIEW_ID_ACCOUNT_LOCKED, CasWebflowConstants.VIEW_ID_ACCOUNT_LOCKED);
             createViewState(flow, CasWebflowConstants.VIEW_ID_ACCOUNT_DISABLED, CasWebflowConstants.VIEW_ID_ACCOUNT_DISABLED);
-            createEndState(flow, CasWebflowConstants.VIEW_ID_PASSWORD_UPDATE_SUCCESS, CasWebflowConstants.VIEW_ID_PASSWORD_UPDATE_SUCCESS);
+            createEndState(flow, CasWebflowConstants.STATE_ID_PASSWORD_UPDATE_SUCCESS, CasWebflowConstants.VIEW_ID_PASSWORD_UPDATE_SUCCESS);
 
             if (casProperties.getAuthn().getPm().isEnabled()) {
                 configure(flow, CasWebflowConstants.VIEW_ID_ACCOUNT_DISABLED);


### PR DESCRIPTION
Commit 6e9ba3b1d0ef7af9990925ef71f9379596ef9ab7 broke the existing password management functionality by replacing the state and view id string literals with the constants.  The wrong constant was used.

`createEndState(flow, "casPasswordUpdateSuccess", "casPasswordUpdateSuccessView");`

was changed to

`createEndState(flow, CasWebflowConstants.VIEW_ID_PASSWORD_UPDATE_SUCCESS, CasWebflowConstants.VIEW_ID_PASSWORD_UPDATE_SUCCESS);`

it needed to be

`createEndState(flow, CasWebflowConstants.STATE_ID_PASSWORD_UPDATE_SUCCESS, CasWebflowConstants.VIEW_ID_PASSWORD_UPDATE_SUCCESS);`