### PR TITLE
make it possible to override the localeResolver

### DIFF
--- a/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
+++ b/webapp-mgmt/cas-management-webapp-support/src/main/java/org/apereo/cas/mgmt/config/CasManagementWebAppConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -179,8 +180,9 @@ public class CasManagementWebAppConfiguration extends WebMvcConfigurerAdapter {
         return new SpringSecurityPropertiesAuthorizationGenerator(userProperties());
     }
 
+    @ConditionalOnMissingBean(name = "localeResolver")
     @Bean
-    public CookieLocaleResolver localeResolver() {
+    public LocaleResolver localeResolver() {
         return new CookieLocaleResolver() {
             @Override
             protected Locale determineDefaultLocale(final HttpServletRequest request) {

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasWebAppConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasWebAppConfiguration.java
@@ -4,11 +4,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.web.Log4jServletContextListener;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
@@ -46,8 +48,9 @@ public class CasWebAppConfiguration extends WebMvcConfigurerAdapter {
         return bean;
     }
 
+    @ConditionalOnMissingBean(name = "localeResolver")
     @Bean
-    public CookieLocaleResolver localeResolver() {
+    public LocaleResolver localeResolver() {
         final CookieLocaleResolver bean = new CookieLocaleResolver() {
             @Override
             protected Locale determineDefaultLocale(final HttpServletRequest request) {


### PR DESCRIPTION
Make the LocaleResolver beans conditional on if another LocaleResolver is already loaded into the spring context.

This will allow deployers to deploy a highly customized LocaleResolver if required.