### PR TITLE
Propose new default value for cas.samlCore.securityManager setting

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -2493,7 +2493,7 @@ Control core SAML functionality within CAS.
 # cas.samlCore.skewAllowance=0
 # cas.samlCore.attributeNamespace=http://www.ja-sig.org/products/cas/
 # cas.samlCore.issuer=localhost
-# cas.samlCore.securityManager=org.apache.xerces.util.SecurityManager
+# cas.samlCore.securityManager=com.sun.org.apache.xerces.internal.util.SecurityManager
 ```
 
 


### PR DESCRIPTION
Resolves the following error in CAS 5.1.1 (Java 8, Tomcat 8):
````
ERROR [org.springframework.boot.SpringApplication] - <Application startup failed>
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'shibboleth.OpenSAMLConfig' defined in class path resource [org/apereo/cas/config/CoreSamlConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.apereo.cas.support.saml.OpenSamlConfigBean]: Factory method 'openSamlConfigBean' threw exception; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'shibboleth.ParserPool' defined in class path resource [org/apereo/cas/config/CoreSamlConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [net.shibboleth.utilities.java.support.xml.BasicParserPool]: Factory method 'parserPool' threw exception; nested exception is java.lang.RuntimeException: java.lang.ClassNotFoundException: org.apache.xerces.util.SecurityManager
````

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
