### PR TITLE
Fixed #2939. Wrong CasConfiguration ctor(String, String) being used. …

### DIFF
--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -17,6 +17,7 @@ import org.apereo.cas.support.pac4j.authentication.handler.support.ClientAuthent
 import org.apereo.cas.support.pac4j.web.flow.SAML2ClientLogoutAction;
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.cas.config.CasConfiguration;
+import org.pac4j.cas.config.CasProtocol;
 import org.pac4j.core.client.BaseClient;
 import org.pac4j.core.client.Clients;
 import org.pac4j.oauth.client.BitbucketClient;
@@ -238,7 +239,7 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration {
                 .stream()
                 .filter(cas -> StringUtils.isNotBlank(cas.getLoginUrl()))
                 .forEach(cas -> {
-                    final CasConfiguration cfg = new CasConfiguration(cas.getLoginUrl(), cas.getProtocol());
+                    final CasConfiguration cfg = new CasConfiguration(cas.getLoginUrl(), CasProtocol.valueOf(cas.getProtocol()));
                     final CasClient client = new CasClient(cfg);
                     final int count = index.intValue();
                     if (StringUtils.isNotBlank(cas.getClientName())) {


### PR DESCRIPTION
When configuring delegate cas server setting the protocol to any value caused a MalformedUrlException. This was due to the incorrect CasConfiguration ctor (String, String) being called instead of the correct (String, CasProtocol).