### PR TITLE
consent: change displayed service id

### DIFF
--- a/support/cas-server-support-consent-webflow/src/main/java/org/apereo/cas/web/flow/AbstractConsentAction.java
+++ b/support/cas-server-support-consent-webflow/src/main/java/org/apereo/cas/web/flow/AbstractConsentAction.java
@@ -82,6 +82,7 @@ public abstract class AbstractConsentAction extends AbstractAction {
         final Map<String, Object> attributes = consentEngine.getConsentableAttributes(authentication, service, registeredService);
         requestContext.getFlowScope().put("attributes", attributes);
         requestContext.getFlowScope().put("principal", authentication.getPrincipal().getId());
+        requestContext.getFlashScope().put("service", service);
 
         final ConsentDecision decision = consentEngine.findConsentDecision(service, registeredService, authentication);
         requestContext.getFlowScope().put("option", decision == null


### PR DESCRIPTION
For Saml services, the previously displayed ${service.id} contained the
callback service with the whole encoded saml request. With this fix, the
actual service as resolved by consent is displayed.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
