### PR TITLE
saml2 Response KeyInfo changed from X509Data to RSAKeyValue #2937

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlRegisteredService.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlRegisteredService.java
@@ -74,7 +74,7 @@ public class SamlRegisteredService extends RegexRegisteredService {
 
     @Column(updatable = true, insertable = true)
     private boolean skipGeneratingSubjectConfirmationNotOnOrAfter;
-    
+
     @Column(updatable = true, insertable = true)
     private boolean skipGeneratingSubjectConfirmationRecipient;
 
@@ -95,6 +95,13 @@ public class SamlRegisteredService extends RegexRegisteredService {
 
     @Column(updatable = true, insertable = true)
     private boolean metadataCriteriaRemoveRolelessEntityDescriptors = true;
+
+    /**
+     * Signing credential type
+     */
+    @Column(length = 255, updatable = true, insertable = true)
+    private String signingCredentialType = "BASIC_X509";
+
 
     @ElementCollection
     @CollectionTable(name = "SamlRegisteredService_AttributeNameFormats")
@@ -285,6 +292,15 @@ public class SamlRegisteredService extends RegexRegisteredService {
         this.metadataExpirationDuration = metadataExpirationDuration;
     }
 
+
+    public String getSigningCredentialType() {
+        return signingCredentialType;
+    }
+
+    public void setSigningCredentialType(final String signingCredentialType) {
+        this.signingCredentialType = signingCredentialType;
+    }
+
     @Override
     protected AbstractRegisteredService newInstance() {
         return new SamlRegisteredService();
@@ -321,7 +337,9 @@ public class SamlRegisteredService extends RegexRegisteredService {
             setSkipGeneratingSubjectConfirmationNotBefore(samlRegisteredService.skipGeneratingSubjectConfirmationNotBefore);
             setSkipGeneratingSubjectConfirmationNotOnOrAfter(samlRegisteredService.skipGeneratingSubjectConfirmationNotOnOrAfter);
             setSkipGeneratingSubjectConfirmationRecipient(samlRegisteredService.skipGeneratingSubjectConfirmationRecipient);
-            
+
+            setSigningCredentialType(samlRegisteredService.getSigningCredentialType());
+
         } catch (final Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -348,6 +366,7 @@ public class SamlRegisteredService extends RegexRegisteredService {
                 .append(this.metadataExpirationDuration, rhs.metadataExpirationDuration)
                 .append(this.signAssertions, rhs.signAssertions)
                 .append(this.signResponses, rhs.signResponses)
+                .append(this.signingCredentialType, rhs.signingCredentialType)
                 .append(this.encryptAssertions, rhs.encryptAssertions)
                 .append(this.requiredNameIdFormat, rhs.requiredNameIdFormat)
                 .append(this.metadataCriteriaDirection, rhs.metadataCriteriaDirection)
@@ -376,6 +395,7 @@ public class SamlRegisteredService extends RegexRegisteredService {
                 .append(this.metadataSignatureLocation)
                 .append(this.signAssertions)
                 .append(this.signResponses)
+                .append(this.signingCredentialType)
                 .append(this.encryptAssertions)
                 .append(this.requiredNameIdFormat)
                 .append(this.metadataCriteriaDirection)
@@ -405,6 +425,7 @@ public class SamlRegisteredService extends RegexRegisteredService {
                 .append("metadataSignatureLocation", this.metadataSignatureLocation)
                 .append("signAssertions", this.signAssertions)
                 .append("signResponses", this.signResponses)
+                .append("signingCredentialType", this.signingCredentialType)
                 .append("encryptAssertions", this.encryptAssertions)
                 .append("requiredNameIdFormat", this.requiredNameIdFormat)
                 .append("metadataCriteriaDirection", this.metadataCriteriaDirection)

--- a/webapp-mgmt/cas-management-webapp/src/domain/saml-service.ts
+++ b/webapp-mgmt/cas-management-webapp/src/domain/saml-service.ts
@@ -14,6 +14,7 @@ export class SamlRegisteredService extends RegexRegisteredService {
   metadataExpirationDuration: String;
   signAssertions: boolean;
   signResponses: boolean;
+  signingCredentialType: String;
   encryptAssertions: boolean;
   metadataCriteriaRoles: String;
   metadataCriteriaRemoveEmptyEntitiesDescriptors: boolean;
@@ -33,6 +34,7 @@ export class SamlRegisteredService extends RegexRegisteredService {
     this.metadataExpirationDuration = "PT60M";
     this.metadataCriteriaRoles = "SPSSODescriptor";
     this.signResponses = true;
+    this.signingCredentialType = "BASIC_X509";
     this.metadataCriteriaRemoveEmptyEntitiesDescriptors = true;
     this.metadataCriteriaRemoveRolelessEntityDescriptors = true;
     this.skipGeneratingSubjectConfirmationNotBefore = true;


### PR DESCRIPTION
An option is create for user to choose from BasicCredential and BasicX509Credential for KeyInfo,
BasicX509Credential being the default option

**Brief description of changes applied**
- a field called signingCredentialType is created in SamlRegisteredService (with getter setter and all the others things),
- which have two possible values being BASIC and BASIC_X509.
- If developer do not specified, default is trigger.
- If developer specified but have wrong value, default is triggered with warn output to the debug log
**Any possible limitations, side effects, etc**
Please note that I have not tested this pull request

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
