### PR TITLE
Fix possible NPE in JcifsSpnegoAuthenticationHandler

### DIFF
--- a/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/handler/support/JcifsSpnegoAuthenticationHandler.java
+++ b/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/handler/support/JcifsSpnegoAuthenticationHandler.java
@@ -60,12 +60,13 @@ public class JcifsSpnegoAuthenticationHandler extends AbstractPreAndPostProcessi
                 this.authentication.process(spnegoCredential.getInitToken());
                 
                 principal = this.authentication.getPrincipal();
-                LOGGER.debug("Authenticated SPNEGO principal [{}]", principal.getName());
+                LOGGER.debug("Authenticated SPNEGO principal [{}]", principal != null ? principal.getName() : null);
 
                 LOGGER.debug("Retrieving the next token for authentication");
                 nextToken = this.authentication.getNextToken();
             }
         } catch (final jcifs.spnego.AuthenticationException e) {
+            LOGGER.debug("Processing SPNEGO authentication failed with exception", e);
             throw new FailedLoginException(e.getMessage());
         }
 

--- a/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/MockJcifsAuthentication.java
+++ b/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/MockJcifsAuthentication.java
@@ -1,9 +1,9 @@
 package org.apereo.cas.support.spnego;
 
+import java.security.Principal;
+
 import jcifs.spnego.Authentication;
 import jcifs.spnego.AuthenticationException;
-
-import java.security.Principal;
 
 /**
  *
@@ -13,29 +13,25 @@ import java.security.Principal;
  */
 public class MockJcifsAuthentication extends Authentication {
 
-    private final Principal principal;
-    private final boolean valid;
-    private final byte[] outToken = new byte[] {4, 5, 6};
+    private Principal principal;
+    private byte[] outToken = new byte[] {4, 5, 6};
 
-    public MockJcifsAuthentication(final boolean valid) {
+    public MockJcifsAuthentication() {
         this.principal = new MockPrincipal("test");
-        this.valid = valid;
     }
 
     @Override
     public byte[] getNextToken() {
-        return this.valid ? this.outToken : null;
+        return this.outToken;
     }
 
     @Override
     public Principal getPrincipal() {
-        return this.valid ? this.principal : null;
+        return this.principal;
     }
 
     @Override
     public void process(final byte[] arg0) throws AuthenticationException {
-        if (!this.valid) {
-            throw new AuthenticationException("not valid");
-        }
+        // empty
     }
 }

--- a/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/MockUnsuccessfulJcifsAuthentication.java
+++ b/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/MockUnsuccessfulJcifsAuthentication.java
@@ -1,0 +1,38 @@
+package org.apereo.cas.support.spnego;
+
+import java.security.Principal;
+
+import jcifs.spnego.Authentication;
+import jcifs.spnego.AuthenticationException;
+
+/**
+ * @author Marc-Antoine Garrigue
+ * @author Arnaud Lesueur
+ * @author Sven Rieckhoff
+ * @since 5.2.0
+ */
+public class MockUnsuccessfulJcifsAuthentication extends Authentication {
+
+    private boolean throwExceptionOnProcess;
+
+    public MockUnsuccessfulJcifsAuthentication(final boolean throwExceptionOnProcess) {
+        this.throwExceptionOnProcess = throwExceptionOnProcess;
+    }
+
+    @Override
+    public byte[] getNextToken() {
+        return null;
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public void process(final byte[] arg0) throws AuthenticationException {
+        if (this.throwExceptionOnProcess) {
+            throw new AuthenticationException("not valid"); //$NON-NLS-1$
+        }
+    }
+}

--- a/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/authentication/handler/support/JcifsSpnegoAuthenticationHandlerTests.java
+++ b/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/authentication/handler/support/JcifsSpnegoAuthenticationHandlerTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.authentication.UsernamePasswordCredential;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.support.spnego.MockJcifsAuthentication;
+import org.apereo.cas.support.spnego.MockUnsuccessfulJcifsAuthentication;
 import org.apereo.cas.support.spnego.authentication.principal.SpnegoCredential;
 import org.junit.Test;
 
@@ -24,8 +25,7 @@ public class JcifsSpnegoAuthenticationHandlerTests {
     @Test
     public void verifySuccessfulAuthenticationWithDomainName() throws Exception {
         final SpnegoCredential credentials = new SpnegoCredential(new byte[] {0, 1, 2});
-        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(true), true,
-                true);
+        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(), true, true);
         assertNotNull(authenticationHandler.authenticate(credentials));
         assertEquals("test", credentials.getPrincipal().getId());
         assertNotNull(credentials.getNextToken());
@@ -34,18 +34,32 @@ public class JcifsSpnegoAuthenticationHandlerTests {
     @Test
     public void verifySuccessfulAuthenticationWithoutDomainName() throws Exception {
         final SpnegoCredential credentials = new SpnegoCredential(new byte[] {0, 1, 2});
-        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(true), false,
-                true);
+        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(), false, true);
         assertNotNull(authenticationHandler.authenticate(credentials));
         assertEquals("test", credentials.getPrincipal().getId());
         assertNotNull(credentials.getNextToken());
     }
 
     @Test
+    public void verifyUnsuccessfulAuthenticationWithExceptionOnProcess() throws Exception {
+        final SpnegoCredential credentials = new SpnegoCredential(new byte[] {0, 1, 2});
+        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockUnsuccessfulJcifsAuthentication(true),
+                true, true);
+
+        try {
+            authenticationHandler.authenticate(credentials);
+            fail("An AbstractAuthenticationException should have been thrown");
+        } catch (final GeneralSecurityException e) {
+            assertNull(credentials.getNextToken());
+            assertNull(credentials.getPrincipal());
+        }
+    }
+
+    @Test
     public void verifyUnsuccessfulAuthentication() throws Exception {
         final SpnegoCredential credentials = new SpnegoCredential(new byte[] {0, 1, 2});
-        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(false), true,
-                true);
+        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockUnsuccessfulJcifsAuthentication(false),
+                true, true);
 
         try {
             authenticationHandler.authenticate(credentials);
@@ -58,8 +72,7 @@ public class JcifsSpnegoAuthenticationHandlerTests {
 
     @Test
     public void verifySupports() {
-        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(true), true,
-                true);
+        final AuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(), true, true);
 
         assertFalse(authenticationHandler.supports(null));
         assertTrue(authenticationHandler.supports(new SpnegoCredential(new byte[] {0, 1, 2})));
@@ -73,14 +86,14 @@ public class JcifsSpnegoAuthenticationHandlerTests {
         final String myKerberosUser = "Username@DOMAIN.COM";
 
         final PrincipalFactory factory = new DefaultPrincipalFactory();
-        final JcifsSpnegoAuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(true),
-                true, true);
+        final JcifsSpnegoAuthenticationHandler authenticationHandler = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(), true,
+                true);
 
         assertEquals(factory.createPrincipal(myNtlmUser), authenticationHandler.getPrincipal(myNtlmUser, true));
         assertEquals(factory.createPrincipal(myNtlmUserWithNoDomain), authenticationHandler.getPrincipal(myNtlmUserWithNoDomain, false));
         assertEquals(factory.createPrincipal(myKerberosUser), authenticationHandler.getPrincipal(myKerberosUser, false));
 
-        final JcifsSpnegoAuthenticationHandler handlerNoDomain = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(true), false,
+        final JcifsSpnegoAuthenticationHandler handlerNoDomain = new JcifsSpnegoAuthenticationHandler("", null, null, new MockJcifsAuthentication(), false,
                 true);
         assertEquals(factory.createPrincipal(USERNAME), handlerNoDomain.getPrincipal(myNtlmUser, true));
         assertEquals(factory.createPrincipal(USERNAME), handlerNoDomain.getPrincipal(myNtlmUserWithNoDomain, true));


### PR DESCRIPTION
**Brief description of changes applied**
An unsuccessful SPNEGO authentication may result in
jcifs.spnego.Authentication.process() to pass without exception and in
authentication.getPrincipal() == null. Fixed code to be null safe
and extended tests to encompass this scenario.

**Any documentation on how to configure, test**
The mentioned scenario occurs if cas-server-support-spnego is enabled
and a windows client tries to authenticate with a local user (= a
user that is unknown for jcifs.spnego.Authentication).

**Any possible limitations, side effects, etc**
Nothing