### PR TITLE
refixed UIInfo to avoid ClassCast and NullPointerException

### DIFF
--- a/support/cas-server-support-saml-mdui-core/src/main/java/org/apereo/cas/support/saml/mdui/SamlMetadataUIInfo.java
+++ b/support/cas-server-support-saml-mdui-core/src/main/java/org/apereo/cas/support/saml/mdui/SamlMetadataUIInfo.java
@@ -143,8 +143,11 @@ public class SamlMetadataUIInfo extends DefaultRegisteredServiceUserInterfaceInf
      * @return the description
      */
     public String getDescription(final String locale) {
-        final String description = getLocalizedValues(locale, List.class.cast(this.getDescriptions()));
-        return (description != null) ? description : super.getDescription();
+        if (this.uiInfo != null) {
+            final String description = getLocalizedValues(locale, this.uiInfo.getDescriptions());
+            return (description != null) ? description : super.getDescription();
+        }
+        return super.getDescription();
     }
 
     @Override
@@ -159,8 +162,11 @@ public class SamlMetadataUIInfo extends DefaultRegisteredServiceUserInterfaceInf
      * @return the displayName
      */
     public String getDisplayName(final String locale) {
-        final String displayName = getLocalizedValues(locale, List.class.cast(this.getDisplayNames()));
-        return (displayName != null) ? displayName : super.getDisplayName();
+        if (this.uiInfo != null) {
+            final String displayName = getLocalizedValues(locale, this.uiInfo.getDisplayNames());
+            return (displayName != null) ? displayName : super.getDisplayName();
+        }
+        return super.getDisplayName();
     }
 
     @Override
@@ -175,8 +181,11 @@ public class SamlMetadataUIInfo extends DefaultRegisteredServiceUserInterfaceInf
      * @return the informationURL
      */
     public String getInformationURL(final String locale) {
-        final String informationUrl = getLocalizedValues(locale, List.class.cast(this.getInformationURLs()));
-        return (informationUrl != null) ? informationUrl : super.getInformationURL();
+        if (this.uiInfo != null) {
+            final String informationUrl = getLocalizedValues(locale, this.uiInfo.getInformationURLs());
+            return (informationUrl != null) ? informationUrl : super.getInformationURL();
+        }
+        return super.getInformationURL();
     }
 
     @Override
@@ -191,8 +200,11 @@ public class SamlMetadataUIInfo extends DefaultRegisteredServiceUserInterfaceInf
      * @return the privacyStatementURL
      */
     public String getPrivacyStatementURL(final String locale) {
-        final String privacyStatementURL = getLocalizedValues(locale, List.class.cast(this.getPrivacyStatementURLs()));
-        return (privacyStatementURL != null) ? privacyStatementURL : super.getPrivacyStatementURL();
+        if (this.uiInfo != null) {
+            final String privacyStatementURL = getLocalizedValues(locale, this.uiInfo.getPrivacyStatementURLs());
+            return (privacyStatementURL != null) ? privacyStatementURL : super.getPrivacyStatementURL();
+        }
+        return super.getPrivacyStatementURL();
     }
 
     @Override


### PR DESCRIPTION
* call this.uiInfo again to get LocalizedNames
* add null check to avoid NPE

This bug has a history already:
PR https://github.com/apereo/cas/pull/2832
PR https://github.com/apereo/cas/pull/2872 (5.1.x)
Closes #2880
