### PR TITLE
REST PM calling wrong endpoint

### DIFF
--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/rest/RestPasswordManagementService.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/rest/RestPasswordManagementService.java
@@ -53,7 +53,7 @@ public class RestPasswordManagementService extends BasePasswordManagementService
         headers.put("oldPassword", Arrays.asList(upc.getPassword()));
 
         final HttpEntity<String> entity = new HttpEntity<>(headers);
-        final ResponseEntity<Boolean> result = restTemplate.exchange(rest.getEndpointUrlEmail(), HttpMethod.POST, entity, Boolean.class);
+        final ResponseEntity<Boolean> result = restTemplate.exchange(rest.getEndpointUrlChange(), HttpMethod.POST, entity, Boolean.class);
         if (result.getStatusCodeValue() == HttpStatus.OK.value()) {
             return result.getBody();
         }

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -15,6 +15,7 @@ import javax.security.auth.login.AccountExpiredException;
 import javax.security.auth.login.AccountLockedException;
 import javax.security.auth.login.AccountNotFoundException;
 import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.CredentialExpiredException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 
@@ -65,6 +66,9 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
                 throw new AccountLockedException("Could not authenticate locked account for " + c.getUsername());
             }
             if (e.getStatusCode() == HttpStatus.PRECONDITION_REQUIRED) {
+                throw new CredentialExpiredException("Account password must change for " + c.getUsername());
+            }
+            if (e.getStatusCode() == HttpStatus.PRECONDITION_FAILED) {
                 throw new AccountExpiredException("Could not authenticate expired account for " + c.getUsername());
             }
 

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -16,7 +16,7 @@ import javax.security.auth.login.AccountExpiredException;
 import javax.security.auth.login.AccountLockedException;
 import javax.security.auth.login.AccountNotFoundException;
 import javax.security.auth.login.FailedLoginException;
-import javax.security.auth.login.CredentialExpiredException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 
 /**

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -2,6 +2,7 @@ package org.apereo.cas.adaptors.rest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.exceptions.AccountDisabledException;
+import org.apereo.cas.authentication.exceptions.AccountPasswordMustChangeException;
 import org.apereo.cas.authentication.HandlerResult;
 import org.apereo.cas.authentication.PreventedException;
 import org.apereo.cas.authentication.UsernamePasswordCredential;
@@ -16,7 +17,6 @@ import javax.security.auth.login.AccountLockedException;
 import javax.security.auth.login.AccountNotFoundException;
 import javax.security.auth.login.FailedLoginException;
 import javax.security.auth.login.CredentialExpiredException;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 
 /**
@@ -66,7 +66,7 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
                 throw new AccountLockedException("Could not authenticate locked account for " + c.getUsername());
             }
             if (e.getStatusCode() == HttpStatus.PRECONDITION_REQUIRED) {
-                throw new CredentialExpiredException("Account password must change for " + c.getUsername());
+                throw new AccountPasswordMustChangeException("Account password must change for " + c.getUsername());
             }
             if (e.getStatusCode() == HttpStatus.PRECONDITION_FAILED) {
                 throw new AccountExpiredException("Could not authenticate expired account for " + c.getUsername());


### PR DESCRIPTION
Should call getEndpointUrlChange instead of getEndpointUrlEmail for password change.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied

Changed endpoint call from getEndpointUrlEmail to getEndpointUrlChange

- [] Any documentation on how to configure, test

none

- [] Any possible limitations, side effects, etc

none

- [] Reference any other pull requests that might be related.

none

-->
