### PR TITLE
Use 'Google' name for Google2 pac4j client

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jProperties.java
@@ -194,6 +194,7 @@ public class Pac4jProperties {
         private String secret;
         private String scope;
         private String fields;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -225,6 +226,14 @@ public class Pac4jProperties {
 
         public void setFields(final String fields) {
             this.fields = fields;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
@@ -233,6 +242,7 @@ public class Pac4jProperties {
         private String secret;
         private String scope;
         private String fields;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -265,11 +275,20 @@ public class Pac4jProperties {
         public void setFields(final String fields) {
             this.fields = fields;
         }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
+        }
     }
 
     public static class Bitbucket {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -285,12 +304,21 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
     public static class Wordpress {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -306,12 +334,21 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
     public static class Paypal {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -327,6 +364,14 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
@@ -341,6 +386,7 @@ public class Pac4jProperties {
         private String profileVerb = "POST";
         private Map<String, String> profileAttrs;
         private Map<String, String> customParams;
+        private String clientName;
 
         public String getAuthUrl() {
             return authUrl;
@@ -413,12 +459,21 @@ public class Pac4jProperties {
         public void setSecret(final String secret) {
             this.secret = secret;
         }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
+        }
     }
 
 
     public static class Twitter {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -435,6 +490,14 @@ public class Pac4jProperties {
         public void setSecret(final String secret) {
             this.secret = secret;
         }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
+        }
     }
 
     public static class Saml {
@@ -445,6 +508,7 @@ public class Pac4jProperties {
         private int maximumAuthenticationLifetime = 600;
         private String serviceProviderEntityId;
         private String serviceProviderMetadataPath;
+        private String clientName;
 
         public String getKeystorePassword() {
             return this.keystorePassword;
@@ -501,11 +565,20 @@ public class Pac4jProperties {
         public void setServiceProviderMetadataPath(final String serviceProviderMetadataPath) {
             this.serviceProviderMetadataPath = serviceProviderMetadataPath;
         }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
+        }
     }
 
     public static class Cas {
         private String loginUrl;
         private String protocol;
+        private String clientName;
 
         public String getLoginUrl() {
             return this.loginUrl;
@@ -522,6 +595,14 @@ public class Pac4jProperties {
         public void setProtocol(final String protocol) {
             this.protocol = protocol;
         }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
+        }
     }
 
     public static class Oidc {
@@ -534,6 +615,7 @@ public class Pac4jProperties {
         private String preferredJwsAlgorithm;
         private int maxClockSkew;
         private Map<String, String> customParams = new HashMap<>();
+        private String clientName;
 
         public Map<String, String> getCustomParams() {
             return customParams;
@@ -606,11 +688,20 @@ public class Pac4jProperties {
         public void setMaxClockSkew(final int maxClockSkew) {
             this.maxClockSkew = maxClockSkew;
         }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
+        }
     }
 
     public static class Github {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -626,12 +717,21 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
     public static class Yahoo {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -647,12 +747,21 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
     public static class Foursquare {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -668,12 +777,21 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
     public static class Dropbox {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -689,12 +807,21 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
     public static class WindowsLive {
         private String id;
         private String secret;
+        private String clientName;
 
         public String getId() {
             return this.id;
@@ -710,6 +837,14 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 
@@ -717,6 +852,7 @@ public class Pac4jProperties {
         private String id;
         private String secret;
         private String scope;
+        private String clientName;
 
         public String getScope() {
             return scope;
@@ -740,6 +876,14 @@ public class Pac4jProperties {
 
         public void setSecret(final String secret) {
             this.secret = secret;
+        }
+
+        public String getClientName() {
+            return this.clientName;
+        }
+
+        public void setClientName(final String clientName) {
+            this.clientName = clientName;
         }
     }
 }

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -2878,6 +2878,8 @@ Delegate authentication to an external CAS server.
 ```properties
 # cas.authn.pac4j.cas[0].loginUrl=
 # cas.authn.pac4j.cas[0].protocol=
+# (Optional) Friendly name for CAS, e.g. "This Organization" or "That Organization"
+# cas.authn.pac4j.cas[0].clientName=
 ```
 
 ### Facebook
@@ -2889,6 +2891,7 @@ Delegate authentication to Facebook.
 # cas.authn.pac4j.facebook.id=
 # cas.authn.pac4j.facebook.secret=
 # cas.authn.pac4j.facebook.scope=
+# cas.authn.pac4j.facebook.clientName=
 ```
 
 ### LinkedIn
@@ -2900,6 +2903,7 @@ Delegate authentication to LinkedIn.
 # cas.authn.pac4j.linkedIn.id=
 # cas.authn.pac4j.linkedIn.secret=
 # cas.authn.pac4j.linkedIn.scope=
+# cas.authn.pac4j.linkedIn.clientName=
 ```
 
 ### Twitter
@@ -2909,6 +2913,7 @@ Delegate authentication to Twitter.
 ```properties
 # cas.authn.pac4j.twitter.id=
 # cas.authn.pac4j.twitter.secret=
+# cas.authn.pac4j.twitter.clientName=
 ```
 
 
@@ -2919,6 +2924,7 @@ Delegate authentication to Paypal.
 ```properties
 # cas.authn.pac4j.paypal.id=
 # cas.authn.pac4j.paypal.secret=
+# cas.authn.pac4j.paypal.clientName=
 ```
 
 
@@ -2929,6 +2935,7 @@ Delegate authentication to Wordpress.
 ```properties
 # cas.authn.pac4j.wordpress.id=
 # cas.authn.pac4j.wordpress.secret=
+# cas.authn.pac4j.wordpress.clientName=
 ```
 
 ### OAuth20
@@ -2945,6 +2952,8 @@ Delegate authentication to an generic OAuth2 server.
 # cas.authn.pac4j.oauth2[0].profileVerb=GET|POST
 # cas.authn.pac4j.oauth2[0].profileAttrs.attr1=path-to-attr-in-profile
 # cas.authn.pac4j.oauth2[0].customParams.param1=value1
+# (Optional) Friendly name for OAuth 2 provider, e.g. "This Organization" or "That Organization"
+# cas.authn.pac4j.oauth2[0].clientName=
 ```
 
 ### OpenID Connect
@@ -2961,6 +2970,9 @@ Delegate authentication to an external OpenID Connect server.
 # cas.authn.pac4j.oidc[0].useNonce=
 # cas.authn.pac4j.oidc[0].preferredJwsAlgorithm=
 # cas.authn.pac4j.oidc[0].customParams.param1=value1
+# (Optional) Friendly name for OIDC provider, e.g. "This Organization" or "That Organization"
+# cas.authn.pac4j.oidc[0].clientName=
+
 ```
 
 ### SAML
@@ -3000,6 +3012,7 @@ Delegate authentication to Yahoo.
 ```properties
 # cas.authn.pac4j.yahoo.id=
 # cas.authn.pac4j.yahoo.secret=
+# cas.authn.pac4j.yahoo.clientName=
 ```
 
 ### Dropbox
@@ -3009,6 +3022,7 @@ Delegate authentication to Dropbox.
 ```properties
 # cas.authn.pac4j.dropbox.id=
 # cas.authn.pac4j.dropbox.secret=
+# cas.authn.pac4j.dropbox.clientName=
 ```
 
 ### Github
@@ -3018,6 +3032,7 @@ Delegate authentication to Github.
 ```properties
 # cas.authn.pac4j.github.id=
 # cas.authn.pac4j.github.secret=
+# cas.authn.pac4j.github.clientName=
 ```
 
 ### Foursquare
@@ -3027,6 +3042,7 @@ Delegate authentication to Foursquare.
 ```properties
 # cas.authn.pac4j.foursquare.id=
 # cas.authn.pac4j.foursquare.secret=
+# cas.authn.pac4j.foursquare.clientName=
 ```
 
 ### WindowsLive
@@ -3036,6 +3052,7 @@ Delegate authentication to WindowsLive.
 ```properties
 # cas.authn.pac4j.windowsLive.id=
 # cas.authn.pac4j.windowsLive.secret=
+# cas.authn.pac4j.windowsLive.clientName=
 ```
 
 ### Google
@@ -3046,6 +3063,7 @@ Delegate authentication to Google.
 # cas.authn.pac4j.google.id=
 # cas.authn.pac4j.google.secret=
 # cas.authn.pac4j.google.scope=EMAIL|PROFILE|EMAIL_AND_PROFILE
+# cas.authn.pac4j.google.clientName=
 ```
 
 ## WS Federation

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
@@ -36,6 +36,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * This class represents an action to put at the beginning of the webflow.
@@ -75,6 +76,8 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
     public static final String VIEW_ID_STOP_WEBFLOW = "casPac4jStopWebflow";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DelegatedClientAuthenticationAction.class);
+
+    private static final Pattern PAC4J_CLIENT_SUFFIX_PATTERN = Pattern.compile("Client\\d*");
 
     private final Clients clients;
     private final AuthenticationSystemSupport authenticationSystemSupport;
@@ -197,10 +200,11 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
             try {
                 final IndirectClient indirectClient = (IndirectClient) client;
 
-                final String name = client.getName().replaceAll("Client\\d*", StringUtils.EMPTY);
+                final String name = client.getName();
+                final String type = PAC4J_CLIENT_SUFFIX_PATTERN.matcher(client.getClass().getSimpleName()).replaceAll(StringUtils.EMPTY).toLowerCase();
                 final String redirectionUrl = indirectClient.getRedirectAction(webContext).getLocation();
                 LOGGER.debug("[{}] -> [{}]", name, redirectionUrl);
-                urls.add(new ProviderLoginPageConfiguration(name, redirectionUrl, name.toLowerCase()));
+                urls.add(new ProviderLoginPageConfiguration(name, redirectionUrl, type));
             } catch (final HttpAction e) {
                 if (e.getCode() == HttpStatus.UNAUTHORIZED.value()) {
                     LOGGER.debug("Authentication request was denied from the provider [{}]", client.getName());

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -81,6 +81,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Github github = casProperties.getAuthn().getPac4j().getGithub();
         if (StringUtils.isNotBlank(github.getId()) && StringUtils.isNotBlank(github.getSecret())) {
             final GitHubClient client = new GitHubClient(github.getId(), github.getSecret());
+            if (StringUtils.isNotBlank(github.getClientName())) {
+                client.setName(github.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -90,6 +93,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Dropbox db = casProperties.getAuthn().getPac4j().getDropbox();
         if (StringUtils.isNotBlank(db.getId()) && StringUtils.isNotBlank(db.getSecret())) {
             final DropBoxClient client = new DropBoxClient(db.getId(), db.getSecret());
+            if (StringUtils.isNotBlank(db.getClientName())) {
+                client.setName(db.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -99,6 +105,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.WindowsLive live = casProperties.getAuthn().getPac4j().getWindowsLive();
         if (StringUtils.isNotBlank(live.getId()) && StringUtils.isNotBlank(live.getSecret())) {
             final WindowsLiveClient client = new WindowsLiveClient(live.getId(), live.getSecret());
+            if (StringUtils.isNotBlank(live.getClientName())) {
+                client.setName(live.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -108,6 +117,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Yahoo yahoo = casProperties.getAuthn().getPac4j().getYahoo();
         if (StringUtils.isNotBlank(yahoo.getId()) && StringUtils.isNotBlank(yahoo.getSecret())) {
             final YahooClient client = new YahooClient(yahoo.getId(), yahoo.getSecret());
+            if (StringUtils.isNotBlank(yahoo.getClientName())) {
+                client.setName(yahoo.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -117,6 +129,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Foursquare foursquare = casProperties.getAuthn().getPac4j().getFoursquare();
         if (StringUtils.isNotBlank(foursquare.getId()) && StringUtils.isNotBlank(foursquare.getSecret())) {
             final FoursquareClient client = new FoursquareClient(foursquare.getId(), foursquare.getSecret());
+            if (StringUtils.isNotBlank(foursquare.getClientName())) {
+                client.setName(foursquare.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -126,6 +141,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Google google = casProperties.getAuthn().getPac4j().getGoogle();
         final Google2Client client = new Google2Client(google.getId(), google.getSecret());
         if (StringUtils.isNotBlank(google.getId()) && StringUtils.isNotBlank(google.getSecret())) {
+            if (StringUtils.isNotBlank(google.getClientName())) {
+                client.setName(google.getClientName());
+            }
             if (StringUtils.isNotBlank(google.getScope())) {
                 client.setScope(Google2Client.Google2Scope.valueOf(google.getScope().toUpperCase()));
             }
@@ -138,6 +156,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Facebook fb = casProperties.getAuthn().getPac4j().getFacebook();
         if (StringUtils.isNotBlank(fb.getId()) && StringUtils.isNotBlank(fb.getSecret())) {
             final FacebookClient client = new FacebookClient(fb.getId(), fb.getSecret());
+            if (StringUtils.isNotBlank(fb.getClientName())) {
+                client.setName(fb.getClientName());
+            }
             if (StringUtils.isNotBlank(fb.getScope())) {
                 client.setScope(fb.getScope());
             }
@@ -154,7 +175,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.LinkedIn ln = casProperties.getAuthn().getPac4j().getLinkedIn();
         if (StringUtils.isNotBlank(ln.getId()) && StringUtils.isNotBlank(ln.getSecret())) {
             final LinkedIn2Client client = new LinkedIn2Client(ln.getId(), ln.getSecret());
-
+            if (StringUtils.isNotBlank(ln.getClientName())) {
+                client.setName(ln.getClientName());
+            }
             if (StringUtils.isNotBlank(ln.getScope())) {
                 client.setScope(ln.getScope());
             }
@@ -171,6 +194,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Twitter twitter = casProperties.getAuthn().getPac4j().getTwitter();
         if (StringUtils.isNotBlank(twitter.getId()) && StringUtils.isNotBlank(twitter.getSecret())) {
             final TwitterClient client = new TwitterClient(twitter.getId(), twitter.getSecret());
+            if (StringUtils.isNotBlank(twitter.getClientName())) {
+                client.setName(twitter.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -180,6 +206,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Wordpress wp = casProperties.getAuthn().getPac4j().getWordpress();
         if (StringUtils.isNotBlank(wp.getId()) && StringUtils.isNotBlank(wp.getSecret())) {
             final WordPressClient client = new WordPressClient(wp.getId(), wp.getSecret());
+            if (StringUtils.isNotBlank(wp.getClientName())) {
+                client.setName(wp.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -189,6 +218,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Bitbucket bb = casProperties.getAuthn().getPac4j().getBitbucket();
         if (StringUtils.isNotBlank(bb.getId()) && StringUtils.isNotBlank(bb.getSecret())) {
             final BitbucketClient client = new BitbucketClient(bb.getId(), bb.getSecret());
+            if (StringUtils.isNotBlank(bb.getClientName())) {
+                client.setName(bb.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -198,6 +230,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
         final Pac4jProperties.Paypal paypal = casProperties.getAuthn().getPac4j().getPaypal();
         if (StringUtils.isNotBlank(paypal.getId()) && StringUtils.isNotBlank(paypal.getSecret())) {
             final PayPalClient client = new PayPalClient(paypal.getId(), paypal.getSecret());
+            if (StringUtils.isNotBlank(paypal.getClientName())) {
+                client.setName(paypal.getClientName());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }
@@ -212,7 +247,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
                     final CasConfiguration cfg = new CasConfiguration(cas.getLoginUrl(), cas.getProtocol());
                     final CasClient client = new CasClient(cfg);
                     final int count = index.intValue();
-                    if (count > 0) {
+                    if (StringUtils.isNotBlank(cas.getClientName())) {
+                        client.setName(cas.getClientName());
+                    } else if (count > 0) {
                         client.setName(client.getClass().getSimpleName() + count);
                     }
                     index.incrementAndGet();
@@ -236,7 +273,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
                     final SAML2Client client = new SAML2Client(cfg);
                     
                     final int count = index.intValue();
-                    if (count > 0) {
+                    if (StringUtils.isNotBlank(saml.getClientName())) {
+                        client.setName(saml.getClientName());
+                    } else if (count > 0) {
                         client.setName(client.getClass().getSimpleName() + count);
                     }
                     index.incrementAndGet();
@@ -262,7 +301,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
                     client.setAuthUrl(oauth.getAuthUrl());
                     client.setCustomParams(oauth.getCustomParams());
                     final int count = index.intValue();
-                    if (count > 0) {
+                    if (StringUtils.isNotBlank(oauth.getClientName())) {
+                        client.setName(oauth.getClientName());
+                    } else if (count > 0) {
                         client.setName(client.getClass().getSimpleName() + count);
                     }
                     index.incrementAndGet();
@@ -308,7 +349,9 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration implements Authe
                             break;
                     }
                     final int count = index.intValue();
-                    if (count > 0) {
+                    if (StringUtils.isNotBlank(oidc.getClientName())) {
+                        client.setName(oidc.getClientName());
+                    } else if (count > 0) {
                         client.setName(client.getClass().getSimpleName() + count);
                     }
                     index.incrementAndGet();

--- a/webapp/resources/application.properties
+++ b/webapp/resources/application.properties
@@ -94,3 +94,19 @@ spring.aop.proxy-target-class=true
 # CAS Authentication Credentials
 #
 cas.authn.accept.users=casuser::Mellon
+
+##
+# CAS Delegated Authentication
+#
+cas.authn.pac4j.bitbucket.clientName=Bitbucket
+cas.authn.pac4j.dropbox.clientName=Dropbox
+cas.authn.pac4j.facebook.clientName=Facebook
+cas.authn.pac4j.foursquare.clientName=Foursquare
+cas.authn.pac4j.github.clientName=Github
+cas.authn.pac4j.google.clientName=Google
+cas.authn.pac4j.linkedIn.clientName=LinkedIn
+cas.authn.pac4j.paypal.clientName=PayPal
+cas.authn.pac4j.twitter.clientName=Twitter
+cas.authn.pac4j.yahoo.clientName=Yahoo
+cas.authn.pac4j.windowsLive.clientName=Windows Live
+cas.authn.pac4j.wordpress.clientName=WordPress


### PR DESCRIPTION
This fixes the default Google pac4j login button appearing with a label of Google2 and a class of btn-google2 (instead of bootstrap-social's btn-google).
