### PR TITLE
initFromJson creates duplicate records when ids are assigned by the DAO

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistryDao.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistryDao.java
@@ -51,6 +51,14 @@ public interface ServiceRegistryDao {
     RegisteredService findServiceById(String id);
 
     /**
+     * Find a service by an exact match of the service id.
+     *
+     * @param id the id
+     * @return the registered service
+     */
+    RegisteredService findServiceByExactServiceId(String id);
+
+    /**
      * Return number of records held in this service registry. Provides Java 8 supported default implementation so that implementations
      * needed this new functionality could override it and other implementations not caring for it could be left alone.
      *

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServiceRegistryDao.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServiceRegistryDao.java
@@ -25,6 +25,11 @@ public abstract class AbstractServiceRegistryDao implements ServiceRegistryDao {
     @Autowired
     private transient ApplicationEventPublisher eventPublisher;
 
+    @Override
+    public RegisteredService findServiceByExactServiceId(String id) {
+        return load().stream().filter((r) -> r.getServiceId().equals(id)).findFirst().orElse(null);
+    }
+
     /**
      * Publish event.
      *

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServiceRegistryDao.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServiceRegistryDao.java
@@ -26,7 +26,7 @@ public abstract class AbstractServiceRegistryDao implements ServiceRegistryDao {
     private transient ApplicationEventPublisher eventPublisher;
 
     @Override
-    public RegisteredService findServiceByExactServiceId(String id) {
+    public RegisteredService findServiceByExactServiceId(final String id) {
         return load().stream().filter((r) -> r.getServiceId().equals(id)).findFirst().orElse(null);
     }
 

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ServiceRegistryInitializer.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ServiceRegistryInitializer.java
@@ -75,6 +75,11 @@ public class ServiceRegistryInitializer {
             LOGGER.warn("Skipping [{}] JSON service definition as a matching service [{}] is found in the registry", r.getName(), match.getName());
             return true;
         }
+        match = this.serviceRegistryDao.findServiceByExactServiceId(r.getServiceId());
+        if (match != null) {
+            LOGGER.warn("Skipping [{}] JSON service definition as a matching service [{}] is found in the registry", r.getName(), match.getName());
+            return true;
+        }
         match = this.serviceRegistryDao.findServiceById(r.getId());
         if (match != null) {
             LOGGER.warn("Skipping [{}] JSON service definition as a matching id [{}] is found in the registry", r.getName(), match.getId());

--- a/core/cas-server-core-services-registry/src/test/java/org/apereo/cas/services/ServiceRegistryInitializerTests.java
+++ b/core/cas-server-core-services-registry/src/test/java/org/apereo/cas/services/ServiceRegistryInitializerTests.java
@@ -41,7 +41,7 @@ public class ServiceRegistryInitializerTests {
     }
 
 
-    RegexRegisteredService newService() {
+    private RegexRegisteredService newService() {
         final RegexRegisteredService service = new RegexRegisteredService();
         service.setServiceId("^https?://.*");
         service.setName("Test");

--- a/core/cas-server-core-services-registry/src/test/java/org/apereo/cas/services/ServiceRegistryInitializerTests.java
+++ b/core/cas-server-core-services-registry/src/test/java/org/apereo/cas/services/ServiceRegistryInitializerTests.java
@@ -1,0 +1,51 @@
+package org.apereo.cas.services;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * @since 5.2.0
+ */
+public class ServiceRegistryInitializerTests {
+
+    @Test
+    public void ensureInitFromJsonDoesNotCreateDuplicates() {
+        RegexRegisteredService initialService = newService();
+
+        final ServicesManager servicesManager = mock(ServicesManager.class);
+        final ServiceRegistryDao jsonServiceRegistryDao = mock(ServiceRegistryDao.class);
+        when(jsonServiceRegistryDao.load()).thenReturn(Arrays.asList(initialService));
+
+        final ServiceRegistryDao serviceRegistryDao = new InMemoryServiceRegistry();
+        final ServiceRegistryInitializer serviceRegistryInitializer = new ServiceRegistryInitializer(jsonServiceRegistryDao, serviceRegistryDao, 
+                                                                                                     servicesManager, true);
+
+        // when initServiceRegistryIfNecessary is called
+        serviceRegistryInitializer.initServiceRegistryIfNecessary();
+
+        // then the initial service is added to the serviceRegistry
+        assertThat(serviceRegistryDao.size()).isEqualTo(1);
+
+        // given a new list of services with the same serviceId
+        initialService = newService(); // create a new service object to simulate running the app multiple times
+        when(jsonServiceRegistryDao.load()).thenReturn(Arrays.asList(initialService));
+
+        // when initServiceRegistryIfNecessary is called a second time
+        serviceRegistryInitializer.initServiceRegistryIfNecessary();
+
+        // then the initial service is skipped as it already exists
+        assertThat(serviceRegistryDao.size()).isEqualTo(1);
+    }
+
+
+    RegexRegisteredService newService() {
+        final RegexRegisteredService service = new RegexRegisteredService();
+        service.setServiceId("^https?://.*");
+        service.setName("Test");
+        service.setDescription("Test");
+        return service;
+    }
+}


### PR DESCRIPTION
The first commit contains a test that demonstrates the problem.  The second commit contains a potential fix for the problem.