### PR TITLE
consent: fixed registered service for e.g. saml

### DIFF
--- a/support/cas-server-support-consent-webflow/src/main/java/org/apereo/cas/web/flow/AbstractConsentAction.java
+++ b/support/cas-server-support-consent-webflow/src/main/java/org/apereo/cas/web/flow/AbstractConsentAction.java
@@ -56,10 +56,7 @@ public abstract class AbstractConsentAction extends AbstractAction {
      * @return the registered service for consent
      */
     protected RegisteredService getRegisteredServiceForConsent(final RequestContext requestContext, final Service service) {
-        RegisteredService registeredService = WebUtils.getRegisteredService(requestContext);
-        if (registeredService == null) {
-            registeredService = this.servicesManager.findServiceBy(service);
-        }
+        RegisteredService registeredService = this.servicesManager.findServiceBy(service);
         RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);
         return registeredService;
     }

--- a/support/cas-server-support-consent-webflow/src/main/java/org/apereo/cas/web/flow/AbstractConsentAction.java
+++ b/support/cas-server-support-consent-webflow/src/main/java/org/apereo/cas/web/flow/AbstractConsentAction.java
@@ -56,7 +56,7 @@ public abstract class AbstractConsentAction extends AbstractAction {
      * @return the registered service for consent
      */
     protected RegisteredService getRegisteredServiceForConsent(final RequestContext requestContext, final Service service) {
-        RegisteredService registeredService = this.servicesManager.findServiceBy(service);
+        final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
         RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);
         return registeredService;
     }


### PR DESCRIPTION
For SAML2 services, the RequestContext's service and registered service are both the SAML2/Callback service. 

For consent, service gets resolved to be the SAML service, but in line 59 the registered service was set to the Callback service. I believe this should also be the SAML service, to resolve consentableAttributes correctly.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
