### PR TITLE
Enable use CAS throttling support with OAuth module.

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -53,6 +53,8 @@ public class OAuthProperties implements Serializable {
      */
     private UserProfileViewTypes userProfileViewType = UserProfileViewTypes.NESTED;
 
+    private String throttler = "neverThrottle";
+
     public UserProfileViewTypes getUserProfileViewType() {
         return userProfileViewType;
     }
@@ -91,6 +93,14 @@ public class OAuthProperties implements Serializable {
 
     public void setCode(final OAuthCodeProperties code) {
         this.code = code;
+    }
+
+    public String getThrottler() {
+        return throttler;
+    }
+
+    public void setThrottler(String throttler) {
+        this.throttler = throttler;
     }
 }
 

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -99,7 +99,7 @@ public class OAuthProperties implements Serializable {
         return throttler;
     }
 
-    public void setThrottler(String throttler) {
+    public void setThrottler(final String throttler) {
         this.throttler = throttler;
     }
 }

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -53,6 +53,15 @@ public class OAuthProperties implements Serializable {
      */
     private UserProfileViewTypes userProfileViewType = UserProfileViewTypes.NESTED;
 
+    /**
+     * Name of the authentication throttling bean from cas-server-support-throttle.  Defaults to neverThrottle which
+     * disables throttling.  If cas-server-support-throttle module is added then authenticationThrottle bean will be created.
+     * This default bean authenticationThrottle can be overridden and/or different ThrottleSubmissionHandlerInterceptor
+     * maybe configured for use.
+     *
+     * @see org.apereo.cas.web.support.ThrottledSubmissionHandlerInterceptor
+     * @see org.apereo.cas.web.support.config.CasThrottlingConfiguration#authenticationThrottle()
+     */
     private String throttler = "neverThrottle";
 
     public UserProfileViewTypes getUserProfileViewType() {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -59,8 +59,8 @@ public class OAuthProperties implements Serializable {
      * This default bean authenticationThrottle can be overridden and/or different ThrottleSubmissionHandlerInterceptor
      * maybe configured for use.
      *
-     * @see org.apereo.cas.web.support.ThrottledSubmissionHandlerInterceptor
-     * @see org.apereo.cas.web.support.config.CasThrottlingConfiguration#authenticationThrottle()
+     * org.apereo.cas.web.support.ThrottledSubmissionHandlerInterceptor
+     * org.apereo.cas.web.support.config.CasThrottlingConfiguration#authenticationThrottle()
      */
     private String throttler = "neverThrottle";
 

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3865,6 +3865,7 @@ To learn more about this topic, [please review this guide](OAuth-OpenId-Authenti
 # cas.authn.oauth.grants.resourceOwner.requireServiceHeader=true
 
 # cas.authn.oauth.userProfileViewType=NESTED|FLAT
+# cas.authn.oauth.throttler=neverThrottle|authenticationThrottle
 ```
 
 ## Localization

--- a/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
+++ b/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
@@ -196,6 +196,16 @@ public class MyOAuthConfiguration {
 
 [See this guide](Configuration-Management-Extensions.html) to learn more about how to register configurations into the CAS runtime.
 
+## Configuring Throttling for OAuth
+
+Authentication throttling maybe enabled for `/oauth2.0/accessToken` by including `cas-server-support-throttle` and configuring name of the `ThrottledSubmissionHandlerInterceptor` bean in the oauth properties.  Default property configuration is `neverThrottle`.  Update properties
+ to use the `authenticationThrottle` bean or another bean which you have defined.  The default throttling `authenticationThrottle` bean 
+ may also be defined in cas overlay project.
+
+To see the relevant list of CAS properties, please [review this guide](Configuration-Properties.html#oauth2).
+    
+[See this guide](Configuring-Authentication-Throttling.md) to learn about CAS Authentication Throttling.
+
 ## Server Configuration
 
 Remember that OAuth features of CAS require session affinity (and optionally session replication),

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -224,7 +224,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     @RefreshScope
     public HandlerInterceptorAdapter oauthInterceptor() {
         final String throttler = casProperties.getAuthn().getOauth().getThrottler();
-        OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(),
+        final OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(),
                 requiresAuthenticationAuthorizeInterceptor(), accessTokenGrantRequestExtractors());
 
         if ("neverThrottle".equals(throttler)) {
@@ -232,7 +232,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         } else {
             final HandlerInterceptor throttledInterceptor = this.applicationContext.getBean(throttler, HandlerInterceptor.class);
             final String throttledUrl = BASE_OAUTH20_URL.concat("/").concat(ACCESS_TOKEN_URL);
-            HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
+            final HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
                 @Override
                 public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl) && !throttledInterceptor.preHandle(request, response, handler)) {
@@ -242,7 +242,8 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
                 }
 
                 @Override
-                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView) throws Exception {
+                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView)
+                        throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl)) {
                         throttledInterceptor.postHandle(request, response, handler, modelAndView);
                     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -224,8 +224,8 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     @RefreshScope
     public HandlerInterceptorAdapter oauthInterceptor() {
         final String throttler = casProperties.getAuthn().getOauth().getThrottler();
-        final OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(),
-                requiresAuthenticationAuthorizeInterceptor(), accessTokenGrantRequestExtractors());
+        final OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(
+                requiresAuthenticationAccessTokenInterceptor(), requiresAuthenticationAuthorizeInterceptor(), accessTokenGrantRequestExtractors());
 
         if ("neverThrottle".equals(throttler)) {
             return oAuth20HandlerInterceptorAdapter;
@@ -242,8 +242,8 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
                 }
 
                 @Override
-                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView)
-                        throws Exception {
+                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler,
+                                       final ModelAndView modelAndView) throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl)) {
                         throttledInterceptor.postHandle(request, response, handler, modelAndView);
                     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -87,11 +87,15 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -219,8 +223,33 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
     @Bean
     @RefreshScope
     public HandlerInterceptorAdapter oauthInterceptor() {
-        return new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(),
+        final String throttler = casProperties.getAuthn().getOauth().getThrottler();
+        OAuth20HandlerInterceptorAdapter oAuth20HandlerInterceptorAdapter = new OAuth20HandlerInterceptorAdapter(requiresAuthenticationAccessTokenInterceptor(),
                 requiresAuthenticationAuthorizeInterceptor(), accessTokenGrantRequestExtractors());
+
+        if ("neverThrottle".equals(throttler)) {
+            return oAuth20HandlerInterceptorAdapter;
+        } else {
+            final HandlerInterceptor throttledInterceptor = this.applicationContext.getBean(throttler, HandlerInterceptor.class);
+            final String throttledUrl = BASE_OAUTH20_URL.concat("/").concat(ACCESS_TOKEN_URL);
+            HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
+                @Override
+                public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+                    if (request.getServletPath().startsWith(throttledUrl) && !throttledInterceptor.preHandle(request, response, handler)) {
+                        return false;
+                    }
+                    return oAuth20HandlerInterceptorAdapter.preHandle(request, response, handler);
+                }
+
+                @Override
+                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView) throws Exception {
+                    if (request.getServletPath().startsWith(throttledUrl)) {
+                        throttledInterceptor.postHandle(request, response, handler, modelAndView);
+                    }
+                }
+            };
+            return throttledInceptorAdapter;
+        }
     }
 
     @Override


### PR DESCRIPTION
Enables CAS Throttle to be configured for accessing an OAuth token. Prevents brute force attacks on OAuth configured CAS on the /accessToken path. Similar to the CAS Rest configuration for CAS Throttle.
