### PR TITLE
Enable use CAS throttling support with OAuth module.

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -51,7 +51,7 @@ public class OAuthProperties {
         return throttler;
     }
 
-    public void setThrottler(String throttler) {
+    public void setThrottler(final String throttler) {
         this.throttler = throttler;
     }
 

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -13,6 +13,7 @@ public class OAuthProperties {
     private Code code = new Code();
     private AccessToken accessToken = new AccessToken();
     private RefreshToken refreshToken = new RefreshToken();
+    private String throttler = "neverThrottle";
 
     public Grants getGrants() {
         return grants;
@@ -44,6 +45,14 @@ public class OAuthProperties {
 
     public void setCode(final Code code) {
         this.code = code;
+    }
+
+    public String getThrottler() {
+        return throttler;
+    }
+
+    public void setThrottler(String throttler) {
+        this.throttler = throttler;
     }
 
     public static class Code {

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -199,13 +199,13 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     @RefreshScope
     public HandlerInterceptorAdapter oauthInterceptor() {
         final String throttler = casProperties.getAuthn().getOauth().getThrottler();
-        OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(), requiresAuthenticationAuthorizeInterceptor());
+        final OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(), requiresAuthenticationAuthorizeInterceptor());
         if ("neverThrottle".equals(throttler)) {
             return oAuth20HandlerInterceptorAdapter;
         } else {
             final HandlerInterceptor throttledInterceptor = this.applicationContext.getBean(throttler, HandlerInterceptor.class);
             final String throttledUrl = BASE_OAUTH20_URL.concat("/").concat(ACCESS_TOKEN_URL);
-            HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
+            final HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
                 @Override
                 public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl) && !throttledInterceptor.preHandle(request, response, handler)) {

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -199,7 +199,8 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     @RefreshScope
     public HandlerInterceptorAdapter oauthInterceptor() {
         final String throttler = casProperties.getAuthn().getOauth().getThrottler();
-        final OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(), requiresAuthenticationAuthorizeInterceptor());
+        final OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(
+                requiresAuthenticationAccessTokenInterceptor(), requiresAuthenticationAuthorizeInterceptor());
         if ("neverThrottle".equals(throttler)) {
             return oAuth20HandlerInterceptorAdapter;
         } else {
@@ -215,7 +216,8 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
                 }
 
                 @Override
-                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView) throws Exception {
+                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler,
+                                       final ModelAndView modelAndView) throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl)) {
                         throttledInterceptor.postHandle(request, response, handler, modelAndView);
                     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -62,13 +62,18 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.security.SecureRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -91,6 +96,9 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     
     @Autowired
     private CasConfigurationProperties casProperties;
+
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
 
     @Autowired
     @Qualifier("webApplicationServiceFactory")
@@ -190,7 +198,31 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     @Bean
     @RefreshScope
     public HandlerInterceptorAdapter oauthInterceptor() {
-        return new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(), requiresAuthenticationAuthorizeInterceptor());
+        final String throttler = casProperties.getAuthn().getOauth().getThrottler();
+        OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(), requiresAuthenticationAuthorizeInterceptor());
+        if ("neverThrottle".equals(throttler)) {
+            return oAuth20HandlerInterceptorAdapter;
+        } else {
+            final HandlerInterceptor throttledInterceptor = this.applicationContext.getBean(throttler, HandlerInterceptor.class);
+            final String throttledUrl = BASE_OAUTH20_URL.concat("/").concat(ACCESS_TOKEN_URL);
+            HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
+                @Override
+                public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+                    if (request.getServletPath().startsWith(throttledUrl) && !throttledInterceptor.preHandle(request, response, handler)) {
+                        return false;
+                    }
+                    return oAuth20HandlerInterceptorAdapter.preHandle(request, response, handler);
+                }
+
+                @Override
+                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView) throws Exception {
+                    if (request.getServletPath().startsWith(throttledUrl)) {
+                        throttledInterceptor.postHandle(request, response, handler, modelAndView);
+                    }
+                }
+            };
+            return throttledInceptorAdapter;
+        }
     }
 
     @Override

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
@@ -196,7 +196,7 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
 
         final Set<ProviderLoginPageConfiguration> urls = new LinkedHashSet<>();
 
-        this.clients.findAllClients().forEach(client -> {
+        this.clients.findAllClients().stream().filter(c -> c instanceof IndirectClient).forEach(client -> {
             try {
                 final IndirectClient indirectClient = (IndirectClient) client;
 

--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
@@ -53,7 +53,7 @@ public class MultifactorAuthenticationTrustRecord implements Comparable<Multifac
     }
 
     public String getRecordKey() {
-    	return recordKey;
+        return recordKey;
     }
 
     public void setRecordKey(final String id) {


### PR DESCRIPTION
Enables CAS Throttle to be configured for accessing an OAuth token. Prevents brute force attacks on OAuth configured CAS on the /accessToken path. Similar to the CAS Rest configuration for CAS Throttle.

