### PR TITLE
fixes casPropagateLogoutView

### DIFF
--- a/webapp/resources/templates/casPropagateLogoutView.html
+++ b/webapp/resources/templates/casPropagateLogoutView.html
@@ -7,15 +7,15 @@
     <script th:inline="javascript">
         /*<![CDATA[*/
         function redirectToApp() {
-            window.location = /*[[${logoutRedirectUrl}]]*/ ;
+            window.location = [[${logoutRedirectUrl}]] ;
         }
         
         function handleCallback(index, status) {
             if (status == 200) {
-                $("#service" + index).addClass("fa fa-check")
+                $("#service" + index).addClass("fa-check").removeClass("fa-question");
                 $("#service" + index).prop('title', 'Logout request was successfully received.');
             } else {
-                $("#service" + index).addClass("fa fa-error")
+                $("#service" + index).addClass("fa-warning").removeClass("fa-question");
                 $("#service" + index).prop('title', 'Logout notification could not be sent.');
             }
         }
@@ -30,32 +30,33 @@
         <p th:utext="#{screen.logout.fc.success}"/>
         <br/><br/>
         <div>
-            <ul start="a">
+            <ol start="a">
                 <li th:each="entry,iterStat : ${logoutUrls}">
                     <script type="text/javascript" th:inline="javascript">
-                        
+                        /*<![CDATA[*/
                         $.ajax({
-                            url:/*[[${entry.key.logoutUrl.toExternalForm()}]]*/,
+                            url: [[${entry.key.logoutUrl.toExternalForm()}]],
                             dataType: 'jsonp',
                             async: true,
-                            contentType: /*[[${entry.value.contentType}]]*/
-                            , data: /*[[${entry.value.message}]]*/
+                            contentType: [[${entry.value.contentType}]]
+                            , data: [[${entry.value.message}]]
                             , success: function (data) {
-                                var index = /*[[${iterStat.index}]]*/;
+                                var index = [[${iterStat.index}]];
                                 handleCallback(index, 200);
                             },
                             error: function (err, textStatus, errorThrown) {
-                                var index = /*[[${iterStat.index}]]*/;
+                                var index = [[${iterStat.index}]];
                                 handleCallback(index, err.status);
                             }
                         });
+                        /*]]>*/
                     </script>
                     <p>
-                        <i data-toggle="tooltip" data-placement="top" th:id="${'service'+iterStat.index}"/> 
-                        <a class="btn btn-link" th:href="${entry.key.service.id}" th:text="${entry.key.service.id}"/>
+                        <i data-toggle="tooltip" data-placement="top" class="fa fa-question" th:id="${'service'+iterStat.index}" title="Logout request pending..."> </i>
+                        <kbd th:text="${entry.key.service.id}"/>
                     </p>
                 </li>
-            </ul>
+            </ol>
 
             
         </div>


### PR DESCRIPTION
This functionality seems to me unfinished - so I provide my working changes. 

- splits empty tag *i* for proper rendering
- properly encloses injected variables
- uses only id for service didplay
- provides interim question icon for pending requests

There are small known bug
- error responses from other domains are not rendered - as error callback is not called in jQuery.

For testing
- set logoutType to FRONT_CHANNEL
- log in to several CASified applications
- logout in CAS and check behaviour of logout page.
- be aware that URLs endings with localdomain are discarded by URLValidator in CAS so more valid URLs should be used

I am not sure how to automate testing of this change.
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
