### PR TITLE
Make it easier to add custom audit action and resource resolvers

### DIFF
--- a/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
+++ b/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
@@ -189,6 +189,9 @@ public class CasCoreAuditConfiguration {
         return map;
     }
 
+    /**
+     * Extension point for deployers to define custom AuditActionResolvers to extend the stock resolvers.
+     */
     @ConditionalOnMissingBean(name = "customAuditActionResolverMap")
     @Bean
     public Map<String, AuditActionResolver> customAuditActionResolverMap() {
@@ -220,6 +223,9 @@ public class CasCoreAuditConfiguration {
         return map;
     }
 
+    /**
+     * Extension point for deployers to define custom AuditResourceResolvers to extend the stock resolvers.
+     */
     @ConditionalOnMissingBean(name = "customAuditResourceResolverMap")
     @Bean
     public Map<String, AuditResourceResolver> customAuditResourceResolverMap() {

--- a/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
+++ b/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
@@ -184,7 +184,15 @@ public class CasCoreAuditConfiguration {
 
         map.put("VALIDATE_SERVICE_TICKET_RESOLVER", ticketValidationActionResolver());
 
+        map.putAll(customAuditActionResolverMap());
+
         return map;
+    }
+
+    @ConditionalOnMissingBean(name = "customAuditActionResolverMap")
+    @Bean
+    public Map<String, AuditActionResolver> customAuditActionResolverMap() {
+        return new HashMap<>();
     }
 
     @ConditionalOnMissingBean(name = "auditResourceResolverMap")
@@ -208,7 +216,14 @@ public class CasCoreAuditConfiguration {
         map.put("TRUSTED_AUTHENTICATION_RESOURCE_RESOLVER", returnValueResourceResolver);
         map.put("ADAPTIVE_RISKY_AUTHENTICATION_RESOURCE_RESOLVER", returnValueResourceResolver);
         map.put("AUTHENTICATION_EVENT_RESOURCE_RESOLVER", nullableReturnValueResourceResolver());
+        map.putAll(customAuditResourceResolverMap());
         return map;
+    }
+
+    @ConditionalOnMissingBean(name = "customAuditResourceResolverMap")
+    @Bean
+    public Map<String, AuditResourceResolver> customAuditResourceResolverMap() {
+        return new HashMap<>();
     }
 
     @ConditionalOnMissingBean(name = "auditablePrincipalResolver")


### PR DESCRIPTION
This allows a deployer that has custom audits to extend the default resolvers instead of replacing all of them.