### PR TITLE
Add successWithWarnings transition to the list of standard recognized transitions

### DIFF
--- a/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/RankedAuthenticationProviderWebflowEventResolver.java
+++ b/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/RankedAuthenticationProviderWebflowEventResolver.java
@@ -94,7 +94,8 @@ public class RankedAuthenticationProviderWebflowEventResolver extends AbstractCa
 
         if (id.equals(CasWebflowConstants.TRANSITION_ID_ERROR)
                 || id.equals(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE)
-                || id.equals(CasWebflowConstants.TRANSITION_ID_SUCCESS)) {
+                || id.equals(CasWebflowConstants.TRANSITION_ID_SUCCESS)
+                || id.equals(CasWebflowConstants.TRANSITION_ID_SUCCESS_WITH_WARNINGS)) {
             LOGGER.debug("Returning webflow event as [{}]", id);
             return CollectionUtils.wrapSet(event);
         }


### PR DESCRIPTION
Lack of this transition here shows up in the logs as error condition when LPPE warnings are present in the primary authentication leg.