### PR TITLE
Add cas throttle to o auth

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -12,6 +12,7 @@ public class OAuthProperties {
     private Code code = new Code();
     private AccessToken accessToken = new AccessToken();
     private RefreshToken refreshToken = new RefreshToken();
+    private String throttler = "neverThrottle";
 
     public AccessToken getAccessToken() {
         return accessToken;
@@ -89,6 +90,14 @@ public class OAuthProperties {
         public void setTimeToKillInSeconds(final long timeToKillInSeconds) {
             this.timeToKillInSeconds = timeToKillInSeconds;
         }
+    }
+
+    public String getThrottler() {
+        return throttler;
+    }
+
+    public void setThrottler(final String throttler) {
+        this.throttler = throttler;
     }
 }
 

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -246,7 +246,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
             HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
                 @Override
                 public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-                    if (request.getContextPath().startsWith(throttledUrl)) {
+                    if (request.getServletPath().startsWith(throttledUrl)) {
                         if (!throttledInterceptor.preHandle(request, response, handler)) {
                             return false;
                         }
@@ -256,7 +256,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
 
                 @Override
                 public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
-                    if (request.getContextPath().startsWith(throttledUrl)) {
+                    if (request.getServletPath().startsWith(throttledUrl)) {
                         throttledInterceptor.postHandle(request, response, handler, modelAndView);
                     }
                 }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.config;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
@@ -238,24 +237,22 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
             }
         };
         final String throttler = casProperties.getAuthn().getOauth().getThrottler();
-        if (throttler.equals("neverThrottle")) {
+        if ("neverThrottle".equals(throttler)) {
             return oauthHandlerInterceptorAdapter;
         } else {
             final HandlerInterceptor throttledInterceptor = this.applicationContext.getBean(throttler, HandlerInterceptor.class);
             final String throttledUrl = BASE_OAUTH20_URL.concat("/").concat(ACCESS_TOKEN_URL);
             HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
                 @Override
-                public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-                    if (request.getServletPath().startsWith(throttledUrl)) {
-                        if (!throttledInterceptor.preHandle(request, response, handler)) {
-                            return false;
-                        }
+                public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+                    if (request.getServletPath().startsWith(throttledUrl) && !throttledInterceptor.preHandle(request, response, handler)) {
+                        return false;
                     }
                     return oauthHandlerInterceptorAdapter.preHandle(request, response, handler);
                 }
 
                 @Override
-                public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView) throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl)) {
                         throttledInterceptor.postHandle(request, response, handler, modelAndView);
                     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.config;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
@@ -58,8 +59,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -71,6 +75,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import static org.apereo.cas.support.oauth.OAuthConstants.ACCESS_TOKEN_URL;
 import static org.apereo.cas.support.oauth.OAuthConstants.BASE_OAUTH20_URL;
 
 /**
@@ -87,6 +92,9 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
 
     @Autowired
     private CasConfigurationProperties casProperties;
+
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
 
     @Autowired
     @Qualifier("webApplicationServiceFactory")
@@ -210,7 +218,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
 
     @Bean
     public HandlerInterceptorAdapter oauthInterceptor() {
-        return new HandlerInterceptorAdapter() {
+        final HandlerInterceptorAdapter oauthHandlerInterceptorAdapter = new HandlerInterceptorAdapter() {
             @Override
             public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
                                      final Object handler) throws Exception {
@@ -229,6 +237,32 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
 
             }
         };
+        final String throttler = casProperties.getAuthn().getOauth().getThrottler();
+        if (throttler.equals("neverThrottle")) {
+            return oauthHandlerInterceptorAdapter;
+        } else {
+            final HandlerInterceptor throttledInterceptor = this.applicationContext.getBean(throttler, HandlerInterceptor.class);
+            final String throttledUrl = BASE_OAUTH20_URL.concat("/").concat(ACCESS_TOKEN_URL);
+            HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
+                @Override
+                public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+                    if (request.getContextPath().startsWith(throttledUrl)) {
+                        if (!throttledInterceptor.preHandle(request, response, handler)) {
+                            return false;
+                        }
+                    }
+                    return oauthHandlerInterceptorAdapter.preHandle(request, response, handler);
+                }
+
+                @Override
+                public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+                    if (request.getContextPath().startsWith(throttledUrl)) {
+                        throttledInterceptor.postHandle(request, response, handler, modelAndView);
+                    }
+                }
+            };
+            return throttledInceptorAdapter;
+        }
     }
 
     @Override

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenController.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenController.java
@@ -55,7 +55,7 @@ public class OAuth20AccessTokenController extends BaseOAuthWrapperController {
      * @return the model and view
      * @throws Exception the exception
      */
-    @RequestMapping(path = OAuthConstants.BASE_OAUTH20_URL + '/' + OAuthConstants.ACCESS_TOKEN_URL, method = RequestMethod.GET)
+    @RequestMapping(path = OAuthConstants.BASE_OAUTH20_URL + '/' + OAuthConstants.ACCESS_TOKEN_URL, method = RequestMethod.POST)
     protected ModelAndView handleRequestInternal(final HttpServletRequest request, final HttpServletResponse response) throws Exception {
         response.setContentType(MediaType.TEXT_PLAIN_VALUE);
 


### PR DESCRIPTION
Enables CAS Throttle to be configured for accessing an OAuth token.  Prevents brute force attacks on OAuth configured CAS on the /accessToken path.  Similar to the CAS Rest configuration for CAS Throttle.

Also reverts change to /accessToken from GET back to POST.  Please see https://tools.ietf.org/html/rfc6749#section-4.1.3.  Plus the CAS documentation also specifies it should be a POST and not a GET.
