### PR TITLE
Issue reasonable log message for authentication failure (cas-server-support-rest)

### DIFF
--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
@@ -157,7 +157,7 @@ public class TicketGrantingTicketResource {
                 .collect(Collectors.toList());
         final Map<String, List<String>> errorsMap = new HashMap<>();
         errorsMap.put("authentication_exceptions", authnExceptions);
-        LOGGER.error("[{}] Caused by: [{}]", e.getMessage(), authnExceptions, e);
+        LOGGER.warn("[{}] Caused by: [{}]", e.getMessage(), authnExceptions);
         try {
             return new ResponseEntity<>(this.jacksonPrettyWriter.writeValueAsString(errorsMap), HttpStatus.UNAUTHORIZED);
         } catch (final JsonProcessingException exception) {


### PR DESCRIPTION
On a regular authentication failure (wrong password etc.) TicketGrantingTicketResource issues a log message with level ERROR and a stacktrace. This seems inappropriate because 
1) the stacktrace does not provide any useful insights and 
2) the ERROR log level suggest a fatal error although this is a regular result from login workflow.

More reasonable is a WARNing without stacktrace.