### PR TITLE
Fix rest NPE

### DIFF
--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/TicketsResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/TicketsResource.java
@@ -171,6 +171,7 @@ public class TicketsResource {
     public ResponseEntity<String> createServiceTicket(@RequestBody final MultiValueMap<String, String> requestBody,
                                                       @PathVariable("tgtId") final String tgtId) {
         try {
+            this.centralAuthenticationService.getTicket(tgtId);
             final String serviceId = requestBody.getFirst(CasProtocolConstants.PARAMETER_SERVICE);
             final AuthenticationResultBuilder builder = new DefaultAuthenticationResultBuilder(
                     this.authenticationSystemSupport.getPrincipalElectionStrategy());


### PR DESCRIPTION
Fixes NPE during createServiceTicket REST call with invalid TGT.
I have chosen the shortest way to keep performance high.

ERROR [org.apereo.cas.support.rest.TicketsResource] - <null>
java.lang.NullPointerException: null
        at org.apereo.cas.authentication.DefaultAuthenticationResultBuilder.lambda$buildAuthenticationHistory$1(DefaultAuthenticationResultBuilder.java:118) ~[cas-server-core-authentication-5.1.4-SNAPSHOT.jar:5.1.4-SNAPSHOT]
        at java.util.Iterator.forEachRemaining(Iterator.java:116) ~[?:1.8.0_66]
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[?:1.8.0_66]
        at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580) ~[?:1.8.0_66]
        at org.apereo.cas.authentication.DefaultAuthenticationResultBuilder.buildAuthenticationHistory(DefaultAuthenticationResultBuilder.java:117) ~[cas-server-core-authentication-5.1.4-SNAPSHOT.jar:5.1.4-SNAPSHOT]