### PR TITLE
CAS Issue 2921 - Fix memcached deserialization exception for Service …

### DIFF
--- a/support/cas-server-support-memcached-ticket-registry/build.gradle
+++ b/support/cas-server-support-memcached-ticket-registry/build.gradle
@@ -8,14 +8,12 @@ dependencies {
     compile project(":core:cas-server-core-tickets")
     compile project(":core:cas-server-core-services")
     compile project(":core:cas-server-core-configuration")
-    compile project(":support:cas-server-support-oauth")
 
     testImplementation project(":core:cas-server-core-util")
     testCompileOnly libraries.metrics
     testImplementation project(path: ":core:cas-server-core-authentication", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-tickets", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-services", configuration: "tests")
-    testImplementation project(path: ":support:cas-server-support-oauth", configuration: "tests")
     compileOnly project(":support:cas-server-support-saml")
     compileOnly project(":support:cas-server-support-saml-googleapps-core")
 }

--- a/support/cas-server-support-memcached-ticket-registry/build.gradle
+++ b/support/cas-server-support-memcached-ticket-registry/build.gradle
@@ -1,6 +1,6 @@
 description = "Apereo CAS Memcached Integration"
 dependencies {
-    
+
     implementation libraries.memcached
     implementation libraries.kryo
 
@@ -14,6 +14,7 @@ dependencies {
     testImplementation project(path: ":core:cas-server-core-authentication", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-tickets", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-services", configuration: "tests")
+    compileOnly project(":support:cas-server-support-oauth")
     compileOnly project(":support:cas-server-support-saml")
     compileOnly project(":support:cas-server-support-saml-googleapps-core")
 }

--- a/support/cas-server-support-memcached-ticket-registry/build.gradle
+++ b/support/cas-server-support-memcached-ticket-registry/build.gradle
@@ -8,13 +8,14 @@ dependencies {
     compile project(":core:cas-server-core-tickets")
     compile project(":core:cas-server-core-services")
     compile project(":core:cas-server-core-configuration")
+    compile project(":support:cas-server-support-oauth")
 
     testImplementation project(":core:cas-server-core-util")
     testCompileOnly libraries.metrics
     testImplementation project(path: ":core:cas-server-core-authentication", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-tickets", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-services", configuration: "tests")
-    compileOnly project(":support:cas-server-support-oauth")
+    testImplementation project(path: ":support:cas-server-support-oauth", configuration: "tests")
     compileOnly project(":support:cas-server-support-saml")
     compileOnly project(":support:cas-server-support-saml-googleapps-core")
 }

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoder.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoder.java
@@ -22,6 +22,7 @@ import de.javakaffee.kryoserializers.guava.ImmutableSetSerializer;
 import net.spy.memcached.CachedData;
 import net.spy.memcached.transcoders.Transcoder;
 import org.apereo.cas.authentication.BasicCredentialMetaData;
+import org.apereo.cas.authentication.DefaultAuthentication;
 import org.apereo.cas.authentication.DefaultHandlerResult;
 import org.apereo.cas.authentication.UsernamePasswordCredential;
 import org.apereo.cas.authentication.principal.SimplePrincipal;
@@ -29,11 +30,15 @@ import org.apereo.cas.authentication.principal.SimpleWebApplicationServiceImpl;
 import org.apereo.cas.services.RegexRegisteredService;
 import org.apereo.cas.ticket.ServiceTicketImpl;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
+import org.apereo.cas.ticket.accesstoken.OAuthAccessTokenExpirationPolicy;
+import org.apereo.cas.ticket.code.OAuthCodeExpirationPolicy;
+import org.apereo.cas.ticket.refreshtoken.OAuthRefreshTokenExpirationPolicy;
 import org.apereo.cas.ticket.registry.EncodedTicket;
 import org.apereo.cas.ticket.registry.support.kryo.serial.RegisteredServiceSerializer;
 import org.apereo.cas.ticket.registry.support.kryo.serial.SimpleWebApplicationServiceSerializer;
 import org.apereo.cas.ticket.registry.support.kryo.serial.URLSerializer;
 import org.apereo.cas.ticket.registry.support.kryo.serial.ZonedDateTimeTranscoder;
+import org.apereo.cas.ticket.support.AlwaysExpiresExpirationPolicy;
 import org.apereo.cas.ticket.support.HardTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.MultiTimeUseOrTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
@@ -41,7 +46,6 @@ import org.apereo.cas.ticket.support.RememberMeDelegatingExpirationPolicy;
 import org.apereo.cas.ticket.support.ThrottledUseAndTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.TicketGrantingTicketExpirationPolicy;
 import org.apereo.cas.ticket.support.TimeoutExpirationPolicy;
-import org.apereo.cas.authentication.DefaultAuthentication;
 
 import javax.annotation.PostConstruct;
 import java.io.ByteArrayInputStream;
@@ -114,7 +118,13 @@ public class KryoTranscoder implements Transcoder<Object> {
         this.kryo.register(DefaultHandlerResult.class);
         this.kryo.register(DefaultAuthentication.class);
         this.kryo.register(MultiTimeUseOrTimeoutExpirationPolicy.class);
+        this.kryo.register(MultiTimeUseOrTimeoutExpirationPolicy.ProxyTicketExpirationPolicy.class);
+        this.kryo.register(MultiTimeUseOrTimeoutExpirationPolicy.ServiceTicketExpirationPolicy.class);
         this.kryo.register(NeverExpiresExpirationPolicy.class);
+        this.kryo.register(OAuthAccessTokenExpirationPolicy.class);
+        this.kryo.register(OAuthCodeExpirationPolicy.class);
+        this.kryo.register(OAuthRefreshTokenExpirationPolicy.class);
+        this.kryo.register(AlwaysExpiresExpirationPolicy.class);
         this.kryo.register(RememberMeDelegatingExpirationPolicy.class);
         this.kryo.register(ServiceTicketImpl.class);
         this.kryo.register(SimpleWebApplicationServiceImpl.class, new SimpleWebApplicationServiceSerializer());
@@ -133,7 +143,7 @@ public class KryoTranscoder implements Transcoder<Object> {
 
         // we add these ones for tests only
         this.kryo.register(RegexRegisteredService.class, new RegisteredServiceSerializer());
-        
+
         // from the kryo-serializers library (https://github.com/magro/kryo-serializers)
         UnmodifiableCollectionsSerializer.registerSerializers(this.kryo);
         ImmutableListSerializer.registerSerializers(this.kryo);

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoder.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoder.java
@@ -123,9 +123,11 @@ public class KryoTranscoder implements Transcoder<Object> {
         this.kryo.register(HashMap.class);
         this.kryo.register(LinkedHashMap.class);
         this.kryo.register(HashSet.class);
-        Set singletonSet = Collections.singleton("test");
+        // Can't directly access Collections.SingletonSet (private class), so instantiate one and do a getClass().
+        final Set singletonSet = Collections.singleton("test");
         this.kryo.register(singletonSet.getClass());
-        Map singletonMap = Collections.singletonMap("key", "value");
+        // Can't directly access Collections.SingletonMap (private class), so instantiate one and do a getClass().
+        final Map singletonMap = Collections.singletonMap("key", "value");
         this.kryo.register(singletonMap.getClass());
         this.kryo.register(DefaultHandlerResult.class);
         this.kryo.register(DefaultAuthentication.class);

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -58,6 +58,9 @@ public class KryoTranscoderTests {
     private static final String NICKNAME_KEY = "nickname";
     private static final String NICKNAME_VALUE = "bob";
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     private final KryoTranscoder transcoder;
 
     private final Map<String, Object> principalAttributes;
@@ -65,7 +68,7 @@ public class KryoTranscoderTests {
     /**
      * Class for testing Kryo unregistered class handling.
      */
-    public static class UnregisteredServiceTicketExpirationPolicy extends MultiTimeUseOrTimeoutExpirationPolicy {
+    private static class UnregisteredServiceTicketExpirationPolicy extends MultiTimeUseOrTimeoutExpirationPolicy {
 
         private static final long serialVersionUID = -1;
 
@@ -79,10 +82,6 @@ public class KryoTranscoderTests {
             super(numberOfUses, timeToKillInSeconds);
         }
     }
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
 
     public KryoTranscoderTests() {
         transcoder = new KryoTranscoder();

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -22,9 +22,7 @@ import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.support.MultiTimeUseOrTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import javax.security.auth.login.AccountNotFoundException;
 import java.net.MalformedURLException;
@@ -39,7 +37,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Unit test for {@link KryoTranscoder} class.
@@ -57,9 +57,6 @@ public class KryoTranscoderTests {
     private static final String PASSWORD = "foo";
     private static final String NICKNAME_KEY = "nickname";
     private static final String NICKNAME_VALUE = "bob";
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private final KryoTranscoder transcoder;
 
@@ -127,7 +124,9 @@ public class KryoTranscoderTests {
 
         assertEquals(expectedTGT, resultTicket);
         result = transcoder.encode(ticket);
-        final ServiceTicket resultStTicket = (ServiceTicket) transcoder.decode(result);
+        ServiceTicket resultStTicket = (ServiceTicket) transcoder.decode(result);
+        assertEquals(ticket, resultStTicket);
+        resultStTicket = (ServiceTicket) transcoder.decode(result);
         assertEquals(ticket, resultStTicket);
 
     }
@@ -141,7 +140,9 @@ public class KryoTranscoderTests {
         final Credential userPassCredential = new UsernamePasswordCredential(USERNAME, PASSWORD);
         final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(USERNAME);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
 
         internalProxyTest("http://localhost");
         internalProxyTest("https://localhost:8080/path/file.html?p1=v1&p2=v2#fragment");
@@ -151,7 +152,9 @@ public class KryoTranscoderTests {
         final Credential proxyCredential = new HttpBasedServiceCredential(new URL(proxyUrl), RegisteredServiceTestUtils.getRegisteredService("https://.+"));
         final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(USERNAME);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
@@ -160,7 +163,9 @@ public class KryoTranscoderTests {
         final TicketGrantingTicket expectedTGT =
                 new MockTicketGrantingTicket(TGT_ID, userPassCredential, new HashMap<>(this.principalAttributes));
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
@@ -172,7 +177,9 @@ public class KryoTranscoderTests {
         newAttributes.put(NICKNAME_KEY, Collections.unmodifiableList(values));
         final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(TGT_ID, userPassCredential, newAttributes);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
@@ -181,7 +188,9 @@ public class KryoTranscoderTests {
         final TicketGrantingTicket expectedTGT =
                 new MockTicketGrantingTicket(TGT_ID, userPassCredential, new LinkedHashMap<>(this.principalAttributes));
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
@@ -191,7 +200,9 @@ public class KryoTranscoderTests {
         final TicketGrantingTicket expectedTGT =
                 new MockTicketGrantingTicket(TGT_ID, userPassCredential, this.principalAttributes);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
@@ -203,7 +214,8 @@ public class KryoTranscoderTests {
         final Credential userPassCredential = new UsernamePasswordCredential(USERNAME, PASSWORD);
         final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(TGT_ID, userPassCredential, newAttributes);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
@@ -213,7 +225,9 @@ public class KryoTranscoderTests {
         final Credential userPassCredential = new UsernamePasswordCredential(USERNAME, PASSWORD);
         final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(TGT_ID, userPassCredential, newAttributes);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
@@ -222,13 +236,17 @@ public class KryoTranscoderTests {
         final Credential userPassCredential = new UsernamePasswordCredential(USERNAME, PASSWORD);
         final TicketGrantingTicket expectedTGT = new MockTicketGrantingTicket(TGT_ID, userPassCredential, newAttributes);
         expectedTGT.grantServiceTicket(ST_ID, null, null, false, true);
-        assertEquals(expectedTGT, transcoder.decode(transcoder.encode(expectedTGT)));
+        final CachedData result = transcoder.encode(expectedTGT);
+        assertEquals(expectedTGT, transcoder.decode(result));
+        assertEquals(expectedTGT, transcoder.decode(result));
     }
 
     @Test
     public void verifyEncodeDecodeRegisteredService() throws Exception {
         final RegisteredService service = RegisteredServiceTestUtils.getRegisteredService("helloworld");
-        assertEquals(service, transcoder.decode(transcoder.encode(service)));
+        final CachedData result = transcoder.encode(service);
+        assertEquals(service, transcoder.decode(result));
+        assertEquals(service, transcoder.decode(result));
     }
 
     @Test
@@ -240,17 +258,14 @@ public class KryoTranscoderTests {
         final MultiTimeUseOrTimeoutExpirationPolicy.ServiceTicketExpirationPolicy step
                 = new MultiTimeUseOrTimeoutExpirationPolicy.ServiceTicketExpirationPolicy(1, 600);
         expectedST.setExpiration(step);
-        final CachedData cachedData = transcoder.encode(expectedST);
-        assertEquals(expectedST, transcoder.decode(cachedData));
-        // Test it a second time - there's a Kryo 4.0.0 bug that causes the second deserialize of an object
-        // containing an unregistered class to fail - we want to make sure it works with a registered class.
-        assertEquals(expectedST, transcoder.decode(cachedData));
+        final CachedData result = transcoder.encode(expectedST);
+        assertEquals(expectedST, transcoder.decode(result));
+        // Test it a second time - Ensure there's no problem with subsequent deserializations.
+        assertEquals(expectedST, transcoder.decode(result));
     }
 
     @Test
     public void verifyEncodeDecodeNonRegisteredClass() throws Exception {
-        thrown.expect(KryoException.class);
-
         // UnregisteredServiceTicketExpirationPolicy is not registered with Kryo...
         transcoder.getKryo().getClassResolver().reset();
         final TicketGrantingTicket tgt = new MockTicketGrantingTicket(USERNAME);
@@ -258,12 +273,22 @@ public class KryoTranscoderTests {
         final UnregisteredServiceTicketExpirationPolicy step
                 = new UnregisteredServiceTicketExpirationPolicy(1, 600);
         expectedST.setExpiration(step);
-        final CachedData cachedData = transcoder.encode(expectedST);
-        assertEquals(expectedST, transcoder.decode(cachedData));
-        // Test it a second time - because KryoTranscoder sets the Kryo auto reset to false, and nothing explicitly
-        // calls reset, there's a potential problem with the second deserialize of an object containing an
-        // unregistered class failing...
-        assertEquals(expectedST, transcoder.decode(cachedData));
-        fail("Expected Kryo exception due to not resetting Kryo between deserializations.");
+        final CachedData result = transcoder.encode(expectedST);
+        assertEquals(expectedST, transcoder.decode(result));
+        // Test it a second time - Ensure there's no problem with subsequent deserializations.
+        // Because KryoTranscoder sets 'autoRest' to false, that means between calls to
+        // deserialize (i.e. transcoder.decode), Kryo has now cached the unregistered class, and the second time
+        // through, will not scan past the embedded class name in the serialized data, causing the second (and
+        // subsequent) deserialize to fail.  This second time, we expect Kryo to throw an exception
+        // Note: depending on how the Serialization handling sequences the fields of the object to be
+        // deserialized, the deserialize may throw an exception, or it may return without an exception but
+        // with a value different than the original.  Check for either case.
+        try {
+            assertNotEquals(expectedST, transcoder.decode(result));
+        } catch (KryoException e) {
+            // expected alternative result.
+        } catch (Exception e) {
+            fail("Unexpected exception due to not resetting Kryo between deserializations with unregistered class.");
+        }
     }
 }

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -37,9 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Unit test for {@link KryoTranscoder} class.

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -78,7 +78,7 @@ public class KryoTranscoderTests {
          * @param numberOfUses        the number of uses
          * @param timeToKillInSeconds the time to kill in seconds
          */
-        public UnregisteredServiceTicketExpirationPolicy(final int numberOfUses, final long timeToKillInSeconds) {
+        UnregisteredServiceTicketExpirationPolicy(final int numberOfUses, final long timeToKillInSeconds) {
             super(numberOfUses, timeToKillInSeconds);
         }
     }

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -74,7 +74,7 @@ public class KryoTranscoderTests {
          * @param numberOfUses        the number of uses
          * @param timeToKillInSeconds the time to kill in seconds
          */
-        public UnregisteredServiceTicketExpirationPolicy(int numberOfUses, long timeToKillInSeconds) {
+        public UnregisteredServiceTicketExpirationPolicy(final int numberOfUses, final long timeToKillInSeconds) {
             super(numberOfUses, timeToKillInSeconds);
         }
     }
@@ -242,7 +242,7 @@ public class KryoTranscoderTests {
         assertEquals(expectedST, transcoder.decode(cachedData));
     }
 
-    @Test
+    @Test(expected = KryoException.class)
     public void verifyEncodeDecodeNonRegisteredClass() throws Exception {
         // UnregisteredServiceTicketExpirationPolicy is not registered with Kryo...
         transcoder.getKryo().getClassResolver().reset();
@@ -253,14 +253,9 @@ public class KryoTranscoderTests {
         CachedData cachedData = transcoder.encode(expectedST);
         assertEquals(expectedST, transcoder.decode(cachedData));
         // Test it a second time - there's a Kryo 4.0.0 bug that causes the second deserialize of an object
-        // containing an unregistered class to fail...
-        try {
-            assertEquals(expectedST, transcoder.decode(cachedData));
-            fail("Expected Kryo exception due to bug in 4.0.0.  If Kryo has been updated, this test case will need adjusting.");
-        } catch (KryoException e) {
-            // expected
-        } catch (Exception e) {
-            fail("Unexpected exception testing multiple deserialize of object containing unregistered class " + e.getMessage());
-        }
+        // containing an unregistered class to fail...  When this test fails (i.e. after a new working Kryo version
+        // comes along), remove the expected KryoException from the test annotation, and remove the fail() from just below...
+        assertEquals(expectedST, transcoder.decode(cachedData));
+        fail("Expected Kryo exception due to bug in 4.0.0.  If Kryo has been updated, this test case will need adjusting.");
     }
 }

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -283,9 +283,9 @@ public class KryoTranscoderTests {
         // with a value different than the original.  Check for either case.
         try {
             assertNotEquals(expectedST, transcoder.decode(result));
-        } catch (KryoException e) {
+        } catch (final KryoException e) {
             // expected alternative result.
-        } catch (Exception e) {
+        } catch (final Exception e) {
             fail("Unexpected exception due to not resetting Kryo between deserializations with unregistered class.");
         }
     }

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -79,7 +79,7 @@ public class KryoTranscoderTests {
          * @param numberOfUses        the number of uses
          * @param timeToKillInSeconds the time to kill in seconds
          */
-        public UnregisteredServiceTicketExpirationPolicy (final int numberOfUses, final long timeToKillInSeconds) {
+        public UnregisteredServiceTicketExpirationPolicy(final int numberOfUses, final long timeToKillInSeconds) {
             super(numberOfUses, timeToKillInSeconds);
         }
     }

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/kryo/KryoTranscoderTests.java
@@ -39,8 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Unit test for {@link KryoTranscoder} class.
@@ -63,15 +62,12 @@ public class KryoTranscoderTests {
 
     private final Map<String, Object> principalAttributes;
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     /**
      * Class for testing Kryo unregistered class handling.
      */
     public static class UnregisteredServiceTicketExpirationPolicy extends MultiTimeUseOrTimeoutExpirationPolicy {
 
-        private static final long serialVersionUID  = -1;
+        private static final long serialVersionUID = -1;
 
         /**
          * Instantiates a new Service ticket expiration policy.
@@ -83,6 +79,10 @@ public class KryoTranscoderTests {
             super(numberOfUses, timeToKillInSeconds);
         }
     }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
 
     public KryoTranscoderTests() {
         transcoder = new KryoTranscoder();

--- a/support/cas-server-support-memcached-ticket-registry/src/test/resources/ticketRegistry-test.xml
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/resources/ticketRegistry-test.xml
@@ -14,7 +14,7 @@
             </bean>
         </constructor-arg>
     </bean>
-    
+
     <bean id="testCase2" class="org.apereo.cas.ticket.registry.MemCacheTicketRegistry">
         <constructor-arg index="0">
             <bean class="net.spy.memcached.spring.MemcachedClientFactoryBean"
@@ -33,7 +33,7 @@
     <bean id="serialTranscoder" class="net.spy.memcached.transcoders.SerializingTranscoder"
           p:compressionThreshold="2048"/>
 
-    <bean id="kryoTranscover" class="org.apereo.cas.ticket.registry.support.kryo.KryoTranscoder"/>
+    <bean id="kryoTranscoder" class="org.apereo.cas.ticket.registry.support.kryo.KryoTranscoder"/>
 
     <bean id="validationAnnotationBeanPostProcessor" class="org.apereo.cas.util.spring.CustomBeanValidationPostProcessor"
           p:afterInitialization="true"/>


### PR DESCRIPTION
CAS Issue 2921 - Fix memcached deserialization exception for Service Tickets with embedded class MultiTimeUseOrTimeoutExpirationPolicy.ServiceTicketExpirationPolicy
- Also ensure that all other ExpirationPolicy based classes are registered to avoid a similar issue with them.

Caused by CAS code choice in KryoTranscoder class to call kryo.setAutoRest(false).  This means that Kryo will not work well when multiple de-serializations of the same object take place, where that object involves a non-Kryo-registered class.  I.E. where second and subsequent deserialization of an object with an embedded, non-registered class throws off the input stream pointer (fails to read the embedded class name, leaves pointer at beginning of class name instead of at the end of it - subsequent deserialization will either fail or cause incorrect values in the deserialized object...)  The 'fix' is to either:
- Make sure that all possible classes for serialization are registered with Kryo
- Add a manual 'reset' somewhere in the CAS code - but that would tend to go against the specific setting in KryoTranscoder
- Turn off that setting in KryoTranscoder - but that could have other consequences :(.

Closes #2921 

Test Class updated with two new tests:
- verifySTWithServiceTicketExpirationPolicy tests the fix.  If you comment out the changes in KryoTranscoder, this test will fail.
- verifyEncodeDecodeNonRegisteredClass 'tests' the Kryo setting-related bug that's the cause of this. 