### PR TITLE
Only need one MongoClient for this MongoAuthenticationHandler bean.  …

### DIFF
--- a/support/cas-server-support-mongo/src/main/java/org/apereo/cas/authentication/MongoAuthenticationHandler.java
+++ b/support/cas-server-support-mongo/src/main/java/org/apereo/cas/authentication/MongoAuthenticationHandler.java
@@ -11,6 +11,9 @@ import org.pac4j.mongo.credentials.authenticator.MongoAuthenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
 /**
  * An authentication handler to verify credentials against a MongoDb instance.
  * @author Misagh Moayyed
@@ -25,13 +28,24 @@ public class MongoAuthenticationHandler extends UsernamePasswordWrapperAuthentic
     private String attributes;
     private String usernameAttribute;
     private String passwordAttribute;
-    
+    private MongoClientURI uri;
+    private MongoClient client;
+
     private PasswordEncoder mongoPasswordEncoder = new NopPasswordEncoder();
+
+    @PostConstruct
+    private void createMongoClient() {
+        uri = new MongoClientURI(this.mongoHostUri);
+        client = new MongoClient(uri);
+    }
+
+    @PreDestroy
+    private void cleanupResources() {
+        client.close();
+    }
 
     @Override
     protected Authenticator<UsernamePasswordCredentials> getAuthenticator(final Credential credential) {
-        final MongoClientURI uri = new MongoClientURI(this.mongoHostUri);
-        final MongoClient client = new MongoClient(uri);
         LOGGER.info("Connected to MongoDb instance @ {} using database [{}]",
                 uri.getHosts(), uri.getDatabase());
 


### PR DESCRIPTION
…Everytime getAuthentication is called resource are created which are never being returned.   MongoClient has connection pool and threads which monitor that pool.  Probably only need one MongoClient for the application.  At min we just need one for this bean.  @PostConstruct will create the connection after bean is initialized and the @PreDestroy will close it returning resources.  Old methods was causing thousands of threads on our server until we restarted CAS.

I have tested something similar but not exactly this change.  I've built my own MongoAuthenicatorHandler(s) as we have both PIN and password codes.  It's the same code just in my own classes and packages.  Which I tested with 5.0.5 of CAS.  Mostly I wanted all to be aware of this issue and fix it as suggested in this pull request or another way.
