### PR TITLE
NativePRNG too slow

### DIFF
--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceTestUtils.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceTestUtils.java
@@ -105,7 +105,7 @@ public final class RegisteredServiceTestUtils {
             s.setName("Test registered service " + id);
             s.setDescription("Registered service description");
             s.setProxyPolicy(new RegexMatchingRegisteredServiceProxyPolicy("^https?://.+"));
-            s.setId(RandomUtils.getInstanceStrong().nextInt(Math.abs(s.hashCode())));
+            s.setId(RandomUtils.getInstanceGood().nextInt(Math.abs(s.hashCode())));
             s.setTheme("exampleTheme");
             s.setUsernameAttributeProvider(new PrincipalAttributeRegisteredServiceUsernameProvider("uid"));
             final DefaultRegisteredServiceAccessStrategy accessStrategy =

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RandomUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/RandomUtils.java
@@ -9,7 +9,7 @@ import java.security.SecureRandom;
  * in one spot.
  *
  * @author Timur Duehr timur.duehr@nccgroup.trust
- * @since 5.0.0
+ * @since 5.2.0
  */
 public final class RandomUtils {
     private RandomUtils() {
@@ -25,6 +25,19 @@ public final class RandomUtils {
             return SecureRandom.getInstanceStrong();
         } catch (final NoSuchAlgorithmException e) {
             throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get strong enough SecureRandom instance and wrap the checked exception.
+     *
+     * @return the strong instance
+     */
+    public static SecureRandom getInstanceGood() {
+        try {
+            return SecureRandom.getInstance("NativePRNGNonBlocking");
+        } catch (final NoSuchAlgorithmException e) {
+            return new SecureRandom();
         }
     }
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/gen/AbstractRandomStringGenerator.java
@@ -16,7 +16,7 @@ import java.security.SecureRandom;
  */
 public abstract class AbstractRandomStringGenerator implements RandomStringGenerator{
     /** An instance of secure random to ensure randomness is secure. */
-    protected final SecureRandom randomizer = RandomUtils.getInstanceStrong();
+    protected final SecureRandom randomizer = RandomUtils.getInstanceGood();
 
     /** Default string length before encoding. */
     protected final int defaultLength;

--- a/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/JsonConsentRepository.java
+++ b/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/JsonConsentRepository.java
@@ -54,7 +54,7 @@ public class JsonConsentRepository implements ConsentRepository {
         if (consent != null) {
             this.consentDecisions.remove(decision);
         } else {
-            decision.setId(Math.abs(RandomUtils.getInstanceStrong().nextInt()));
+            decision.setId(Math.abs(RandomUtils.getInstanceGood().nextInt()));
         }
         this.consentDecisions.add(decision);
         writeAccountToJsonResource();

--- a/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/util/DigestAuthenticationUtils.java
+++ b/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/util/DigestAuthenticationUtils.java
@@ -26,7 +26,7 @@ public final class DigestAuthenticationUtils {
      */
     public static String createNonce() {
         final String fmtDate = ZonedDateTime.now().toString();
-        final SecureRandom rand = RandomUtils.getInstanceStrong();
+        final SecureRandom rand = RandomUtils.getInstanceGood();
         final Integer randomInt = rand.nextInt();
         return DigestUtils.md5Hex(fmtDate + randomInt);
     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -500,7 +500,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
 
         if (svc == null || !svc.getServiceId().equals(oAuthCallbackUrl)) {
             final RegexRegisteredService service = new RegexRegisteredService();
-            service.setId(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
+            service.setId(Math.abs(RandomUtils.getInstanceGood().nextLong()));
             service.setEvaluationOrder(0);
             service.setName(service.getClass().getSimpleName());
             service.setDescription("OAuth Authentication Callback Request URL");

--- a/support/cas-server-support-saml-googleapps-core/src/main/java/org/apereo/cas/support/saml/authentication/principal/GoogleAccountsServiceResponseBuilder.java
+++ b/support/cas-server-support-saml-googleapps-core/src/main/java/org/apereo/cas/support/saml/authentication/principal/GoogleAccountsServiceResponseBuilder.java
@@ -163,7 +163,7 @@ public class GoogleAccountsServiceResponseBuilder extends AbstractWebApplication
                 this.samlObjectBuilder.generateSecureRandomId(), currentDateTime, null, service);
         response.setStatus(this.samlObjectBuilder.newStatus(StatusCode.SUCCESS, null));
 
-        final String sessionIndex = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
+        final String sessionIndex = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceGood().nextLong()));
         final AuthnStatement authnStatement = this.samlObjectBuilder.newAuthnStatement(AuthnContext.PASSWORD_AUTHN_CTX, currentDateTime, sessionIndex);
         final Assertion assertion = this.samlObjectBuilder.newAssertion(authnStatement, casServerPrefix,
                 notBeforeIssueInstant, this.samlObjectBuilder.generateSecureRandomId());

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlProfileHandlerController.java
@@ -241,7 +241,7 @@ public abstract class AbstractSamlProfileHandlerController {
             LOGGER.debug("Initializing callback service [{}]", callbackService);
 
             final RegexRegisteredService service = new RegexRegisteredService();
-            service.setId(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
+            service.setId(Math.abs(RandomUtils.getInstanceGood().nextLong()));
             service.setEvaluationOrder(0);
             service.setName(service.getClass().getSimpleName());
             service.setDescription("SAML Authentication Request");

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAssertionBuilder.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAssertionBuilder.java
@@ -75,7 +75,7 @@ public class SamlProfileSamlAssertionBuilder extends AbstractSaml20ObjectBuilder
         statements.add(this.samlProfileSamlAttributeStatementBuilder.build(authnRequest, request,
                 response, casAssertion, service, adaptor, binding));
 
-        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
+        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceGood().nextLong()));
         final Assertion assertion = newAssertion(statements, casProperties.getAuthn().getSamlIdp().getEntityId(),
                 ZonedDateTime.now(ZoneOffset.UTC), id);
         assertion.setSubject(this.samlProfileSamlSubjectBuilder.build(authnRequest, request, response,

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAuthNStatementBuilder.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileSamlAuthNStatementBuilder.java
@@ -69,7 +69,7 @@ public class SamlProfileSamlAuthNStatementBuilder extends AbstractSaml20ObjectBu
                                                final SamlRegisteredService service, final String binding) throws SamlException {
 
         final String authenticationMethod = this.authnContextClassRefBuilder.build(assertion, authnRequest, adaptor, service);
-        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
+        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceGood().nextLong()));
         final AuthnStatement statement = newAuthnStatement(authenticationMethod, DateTimeUtils.zonedDateTimeOf(assertion.getAuthenticationDate()), id);
         if (assertion.getValidUntilDate() != null) {
             final ZonedDateTime dt = DateTimeUtils.zonedDateTimeOf(assertion.getValidUntilDate());

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/SamlProfileSaml2ResponseBuilder.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/SamlProfileSaml2ResponseBuilder.java
@@ -57,7 +57,7 @@ public class SamlProfileSaml2ResponseBuilder extends BaseSamlProfileSamlResponse
                                      final HttpServletRequest request,
                                      final HttpServletResponse response,
                                      final String binding) throws SamlException {
-        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
+        final String id = '_' + String.valueOf(Math.abs(RandomUtils.getInstanceGood().nextLong()));
         Response samlResponse = newResponse(id, ZonedDateTime.now(ZoneOffset.UTC), authnRequest.getID(), null);
         samlResponse.setVersion(SAMLVersion.VERSION_20);
         samlResponse.setIssuer(buildEntityIssuer());

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
@@ -364,7 +364,7 @@ public abstract class AbstractSaml20ObjectBuilder extends AbstractSamlObjectBuil
 
     @Override
     public String generateSecureRandomId() {
-        final SecureRandom generator = RandomUtils.getInstanceStrong();
+        final SecureRandom generator = RandomUtils.getInstanceGood();
         final char[] charMappings = {
             'a', 'b', 'c', 'd', 'e', 'f', 'g',
             'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/SamlCompliantUniqueTicketIdGenerator.java
@@ -56,7 +56,7 @@ public class SamlCompliantUniqueTicketIdGenerator implements UniqueTicketIdGener
         } catch (final Exception e) {
             throw new IllegalStateException("Exception generating digest of source ID.", e);
         }
-        this.random = RandomUtils.getInstanceStrong();
+        this.random = RandomUtils.getInstanceGood();
     }
 
     /**

--- a/support/cas-server-support-sqrl/src/main/java/org/apereo/cas/config/SqrlConfiguration.java
+++ b/support/cas-server-support-sqrl/src/main/java/org/apereo/cas/config/SqrlConfiguration.java
@@ -75,7 +75,7 @@ public class SqrlConfiguration {
     @Bean
     public SqrlNutService sqrlNutService() {
         try {
-            return new SqrlNutService(RandomUtils.getInstanceStrong(), sqrlConfig(),
+            return new SqrlNutService(RandomUtils.getInstanceGood(), sqrlConfig(),
                     MessageDigest.getInstance("SHA-256"), sqrlAesKey());
         } catch (final Exception e) {
             throw new BeanCreationException(e.getMessage(), e);

--- a/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/BaseWSFederationRequestController.java
+++ b/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/BaseWSFederationRequestController.java
@@ -145,7 +145,7 @@ public abstract class BaseWSFederationRequestController {
             LOGGER.debug("Initializing callback service [{}]", callbackService);
 
             final RegexRegisteredService service = new RegexRegisteredService();
-            service.setId(Math.abs(RandomUtils.getInstanceStrong().nextLong()));
+            service.setId(Math.abs(RandomUtils.getInstanceGood().nextLong()));
             service.setEvaluationOrder(0);
             service.setName(service.getClass().getSimpleName());
             service.setDescription("WS-Federation Authentication Request");


### PR DESCRIPTION
Try NativePRNGNonBlocking and failover to SHA1PRNG until Java 9

- [] Any possible limitations, side effects, etc

Weakens random source slightly.

- [] Reference any other pull requests that might be related.

#2812 moved SecureRandom to NativePRNG which is too slow on some platforms for the volume of data retrieved.

This corrects that by moving it to non blocking IO and falling back to the default.