### PR TITLE
SAML2ClientLogoutAction Fix - Use Specific SAML2 Client [branch 5.1.x]

### DIFF
--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
@@ -27,6 +27,10 @@ import javax.servlet.http.HttpServletResponse;
  * The action takes into account the currently used PAC4J client which is stored
  * in the user profile. If the client is not a SAML2 client, nothing happens. If
  * it is a SAML2 client, its logout action is executed.
+ * 
+ * Assumption: The PAC4J user profile should be in the user session during
+ * logout, accessible with PAC4J Profile Manager. The Logout web flow should
+ * make sure the user profile is present.
  *
  * @author Misagh Moayyed
  * @since 5.1.0
@@ -60,7 +64,7 @@ public class SAML2ClientLogoutAction extends AbstractAction {
 
             // Call logout on SAML2 clients only
             if (client instanceof SAML2Client) {
-            	final SAML2Client saml2Client = (SAML2Client) client;
+                final SAML2Client saml2Client = (SAML2Client) client;
                 LOGGER.debug("Located SAML2 client [{}]", saml2Client);
                 final RedirectAction action = saml2Client.getLogoutAction(context, null, null);
                 LOGGER.debug("Preparing logout message to send is [{}]", action.getLocation());

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
@@ -1,9 +1,13 @@
 package org.apereo.cas.support.pac4j.web.flow;
 
 import org.apereo.cas.web.support.WebUtils;
+import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.redirect.RedirectAction;
 import org.pac4j.saml.client.SAML2Client;
 import org.slf4j.Logger;
@@ -12,11 +16,17 @@ import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
+import java.util.Optional;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
  * This is {@link SAML2ClientLogoutAction}.
+ * 
+ * The action takes into account the currently used PAC4J client which is stored
+ * in the user profile. If the client is not a SAML2 client, nothing happens. If
+ * it is a SAML2 client, its logout action is executed.
  *
  * @author Misagh Moayyed
  * @since 5.1.0
@@ -37,23 +47,47 @@ public class SAML2ClientLogoutAction extends AbstractAction {
             final HttpServletRequest request = WebUtils.getHttpServletRequest(requestContext);
             final HttpServletResponse response = WebUtils.getHttpServletResponse(requestContext);
             final J2EContext context = WebUtils.getPac4jJ2EContext(request, response);
-            SAML2Client client;
+
+            Client<?, ?> client;
             try {
-                client = clients.findClient(SAML2Client.class);
+                final String currentClientName = findCurrentClientName(context);
+                client = (currentClientName == null) ? null : clients.findClient(currentClientName);
             } catch(final TechnicalException e) {
                 // this exception indicates that the SAML2Client is not in the list
                 LOGGER.debug("No SAML2 client found");
                 client = null;
             }
-            if (client != null) {
-                LOGGER.debug("Located SAML2 client [{}]", client);
-                final RedirectAction action = client.getLogoutAction(context, null, null);
+
+            // Call logout on SAML2 clients only
+            if (client instanceof SAML2Client) {
+            	final SAML2Client saml2Client = (SAML2Client) client;
+                LOGGER.debug("Located SAML2 client [{}]", saml2Client);
+                final RedirectAction action = saml2Client.getLogoutAction(context, null, null);
                 LOGGER.debug("Preparing logout message to send is [{}]", action.getLocation());
                 action.perform(context);
+            } else {
+                LOGGER.debug("The current client is not a SAML2 client or it cannot be found at all, no logout action will be executed.");
             }
         } catch (final Exception e) {
             LOGGER.warn(e.getMessage(), e);
         }
         return null;
     }
+
+    /**
+     * Finds the current client name from the context, using the PAC4J Profile Manager. It is assumed that the context has previously been
+     * populated with the profile.
+     * 
+     * @param webContext
+     *            A web context (request + response).
+     * 
+     * @return The currently used client's name or {@code null} if there is no active profile.
+     */
+    private String findCurrentClientName(final WebContext webContext) {
+        @SuppressWarnings("unchecked")
+        final ProfileManager<? extends CommonProfile> pm = WebUtils.getPac4jProfileManager(webContext);
+        final Optional<? extends CommonProfile> profile = pm.get(true);
+        return profile.map(CommonProfile::getClientName).orElse(null);
+    }
+
 }


### PR DESCRIPTION
Hello!

We encountered a little issue with the SAML2 Client Logout Action with PAC4J. This pull request should fix it for CAS 5.1.
The action took a random (any) SAML2 client from all PAC4J clients. This worked fine if there were
exactly 1 SAML2 client in the system and just this client was used. However, it did not work if no PAC4J client was used (standard login) or if there were more than 1 SAML2 client.
Now, the SAML2ClientLogoutAction now takes into account the currently used PAC4J client, which is resolved from the PAC4J user profile.

To test:
- Configure CAS with PAC4J and at least 2 different SAML2 clients
- Log in using SAML
- Log out
- The logout should take you to the correct IdP server (provided it supports single logout)
- Log in without SAML
- Log out
- You should end on the CAS Logout screen. You should not be redirected anywhere (this was happening with more SAML clients configured but not used for login).

Assumption:
- The PAC4J user profile should be in the user session during logout, accessible with PAC4J Profile Manager. Currently this is not true but can be achieved, we already have working code for that; we will discuss it with PAC4J developers, as suggested on the CAS DEV list.

If something is unclear, please ask, I'll be glad to answer.

Thank you!