### PR TITLE
Add clientMode config option to run the Ignite node as a client for externalizing the server node

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ignite/IgniteProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ignite/IgniteProperties.java
@@ -127,6 +127,12 @@ public class IgniteProperties implements Serializable {
     private int threadPriority = 10;
 
     /**
+     * Start in client mode.
+     * If true the local node is started as a client.
+     */
+    private boolean clientMode;
+
+    /**
      * Sets force server mode flag.
      * If true {@code TcpDiscoverySpi} is started in server mode regardless of {@code IgniteConfiguration.isClientMode()}.
      */
@@ -200,6 +206,14 @@ public class IgniteProperties implements Serializable {
 
     public void setForceServerMode(final boolean forceServerMode) {
         this.forceServerMode = forceServerMode;
+    }
+
+    public boolean isClientMode() {
+        return clientMode;
+    }
+
+    public void setClientMode(final boolean clientMode) {
+        this.clientMode = clientMode;
     }
 
     public EncryptionRandomizedSigningJwtCryptographyProperties getCrypto() {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -4434,6 +4434,7 @@ To learn more about this topic, [please review this guide](Ignite-Ticket-Registr
 # cas.ticket.registry.ignite.socketTimeout=5000
 # cas.ticket.registry.ignite.threadPriority=10
 # cas.ticket.registry.ignite.forceServerMode=false
+# cas.ticket.registry.ignite.clientMode=false
 
 # cas.ticket.registry.ignite.ticketsCache.writeSynchronizationMode=FULL_SYNC
 # cas.ticket.registry.ignite.ticketsCache.atomicityMode=TRANSACTIONAL

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -876,7 +876,7 @@ ext.libraries = [
                 dependencies.create("org.apache.ignite:ignite-core:$igniteVersion") {
                     force = true
                 },
-                dependencies.create("org.apache.ignite:ignite-log4j:$igniteVersion") {
+                dependencies.create("org.apache.ignite:ignite-log4j2:$igniteVersion") {
                     exclude(group: "log4j", module: "log4j")
                     force = true
                 },

--- a/support/cas-server-support-ignite-ticket-registry/build.gradle
+++ b/support/cas-server-support-ignite-ticket-registry/build.gradle
@@ -1,8 +1,10 @@
 description = "Apereo CAS Ignite Integration"
 dependencies {
     implementation libraries.ignite
+
     compile project(":api:cas-server-core-api")
     compile project(":core:cas-server-core-tickets")
+    compile project(":core:cas-server-core-logging")
 
     testImplementation project(":support:cas-server-support-person-directory")
     testImplementation project(path: ":core:cas-server-core-authentication", configuration: "tests")

--- a/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/config/IgniteTicketRegistryConfiguration.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/config/IgniteTicketRegistryConfiguration.java
@@ -22,11 +22,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
-import javax.cache.expiry.CreatedExpiryPolicy;
-import javax.cache.expiry.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
 
 /**
  * This is {@link IgniteTicketRegistryConfiguration}.
@@ -74,6 +74,7 @@ public class IgniteTicketRegistryConfiguration {
         config.setDiscoverySpi(spi);
         final Collection<CacheConfiguration> cacheConfigurations = buildIgniteTicketCaches(ignite, ticketCatalog);
         config.setCacheConfiguration(cacheConfigurations.toArray(new CacheConfiguration[]{}));
+        config.setClientMode(ignite.isClientMode());
 
         return config;
     }


### PR DESCRIPTION
# Details

Completes support for logging through log4j2 to the ignite support.

Adds client mode config option to run the Ignite node as a client for externalizing the server node.
  - Netsplits caused the ignite grid to segregate and ignite has no good way of handling this without restarting the JVM.

No doc needed for the log4j stuff, it's just completing the support so ignite will use log4j2. The client mode change has an entry for the config option added and needs no other doc.

Fixes limitations of my prior ignite work.