### PR TITLE
5.1.x fix principal dn

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
@@ -29,6 +29,8 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
 
     private String principalAttributeId;
 
+    private String principalDnAttributeName;
+
     private List principalAttributeList = new ArrayList();
     private boolean allowMultiplePrincipalAttributeValues;
     private List additionalAttributes = new ArrayList();
@@ -75,6 +77,14 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
 
     public void setPrincipalAttributeId(final String principalAttributeId) {
         this.principalAttributeId = principalAttributeId;
+    }
+
+    public String getPrincipalDnAttributeName() {
+        return principalDnAttributeName;
+    }
+
+    public void setPrincipalDnAttributeName(final String principalDnAttributeName) {
+        this.principalDnAttributeName = principalDnAttributeName;
     }
 
     public List getPrincipalAttributeList() {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1583,6 +1583,7 @@ You may receive unexpected LDAP failures, when CAS is configured to authenticate
 # cas.authn.ldap[0].enhanceWithEntryResolver=true
 # cas.authn.ldap[0].dnFormat=uid=%s,ou=people,dc=example,dc=org
 # cas.authn.ldap[0].principalAttributeId=uid
+# cas.authn.ldap[0].principalDnAttributeName=principalDN
 # cas.authn.ldap[0].principalAttributePassword=password
 # cas.authn.ldap[0].principalAttributeList=sn,cn:commonName,givenName,eduPersonTargettedId:SOME_IDENTIFIER
 # cas.authn.ldap[0].allowMultiplePrincipalAttributeValues=true

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1583,7 +1583,7 @@ You may receive unexpected LDAP failures, when CAS is configured to authenticate
 # cas.authn.ldap[0].enhanceWithEntryResolver=true
 # cas.authn.ldap[0].dnFormat=uid=%s,ou=people,dc=example,dc=org
 # cas.authn.ldap[0].principalAttributeId=uid
-# cas.authn.ldap[0].principalDnAttributeName=principalDN
+# cas.authn.ldap[0].principalDnAttributeName=principalLdapDn
 # cas.authn.ldap[0].principalAttributePassword=password
 # cas.authn.ldap[0].principalAttributeList=sn,cn:commonName,givenName,eduPersonTargettedId:SOME_IDENTIFIER
 # cas.authn.ldap[0].allowMultiplePrincipalAttributeValues=true

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
@@ -115,10 +115,10 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     /**
      * Sets the name of the principal's dn attribute.
      *
-     * @param principalDnattributeName principal's DN attribute name.
+     * @param principalDnAttributeName principal's DN attribute name.
      */
-    public void setPrincipalDnAttributeName(final String principalDnattributeName) {
-        this.principalDnAttributeName = principalDnattributeName;
+    public void setPrincipalDnAttributeName(final String principalDnAttributeName) {
+        this.principalDnAttributeName = principalDnAttributeName;
     }
 
     /**

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
@@ -83,7 +83,7 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     /**
      * Name of attribute to be used for principal's DN.
      */
-    private String principalDnAttributeName = "principalDN";
+    private String principalDnAttributeName = "principalLdapDn";
 
     /**
      * Creates a new authentication handler that delegates to the given authenticator.

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
@@ -225,10 +225,9 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
                         key, ldapEntry.getDn());
             }
         });
-        final String dnAttribute = (StringUtils.isNotBlank(this.principalDnAttributeName)) ? this.principalDnAttributeName : principalDnAttributeName;
-        LOGGER.debug("Recording principal DN attribute as [{}]", dnAttribute);
+        LOGGER.debug("Recording principal DN attribute as [{}]", this.principalDnAttributeName);
 
-        attributeMap.put(dnAttribute, ldapEntry.getDn());
+        attributeMap.put(this.principalDnAttributeName, ldapEntry.getDn());
         LOGGER.debug("Created LDAP principal for id [{}] and [{}] attributes", id, attributeMap.size());
         return this.principalFactory.createPrincipal(id, attributeMap);
     }

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
@@ -81,6 +81,11 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     private String[] authenticatedEntryAttributes = ReturnAttributes.NONE.value();
 
     /**
+     * Name of attribute to be used for principal's DN.
+     */
+    private String principalDnAttributeName = "principalDN";
+
+    /**
      * Creates a new authentication handler that delegates to the given authenticator.
      *
      * @param name             the name
@@ -105,6 +110,15 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
      */
     public void setPrincipalIdAttribute(final String attributeName) {
         this.principalIdAttribute = attributeName;
+    }
+
+    /**
+     * Sets the name of the principal's dn attribute.
+     *
+     * @param principalDnattributeName principal's DN attribute name.
+     */
+    public void setPrincipalDnAttributeName(final String principalDnattributeName) {
+        this.principalDnAttributeName = principalDnattributeName;
     }
 
     /**
@@ -211,7 +225,7 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
                         key, ldapEntry.getDn());
             }
         });
-        final String dnAttribute = getName().concat(".").concat(id);
+        final String dnAttribute = (StringUtils.isNotBlank(this.principalDnAttributeName)) ? this.principalDnAttributeName : principalDnAttributeName;
         LOGGER.debug("Recording principal DN attribute as [{}]", dnAttribute);
 
         attributeMap.put(dnAttribute, ldapEntry.getDn());

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
@@ -101,6 +101,9 @@ public class LdapAuthenticationConfiguration {
                     if (StringUtils.isNotBlank(l.getPrincipalAttributeId())) {
                         additionalAttributes.add(l.getPrincipalAttributeId());
                     }
+                    if (StringUtils.isNotBlank(l.getPrincipalDnAttributeName())) {
+                        handler.setPrincipalDnAttributeName(l.getPrincipalDnAttributeName());
+                    }
                     handler.setAllowMultiplePrincipalAttributeValues(l.isAllowMultiplePrincipalAttributeValues());
                     handler.setAllowMissingPrincipalAttributeValue(l.isAllowMissingPrincipalAttributeValue());
                     handler.setPasswordEncoder(Beans.newPasswordEncoder(l.getPasswordEncoder()));


### PR DESCRIPTION
Using a fixed name for principal's DN attribute name (principalDnAttributeName) solves the following issues:

- if user's id (i.e user@example.com) contains illegal (for xml naming) characters, the following exception occurs when validating ST tickets (CAS3.0 protocol):
`org.xml.sax.SAXParseException: Element type "cas:LdapAuthenticationHandler.user" must be followed by either attribute specifications, ">" or "/>".`

- principal's DN attribute can be referenced, easier, in attribute filtering
policies.
