### PR TITLE
Fix Cloud Directory authentication for PasswordEncoder types that use randomly generated salts

### DIFF
--- a/support/cas-server-support-cloud-directory-authentication/src/main/java/org/apereo/cas/authentication/CloudDirectoryAuthenticationHandler.java
+++ b/support/cas-server-support-cloud-directory-authentication/src/main/java/org/apereo/cas/authentication/CloudDirectoryAuthenticationHandler.java
@@ -40,7 +40,6 @@ public class CloudDirectoryAuthenticationHandler extends AbstractUsernamePasswor
                                                                  final String originalPassword) throws GeneralSecurityException, PreventedException {
 
         final String username = credential.getUsername();
-        final String password = credential.getPassword();
 
         final Map<String, Object> attributes = repository.getUser(username);
 
@@ -54,7 +53,7 @@ public class CloudDirectoryAuthenticationHandler extends AbstractUsernamePasswor
         LOGGER.debug("Located account attributes [{}] for [{}]", attributes.keySet(), username);
 
         final String userPassword = attributes.get(cloudDirectoryProperties.getPasswordAttributeName()).toString();
-        if (!password.equals(userPassword)) {
+        if (!matches(originalPassword, userPassword)) {
             LOGGER.warn("Account password on record for [{}] does not match the given/encoded password", username);
             throw new FailedLoginException();
         }


### PR DESCRIPTION
# Details
The current password checking/matching only works for encoding algorithms that always encode to the same value. `PasswordEncoder` types like `BCryptPasswordEncoder` and `StandardPasswordEncoder` from `spring-security` use randomly generated salts and therefore encode to a different value every time. To fix this we need to use the `PasswordEncoder`'s `matches` method instead. `AbstractUsernamePasswordAuthenticationHandler` already provides a protected method that calls this.

This issue might be present in the other authentication handlers as well. Just glancing over a couple of them, it looks like the issue also exists in the Cassandra one.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
