### PR TITLE
Allow PasswordManagementService to perform security question validation (take 2)

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifySecurityQuestionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifySecurityQuestionsAction.java
@@ -48,7 +48,7 @@ public class VerifySecurityQuestionsAction extends AbstractAction {
         final AtomicInteger i = new AtomicInteger(0);
         final long c = questions.entrySet().stream().filter(e -> {
             final String answer = request.getParameter("q" + i.getAndIncrement());
-            return passwordManagementService.checkSecurityQuestionAnswer(username, e.getKey(), e.getValue(), answer);
+            return passwordManagementService.isValidSecurityQuestionAnswer(username, e.getKey(), e.getValue(), answer);
         }).count();
         if (c == questions.size()) {
             return success();

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifySecurityQuestionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifySecurityQuestionsAction.java
@@ -46,9 +46,9 @@ public class VerifySecurityQuestionsAction extends AbstractAction {
         
         final Map<String, String> questions = passwordManagementService.getSecurityQuestions(username);
         final AtomicInteger i = new AtomicInteger(0);
-        final long c = questions.values().stream().filter(v -> {
+        final long c = questions.entrySet().stream().filter(e -> {
             final String answer = request.getParameter("q" + i.getAndIncrement());
-            return answer.equals(v);
+            return passwordManagementService.checkSecurityQuestionAnswer(username, e.getKey(), e.getValue(), answer);
         }).count();
         if (c == questions.size()) {
             return success();

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
@@ -57,6 +57,9 @@ public interface PasswordManagementService {
     /**
      * Gets security questions.
      *
+     * The return object must have predictable iteration (use LinkedHashMap
+     * instead of HashMap, for example).
+     * 
      * @param username the username
      * @return the security questions
      */
@@ -73,7 +76,7 @@ public interface PasswordManagementService {
      * @param input user response to question
      * @return whether the answer is correct
      */
-    default boolean checkSecurityQuestionAnswer(String username, String question, String answer, String input) {
+    default boolean isValidSecurityQuestionAnswer(String username, String question, String answer, String input) {
         if (answer != null) {
             return answer.equals(input);
         }

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
@@ -63,4 +63,20 @@ public interface PasswordManagementService {
     default Map<String, String> getSecurityQuestions(String username) {
         return new LinkedHashMap<>();
     }
+
+    /**
+     * Checks a security questions answer
+     *
+     * @param username the username
+     * @param question the text of the question
+     * @param answer stored answer
+     * @param input user response to question
+     * @return whether the answer is correct
+     */
+    default boolean checkSecurityQuestionAnswer(String username, String question, String answer, String input) {
+        if(answer != null) {
+            return answer.equals(input);
+        }
+        return false;
+    }
 }

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
@@ -74,7 +74,7 @@ public interface PasswordManagementService {
      * @return whether the answer is correct
      */
     default boolean checkSecurityQuestionAnswer(String username, String question, String answer, String input) {
-        if(answer != null) {
+        if (answer != null) {
             return answer.equals(input);
         }
         return false;

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
@@ -65,7 +65,7 @@ public interface PasswordManagementService {
     }
 
     /**
-     * Checks a security questions answer
+     * Checks a security questions answer.
      *
      * @param username the username
      * @param question the text of the question


### PR DESCRIPTION
This allows for implementations of `PasswordManagementService` to implement their own security question answer verification. 

Our answers are hashed so this change allows us to add on to instead of replacing CAS code. We can keep the entire existing password reset process by only implementing a `PasswordManagementService`. While on the face it seems unnecessary to pass _everything_ back for checking it allows the service to check the answer without doing another lookup or otherwise storing data.

I tried to keep this as simple as possible by implementing the default code in the interface. If you'd prefer it in `BasePasswordManagementService` let me know. 

While working on this I noticed that the pm flow relies on `PasswordManagementService.getSecurityQuestions()` having a stable/consistent iterator, but that's not documented in the interface. It may be worth another commit to get that spelled out explicitly in the javadoc. If the iterator is not consistent it may not match the order of question and answers during verification in `VerifySecurityQuestionsAction` (which uses a stream and a question index to match to form input)
