### PR TITLE
Added cas.samlCore.issueLength property to fix assertion validity period

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/saml/SamlCore.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/saml/SamlCore.java
@@ -10,6 +10,8 @@ package org.apereo.cas.configuration.model.support.saml;
 public class SamlCore {
     private int skewAllowance = 5;
 
+    private int issueLength = 30;
+
     private String attributeNamespace = "http://www.ja-sig.org/products/cas/";
 
     private String issuer = "localhost";
@@ -48,6 +50,14 @@ public class SamlCore {
 
     public void setSkewAllowance(final int skewAllowance) {
         this.skewAllowance = skewAllowance;
+    }
+
+    public int getIssueLength() {
+        return issueLength;
+    }
+
+    public void setIssueLength(final int issueLength) {
+        this.issueLength = issueLength;
     }
 
     public boolean isTicketidSaml2() {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -2490,7 +2490,8 @@ Control core SAML functionality within CAS.
 
 ```properties
 # cas.samlCore.ticketidSaml2=false
-# cas.samlCore.skewAllowance=0
+# cas.samlCore.skewAllowance=5
+# cas.samlCore.issueLength=30
 # cas.samlCore.attributeNamespace=http://www.ja-sig.org/products/cas/
 # cas.samlCore.issuer=localhost
 # cas.samlCore.securityManager=com.sun.org.apache.xerces.internal.util.SecurityManager

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
@@ -91,7 +91,8 @@ public class SamlConfiguration {
                 servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(),
                 saml10ObjectBuilder(), new DefaultArgumentExtractor(new SamlServiceFactory()),
                 StandardCharsets.UTF_8.name(), casProperties.getSamlCore().getSkewAllowance(),
-                casProperties.getSamlCore().getIssuer(), casProperties.getSamlCore().getAttributeNamespace());
+                casProperties.getSamlCore().getIssueLength(), casProperties.getSamlCore().getIssuer(),
+                casProperties.getSamlCore().getAttributeNamespace());
     }
 
     @ConditionalOnMissingBean(name = "casSamlServiceFailureView")
@@ -101,7 +102,8 @@ public class SamlConfiguration {
         return new Saml10FailureResponseView(protocolAttributeEncoder,
                 servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(),
                 saml10ObjectBuilder(), new DefaultArgumentExtractor(new SamlServiceFactory()),
-                StandardCharsets.UTF_8.name(), casProperties.getSamlCore().getSkewAllowance());
+                StandardCharsets.UTF_8.name(), casProperties.getSamlCore().getSkewAllowance(),
+                casProperties.getSamlCore().getIssueLength());
     }
 
 

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/Saml10ObjectBuilder.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/util/Saml10ObjectBuilder.java
@@ -124,7 +124,7 @@ public class Saml10ObjectBuilder extends AbstractSamlObjectBuilder {
     public Conditions newConditions(final ZonedDateTime issuedAt, final String audienceUri, final long issueLength) {
         final Conditions conditions = newSamlObject(Conditions.class);
         conditions.setNotBefore(DateTimeUtils.dateTimeOf(issuedAt));
-        conditions.setNotOnOrAfter(DateTimeUtils.dateTimeOf(issuedAt.plus(issueLength, ChronoUnit.MILLIS)));
+        conditions.setNotOnOrAfter(DateTimeUtils.dateTimeOf(issuedAt.plus(issueLength, ChronoUnit.SECONDS)));
         final AudienceRestrictionCondition audienceRestriction = newSamlObject(AudienceRestrictionCondition.class);
         final Audience audience = newSamlObject(Audience.class);
         audience.setUri(audienceUri);

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -39,6 +39,9 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
      **/
     protected final int skewAllowance;
 
+    /**
+     * Assertion validity period length.
+     **/
     protected final int issueLength;
     
     private final ArgumentExtractor samlArgumentExtractor;

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -38,6 +38,8 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
      * Skew time.
      **/
     protected final int skewAllowance;
+
+    protected final int issueLength;
     
     private final ArgumentExtractor samlArgumentExtractor;
 
@@ -69,6 +71,8 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
      *                                       be used in situations where the NTP server is unresponsive to
      *                                       sync time on the client, or the client is simply unable
      *                                       to adjust their server time configuration.
+     * @param issueLength                    Sets the length of time in seconds between the {@code NotBefore}
+     *                                       and {@code NotOnOrAfter} attributes in the SAML assertion. Default 30s.
      */
     public AbstractSaml10ResponseView(final boolean successResponse,
                                       final ProtocolAttributeEncoder protocolAttributeEncoder,
@@ -77,11 +81,13 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
                                       final Saml10ObjectBuilder samlObjectBuilder,
                                       final ArgumentExtractor samlArgumentExtractor,
                                       final String encoding,
-                                      final int skewAllowance) {
+                                      final int skewAllowance,
+                                      final int issueLength) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute);
         this.samlObjectBuilder = samlObjectBuilder;
         this.samlArgumentExtractor = samlArgumentExtractor;
         this.encoding = encoding;
+        this.issueLength = issueLength;
 
         LOGGER.debug("Using [{}] seconds as skew allowance.", skewAllowance);
         this.skewAllowance = skewAllowance;

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseView.java
@@ -26,9 +26,10 @@ public class Saml10FailureResponseView extends AbstractSaml10ResponseView {
             final Saml10ObjectBuilder samlObjectBuilder,
             final ArgumentExtractor samlArgumentExtractor, 
             final String encoding, 
-            final int skewAllowance) {
+            final int skewAllowance,
+            final int issueLength) {
         super(false, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, 
-                samlObjectBuilder, samlArgumentExtractor, encoding, skewAllowance);
+                samlObjectBuilder, samlArgumentExtractor, encoding, skewAllowance, issueLength);
     }
 
     @Override

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseView.java
@@ -56,10 +56,11 @@ public class Saml10SuccessResponseView extends AbstractSaml10ResponseView {
                                      final ArgumentExtractor samlArgumentExtractor,
                                      final String encoding,
                                      final int skewAllowance,
+                                     final int issueLength,
                                      final String issuer,
                                      final String defaultAttributeNamespace) {
         super(true, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                samlObjectBuilder, samlArgumentExtractor, encoding, skewAllowance);
+                samlObjectBuilder, samlArgumentExtractor, encoding, skewAllowance, issueLength);
         this.issuer = issuer;
         this.rememberMeAttributeName = CasProtocolConstants.VALIDATION_REMEMBER_ME_ATTRIBUTE_NAME;
         this.defaultAttributeNamespace = defaultAttributeNamespace;
@@ -86,7 +87,7 @@ public class Saml10SuccessResponseView extends AbstractSaml10ResponseView {
                 this.samlObjectBuilder.generateSecureRandomId());
         LOGGER.debug("Built assertion for issuer [{}] dated at [{}]", this.issuer, issuedAt);
         
-        final Conditions conditions = this.samlObjectBuilder.newConditions(issuedAt, service.getId(), this.skewAllowance);
+        final Conditions conditions = this.samlObjectBuilder.newConditions(issuedAt, service.getId(), this.issueLength);
         assertion.setConditions(conditions);
         LOGGER.debug("Built assertion conditions for issuer [{}] and service [{}] ", this.issuer, service.getId());
         

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseViewTests.java
@@ -31,7 +31,7 @@ public class Saml10FailureResponseViewTests extends AbstractOpenSamlTests {
         final Saml10ObjectBuilder builder = new Saml10ObjectBuilder(this.configBean);
         view = new Saml10FailureResponseView(null, null, "attribute",
                 builder, new DefaultArgumentExtractor(new SamlServiceFactory()),
-                StandardCharsets.UTF_8.name(), 0);
+                StandardCharsets.UTF_8.name(), 0, 30);
     }
 
     @Test

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
@@ -62,7 +62,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
         this.response = new Saml10SuccessResponseView(new DefaultCasProtocolAttributeEncoder(mgmr, NoOpCipherExecutor.getInstance()),
                 mgmr, "attribute", new Saml10ObjectBuilder(configBean),
                 new DefaultArgumentExtractor(new SamlServiceFactory()), StandardCharsets.UTF_8.name(),
-                1000, "testIssuer", "whatever");         
+                1000, 30, "testIssuer", "whatever");         
     }
 
     @Test


### PR DESCRIPTION
Addresses #2836

### Brief description of changes applied
This adds a `cas.samlCore.issueLength` property with a default value of 30 seconds to properly set the interval between the `NotBefore` and `NotOnOrAfter` timestamps in the SAML assertion. Currently this interval is configured using the `cas.samlCore.skewAllowance` property, which is used to adjust for clock skew.

### Any documentation on how to configure, test
Examining a SAML assertion using the current code and default configuration (with the `skewAllowance` set to `5`) will show the `NotBefore` timestamp set to 5 seconds in the past and `NotOnOrAfter` timestamp set to 5 seconds after `NotBefore`. This results in a validity period that will expire almost immediately after it is issued.

With these changes, the default behavior will result in the `NotBefore` timestamp set to 5 seconds in the past and `NotOnOrAfter` timestamp set to 30 seconds after `NotBefore`, effectively giving the client ~25 seconds to validate the assertion.

### Any possible limitations, side effects, etc
No negative side effects. This will provide backwards compatibility with 4.x, which had a default validity period of 30 seconds.
