### PR TITLE
Add extra text snippet for error page

### DIFF
--- a/webapp/resources/messages.properties
+++ b/webapp/resources/messages.properties
@@ -220,6 +220,7 @@ screen.oidc.confirm.asksinfo=The client is asked for the following information:
 screen.oidc.confirm.dynamic=This client was dynamically registered at <code>{0}</code>.
 
 # Unavailable
+screen.unavailable.header=CAS error
 screen.unavailable.heading=CAS is unable to process this request: "{0}:{1}"
 screen.unavailable.message=There was an error trying to complete your request. \
 <strong>Please notify your support desk or try again.</strong> \

--- a/webapp/resources/messages_de.properties
+++ b/webapp/resources/messages_de.properties
@@ -84,5 +84,6 @@ screen.oauth.confirm.message=Wollen Sie "{0}" vollen Zugriff auf Ihr Profil gest
 screen.oauth.confirm.allow=Erlauben
 
 # Unavailable
+screen.unavailable.header=CAS Fehler
 screen.unavailable.heading=CAS ist nicht verf\u00FCgbar
 screen.unavailable.message=Beim Verarbeiten Ihrer Anfrage ist ein Fehler aufgetreten. Bitte informieren Sie Ihren Support oder versuchen Sie es noch einmal.

--- a/webapp/resources/templates/error.html
+++ b/webapp/resources/templates/error.html
@@ -2,7 +2,7 @@
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
 
 <head>
-    <title th:text="#{screen.badhours.heading}"></title>
+    <title th:text="#{screen.unavailable.header}"></title>
 
     <script th:inline="javascript">
         /*<![CDATA[*/


### PR DESCRIPTION
The error page was using the snippet for the "bad hours" page which is not
correct for the general error. This should clarify the intention of the error
page

How is the policy with adding new text snippet? Do I need to update all the other language files too?

See https://github.com/apereo/cas/issues/2958.
