### PR TITLE
Fix question order for backing stores with inconsistent ordering

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -3,6 +3,7 @@ package org.apereo.cas.pm.web.flow.actions;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.pm.PasswordManagementProperties;
+import org.apereo.cas.pm.BasePasswordManagementService;
 import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.web.support.WebUtils;
 import org.slf4j.Logger;
@@ -14,8 +15,7 @@ import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.List;
 
 import static org.apereo.cas.pm.web.flow.actions.SendPasswordResetInstructionsAction.*;
 
@@ -56,12 +56,13 @@ public class VerifyPasswordResetRequestAction extends AbstractAction {
         }
 
         if (pm.getReset().isSecurityQuestionsEnabled()) {
-            final Map<String, String> questions = passwordManagementService.getSecurityQuestions(username);
+            final List<String> questions = BasePasswordManagementService
+                    .canonicalizeSecurityQuestions(passwordManagementService.getSecurityQuestions(username));
             if (questions.isEmpty()) {
                 LOGGER.warn("No security questions could be found for [{}]", username);
                 return error();
             }
-            requestContext.getFlowScope().put("questions", new LinkedHashSet<>(questions.keySet()));
+            requestContext.getFlowScope().put("questions", questions);
         } else {
             LOGGER.debug("Security questions are not enabled");
         }

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifySecurityQuestionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifySecurityQuestionsAction.java
@@ -2,6 +2,7 @@ package org.apereo.cas.pm.web.flow.actions;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.pm.PasswordManagementProperties;
+import org.apereo.cas.pm.BasePasswordManagementService;
 import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.web.support.WebUtils;
 import org.slf4j.Logger;
@@ -12,6 +13,8 @@ import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
 import javax.servlet.http.HttpServletRequest;
+
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,10 +48,11 @@ public class VerifySecurityQuestionsAction extends AbstractAction {
         }
         
         final Map<String, String> questions = passwordManagementService.getSecurityQuestions(username);
+        final List<String> canonicalQuestions = BasePasswordManagementService.canonicalizeSecurityQuestions(questions);
         final AtomicInteger i = new AtomicInteger(0);
-        final long c = questions.entrySet().stream().filter(e -> {
+        final long c = canonicalQuestions.stream().filter(q -> {
             final String answer = request.getParameter("q" + i.getAndIncrement());
-            return passwordManagementService.isValidSecurityQuestionAnswer(username, e.getKey(), e.getValue(), answer);
+            return passwordManagementService.isValidSecurityQuestionAnswer(username, q, questions.get(q), answer);
         }).count();
         if (c == questions.size()) {
             return success();

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
@@ -13,6 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -123,5 +126,17 @@ public class BasePasswordManagementService implements PasswordManagementService 
      */
     public boolean changeInternal(final Credential c, final PasswordChangeBean bean) throws InvalidPasswordException {
         return false;
+    }
+
+    /**
+     * Orders security questions consistently.
+     *
+     * @param questionMap A map of question/answer key/value pairs
+     * @return A list of questions in a consistent order
+     */
+    public static List<String> canonicalizeSecurityQuestions(final Map<String, String> questionMap) {
+        final List<String> keys = new ArrayList<>(questionMap.keySet());
+        keys.sort(String.CASE_INSENSITIVE_ORDER);
+        return keys;
     }
 }


### PR DESCRIPTION
The [PR yesterday](https://github.com/apereo/cas/pull/2968) fixed question order for `PasswordManagementService`s that are backed by a consistent store, but for ones with an inconsistent store (json, rest, jdbc?) questions could be ordered differently for each request. This PR takes it a step further and sorts the questions when displayed or verified to ensure they are consistent in all cases.