### PR TITLE
Fix for Shibboleth compatible PersistentID generator

### DIFF
--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGenerator.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGenerator.java
@@ -72,7 +72,7 @@ public class ShibbolethCompatiblePersistentIdGenerator implements PersistentIdGe
     @Override
     public String generate(final String principal, final String service) {
         final String data = String.join(CONST_SEPARATOR, service, principal);
-        final String result = StringUtils.remove(DigestUtils.shaBase64(this.salt, data), System.getProperty("line.separator"));
+        final String result = StringUtils.remove(DigestUtils.shaBase64(this.salt, data, CONST_SEPARATOR), System.getProperty("line.separator"));
         LOGGER.debug("Generated persistent id for [{}] is [{}]", data, result);
         return result;
     }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGeneratorTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGeneratorTests.java
@@ -32,6 +32,19 @@ public class ShibbolethCompatiblePersistentIdGeneratorTests {
     }
 
     @Test
+    public void realTestofGeneratorThatVerifiesValueReturned() {
+        final ShibbolethCompatiblePersistentIdGenerator generator = new ShibbolethCompatiblePersistentIdGenerator("thisisasalt");
+
+        final Principal p = mock(Principal.class);
+        when(p.getId()).thenReturn("grudkin");
+        final Service s = mock(Service.class);
+        when(s.getId()).thenReturn("https://shibboleth.irbmanager.com/");
+
+        final String value = generator.generate(p, s);
+        assertEquals("jvZO/wYedArYIEIORGdHoMO4qkw=", value);
+    }
+
+    @Test
     public void verifySerializeAShibbolethCompatiblePersistentIdGeneratorToJson() throws IOException {
         final ShibbolethCompatiblePersistentIdGenerator generatorWritten = new ShibbolethCompatiblePersistentIdGenerator("scottssalt");
 

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/DigestUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/DigestUtils.java
@@ -77,7 +77,7 @@ public final class DigestUtils {
      * @param separator a string separator, if any
      * @return the string
      */
-    public static String shaBase64(String salt, String data, String separator) {
+    public static String shaBase64(final String salt, final String data, final String separator) {
         final byte[] result = rawDigest(MessageDigestAlgorithms.SHA_1, salt, separator == null ? data : data + separator);
         return EncodingUtils.encodeBase64(result);
     }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/util/DigestUtils.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/util/DigestUtils.java
@@ -66,7 +66,19 @@ public final class DigestUtils {
      * @return the string
      */
     public static String shaBase64(final String salt, final String data) {
-        final byte[] result = rawDigest(MessageDigestAlgorithms.SHA_1, salt, data);
+        return shaBase64(salt, data, null);
+    }
+
+    /**
+     * Sha base 64 string.
+     *
+     * @param salt the salt
+     * @param data the data
+     * @param separator a string separator, if any
+     * @return the string
+     */
+    public static String shaBase64(String salt, String data, String separator) {
+        final byte[] result = rawDigest(MessageDigestAlgorithms.SHA_1, salt, separator == null ? data : data + separator);
         return EncodingUtils.encodeBase64(result);
     }
     
@@ -131,5 +143,4 @@ public final class DigestUtils {
         digest.reset();
         return digest;
     }
-    
 }


### PR DESCRIPTION
This is a fix for the Shibboleth compatible PersistentID generator. The fix is two parts:

* A test that will test for a valid value and verify the returned value of the generated against this value
* Updates to the generator to satisfy the test

No further configuration beyond what is documented should be needed.

There should be no side effects other than the generated ID will be different now, possibly preventing the use of services previously integrated. A new generator might need to be created to replicate the broken state.



<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
