### PR TITLE
Random string generation should use SecureRandom w/ Base64 encoding

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/UniqueTicketIdGenerator.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/UniqueTicketIdGenerator.java
@@ -9,6 +9,11 @@ package org.apereo.cas.ticket;
 @FunctionalInterface
 public interface UniqueTicketIdGenerator {
     /**
+     * Default ticket size 24 bytes raw, 32 bytes once encoded to base64.
+     */
+    int TICKET_SIZE = 24;
+
+    /**
      * Return a new unique ticket id beginning with the prefix.
      *
      * @param prefix The prefix we want attached to the ticket.

--- a/core/cas-server-core-logout/src/main/java/org/apereo/cas/logout/SamlCompliantLogoutMessageCreator.java
+++ b/core/cas-server-core-logout/src/main/java/org/apereo/cas/logout/SamlCompliantLogoutMessageCreator.java
@@ -19,7 +19,7 @@ public class SamlCompliantLogoutMessageCreator implements LogoutMessageCreator {
     private static final Logger LOGGER = LoggerFactory.getLogger(SamlCompliantLogoutMessageCreator.class);
     
     /** A ticket Id generator. */
-    private static final UniqueTicketIdGenerator GENERATOR = new DefaultUniqueTicketIdGenerator();
+    private static final UniqueTicketIdGenerator GENERATOR = new DefaultUniqueTicketIdGenerator(18);
 
     /** The logout request template. */
     private static final String LOGOUT_REQUEST_TEMPLATE =

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceTestUtils.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceTestUtils.java
@@ -8,11 +8,11 @@ import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
 import org.apereo.cas.authentication.principal.cache.AbstractPrincipalAttributesRepository;
 import org.apereo.cas.authentication.principal.cache.CachingPrincipalAttributesRepository;
 import org.apereo.cas.services.support.RegisteredServiceRegexAttributeFilter;
+import org.apereo.cas.util.RandomUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -105,7 +105,7 @@ public final class RegisteredServiceTestUtils {
             s.setName("Test registered service " + id);
             s.setDescription("Registered service description");
             s.setProxyPolicy(new RegexMatchingRegisteredServiceProxyPolicy("^https?://.+"));
-            s.setId(new SecureRandom().nextInt(Math.abs(s.hashCode())));
+            s.setId(RandomUtils.getInstanceStrong().nextInt(Math.abs(s.hashCode())));
             s.setTheme("exampleTheme");
             s.setUsernameAttributeProvider(new PrincipalAttributeRegisteredServiceUsernameProvider("uid"));
             final DefaultRegisteredServiceAccessStrategy accessStrategy =

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
@@ -91,8 +91,8 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
     @Override
     public String getNewTicketId(final String prefix) {
         final String number = this.numericGenerator.getNextNumberAsString();
-        return prefix + '-' + number + '-' +
-            this.randomStringGenerator.getNewString() + this.suffix;
+        return prefix + '-' + number + '-'
+            + this.randomStringGenerator.getNewString() + this.suffix;
     }
 
     /**

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
@@ -91,10 +91,8 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
     @Override
     public String getNewTicketId(final String prefix) {
         final String number = this.numericGenerator.getNextNumberAsString();
-        return prefix + '-' + number +
-          '-' +
-          this.randomStringGenerator.getNewString() +
-          this.suffix;
+        return prefix + '-' + number + '-' +
+            this.randomStringGenerator.getNewString() + this.suffix;
     }
 
     /**

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
@@ -2,8 +2,8 @@ package org.apereo.cas.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.ticket.UniqueTicketIdGenerator;
+import org.apereo.cas.util.gen.Base64RandomStringGenerator;
 import org.apereo.cas.util.gen.DefaultLongNumericGenerator;
-import org.apereo.cas.util.gen.DefaultRandomStringGenerator;
 import org.apereo.cas.util.gen.NumericGenerator;
 import org.apereo.cas.util.gen.RandomStringGenerator;
 
@@ -19,7 +19,7 @@ import org.apereo.cas.util.gen.RandomStringGenerator;
  * @since 3.0.0
  */
 public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
-    
+
     /**
      * The numeric generator to generate the static part of the id.
      */
@@ -35,7 +35,6 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
      * values.
      */
     private String suffix;
-    private int initialCapacity;
 
     /**
      * Creates an instance of DefaultUniqueTicketIdGenerator with default values
@@ -43,7 +42,7 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
      * 1.
      */
     public DefaultUniqueTicketIdGenerator() {
-        this(DefaultRandomStringGenerator.DEFAULT_MAX_RANDOM_LENGTH);
+        this(TICKET_SIZE);
     }
 
     /**
@@ -92,15 +91,10 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
     @Override
     public String getNewTicketId(final String prefix) {
         final String number = this.numericGenerator.getNextNumberAsString();
-        final int capacity = prefix.length() + initialCapacity + number.length();
-        return new StringBuilder(capacity)
-                .append(prefix)
-                .append('-')
-                .append(number)
-                .append('-')
-                .append(this.randomStringGenerator.getNewString())
-                .append(this.suffix)
-                .toString();
+        return prefix + '-' + number +
+          '-' +
+          this.randomStringGenerator.getNewString() +
+          this.suffix;
     }
 
     /**
@@ -110,7 +104,6 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
      */
     public void setSuffix(final String suffix) {
         this.suffix = StringUtils.isNoneBlank(suffix) ? '-' + suffix : StringUtils.EMPTY;
-        initialCapacity = 2 + this.suffix.length() + this.randomStringGenerator.getMaxLength();
     }
 
     /**
@@ -119,7 +112,7 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
      * @param maxLength the max length
      */
     public void setMaxLength(final int maxLength) {
-        this.randomStringGenerator = new DefaultRandomStringGenerator(maxLength);
+        this.randomStringGenerator = new Base64RandomStringGenerator(maxLength);
         this.numericGenerator = new DefaultLongNumericGenerator(1);
     }
 }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/DefaultUniqueTicketIdGeneratorTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/DefaultUniqueTicketIdGeneratorTests.java
@@ -29,10 +29,10 @@ public class DefaultUniqueTicketIdGeneratorTests {
     @Test
     public void verifyNullSuffix() {
         final String nullSuffix = null;
-        final int lengthWithoutSuffix = 17;
-        final DefaultUniqueTicketIdGenerator generator = new DefaultUniqueTicketIdGenerator(10, nullSuffix);
+        final int lengthWithoutSuffix = 23;
+        final DefaultUniqueTicketIdGenerator generator = new DefaultUniqueTicketIdGenerator(12, nullSuffix);
 
         final String ticketId = generator.getNewTicketId("test");
-        assertEquals(ticketId.length(), lengthWithoutSuffix);
+        assertEquals(lengthWithoutSuffix, ticketId.length());
     }
 }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/TicketEncryptionDecryptionTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/TicketEncryptionDecryptionTests.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.*;
 public class TicketEncryptionDecryptionTests {
 
     private final MockTicketGrantingTicket tgt = new MockTicketGrantingTicket("casuser");
-    private final BaseBinaryCipherExecutor cipher = new TestBinaryCipherExecutor("1234567890123456",
+    private final BaseBinaryCipherExecutor cipher = new TestBinaryCipherExecutor("MTIzNDU2Nzg5MDEyMzQ1Ng==",
             "szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w",
             512, 16) {};
 

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CompressionUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CompressionUtils.java
@@ -156,7 +156,7 @@ public final class CompressionUtils {
             zos.write(srcTxt.getBytes());
             IOUtils.closeQuietly(zos);
             final byte[] bytes = rstBao.toByteArray();
-            final String base64 = StringUtils.remove(Base64.encodeBase64String(bytes), '\0');
+            final String base64 = StringUtils.remove(EncodingUtils.encodeBase64(bytes), '\0');
             return new String(StandardCharsets.UTF_8.encode(base64).array(), StandardCharsets.UTF_8);
         } catch (final IOException e) {
             LOGGER.error(e.getMessage(), e);

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CompressionUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CompressionUtils.java
@@ -131,7 +131,7 @@ public final class CompressionUtils {
     public static String decompress(final String zippedBase64Str) {
         GZIPInputStream zi = null;
         try {
-            final byte[] bytes = Base64.decodeBase64(zippedBase64Str);
+            final byte[] bytes = EncodingUtils.decodeBase64(zippedBase64Str);
             zi = new GZIPInputStream(new ByteArrayInputStream(bytes));
             return IOUtils.toString(zi, Charset.defaultCharset());
         } catch (final Exception e) {

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CompressionUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/CompressionUtils.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.util;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/EncodingUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/EncodingUtils.java
@@ -127,6 +127,16 @@ public final class EncodingUtils {
     }
 
     /**
+     * Base64-encode the given string as a string.
+     *
+     * @param data the String to encode
+     * @return the encoded string
+     */
+    public static String encodeBase64(final String data) {
+        return Base64.encodeBase64String(data.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
      * Base64-decode the given string as byte[].
      *
      * @param data the base64 string
@@ -196,6 +206,15 @@ public final class EncodingUtils {
         }
     }
 
+
+    /**
+     * Validates Base64 encoding.
+     * @param value the value to check
+     * @return true if the string is validly Base64 encoded
+     */
+    public static boolean isBase64(final String value) {
+        return Base64.isBase64(value);
+    }
 
     /**
      * Verify jws signature byte [ ].

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/EncodingUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/EncodingUtils.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.util;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwk.JsonWebKey;
@@ -15,7 +16,6 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.Base64;
 import java.util.Map;
 
 /**
@@ -102,8 +102,28 @@ public final class EncodingUtils {
      * @param data the byte array to encode
      * @return the encoded string
      */
+    public static String encodeUrlSafeBase64(final byte[] data) {
+        return Base64.encodeBase64URLSafeString(data);
+    }
+
+    /**
+     * Base64-decode the given string as byte[].
+     *
+     * @param data the base64 string
+     * @return the encoded array
+     */
+    public static byte[] decodeUrlSafeBase64(final String data) {
+        return decodeBase64(data);
+    }
+
+    /**
+     * Base64-encode the given byte[] as a string.
+     *
+     * @param data the byte array to encode
+     * @return the encoded string
+     */
     public static String encodeBase64(final byte[] data) {
-        return Base64.getEncoder().encodeToString(data);
+        return Base64.encodeBase64String(data);
     }
 
     /**
@@ -113,7 +133,7 @@ public final class EncodingUtils {
      * @return the encoded array
      */
     public static byte[] decodeBase64(final String data) {
-        return Base64.getDecoder().decode(data);
+        return Base64.decodeBase64(data);
     }
 
     /**
@@ -123,7 +143,7 @@ public final class EncodingUtils {
      * @return the encoded array
      */
     public static byte[] decodeBase64(final byte[] data) {
-        return Base64.getDecoder().decode(data);
+        return Base64.decodeBase64(data);
     }
 
     /**
@@ -133,7 +153,7 @@ public final class EncodingUtils {
      * @return the byte[] in base64
      */
     public static byte[] encodeBase64ToByteArray(final byte[] data) {
-        return Base64.getEncoder().encode(data);
+        return Base64.encodeBase64(data);
     }
 
 

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RandomUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RandomUtils.java
@@ -1,0 +1,30 @@
+package org.apereo.cas.util;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+/**
+ * This is {@link RandomUtils}
+ * that encapsulates common base64 calls and operations
+ * in one spot.
+ *
+ * @author Timur Duehr timur.duehr@nccgroup.trust
+ * @since 5.0.0
+ */
+public final class RandomUtils {
+    private RandomUtils() {
+    }
+
+    /**
+     * Get strong SecureRandom instance from +securerandom.strongAlgorithms+ and wrap the checked exception.
+     *
+     * @return the strong instance
+     */
+    public static SecureRandom getInstanceStrong() {
+        try {
+            return SecureRandom.getInstanceStrong();
+        } catch (final NoSuchAlgorithmException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RandomUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RandomUtils.java
@@ -24,7 +24,7 @@ public final class RandomUtils {
         try {
             return SecureRandom.getInstanceStrong();
         } catch (final NoSuchAlgorithmException e) {
-            throw new RuntimeException(e.getMessage(), e);
+            throw new IllegalStateException(e.getMessage(), e);
         }
     }
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
@@ -1,19 +1,20 @@
 package org.apereo.cas.util.cipher;
 
-import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.crypto.AesCipherService;
 import org.apache.shiro.crypto.CipherService;
+import org.apereo.cas.util.gen.Base64RandomStringGenerator;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.OctJwkGenerator;
 import org.jose4j.jwk.OctetSequenceJsonWebKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Map;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
  * A implementation that is based on algorithms
@@ -59,9 +60,9 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
         if (StringUtils.isBlank(encryptionSecretKey)) {
             LOGGER.warn("Secret key for encryption is not defined under [{}]. CAS will attempt to auto-generate the encryption key",
                     getEncryptionKeySetting());
-            this.encryptionSecretKey = RandomStringUtils.randomAlphabetic(encryptionKeySize);
+            this.encryptionSecretKey = (new Base64RandomStringGenerator(encryptionKeySize)).getNewString();
             LOGGER.warn("Generated encryption key [{}] of size [{}]. The generated key MUST be added to CAS settings under setting [{}].",
-                    this.encryptionSecretKey, encryptionKeySize, getEncryptionKeySetting());
+              this.encryptionSecretKey, encryptionKeySize, getEncryptionKeySetting());
         } else {
             this.encryptionSecretKey = encryptionSecretKey;
         }
@@ -75,7 +76,7 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
     @Override
     public byte[] encode(final byte[] value) {
         try {
-            final Key key = new SecretKeySpec(this.encryptionSecretKey.getBytes(StandardCharsets.UTF_8),
+            final Key key = new SecretKeySpec(Base64.decodeBase64(this.encryptionSecretKey),
                     this.secretKeyAlgorithm);
             final CipherService cipher = new AesCipherService();
             final byte[] result = cipher.encrypt(value, key.getEncoded()).getBytes();

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
@@ -62,7 +62,7 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
                     getEncryptionKeySetting());
             this.encryptionSecretKey = (new Base64RandomStringGenerator(encryptionKeySize)).getNewString();
             LOGGER.warn("Generated encryption key [{}] of size [{}]. The generated key MUST be added to CAS settings under setting [{}].",
-              this.encryptionSecretKey, encryptionKeySize, getEncryptionKeySetting());
+                this.encryptionSecretKey, encryptionKeySize, getEncryptionKeySetting());
         } else {
             this.encryptionSecretKey = encryptionSecretKey;
         }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
@@ -1,9 +1,9 @@
 package org.apereo.cas.util.cipher;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.crypto.AesCipherService;
 import org.apache.shiro.crypto.CipherService;
+import org.apereo.cas.util.EncodingUtils;
 import org.apereo.cas.util.gen.Base64RandomStringGenerator;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.OctJwkGenerator;
@@ -32,12 +32,12 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
      */
     private String secretKeyAlgorithm = "AES";
 
-    private final String encryptionSecretKey;
+    private final byte[] encryptionSecretKey;
 
     /**
      * Instantiates a new cryptic ticket cipher executor.
      *
-     * @param encryptionSecretKey the encryption secret key
+     * @param encryptionSecretKey the encryption secret key, base64 encoded
      * @param signingSecretKey    the signing key
      * @param signingKeySize      the signing key size
      * @param encryptionKeySize   the encryption key size
@@ -46,6 +46,7 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
                                     final String signingSecretKey,
                                     final int signingKeySize,
                                     final int encryptionKeySize) {
+        final byte[] encryptionKey;
 
         String signingKeyToUse = signingSecretKey;
         if (StringUtils.isBlank(signingKeyToUse)) {
@@ -60,12 +61,26 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
         if (StringUtils.isBlank(encryptionSecretKey)) {
             LOGGER.warn("Secret key for encryption is not defined under [{}]. CAS will attempt to auto-generate the encryption key",
                     getEncryptionKeySetting());
-            this.encryptionSecretKey = (new Base64RandomStringGenerator(encryptionKeySize)).getNewString();
+            final String key = (new Base64RandomStringGenerator(encryptionKeySize)).getNewString();
             LOGGER.warn("Generated encryption key [{}] of size [{}]. The generated key MUST be added to CAS settings under setting [{}].",
-              this.encryptionSecretKey, encryptionKeySize, getEncryptionKeySetting());
+                key, encryptionKeySize, getEncryptionKeySetting());
+            encryptionKey = EncodingUtils.decodeBase64(key);
         } else {
-            this.encryptionSecretKey = encryptionSecretKey;
+            final boolean base64 = EncodingUtils.isBase64(encryptionSecretKey);
+            byte[] key = new byte[0];
+            if (base64) {
+                key = EncodingUtils.decodeBase64(encryptionSecretKey);
+            }
+            if (base64 && key.length == encryptionKeySize) {
+                LOGGER.info("Secret key for encryption defined under [{}] is Base64 encoded.", getEncryptionKeySetting());
+                encryptionKey = key;
+            } else {
+                LOGGER.info("Secret key for encryption defined under [{}] is not Base64 encoded. Clear the setting to regenerate (Recommended) or replace with"
+                    + " [{}].", getEncryptionKeySetting(), EncodingUtils.encodeBase64(encryptionSecretKey));
+                encryptionKey = encryptionSecretKey.getBytes(StandardCharsets.UTF_8);
+            }
         }
+        this.encryptionSecretKey = encryptionKey;
     }
 
 
@@ -76,7 +91,7 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
     @Override
     public byte[] encode(final byte[] value) {
         try {
-            final Key key = new SecretKeySpec(Base64.decodeBase64(this.encryptionSecretKey),
+            final Key key = new SecretKeySpec(this.encryptionSecretKey,
                     this.secretKeyAlgorithm);
             final CipherService cipher = new AesCipherService();
             final byte[] result = cipher.encrypt(value, key.getEncoded()).getBytes();
@@ -91,7 +106,7 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
     public byte[] decode(final byte[] value) {
         try {
             final byte[] verifiedValue = verifySignature(value);
-            final Key key = new SecretKeySpec(this.encryptionSecretKey.getBytes(StandardCharsets.UTF_8),
+            final Key key = new SecretKeySpec(this.encryptionSecretKey,
                     this.secretKeyAlgorithm);
             final CipherService cipher = new AesCipherService();
             return cipher.decrypt(verifiedValue, key.getEncoded()).getBytes();

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
+ * This is {@link BaseBinaryCipherExecutor}.
+ *
  * A implementation that is based on algorithms
  * provided by the default platform's JCE. By default AES encryption is
  * used.
@@ -74,8 +76,12 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
             if (base64 && key.length == encryptionKeySize) {
                 LOGGER.info("Secret key for encryption defined under [{}] is Base64 encoded.", getEncryptionKeySetting());
                 encryptionKey = key;
+            } else if (encryptionSecretKey.length() != encryptionKeySize) {
+                LOGGER.warn("Secret key for encryption defined under [{}] is Base64 encoded but the size does not match the key size [{}].",
+                    getEncryptionKeySetting(), encryptionKeySize);
+                encryptionKey = encryptionSecretKey.getBytes(StandardCharsets.UTF_8);
             } else {
-                LOGGER.info("Secret key for encryption defined under [{}] is not Base64 encoded. Clear the setting to regenerate (Recommended) or replace with"
+                LOGGER.warn("Secret key for encryption defined under [{}] is not Base64 encoded. Clear the setting to regenerate (Recommended) or replace with"
                     + " [{}].", getEncryptionKeySetting(), EncodingUtils.encodeBase64(encryptionSecretKey));
                 encryptionKey = encryptionSecretKey.getBytes(StandardCharsets.UTF_8);
             }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
@@ -62,7 +62,7 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
                     getEncryptionKeySetting());
             this.encryptionSecretKey = (new Base64RandomStringGenerator(encryptionKeySize)).getNewString();
             LOGGER.warn("Generated encryption key [{}] of size [{}]. The generated key MUST be added to CAS settings under setting [{}].",
-                this.encryptionSecretKey, encryptionKeySize, getEncryptionKeySetting());
+              this.encryptionSecretKey, encryptionKeySize, getEncryptionKeySetting());
         } else {
             this.encryptionSecretKey = encryptionSecretKey;
         }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
@@ -3,6 +3,8 @@ package org.apereo.cas.util.gen;
 import java.security.SecureRandom;
 
 /**
+ * This is {@link AbstractRandomStringGenerator}.
+ *
  * Implementation of the RandomStringGenerator that allows you to define the
  * length of the random part.
  *
@@ -37,6 +39,11 @@ public abstract class AbstractRandomStringGenerator implements RandomStringGener
     @Override
     public int getDefaultLength() {
         return defaultLength;
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return randomizer.getAlgorithm();
     }
 
     /**

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
@@ -13,6 +13,8 @@ import java.security.SecureRandom;
 public abstract class AbstractRandomStringGenerator implements RandomStringGenerator{
     /** An instance of secure random to ensure randomness is secure. */
     protected final SecureRandom randomizer = new SecureRandom();
+
+    /** Default string length before encoding. */
     protected final int defaultLength;
 
     /**
@@ -37,12 +39,6 @@ public abstract class AbstractRandomStringGenerator implements RandomStringGener
         return defaultLength;
     }
 
-    @Override
-    public String getNewString(final int size) {
-        final byte[] random = getNewStringAsBytes(size);
-        return this.convertBytesToString(random);
-    }
-
     /**
      * Converts byte[] to String by simple cast. Subclasses should override.
      *
@@ -53,6 +49,11 @@ public abstract class AbstractRandomStringGenerator implements RandomStringGener
         return new String(random);
     }
 
+    @Override
+    public String getNewString(final int size) {
+        final byte[] random = getNewStringAsBytes(size);
+        return this.convertBytesToString(random);
+    }
 
     @Override
     public String getNewString() {

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
@@ -1,0 +1,73 @@
+package org.apereo.cas.util.gen;
+
+import java.security.SecureRandom;
+
+/**
+ * Implementation of the RandomStringGenerator that allows you to define the
+ * length of the random part.
+ *
+ * @author Timur Duehr
+
+ * @since 5.2.0
+ */
+abstract public class AbstractRandomStringGenerator implements RandomStringGenerator{
+    /** An instance of secure random to ensure randomness is secure. */
+    protected final SecureRandom randomizer = new SecureRandom();
+    protected final int defaultLength;
+
+    /**
+     * Instantiates a new default random string generator
+     * with length set to {@link RandomStringGenerator#DEFAULT_LENGTH}.
+     */
+    public AbstractRandomStringGenerator() {
+        this.defaultLength = DEFAULT_LENGTH;
+    }
+
+    /**
+     * Instantiates a new default random string generator.
+     *
+     * @param defaultLength the max random length
+     */
+    public AbstractRandomStringGenerator(final int defaultLength) {
+        this.defaultLength = defaultLength;
+    }
+
+    @Override
+    public int getDefaultLength() {
+        return defaultLength;
+    }
+
+    @Override
+    public String getNewString(int size) {
+        final byte[] random = getNewStringAsBytes(size);
+        return this.convertBytesToString(random);
+    }
+
+    /**
+     * Converts byte[] to String by simple cast. Subclasses should override.
+     *
+     * @param random raw bytes
+     * @return a converted String
+     */
+    protected String convertBytesToString(final byte[] random) {
+        return new String(random);
+    }
+
+
+    @Override
+    public String getNewString() {
+        return getNewString(this.getDefaultLength());
+    }
+
+    @Override
+    public byte[] getNewStringAsBytes(final int size) {
+        final byte[] random = new byte[size];
+        this.randomizer.nextBytes(random);
+        return random;
+    }
+
+    @Override
+    public byte[] getNewStringAsBytes() {
+        return this.getNewStringAsBytes(this.getDefaultLength());
+    }
+}

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
@@ -10,7 +10,7 @@ import java.security.SecureRandom;
 
  * @since 5.2.0
  */
-abstract public class AbstractRandomStringGenerator implements RandomStringGenerator{
+public abstract class AbstractRandomStringGenerator implements RandomStringGenerator{
     /** An instance of secure random to ensure randomness is secure. */
     protected final SecureRandom randomizer = new SecureRandom();
     protected final int defaultLength;
@@ -38,7 +38,7 @@ abstract public class AbstractRandomStringGenerator implements RandomStringGener
     }
 
     @Override
-    public String getNewString(int size) {
+    public String getNewString(final int size) {
         final byte[] random = getNewStringAsBytes(size);
         return this.convertBytesToString(random);
     }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.util.gen;
 
+import org.apereo.cas.util.RandomUtils;
+
 import java.security.SecureRandom;
 
 /**
@@ -14,7 +16,7 @@ import java.security.SecureRandom;
  */
 public abstract class AbstractRandomStringGenerator implements RandomStringGenerator{
     /** An instance of secure random to ensure randomness is secure. */
-    protected final SecureRandom randomizer = new SecureRandom();
+    protected final SecureRandom randomizer = RandomUtils.getInstanceStrong();
 
     /** Default string length before encoding. */
     protected final int defaultLength;

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/Base64RandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/Base64RandomStringGenerator.java
@@ -3,6 +3,8 @@ package org.apereo.cas.util.gen;
 import org.apereo.cas.util.EncodingUtils;
 
 /**
+ * This is {@link Base64RandomStringGenerator}.
+ *
  * URL safe base64 encoding implementation of the RandomStringGenerator that allows you to define the
  * length of the random part.
  *

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/Base64RandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/Base64RandomStringGenerator.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.util.gen;
 
-import org.apache.commons.codec.binary.Base64;
+import org.apereo.cas.util.EncodingUtils;
 
 /**
  * URL safe base64 encoding implementation of the RandomStringGenerator that allows you to define the
@@ -27,7 +27,7 @@ public class Base64RandomStringGenerator extends AbstractRandomStringGenerator {
      * @return a converted String
      */
     protected String convertBytesToString(final byte[] random) {
-        return Base64.encodeBase64URLSafeString(random);
+        return EncodingUtils.encodeUrlSafeBase64(random);
     }
 
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/Base64RandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/Base64RandomStringGenerator.java
@@ -1,0 +1,33 @@
+package org.apereo.cas.util.gen;
+
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * URL safe base64 encoding implementation of the RandomStringGenerator that allows you to define the
+ * length of the random part.
+ *
+ * @author Timur Duehr
+
+ * @since 5.2.0
+ */
+public class Base64RandomStringGenerator extends AbstractRandomStringGenerator {
+
+    public Base64RandomStringGenerator() {
+        super();
+    }
+
+    public Base64RandomStringGenerator(final int defaultLength) {
+        super(defaultLength);
+    }
+
+    /**
+     * Converts byte[] to String by Base64 encoding.
+     *
+     * @param random raw bytes
+     * @return a converted String
+     */
+    protected String convertBytesToString(final byte[] random) {
+        return Base64.encodeBase64URLSafeString(random);
+    }
+
+}

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/DefaultRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/DefaultRandomStringGenerator.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.util.gen;
 
-import java.security.SecureRandom;
 import java.util.stream.IntStream;
 
 /**
@@ -11,58 +10,17 @@ import java.util.stream.IntStream;
 
  * @since 3.0.0
  */
-public class DefaultRandomStringGenerator implements RandomStringGenerator {
-
-    /** The default maximum length. */
-    public static final int DEFAULT_MAX_RANDOM_LENGTH = 35;
+public class DefaultRandomStringGenerator extends AbstractRandomStringGenerator {
 
     /** The array of printable characters to be used in our random string. */
     private static final char[] PRINTABLE_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345679".toCharArray();
 
-    /** An instance of secure random to ensure randomness is secure. */
-    private final SecureRandom randomizer = new SecureRandom();
-
-    /** The maximum length the random string can be. */
-    private final int maximumRandomLength;
-
-    /**
-     * Instantiates a new default random string generator
-     * with length set to {@link #DEFAULT_MAX_RANDOM_LENGTH}.
-     */
     public DefaultRandomStringGenerator() {
-        this.maximumRandomLength = DEFAULT_MAX_RANDOM_LENGTH;
+        super();
     }
 
-    /**
-     * Instantiates a new default random string generator.
-     *
-     * @param maxRandomLength the max random length
-     */
-    public DefaultRandomStringGenerator(final int maxRandomLength) {
-        this.maximumRandomLength = maxRandomLength;
-    }
-
-    @Override
-    public int getMinLength() {
-        return this.maximumRandomLength;
-    }
-
-    @Override
-    public int getMaxLength() {
-        return this.maximumRandomLength;
-    }
-
-    @Override
-    public String getNewString() {
-        final byte[] random = getNewStringAsBytes();
-        return convertBytesToString(random);
-    }
-
-    @Override
-    public byte[] getNewStringAsBytes() {
-        final byte[] random = new byte[this.maximumRandomLength];
-        this.randomizer.nextBytes(random);
-        return random;
+    public DefaultRandomStringGenerator(final int defaultLength) {
+        super(defaultLength);
     }
 
     /**
@@ -71,7 +29,7 @@ public class DefaultRandomStringGenerator implements RandomStringGenerator {
      * @param random the random
      * @return the string
      */
-    private static String convertBytesToString(final byte[] random) {
+    protected String convertBytesToString(final byte[] random) {
         final char[] output = new char[random.length];
         IntStream.range(0, random.length).forEach(i -> {
             final int index = Math.abs(random[i] % PRINTABLE_CHARACTERS.length);

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/HexRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/HexRandomStringGenerator.java
@@ -17,7 +17,7 @@ public class HexRandomStringGenerator extends AbstractRandomStringGenerator {
     }
 
     @Override
-    protected String convertBytesToString(byte[] random) {
+    protected String convertBytesToString(final byte[] random) {
         return EncodingUtils.hexEncode(random);
     }
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/HexRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/HexRandomStringGenerator.java
@@ -3,6 +3,7 @@ package org.apereo.cas.util.gen;
 import org.apereo.cas.util.EncodingUtils;
 
 /**
+ * This is {@link HexRandomStringGenerator}.
  * Hex encoding implementation of the RandomStringGenerator that allows you to define the
  * length of the random part.
  *
@@ -11,6 +12,10 @@ import org.apereo.cas.util.EncodingUtils;
  * @since 5.2.0
  */
 public class HexRandomStringGenerator extends AbstractRandomStringGenerator {
+
+    public HexRandomStringGenerator() {
+        super();
+    }
 
     public HexRandomStringGenerator(final int defaultLength) {
         super(defaultLength);

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/HexRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/HexRandomStringGenerator.java
@@ -1,0 +1,23 @@
+package org.apereo.cas.util.gen;
+
+import org.apereo.cas.util.EncodingUtils;
+
+/**
+ * Hex encoding implementation of the RandomStringGenerator that allows you to define the
+ * length of the random part.
+ *
+ * @author Timur Duehr
+
+ * @since 5.2.0
+ */
+public class HexRandomStringGenerator extends AbstractRandomStringGenerator {
+
+    public HexRandomStringGenerator(final int defaultLength) {
+        super(defaultLength);
+    }
+
+    @Override
+    protected String convertBytesToString(byte[] random) {
+        return EncodingUtils.hexEncode(random);
+    }
+}

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
@@ -18,6 +18,7 @@ public interface RandomStringGenerator {
     int getDefaultLength();
 
     /**
+     * @param size length of random string before encoding
      * @return a new random string of specified initial size
      */
     String getNewString(int size);

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
@@ -40,5 +40,5 @@ public interface RandomStringGenerator {
      * @param size the size of return
      * @return the new random string as bytes
      */
-    byte[] getNewStringAsBytes(final int size);
+    byte[] getNewStringAsBytes(int size);
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
@@ -18,6 +18,11 @@ public interface RandomStringGenerator {
     int getDefaultLength();
 
     /**
+     * @return the algorithm used by the generator's SecureRandom instance.
+     */
+    String getAlgorithm();
+
+    /**
      * @param size length of random string before encoding
      * @return a new random string of specified initial size
      */

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/RandomStringGenerator.java
@@ -9,18 +9,21 @@ package org.apereo.cas.util.gen;
  */
 public interface RandomStringGenerator {
 
-    /**
-     * @return the minimum length as an int guaranteed by this generator.
-     */
-    int getMinLength();
+    /** The default length. */
+    int DEFAULT_LENGTH = 36;
 
     /**
-     * @return the maximum length as an int guaranteed by this generator.
+     * @return the default length as an int.
      */
-    int getMaxLength();
+    int getDefaultLength();
 
     /**
-     * @return the new random string
+     * @return a new random string of specified initial size
+     */
+    String getNewString(int size);
+
+    /**
+     * @return a new random string of default initial size
      */
     String getNewString();
 
@@ -30,4 +33,12 @@ public interface RandomStringGenerator {
      * @return the new random string as bytes
      */
     byte[] getNewStringAsBytes();
+
+    /**
+     * Gets the new string as bytes.
+     *
+     * @param size the size of return
+     * @return the new random string as bytes
+     */
+    byte[] getNewStringAsBytes(final int size);
 }

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/Base64RandomStringGeneratorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/Base64RandomStringGeneratorTests.java
@@ -16,7 +16,7 @@ public class Base64RandomStringGeneratorTests {
     private static final int LENGTH = 36;
 
     private final RandomStringGenerator randomStringGenerator = new Base64RandomStringGenerator(
-      LENGTH);
+        LENGTH);
 
     @Test
     public void verifyDefaultLength() {
@@ -27,6 +27,6 @@ public class Base64RandomStringGeneratorTests {
     @Test
     public void verifyRandomString() {
         assertNotSame(this.randomStringGenerator.getNewString(),
-          this.randomStringGenerator.getNewString());
+            this.randomStringGenerator.getNewString());
     }
 }

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/Base64RandomStringGeneratorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/Base64RandomStringGeneratorTests.java
@@ -7,8 +7,10 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
+ * Tests for {@link Base64RandomStringGenerator}.
+ *
  * @author Timur Duehr
-
+ *
  * @since 5.2.0
  */
 public class Base64RandomStringGeneratorTests {

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/Base64RandomStringGeneratorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/Base64RandomStringGeneratorTests.java
@@ -1,32 +1,32 @@
 package org.apereo.cas.util;
 
-import org.apereo.cas.util.gen.DefaultRandomStringGenerator;
+import org.apereo.cas.util.gen.Base64RandomStringGenerator;
 import org.apereo.cas.util.gen.RandomStringGenerator;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-
 /**
- * @author Scott Battaglia
+ * @author Timur Duehr
 
- * @since 3.0.0
+ * @since 5.2.0
  */
-public class DefaultRandomStringGeneratorTests {
+public class Base64RandomStringGeneratorTests {
 
     private static final int LENGTH = 36;
 
-    private final RandomStringGenerator randomStringGenerator = new DefaultRandomStringGenerator(
-        LENGTH);
+    private final RandomStringGenerator randomStringGenerator = new Base64RandomStringGenerator(
+      LENGTH);
 
     @Test
     public void verifyDefaultLength() {
         assertEquals(LENGTH, this.randomStringGenerator.getDefaultLength());
+        assertEquals(LENGTH, new Base64RandomStringGenerator().getDefaultLength());
     }
 
     @Test
     public void verifyRandomString() {
         assertNotSame(this.randomStringGenerator.getNewString(),
-            this.randomStringGenerator.getNewString());
+          this.randomStringGenerator.getNewString());
     }
 }

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/BinaryCipherExecutorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/BinaryCipherExecutorTests.java
@@ -48,9 +48,9 @@ public class BinaryCipherExecutorTests {
     public void checkLegacyKeys() {
         final String value = "ThisIsATestValueThatIsGoingToBeEncodedAndDecodedAgainAndAgain";
         final CipherExecutor<byte[], byte[]> cc = new TestBinaryCipherExecutor("1234567890123456",
-          "szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w",
-          512,
-          16);
+            "szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w",
+            512,
+            16);
         final byte[] bytes = cc.encode(value.getBytes());
         final byte[] decoded = cc.decode(bytes);
         assertEquals(new String(decoded), value);

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/BinaryCipherExecutorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/BinaryCipherExecutorTests.java
@@ -44,6 +44,17 @@ public class BinaryCipherExecutorTests {
         cc.encode(value.getBytes());
     }
 
+    @Test
+    public void checkLegacyKeys() {
+        final String value = "ThisIsATestValueThatIsGoingToBeEncodedAndDecodedAgainAndAgain";
+        final CipherExecutor<byte[], byte[]> cc = new TestBinaryCipherExecutor("1234567890123456",
+          "szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w",
+          512,
+          16);
+        final byte[] bytes = cc.encode(value.getBytes());
+        final byte[] decoded = cc.decode(bytes);
+        assertEquals(new String(decoded), value);
+    }
     private static class TestBinaryCipherExecutor extends BaseBinaryCipherExecutor {
         TestBinaryCipherExecutor(final String encKey, final String signingKey, final int sKey, final int eKey) {
             super(encKey, signingKey, sKey, eKey);

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/BinaryCipherExecutorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/BinaryCipherExecutorTests.java
@@ -22,7 +22,7 @@ public class BinaryCipherExecutorTests {
     @Test
     public void checkEncodingDecoding() {
         final String value = "ThisIsATestValueThatIsGoingToBeEncodedAndDecodedAgainAndAgain";
-        final CipherExecutor<byte[], byte[]> cc = new TestBinaryCipherExecutor("1234567890123456",
+        final CipherExecutor<byte[], byte[]> cc = new TestBinaryCipherExecutor("MTIzNDU2Nzg5MDEyMzQ1Ng==",
                 "szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w",
                 512,
                 16);

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/HexRandomStringGeneratorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/HexRandomStringGeneratorTests.java
@@ -1,0 +1,32 @@
+package org.apereo.cas.util;
+
+import org.apereo.cas.util.gen.HexRandomStringGenerator;
+import org.apereo.cas.util.gen.RandomStringGenerator;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link HexRandomStringGenerator}.
+ *
+ * @author Timur Duehr
+ *
+ * @since 5.2.0
+ */
+public class HexRandomStringGeneratorTests {
+
+    private static final int LENGTH = 36;
+
+    private final RandomStringGenerator randomStringGenerator = new HexRandomStringGenerator(LENGTH);
+
+    @Test
+    public void verifyDefaultLength() {
+        assertEquals(LENGTH, this.randomStringGenerator.getDefaultLength());
+        assertEquals(LENGTH, new HexRandomStringGenerator().getDefaultLength());
+    }
+
+    @Test
+    public void verifyRandomString() {
+        assertNotSame(this.randomStringGenerator.getNewString(), this.randomStringGenerator.getNewString());
+    }
+}

--- a/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/JsonConsentRepository.java
+++ b/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/JsonConsentRepository.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.util.ResourceUtils;
 import org.hjson.JsonValue;
 import org.springframework.core.io.Resource;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.security.SecureRandom;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -54,7 +54,7 @@ public class JsonConsentRepository implements ConsentRepository {
         if (consent != null) {
             this.consentDecisions.remove(decision);
         } else {
-            decision.setId(Math.abs(new SecureRandom().nextInt()));
+            decision.setId(Math.abs(RandomUtils.getInstanceStrong().nextInt()));
         }
         this.consentDecisions.add(decision);
         writeAccountToJsonResource();

--- a/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/util/DigestAuthenticationUtils.java
+++ b/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/util/DigestAuthenticationUtils.java
@@ -3,6 +3,7 @@ package org.apereo.cas.digest.util;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.impl.auth.DigestScheme;
+import org.apereo.cas.util.RandomUtils;
 
 import java.security.SecureRandom;
 import java.time.ZonedDateTime;
@@ -25,7 +26,7 @@ public final class DigestAuthenticationUtils {
      */
     public static String createNonce() {
         final String fmtDate = ZonedDateTime.now().toString();
-        final SecureRandom rand = new SecureRandom();
+        final SecureRandom rand = RandomUtils.getInstanceStrong();
         final Integer randomInt = rand.nextInt();
         return DigestUtils.md5Hex(fmtDate + randomInt);
     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -60,6 +60,7 @@ import org.apereo.cas.ticket.refreshtoken.OAuthRefreshTokenExpirationPolicy;
 import org.apereo.cas.ticket.refreshtoken.RefreshTokenFactory;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.util.DefaultUniqueTicketIdGenerator;
+import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.cas.config.CasConfiguration;
@@ -83,18 +84,14 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
-import javax.annotation.PostConstruct;
-import java.security.SecureRandom;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.PostConstruct;
 
-import static org.apereo.cas.support.oauth.OAuth20Constants.BASE_OAUTH20_URL;
-import static org.apereo.cas.support.oauth.OAuth20Constants.CALLBACK_AUTHORIZE_URL_DEFINITION;
-import static org.apereo.cas.support.oauth.OAuth20Constants.CLIENT_ID;
-import static org.apereo.cas.support.oauth.OAuth20Constants.CLIENT_SECRET;
+import static org.apereo.cas.support.oauth.OAuth20Constants.*;
 
 /**
  * This this {@link CasOAuthConfiguration}.
@@ -503,7 +500,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
 
         if (svc == null || !svc.getServiceId().equals(oAuthCallbackUrl)) {
             final RegexRegisteredService service = new RegexRegisteredService();
-            service.setId(Math.abs(new SecureRandom().nextLong()));
+            service.setId(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
             service.setEvaluationOrder(0);
             service.setName(service.getClass().getSimpleName());
             service.setDescription("OAuth Authentication Callback Request URL");

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.support.oauth.web;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apereo.cas.CasProtocolConstants;
@@ -31,6 +30,7 @@ import org.apereo.cas.ticket.refreshtoken.DefaultRefreshTokenFactory;
 import org.apereo.cas.ticket.refreshtoken.RefreshToken;
 import org.apereo.cas.ticket.refreshtoken.RefreshTokenFactory;
 import org.apereo.cas.ticket.support.AlwaysExpiresExpirationPolicy;
+import org.apereo.cas.util.EncodingUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
@@ -379,7 +379,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.GRANT_TYPE, OAuth20GrantTypes.AUTHORIZATION_CODE.name().toLowerCase());
         if (basicAuth) {
             final String auth = CLIENT_ID + ':' + CLIENT_SECRET;
-            final String value = Base64.encodeBase64String(auth.getBytes(StandardCharsets.UTF_8));
+            final String value = EncodingUtils.encodeBase64(auth.getBytes(StandardCharsets.UTF_8));
             mockRequest.addHeader(HttpConstants.AUTHORIZATION_HEADER, HttpConstants.BASIC_HEADER_PREFIX + value);
         } else {
             mockRequest.setParameter(OAuth20Constants.CLIENT_ID, CLIENT_ID);

--- a/support/cas-server-support-saml-googleapps-core/src/main/java/org/apereo/cas/support/saml/authentication/principal/GoogleAccountsServiceResponseBuilder.java
+++ b/support/cas-server-support-saml-googleapps-core/src/main/java/org/apereo/cas/support/saml/authentication/principal/GoogleAccountsServiceResponseBuilder.java
@@ -15,6 +15,7 @@ import org.apereo.cas.services.UnauthorizedServiceException;
 import org.apereo.cas.support.saml.SamlProtocolConstants;
 import org.apereo.cas.support.saml.SamlUtils;
 import org.apereo.cas.support.saml.util.GoogleSaml20ObjectBuilder;
+import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.util.crypto.PrivateKeyFactoryBean;
 import org.apereo.cas.util.crypto.PublicKeyFactoryBean;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -33,7 +34,6 @@ import org.springframework.util.ResourceUtils;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.SecureRandom;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -163,7 +163,7 @@ public class GoogleAccountsServiceResponseBuilder extends AbstractWebApplication
                 this.samlObjectBuilder.generateSecureRandomId(), currentDateTime, null, service);
         response.setStatus(this.samlObjectBuilder.newStatus(StatusCode.SUCCESS, null));
 
-        final String sessionIndex = '_' + String.valueOf(Math.abs(new SecureRandom().nextLong()));
+        final String sessionIndex = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
         final AuthnStatement authnStatement = this.samlObjectBuilder.newAuthnStatement(AuthnContext.PASSWORD_AUTHN_CTX, currentDateTime, sessionIndex);
         final Assertion assertion = this.samlObjectBuilder.newAssertion(authnStatement, casServerPrefix,
                 notBeforeIssueInstant, this.samlObjectBuilder.generateSecureRandomId());

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlProfileHandlerController.java
@@ -27,6 +27,7 @@ import org.apereo.cas.support.saml.web.idp.profile.builders.SamlProfileObjectBui
 import org.apereo.cas.support.saml.web.idp.profile.builders.enc.BaseSamlObjectSigner;
 import org.apereo.cas.support.saml.web.idp.profile.builders.enc.SamlObjectSignatureValidator;
 import org.apereo.cas.util.EncodingUtils;
+import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.web.support.WebUtils;
 import org.jasig.cas.client.authentication.AuthenticationRedirectStrategy;
 import org.jasig.cas.client.authentication.DefaultAuthenticationRedirectStrategy;
@@ -47,17 +48,16 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.annotation.PostConstruct;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * A parent controller to handle SAML requests.
@@ -241,7 +241,7 @@ public abstract class AbstractSamlProfileHandlerController {
             LOGGER.debug("Initializing callback service [{}]", callbackService);
 
             final RegexRegisteredService service = new RegexRegisteredService();
-            service.setId(Math.abs(new SecureRandom().nextLong()));
+            service.setId(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
             service.setEvaluationOrder(0);
             service.setName(service.getClass().getSimpleName());
             service.setDescription("SAML Authentication Request");

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAssertionBuilder.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAssertionBuilder.java
@@ -7,6 +7,7 @@ import org.apereo.cas.support.saml.services.SamlRegisteredService;
 import org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade;
 import org.apereo.cas.support.saml.util.AbstractSaml20ObjectBuilder;
 import org.apereo.cas.support.saml.web.idp.profile.builders.enc.BaseSamlObjectSigner;
+import org.apereo.cas.util.RandomUtils;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AttributeStatement;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -18,13 +19,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.security.SecureRandom;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * This is {@link SamlProfileSamlAssertionBuilder}.
@@ -75,7 +75,7 @@ public class SamlProfileSamlAssertionBuilder extends AbstractSaml20ObjectBuilder
         statements.add(this.samlProfileSamlAttributeStatementBuilder.build(authnRequest, request,
                 response, casAssertion, service, adaptor, binding));
 
-        final String id = '_' + String.valueOf(Math.abs(new SecureRandom().nextLong()));
+        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
         final Assertion assertion = newAssertion(statements, casProperties.getAuthn().getSamlIdp().getEntityId(),
                 ZonedDateTime.now(ZoneOffset.UTC), id);
         assertion.setSubject(this.samlProfileSamlSubjectBuilder.build(authnRequest, request, response,

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAuthNStatementBuilder.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAuthNStatementBuilder.java
@@ -9,6 +9,7 @@ import org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceSe
 import org.apereo.cas.support.saml.util.AbstractSaml20ObjectBuilder;
 import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.InetAddressUtils;
+import org.apereo.cas.util.RandomUtils;
 import org.jasig.cas.client.validation.Assertion;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.AuthnStatement;
@@ -16,10 +17,9 @@ import org.opensaml.saml.saml2.core.SubjectLocality;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.ZonedDateTime;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.security.SecureRandom;
-import java.time.ZonedDateTime;
 
 /**
  * This is {@link SamlProfileSamlAuthNStatementBuilder}.
@@ -69,7 +69,7 @@ public class SamlProfileSamlAuthNStatementBuilder extends AbstractSaml20ObjectBu
                                                final SamlRegisteredService service, final String binding) throws SamlException {
 
         final String authenticationMethod = this.authnContextClassRefBuilder.build(assertion, authnRequest, adaptor, service);
-        final String id = '_' + String.valueOf(Math.abs(new SecureRandom().nextLong()));
+        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
         final AuthnStatement statement = newAuthnStatement(authenticationMethod, DateTimeUtils.zonedDateTimeOf(assertion.getAuthenticationDate()), id);
         if (assertion.getValidUntilDate() != null) {
             final ZonedDateTime dt = DateTimeUtils.zonedDateTimeOf(assertion.getValidUntilDate());

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/SamlProfileSaml2ResponseBuilder.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/SamlProfileSaml2ResponseBuilder.java
@@ -9,6 +9,7 @@ import org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceSe
 import org.apereo.cas.support.saml.web.idp.profile.builders.SamlProfileObjectBuilder;
 import org.apereo.cas.support.saml.web.idp.profile.builders.enc.BaseSamlObjectSigner;
 import org.apereo.cas.support.saml.web.idp.profile.builders.enc.SamlObjectEncrypter;
+import org.apereo.cas.util.RandomUtils;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.SAMLVersion;
@@ -24,11 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ui.velocity.VelocityEngineFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.security.SecureRandom;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * This is {@link SamlProfileSaml2ResponseBuilder}.
@@ -57,7 +57,7 @@ public class SamlProfileSaml2ResponseBuilder extends BaseSamlProfileSamlResponse
                                      final HttpServletRequest request,
                                      final HttpServletResponse response,
                                      final String binding) throws SamlException {
-        final String id = '_' + String.valueOf(Math.abs(new SecureRandom().nextLong()));
+        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
         Response samlResponse = newResponse(id, ZonedDateTime.now(ZoneOffset.UTC), authnRequest.getID(), null);
         samlResponse.setVersion(SAMLVersion.VERSION_20);
         samlResponse.setIssuer(buildEntityIssuer());

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
@@ -8,6 +8,7 @@ import org.apereo.cas.util.CompressionUtils;
 import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.EncodingUtils;
 import org.apereo.cas.util.InetAddressUtils;
+import org.apereo.cas.util.RandomUtils;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -363,7 +364,7 @@ public abstract class AbstractSaml20ObjectBuilder extends AbstractSamlObjectBuil
 
     @Override
     public String generateSecureRandomId() {
-        final SecureRandom generator = new SecureRandom();
+        final SecureRandom generator = RandomUtils.getInstanceStrong();
         final char[] charMappings = {
             'a', 'b', 'c', 'd', 'e', 'f', 'g',
             'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSamlObjectBuilder.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSamlObjectBuilder.java
@@ -24,6 +24,17 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.util.Collection;
+import java.util.List;
 import javax.xml.XMLConstants;
 import javax.xml.crypto.dsig.CanonicalizationMethod;
 import javax.xml.crypto.dsig.DigestMethod;
@@ -41,17 +52,6 @@ import javax.xml.crypto.dsig.spec.C14NMethodParameterSpec;
 import javax.xml.crypto.dsig.spec.TransformParameterSpec;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.ByteArrayInputStream;
-import java.io.Serializable;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.nio.charset.Charset;
-import java.security.PrivateKey;
-import java.security.Provider;
-import java.security.PublicKey;
-import java.security.SecureRandom;
-import java.util.Collection;
-import java.util.List;
 
 /**
  * An abstract builder to serve as the template handler
@@ -171,7 +171,7 @@ public abstract class AbstractSamlObjectBuilder implements Serializable {
      */
     public String generateSecureRandomId() {
         try {
-            final SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+            final SecureRandom random = new SecureRandom();
             final byte[] buf = new byte[RANDOM_ID_SIZE];
             random.nextBytes(buf);
             final String hex = EncodingUtils.hexEncode(buf);

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSamlObjectBuilder.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSamlObjectBuilder.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
 import org.apereo.cas.util.CollectionUtils;
-import org.apereo.cas.util.EncodingUtils;
+import org.apereo.cas.util.gen.HexRandomStringGenerator;
 import org.jdom.Document;
 import org.jdom.input.DOMBuilder;
 import org.jdom.input.SAXBuilder;
@@ -32,7 +32,6 @@ import java.nio.charset.Charset;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.PublicKey;
-import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.List;
 import javax.xml.XMLConstants;
@@ -171,14 +170,12 @@ public abstract class AbstractSamlObjectBuilder implements Serializable {
      */
     public String generateSecureRandomId() {
         try {
-            final SecureRandom random = new SecureRandom();
-            final byte[] buf = new byte[RANDOM_ID_SIZE];
-            random.nextBytes(buf);
-            final String hex = EncodingUtils.hexEncode(buf);
+            final HexRandomStringGenerator random = new HexRandomStringGenerator(RANDOM_ID_SIZE);
+            final String hex = random.getNewString();
             if (StringUtils.isBlank(hex)) {
                 throw new IllegalArgumentException("Could not generate a secure random id based on " + random.getAlgorithm());
             }
-            return "_".concat(hex);
+            return "_" + hex;
         } catch (final Exception e) {
             throw new IllegalStateException("Cannot create secure random ID generator for SAML message IDs.", e);
         }

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
@@ -2,6 +2,7 @@ package org.apereo.cas.support.saml.util;
 
 import org.apereo.cas.ticket.UniqueTicketIdGenerator;
 import org.apereo.cas.util.DigestUtils;
+import org.apereo.cas.util.RandomUtils;
 import org.opensaml.saml.common.binding.artifact.AbstractSAMLArtifact;
 import org.opensaml.saml.saml1.binding.artifact.SAML1ArtifactType0001;
 import org.opensaml.saml.saml2.binding.artifact.SAML2ArtifactType0004;
@@ -55,7 +56,7 @@ public class SamlCompliantUniqueTicketIdGenerator implements UniqueTicketIdGener
         } catch (final Exception e) {
             throw new IllegalStateException("Exception generating digest of source ID.", e);
         }
-        this.random = new SecureRandom();
+        this.random = RandomUtils.getInstanceStrong();
     }
 
     /**

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
@@ -6,7 +6,6 @@ import org.opensaml.saml.common.binding.artifact.AbstractSAMLArtifact;
 import org.opensaml.saml.saml1.binding.artifact.SAML1ArtifactType0001;
 import org.opensaml.saml.saml2.binding.artifact.SAML2ArtifactType0004;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 /**
@@ -56,11 +55,7 @@ public class SamlCompliantUniqueTicketIdGenerator implements UniqueTicketIdGener
         } catch (final Exception e) {
             throw new IllegalStateException("Exception generating digest of source ID.", e);
         }
-        try {
-            this.random = SecureRandom.getInstance("SHA1PRNG");
-        } catch (final NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Cannot get SHA1PRNG secure random instance.", e);
-        }
+        this.random = new SecureRandom();
     }
 
     /**

--- a/support/cas-server-support-sqrl/src/main/java/org/apereo/cas/config/SqrlConfiguration.java
+++ b/support/cas-server-support-sqrl/src/main/java/org/apereo/cas/config/SqrlConfiguration.java
@@ -4,6 +4,7 @@ import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.sqrl.SqrlAuthenticationProperties;
 import org.apereo.cas.sqrl.storage.SqrlInMemoryAuthenticationService;
 import org.apereo.cas.sqrl.storage.SqrlInMemoryUserService;
+import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.web.SqrlAuthenticationController;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
 import org.apereo.cas.web.flow.SqrlCleanUpAction;
@@ -25,10 +26,9 @@ import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
 import org.springframework.webflow.execution.Action;
 
-import javax.crypto.KeyGenerator;
 import java.security.Key;
 import java.security.MessageDigest;
-import java.security.SecureRandom;
+import javax.crypto.KeyGenerator;
 
 /**
  * This is {@link SqrlConfiguration}.
@@ -75,7 +75,7 @@ public class SqrlConfiguration {
     @Bean
     public SqrlNutService sqrlNutService() {
         try {
-            return new SqrlNutService(new SecureRandom(), sqrlConfig(),
+            return new SqrlNutService(RandomUtils.getInstanceStrong(), sqrlConfig(),
                     MessageDigest.getInstance("SHA-256"), sqrlAesKey());
         } catch (final Exception e) {
             throw new BeanCreationException(e.getMessage(), e);

--- a/support/cas-server-support-token-authentication/src/test/java/org/apereo/cas/token/authentication/TokenAuthenticationHandlerTests.java
+++ b/support/cas-server-support-token-authentication/src/test/java/org/apereo/cas/token/authentication/TokenAuthenticationHandlerTests.java
@@ -3,7 +3,6 @@ package org.apereo.cas.token.authentication;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JWEAlgorithm;
 import com.nimbusds.jose.JWSAlgorithm;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.HandlerResult;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
@@ -22,7 +21,8 @@ import org.apereo.cas.services.DefaultRegisteredServiceProperty;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ReturnAllAttributeReleasePolicy;
 import org.apereo.cas.token.TokenConstants;
-import org.apereo.cas.util.gen.Base64RandomStringGenerator;
+import org.apereo.cas.util.gen.DefaultRandomStringGenerator;
+import org.apereo.cas.util.gen.RandomStringGenerator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pac4j.core.profile.CommonProfile;
@@ -64,9 +64,9 @@ import static org.junit.Assert.*;
         TokenAuthenticationConfiguration.class})
 public class TokenAuthenticationHandlerTests {
 
-    private static final Base64RandomStringGenerator base64RandomStringGenerator = new Base64RandomStringGenerator();
-    private static final String SIGNING_SECRET = base64RandomStringGenerator.getNewString(256);
-    private static final String ENCRYPTION_SECRET = base64RandomStringGenerator.getNewString(48);
+    private static final RandomStringGenerator generator = new DefaultRandomStringGenerator();
+    private static final String SIGNING_SECRET = generator.getNewString(256);
+    private static final String ENCRYPTION_SECRET = generator.getNewString(48);
 
     @Autowired
     @Qualifier("tokenAuthenticationHandler")

--- a/support/cas-server-support-token-authentication/src/test/java/org/apereo/cas/token/authentication/TokenAuthenticationHandlerTests.java
+++ b/support/cas-server-support-token-authentication/src/test/java/org/apereo/cas/token/authentication/TokenAuthenticationHandlerTests.java
@@ -22,6 +22,7 @@ import org.apereo.cas.services.DefaultRegisteredServiceProperty;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ReturnAllAttributeReleasePolicy;
 import org.apereo.cas.token.TokenConstants;
+import org.apereo.cas.util.gen.Base64RandomStringGenerator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.pac4j.core.profile.CommonProfile;
@@ -63,8 +64,9 @@ import static org.junit.Assert.*;
         TokenAuthenticationConfiguration.class})
 public class TokenAuthenticationHandlerTests {
 
-    private static final String SIGNING_SECRET = RandomStringUtils.randomAlphanumeric(256);
-    private static final String ENCRYPTION_SECRET = RandomStringUtils.randomAlphanumeric(48);
+    private static final Base64RandomStringGenerator base64RandomStringGenerator = new Base64RandomStringGenerator();
+    private static final String SIGNING_SECRET = base64RandomStringGenerator.getNewString(256);
+    private static final String ENCRYPTION_SECRET = base64RandomStringGenerator.getNewString(48);
 
     @Autowired
     @Qualifier("tokenAuthenticationHandler")

--- a/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/BaseWSFederationRequestController.java
+++ b/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/BaseWSFederationRequestController.java
@@ -21,6 +21,7 @@ import org.apereo.cas.ticket.SecurityTokenTicketFactory;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
+import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.util.http.HttpClient;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.apereo.cas.web.support.WebUtils;
@@ -32,11 +33,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.net.URI;
+import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.net.URI;
-import java.security.SecureRandom;
-import java.util.Date;
 
 /**
  * This is {@link BaseWSFederationRequestController}.
@@ -145,7 +145,7 @@ public abstract class BaseWSFederationRequestController {
             LOGGER.debug("Initializing callback service [{}]", callbackService);
 
             final RegexRegisteredService service = new RegexRegisteredService();
-            service.setId(Math.abs(new SecureRandom().nextLong()));
+            service.setId(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
             service.setEvaluationOrder(0);
             service.setName(service.getClass().getSimpleName());
             service.setDescription("WS-Federation Authentication Request");


### PR DESCRIPTION
Closes it's own issue.

changes random string generation to SecureRandom.

Only side effect is some of the strings are larger due to base64 encoding.