### PR TITLE
Set a fixed name for principal's DN attribute.

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
@@ -136,6 +136,14 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
         this.principalAttributeId = principalAttributeId;
     }
 
+    public String getPrincipalDnAttributeName() {
+        return principalDnAttributeName;
+    }
+
+    public void setPrincipalDnAttributeName(final String principalDnAttributeName) {
+        this.principalDnAttributeName = principalDnAttributeName;
+    }
+
     public List getPrincipalAttributeList() {
         return principalAttributeList;
     }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
@@ -51,7 +51,10 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
      */
     private String principalAttributeId;
 
-    private String principalDnAttributeName;
+    /**
+     * Name of attribute to be used for principal's DN.
+     */
+    private String principalDnAttributeName = "principalLdapDn";
 
     /**
      * List of attributes to retrieve from LDAP.
@@ -59,6 +62,7 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
      * Example {@code cn:commonName,givenName,eduPersonTargettedId:SOME_IDENTIFIER}
      */
     private List principalAttributeList = new ArrayList();
+
     /**
      * Sets a flag that determines whether multiple values are allowed for the {@link #principalAttributeId}.
      * This flag only has an effect if {@link #principalAttributeId} is configured. If multiple values are detected
@@ -67,6 +71,7 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
      *
      */
     private boolean allowMultiplePrincipalAttributeValues;
+
     /**
      * List of additional attributes to retrieve, if any.
      */
@@ -77,7 +82,7 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
      * if a specific/configured principal id attribute is not found.
      */
     private boolean allowMissingPrincipalAttributeValue = true;
-    
+
     /**
      * When entry DN should be called as an attribute and stored into the principal.
      */

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapAuthenticationProperties.java
@@ -51,6 +51,8 @@ public class LdapAuthenticationProperties extends AbstractLdapAuthenticationProp
      */
     private String principalAttributeId;
 
+    private String principalDnAttributeName;
+
     /**
      * List of attributes to retrieve from LDAP.
      * Attributes can be virtually remapped to multiple names.

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1867,6 +1867,7 @@ You may receive unexpected LDAP failures, when CAS is configured to authenticate
 
 
 # cas.authn.ldap[0].collectDnAttribute=false
+# cas.authn.ldap[0].principalDnAttributeName=principalLdapDn
 # cas.authn.ldap[0].allowMultiplePrincipalAttributeValues=true
 # cas.authn.ldap[0].allowMissingPrincipalAttributeValue=true
 # cas.authn.ldap[0].credentialCriteria=

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
@@ -82,6 +82,10 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     private String[] authenticatedEntryAttributes = ReturnAttributes.NONE.value();
 
     private boolean collectDnAttribute;
+    /**
+     * Name of attribute to be used for principal's DN.
+     */
+    private String principalDnAttributeName = "principalLdapDn";
 
     /**
      * Creates a new authentication handler that delegates to the given authenticator.
@@ -107,6 +111,15 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
      */
     public void setPrincipalIdAttribute(final String attributeName) {
         this.principalIdAttribute = attributeName;
+    }
+
+    /**
+     * Sets the name of the principal's dn attribute.
+     *
+     * @param principalDnAttributeName principal's DN attribute name.
+     */
+    public void setPrincipalDnAttributeName(final String principalDnAttributeName) {
+        this.principalDnAttributeName = principalDnAttributeName;
     }
 
     /**
@@ -225,9 +238,8 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
         });
 
         if (this.collectDnAttribute) {
-            final String dnAttribute = getName().concat(".").concat(username.trim());
-            LOGGER.debug("Recording principal DN attribute as [{}]", dnAttribute);
-            attributeMap.put(dnAttribute, ldapEntry.getDn());
+            LOGGER.debug("Recording principal DN attribute as [{}]", this.principalDnAttributeName);
+            attributeMap.put(this.principalDnAttributeName, ldapEntry.getDn());
         }
         
         return attributeMap;

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
@@ -98,6 +98,9 @@ public class LdapAuthenticationConfiguration {
                     if (StringUtils.isNotBlank(l.getPrincipalAttributeId())) {
                         additionalAttributes.add(l.getPrincipalAttributeId());
                     }
+                    if (StringUtils.isNotBlank(l.getPrincipalDnAttributeName())) {
+                        handler.setPrincipalDnAttributeName(l.getPrincipalDnAttributeName());
+                    }
                     handler.setAllowMultiplePrincipalAttributeValues(l.isAllowMultiplePrincipalAttributeValues());
                     handler.setAllowMissingPrincipalAttributeValue(l.isAllowMissingPrincipalAttributeValue());
                     handler.setPasswordEncoder(Beans.newPasswordEncoder(l.getPasswordEncoder()));


### PR DESCRIPTION
Set a fixed name (default value principalLdapDn) for principal's DN attribute,
instead of dynamically create one, based on principal's username.