### PR TITLE
Ensure native generator is used to avoid failure on Galera. See HHH-1…

### DIFF
--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/CasEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/dao/CasEvent.java
@@ -3,6 +3,7 @@ package org.apereo.cas.support.events.dao;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apereo.cas.authentication.adaptive.geo.GeoLocationRequest;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -29,7 +30,8 @@ import java.util.Map;
 public class CasEvent {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "native")
+    @GenericGenerator(name = "native", strategy = "native")
     private long id = Integer.MAX_VALUE;
 
     @Column(updatable = true, insertable = true, nullable = false)

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractRegisteredService.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/AbstractRegisteredService.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -57,7 +58,8 @@ public abstract class AbstractRegisteredService implements RegisteredService, Co
     private String theme;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "native")
+    @GenericGenerator(name = "native", strategy = "native")
     private long id = RegisteredService.INITIAL_IDENTIFIER_VALUE;
 
     @Column(length = 255, updatable = true, insertable = true, nullable = false)

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceProperty.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceProperty.java
@@ -3,6 +3,7 @@ package org.apereo.cas.services;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -28,7 +29,8 @@ public class DefaultRegisteredServiceProperty implements RegisteredServiceProper
     private static final long serialVersionUID = 1349556364689133211L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "native")
+    @GenericGenerator(name = "native", strategy = "native")
     private long id;
 
     @Lob

--- a/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/adaptors/gauth/GoogleAuthenticatorRegistrationRecord.java
+++ b/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/adaptors/gauth/GoogleAuthenticatorRegistrationRecord.java
@@ -9,6 +9,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
+import org.hibernate.annotations.GenericGenerator;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +24,8 @@ import java.util.List;
 @Table(name = "GoogleAuthenticatorRegistrationRecord")
 public class GoogleAuthenticatorRegistrationRecord {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "native")
+    @GenericGenerator(name = "native", strategy = "native")
     private long id = Integer.MAX_VALUE;
 
     @Column(updatable = true, insertable = true, nullable = false)

--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -26,7 +27,8 @@ import java.time.LocalDate;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MultifactorAuthenticationTrustRecord implements Comparable<MultifactorAuthenticationTrustRecord> {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "native")
+    @GenericGenerator(name = "native", strategy = "native")
     private long id = Integer.MAX_VALUE;
 
     @Column(updatable = true, insertable = true, nullable = false)


### PR DESCRIPTION
As described on cas-dev, CAS 5.x currently does not work with Galera cluster. 

This is a Hibernate 5.x limitation, as @GeneratedValue(strategy = GenerationType.AUTO) causes the TABLE sequence generator to be used on MySQL, instead of IDENTITY. 

As the hibernate_sequence table does not hold a PK, hibernate_sequence table could not be created on a Galera cluster, as it needs a PK on every table.

See https://hibernate.atlassian.net/browse/HHH-11014

