### PR TITLE
Allow downstream systems to invalidate password changes

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.pm.web.flow.actions;
 
 import org.apereo.cas.authentication.UsernamePasswordCredential;
+import org.apereo.cas.pm.InvalidPasswordException;
 import org.apereo.cas.pm.PasswordChangeBean;
 import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.pm.PasswordValidationService;
@@ -52,6 +53,8 @@ public class PasswordChangeAction extends AbstractAction {
             if (passwordManagementService.change(c, bean)) {
                 return new EventFactorySupport().event(this, PASSWORD_UPDATE_SUCCESS);
             }
+        } catch (final InvalidPasswordException e) {
+            return getErrorEvent(requestContext, "pm.validationFailure");
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
         }

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
@@ -109,7 +109,7 @@ public class BasePasswordManagementService implements PasswordManagementService 
             actionResolverName = "CHANGE_PASSWORD_ACTION_RESOLVER",
             resourceResolverName = "CHANGE_PASSWORD_RESOURCE_RESOLVER")
     @Override
-    public boolean change(final Credential c, final PasswordChangeBean bean) {
+    public boolean change(final Credential c, final PasswordChangeBean bean) throws InvalidPasswordException {
         return changeInternal(c, bean);
     }
 
@@ -119,8 +119,9 @@ public class BasePasswordManagementService implements PasswordManagementService 
      * @param c    the credential
      * @param bean the bean
      * @return the boolean
+     * @throws InvalidPasswordException if new password fails downstream validation
      */
-    public boolean changeInternal(final Credential c, final PasswordChangeBean bean) {
+    public boolean changeInternal(final Credential c, final PasswordChangeBean bean) throws InvalidPasswordException {
         return false;
     }
 }

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/InvalidPasswordException.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/InvalidPasswordException.java
@@ -1,0 +1,14 @@
+package org.apereo.cas.pm;
+
+/**
+ * Raised by {@link PasswordManagementService} if it is also responsible for validating
+ * passwords and a new password fails validation.
+ *
+ * @author Marcus Watkins
+ * @since 5.2.0
+ */
+
+public class InvalidPasswordException extends RuntimeException {
+
+    private static final long serialVersionUID = 458954862481278L;
+}

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordManagementService.java
@@ -19,8 +19,9 @@ public interface PasswordManagementService {
      * @param c    the credentials
      * @param bean the bean
      * @return true /false
+     * @throws InvalidPasswordException if new password fails downstream validation
      */
-    default boolean change(Credential c, PasswordChangeBean bean) {
+    default boolean change(Credential c, PasswordChangeBean bean) throws InvalidPasswordException {
         return false;
     }
 


### PR DESCRIPTION
Our LDAP is the authoritative source for password policy as we have systems besides CAS that do some password management (admin utils, mostly). As a result, implementing a password validator inside of CAS would make for redundant code that may or may not perfectly match the downstream system. (And that doesn't even count things that may not be possible like checking against old passwords)

This pull request allows for a `PasswordManagementService` to report when a downstream system detects a password change with an invalid password.

I looked at various approaches and none seemed great -- this is the least bad approach I could come up with. I'm open to suggestions on alternatives.

Without something like this we resort to replacing the `PasswordChangeAction` bean, and in my continuous quest to **not** replace things I'm looking to solve the problem upstream.