### PR TITLE
Fix of PAC4J client action - Prevent typecast failure [branch 5.1.x]

### DIFF
--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
@@ -196,7 +196,7 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
 
         final Set<ProviderLoginPageConfiguration> urls = new LinkedHashSet<>();
 
-        this.clients.findAllClients().forEach(client -> {
+        this.clients.findAllClients().stream().filter(c -> c instanceof IndirectClient).forEach(client -> {
             try {
                 final IndirectClient indirectClient = (IndirectClient) client;
 


### PR DESCRIPTION
Hello!

It may happen that you configure PAC4J clients to contain a mix of direct and indirect clients. Then, whenever the control flow reaches prepareForLoginPage(), an exception can occur because the current code counts with indirect clients only. This fix should filter-out direct clients before a type cast.

To hit the bug:
- Configure your PAC4J clients to have some indirect and direct clients (some are in the basic CAS configuration)
- Perform a classic login (without any client name)

(If you are OK with this change, I can also prepare the same pull request for master.)
