### PR TITLE
correct small typos in Slovak translation

### DIFF
--- a/webapp/resources/messages_sk.properties
+++ b/webapp/resources/messages_sk.properties
@@ -18,7 +18,7 @@ screen.welcome.button.clear=VYMAZAŤ
 
 screen.welcome.label.loginwith=Alebo sa prihláste pomocou:
 screen.cookies.disabled.title=Cookies v prehliadači sú zakázané
-screen.cookies.disabled.message=Váš browser nepodporuje cookies. Single Sign On NEBUDE FUNGOVAŤ.
+screen.cookies.disabled.message=Váš prehliadač nepodporuje cookies. Zjednotené prihlasovanie NEBUDE FUNGOVAŤ.
 
 screen.pm.button.submit=OK
 screen.pm.button.cancel=ZRUŠIŤ
@@ -37,7 +37,7 @@ screen.aup.button.accept=PRIJAŤ
 screen.aup.button.cancel=ZRUŠIŤ
 
 screen.nonsecure.title=Nezabezpečené spojenie
-screen.nonsecure.message=Pristupujete k serveru CAS cez nezabezpečené spojenie. Single Sign On NEBUDE FUNGOVAŤ. Ak chcete aby single sign on fungovalo, musíte sa prihlásiť cez HTTPS.
+screen.nonsecure.message=Pristupujete k serveru CAS cez nezabezpečené spojenie. Zjednotené prihlasovanie NEBUDE FUNGOVAŤ. Ak chcete aby zjednotené prihlasovanie fungovalo, musíte sa prihlásiť cez HTTPS.
 
 screen.defaultauthn.title=Statická autentifikácia
 screen.defaultauthn.heading=CAS je nakonfigurovaný na akceptovanie pevne definovaného zoznamu používateľov. Upozorňujeme, že toto nastavenie je vhodné LEN pre demonštračné účely.
@@ -57,29 +57,29 @@ screen.blocked.message=Vložili ste viackrát nesprávne heslo. Vaše prihlásen
 AbstractAccessDecisionManager.accessDenied=Nie ste oprávnený k prístupu k tomuto zdroju. Pre viac informácií kontaktujte administrátora.
 
 #Confirmation Screen Messages
-screen.confirmation.message=Kliknite <a href\="{0}">sem</a> pre prístup k aplikácii.
+screen.confirmation.message=Kliknite <a href="{0}">sem</a> pre prístup k aplikácii.
 
 screen.authentication.warning=Prihlásenie sa podarilo s varovaním
 #Generic Success Screen Messages
 screen.success.header=Prihlásenie bolo úspešné
 screen.success.success= {0}, práve ste sa úspešne prihlásili do CAS.
-screen.success.security=Ak ste ukončili prácu, z bezpečnostných dôvodov prosím odhláste sa a ukončite prácu s prehliadačom.
+screen.success.security=Z bezpečnostných dôvodov sa, prosím, <a href="logout">odhláste</a> a ukončite prácu s webovým prehliadačom, ak ste ukončili prácu so službami vyžadujúcimi autentifikáciu!
 
 screen.logout.confirm.header=Chcete sa odhlásiť úplne?
 screen.logout.confirm.text=Aplikácia Vás presmerovala do Central Authentication Service \
   pre úplné odhlásenie. Ak sa rozhodnete odhlásiť, budú po Vás opäť požadované prihlasovacie údaje \
-  pri prístupe ku chránenýn aplikáciám.<p><p><br>Chcete pokračovať v odhlásení? 
+  pri prístupe ku chráneným službám.<p><p><br>Chcete pokračovať v odhlásení? 
 #Logout Screen Messages
 screen.logout.header=Odhlásenie bolo úspešné
 screen.logout.success=Úspešne ste sa odhlásili z CAS. Môžete sa <a href="login">prihlásiť</a> znova. 
-screen.logout.fc.success=Úspešne ste sa odhlásili z CAS. Môžete sa <a href="login">prihlásiť</a> znova. Keďže je nastavené jednotné odhlásenie\
-  nasledujúce aplikácie sú <strong>upozornené</strong>, aby Vás odhlásili a ukončili sedenie. Upozorňujeme, že táto akcia nezaručuje \
-  odhlásenie, pretože je na apilkáciách samotných, aby správne implementovali odhlásenie.
+screen.logout.fc.success=Úspešne ste sa odhlásili z CAS. Môžete sa <a href="login">prihlásiť</a> znova. Keďže je nastavené jednotné odhlásenie \
+  aplikácie boli <strong>upozornené</strong>, aby Vás odhlásili a ukončili sedenie. Upozorňujeme, že táto akcia nezaručuje \
+  odhlásenie, pretože je na aplikáciách samotných, aby správne implementovali odhlásenie.
 screen.logout.security=Z bezpečnostných dôvodov ukončite prácu s prehliadačom.
-screen.logout.redirect=Služba, z ktorej ste prišli poskytla <a href="{0}">linku, ktorú môžete nasledovať kliknutím sem</a>.
+screen.logout.redirect=Služba, z ktorej ste prišli poskytla <a href="{0}">odkaz, ktorý môžete nasledovať kliknutím sem</a>.
 
 screen.service.sso.error.header=Na prístup k službe je nutná opakovaná autentifikácia
-screen.service.sso.error.message=Pokúsili ste sa o prístup k službe, ktorá vyžaduje autentifkáciu bez opätovnej autentifikácie.  Prosím skúste sa <a href\="{0}">autentifikovať znovu</a>.
+screen.service.sso.error.message=Pokúsili ste sa o prístup k chránenej službe, ktorá vyžaduje opakovanie autentifikácie.  Prosím skúste sa <a href="{0}">autentifikovať znovu</a>.
 screen.service.required.message=Pokúsili ste sa autentifikovať bez zadania cieľovej aplikácie. Prosím preverte požiadavku a skúste znovu.
 
 captchaError=reCAPTCHA kontrola bola neúspešná.
@@ -93,7 +93,7 @@ pm.updateFailure=Heslo sa nepodarilo zmeniť. Prosím, skúste znova.
 # Authentication failure messages
 authenticationFailure.AccountDisabledException=Tento používateľský účet bol deaktivovaný.
 authenticationFailure.AccountLockedException=Tento používateľský účet bol uzamknutý.
-authenticationFailure.CredentialExpiredException=Vaše heslo je expirované.
+authenticationFailure.CredentialExpiredException=Platnosť Vášho hesla vypršala.
 authenticationFailure.InvalidLoginLocationException=Z tejto pracovnej stanice nie je možné sa prihlásiť.
 authenticationFailure.InvalidLoginTimeException=Váš účet má v tomto čase zakázaný prístup.
 authenticationFailure.AccountNotFoundException=Nesprávne používateľské meno alebo heslo.
@@ -106,14 +106,14 @@ authenticationFailure.AuthenticationException=Nesprávne používateľské meno 
 INVALID_REQUEST_PROXY=Vaša požiadavka je nekorektne formulovaná. Prosím uistite sa že všetky požadované parametre sú v požiadavke a sú správne formátované.
 INVALID_TICKET_SPEC=Ticket neprešiel validáciou. Možná príčina je validácia Proxy Ticketu cez Service Ticket validator.
 INVALID_REQUEST='service' a 'ticket' parametre sú povinné
-INVALID_AUTHENTICATION_CONTEXT=Požiadavka na overenie pre [''{0}''] nemôže byť potvrdená, pretože je nerozpooznaná alebo neúplná.
+INVALID_AUTHENTICATION_CONTEXT=Požiadavka na overenie pre [''{0}''] nemôže byť potvrdená, pretože je nerozpoznaná alebo neúplná.
 INVALID_TICKET=Ticket ''{0}'' nebol rozpoznaný
 INVALID_PROXY_GRANTING_TICKET=PGT bol pre tento ST už vygenerovaný. Nemôžeme poskytnúť viac ako jeden PGT pre ST.
 INVALID_SERVICE=Ticket ''{0}'' nezodpovedá dodanej službe. Pôvodná služba bola ''{1}'' a dodaná bola ''{2}''.
-INVALID_PROXY_CALLBACK=Dodaný proxy callback url ''{0}'' nemôže byť authentifikovaný.
+INVALID_PROXY_CALLBACK=Dodaný proxy callback url ''{0}'' nemôže byť autentifikovaný.
 UNAUTHORIZED_SERVICE_PROXY=Dodaná služba ''{0}'' nie je autorizovaná na použitie CAS autentifikácie.
 
-UNSATISFIED_AUTHN_POLICY=Prístup ku službe bol zanietnutý pre nesplnenie bezpečnostnej politiky.
+UNSATISFIED_AUTHN_POLICY=Prístup ku službe bol zamietnutý pre nesplnenie bezpečnostnej politiky.
 screen.service.error.header=Aplikácia nie je autorizovaná na použitie CAS
 service.not.authorized.missing.attr=Nie ste autorizovaný na prístup k aplikácii pretože Vaše používateľský účet \
 neobsahuje privilégiá požadované serverom CAS na autentifikáciu do tejto služby. Prosím oboznámte Vášho správcu systému.
@@ -122,14 +122,14 @@ screen.service.empty.error.message=Register služieb serveru CAS je prázdny a n
 Aplikácia ktorá sa chce autentifikovať serverom CAS musí byť explicitne definovaná v registri služieb.
 
 # Password policy
-password.expiration.warning=Vaše heslo expiruje za {0} deň/dní. Prosím <a href="{1}">zmeňte Vaše heslo</a> teraz.
+password.expiration.warning=Platnosť Vášho hesla vyprší za {0} deň/dní. Prosím <a href="{1}">zmeňte Vaše heslo</a> teraz.
 password.expiration.loginsRemaining=Máte {0} prístup(ov) k dispozícii, kým <strong>MUSÍTE</strong> zmeniť Vaše heslo.
 screen.accountdisabled.heading=Tento používateľský účet bol deaktivovaný.
 screen.accountdisabled.message=Prosím kontaktujte systémového administrátora na opätovné získanie prístupu.
 screen.accountlocked.heading=Tento používateľský účet bol uzamknutý.
 screen.accountlocked.message=Prosím kontaktujte systémového administrátora na opätovné získanie prístupu.
-screen.expiredpass.heading=Vaše heslo expirovalo.
-screen.expiredpass.message=Prosím <a href\="{0}">zmeňte svoje heslo</a>.
+screen.expiredpass.heading=Platnosť Vášho hesla vypršala.
+screen.expiredpass.message=Prosím <a href="{0}">zmeňte svoje heslo</a>.
 screen.mustchangepass.heading=Je nutné zmeniť Vaše heslo.
 screen.mustchangepass.message=Prosím <a href="{0}">zmeňte svoje heslo</a>.
 screen.badhours.heading=Váš účet v tomto čase nemá povolený prístup.
@@ -149,7 +149,7 @@ screen.pac4j.unauthz.pagetitle=Nepovolený prístup
 screen.pac4j.unauthz.gotoapp=Späť na aplikáciu
 screen.pac4j.unauthz.login=Späť na CAS
 screen.pac4j.unauthz.heading=Nepotvrdený prístup
-screen.pac4j.unauthz.message=Požiadavka o prihlásenie bola odmientnutá/zrušená, alebo alebo poskytovateľ identity odmietol prístup pre interné pravidlá.
+screen.pac4j.unauthz.message=Požiadavka o prihlásenie bola odmietnutá/zrušená, alebo poskytovateľ identity odmietol prístup pre platné interné pravidlá.
 screen.authentication.gauth.register=Vaše konto nie je registrované. Použite nastavenia nižšie pre registráciu zariadenia v CAS.
 screen.authentication.gauth.key=Tajný kód pre registráciu je {0}
 # OAuth
@@ -173,7 +173,7 @@ cas.mfa.azure.pagetitle=AZURE autentifikácia
 cas.mfa.radius.pagetitle=RADIUS autentifikácia
 cas.mfa.yubikey.pagetitle=YubiKey Autentifikácia
 cas.mfa.authy.pagetitle=Authy autentifikácia
-cas.mfa.registerdevice.label.title=Restrácia zariadenia
+cas.mfa.registerdevice.label.title=Registrácia zariadenia
 cas.mfa.registerdevice.label.intro=Pomenujte toto zariadenie
 cas.mfa.registerdevice.pagetitle=Registrácia zariadenia
 cas.mfa.registerdevice.label.name=Meno


### PR DESCRIPTION
This patch 
- corrects small typos in Slovak translation
- adds logout link in login confirmation screen
- removes redundant escaping for equal sign