### PR TITLE
Serialization Config - Register some additional Expiration Policy classes

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/memcached/BaseMemcachedProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/memcached/BaseMemcachedProperties.java
@@ -120,7 +120,7 @@ public class BaseMemcachedProperties implements Serializable {
      * default serializer for the class used to serialize the object. Subsequent
      * appearances of the class within the same object graph are serialized as an int id.
      * Registered classes are serialized as an int id, avoiding the overhead of serializing the class name, but have the drawback
-     * of needing to know the classes to be serialized up front.
+     * of needing to know the classes to be serialized up front.  See {@code ComponentSerializationPlan} for help here.
      * </p>
      */
     private boolean kryoRegistrationRequired;

--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CasKryoTranscoder.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CasKryoTranscoder.java
@@ -47,6 +47,7 @@ import org.apereo.cas.ticket.ServiceTicketImpl;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.registry.EncodedTicket;
 import org.apereo.cas.ticket.support.AlwaysExpiresExpirationPolicy;
+import org.apereo.cas.ticket.support.BaseDelegatingExpirationPolicy;
 import org.apereo.cas.ticket.support.HardTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.MultiTimeUseOrTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
@@ -248,6 +249,7 @@ public class CasKryoTranscoder implements Transcoder<Object> {
         this.kryo.register(AlwaysExpiresExpirationPolicy.class);
         this.kryo.register(ThrottledUseAndTimeoutExpirationPolicy.class);
         this.kryo.register(TicketGrantingTicketExpirationPolicy.class);
+        this.kryo.register(BaseDelegatingExpirationPolicy.class);
     }
 
     /**

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdpComponentSerializationConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdpComponentSerializationConfiguration.java
@@ -1,0 +1,27 @@
+package org.apereo.cas.config;
+
+import org.apereo.cas.ComponentSerializationPlan;
+import org.apereo.cas.ComponentSerializationPlanConfigurator;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.ticket.artifact.SamlArtifactTicketExpirationPolicy;
+import org.apereo.cas.ticket.query.SamlAttributeQueryTicketExpirationPolicy;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This is {@link SamlIdpComponentSerializationConfiguration}.
+ *
+ * @author Bob Sandiford
+ * @since 5.2.0
+ */
+@Configuration("samlIdpComponentSerializationConfiguration")
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class SamlIdpComponentSerializationConfiguration implements ComponentSerializationPlanConfigurator {
+
+    @Override
+    public void configureComponentSerializationPlan(final ComponentSerializationPlan plan) {
+        plan.registerSerializableClass(SamlArtifactTicketExpirationPolicy.class);
+        plan.registerSerializableClass(SamlAttributeQueryTicketExpirationPolicy.class);
+    }
+
+}


### PR DESCRIPTION
Complete previous 5.1.x work of ensuring that all Expiration Policy classes are registered for memcached Kryo serializer handling.  Related to 5.1.x pull request 2921.

