### PR TITLE
feat(readme): rm codesponsor ad

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ It is recommended to deploy CAS locally using the [WAR Overlay method][overlay].
 
 CAS is 100% free open source software managed by [Apereo](https://www.apereo.org/), licensed under [Apache v2](LICENSE). Our community has access to all releases of the CAS software with absolutely no costs. We welcome contributions from our community of all types and sizes. The time and effort to develop and maintain this project is dedicated by a group of [volunteers and contributors](https://github.com/apereo/cas/graphs/contributors). Support options may be [found here][cassupport]. If you (or your employer) benefit from this project, please consider becoming a [Friend of Apereo](https://www.apereo.org/friends) and contribute.
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/RJa9L5XHCwE3xKoYkAzK3Qcw/apereo/cas'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/RJa9L5XHCwE3xKoYkAzK3Qcw/apereo/cas.svg' /></a>
-
 [wiki]: https://apereo.github.io/cas
 [overlay]: https://apereo.github.io/cas/development/installation/Maven-Overlay-Installation.html
 [contribute]: https://apereo.github.io/cas/developer/Contributor-Guidelines.html


### PR DESCRIPTION
I don't think Apereo projects should be including ads in their websites, not even in their READMEs on GitHub.

This changeset would back out this ad from the CAS README.

(Reverts d8afe813c8b1fc62d63af0c1bf6f202a0ab5878e "[skip tests]".)
