### PR TITLE
WIP: Enhancements for PAC4J SAML Single Logout on CAS [5.1.x]

### DIFF
--- a/support/cas-server-support-pac4j-core-clients/build.gradle
+++ b/support/cas-server-support-pac4j-core-clients/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     compile project(":core:cas-server-core-tickets")
     compile project(":core:cas-server-core-web")
     compile project(":support:cas-server-support-pac4j-core")
+    compile project(":support:cas-server-support-actions")
     implementation libraries.pac4j
     implementation libraries.opensaml
     

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/util/Pac4JUtils.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/util/Pac4JUtils.java
@@ -12,8 +12,10 @@ import org.pac4j.core.profile.ProfileManager;
  * A collection of utility methods related to PAC4J.
  * 
  * @author jkacer
+ * 
+ * @since 5.1.6
  */
-public class Pac4JUtils {
+public final class Pac4JUtils {
 
     /**
      * Private constructor to disable instantiation.

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/util/Pac4JUtils.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/util/Pac4JUtils.java
@@ -1,0 +1,42 @@
+package org.apereo.cas.support.pac4j.util;
+
+import java.util.Optional;
+
+import org.apereo.cas.web.support.WebUtils;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileManager;
+
+
+/**
+ * A collection of utility methods related to PAC4J.
+ * 
+ * @author jkacer
+ */
+public class Pac4JUtils {
+
+    /**
+     * Private constructor to disable instantiation.
+     */
+    private Pac4JUtils() {
+        super();
+    }
+
+
+    /**
+     * Finds the current client name from the context, using the PAC4J Profile Manager. It is assumed that the context has previously been
+     * populated with the profile.
+     * 
+     * @param webContext
+     *            A web context (request + response).
+     * 
+     * @return The currently used client's name or {@code null} if there is no active profile.
+     */
+    public static String findCurrentClientName(final WebContext webContext) {
+        @SuppressWarnings("unchecked")
+        final ProfileManager<? extends CommonProfile> pm = WebUtils.getPac4jProfileManager(webContext);
+        final Optional<? extends CommonProfile> profile = pm.get(true);
+        return profile.map(CommonProfile::getClientName).orElse(null);
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
@@ -18,6 +18,8 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.service.ProfileService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -85,16 +87,19 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
     private final String themeParamName;
     private final String localParamName;
     private final boolean autoRedirect;
+    private final ProfileService<CommonProfile> profileService;
 
     public DelegatedClientAuthenticationAction(final Clients clients, final AuthenticationSystemSupport authenticationSystemSupport,
                                                final CentralAuthenticationService centralAuthenticationService, final String themeParamName,
-                                               final String localParamName, final boolean autoRedirect) {
+                                               final String localParamName, final boolean autoRedirect,
+                                               final ProfileService<CommonProfile> profileService) {
         this.clients = clients;
         this.authenticationSystemSupport = authenticationSystemSupport;
         this.centralAuthenticationService = centralAuthenticationService;
         this.themeParamName = themeParamName;
         this.localParamName = localParamName;
         this.autoRedirect = autoRedirect;
+        this.profileService = profileService;
     }
 
     @Override
@@ -148,6 +153,10 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
 
                 final TicketGrantingTicket tgt = this.centralAuthenticationService.createTicketGrantingTicket(authenticationResult);
                 WebUtils.putTicketGrantingTicketInScopes(context, tgt);
+
+                // Prepare for future Single Logout - save the profile
+                prepareForFutureSingleLogout(client, credentials, webContext);
+
                 return success();
             }
         }
@@ -285,6 +294,32 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
         }
         return Optional.empty();
     }
+
+    /**
+     * Prepares for a future SAML Single Logout by saving the current user profile through a PAC4J profile service.
+     * 
+     * @param client
+     *            The current PAC4J client.
+     * @param credentials
+     *            Credentials from the user.
+     * @param webContext
+     *            PAC4J web context.
+     * 
+     * @throws Exception
+     *             If anything fails.
+     */
+    private void prepareForFutureSingleLogout(final BaseClient<Credentials, ? extends UserProfile> client, final Credentials credentials,
+            final WebContext webContext) throws HttpAction {
+        if (profileService != null) {
+            final CommonProfile profile = client.getUserProfile(credentials, webContext);
+            /* TODO: Unclear point here. What should the password be? Can it be the TGT ID? See SingleLogoutPreparationAction:57; we use
+             * the TGT ID to read he profile from the service there.
+             */
+            final String password = "TODO";
+            profileService.create(profile, password);
+        }
+    }
+
 
     /**
      * The Provider login page configuration.

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
@@ -312,7 +312,7 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
             final WebContext webContext) throws HttpAction {
         if (profileService != null) {
             final CommonProfile profile = client.getUserProfile(credentials, webContext);
-            /* TODO: Unclear point here. What should the password be? Can it be the TGT ID? See SingleLogoutPreparationAction:57; we use
+            /* Unclear point here. What should the password be? Can it be the TGT ID? See SingleLogoutPreparationAction:57; we use
              * the TGT ID to read he profile from the service there.
              */
             final String password = "TODO";

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesAction.java
@@ -25,9 +25,11 @@ import com.google.common.base.Throwables;
  * 
  * It is assumed that the session itself will be terminated in {@link TerminateSessionFlowExecutionListener}.
  * 
+ * @author jkacer
+ * 
  * @see TerminateSessionFlowExecutionListener
  * 
- * @author jkacer
+ * @since 5.1.6
  */
 public class DestroyTgtAndCookiesAction extends TerminateSessionAction {
 

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesAction.java
@@ -1,0 +1,84 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apereo.cas.CentralAuthenticationService;
+import org.apereo.cas.configuration.model.core.logout.LogoutProperties;
+import org.apereo.cas.logout.LogoutRequest;
+import org.apereo.cas.web.flow.TerminateSessionAction;
+import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
+import org.apereo.cas.web.support.WebUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.webflow.action.EventFactorySupport;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+
+import com.google.common.base.Throwables;
+
+
+/**
+ * A light version of {@link TerminateSessionAction} that does NOT destroy the HTTP session, only destroys the TGT and cookies.
+ * 
+ * It is assumed that the session itself will be terminated in {@link TerminateSessionFlowExecutionListener}.
+ * 
+ * @see TerminateSessionFlowExecutionListener
+ * 
+ * @author jkacer
+ */
+public class DestroyTgtAndCookiesAction extends TerminateSessionAction {
+
+    private final Logger logger2 = LoggerFactory.getLogger(DestroyTgtAndCookiesAction.class);
+
+    private final EventFactorySupport eventFactorySupport;
+    private final CentralAuthenticationService centralAuthenticationService;
+    private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
+    private final CookieRetrievingCookieGenerator warnCookieGenerator;
+
+
+    public DestroyTgtAndCookiesAction(
+            final CentralAuthenticationService centralAuthenticationService,
+            final CookieRetrievingCookieGenerator tgtCookieGenerator,
+            final CookieRetrievingCookieGenerator warnCookieGenerator,
+            final LogoutProperties logoutProperties) {
+        super(centralAuthenticationService, tgtCookieGenerator, warnCookieGenerator, logoutProperties);
+        this.eventFactorySupport = new EventFactorySupport();
+        this.centralAuthenticationService = centralAuthenticationService;
+        this.ticketGrantingTicketCookieGenerator = tgtCookieGenerator;
+        this.warnCookieGenerator = warnCookieGenerator;
+    }
+
+
+    @Override
+    public Event terminate(final RequestContext context) {
+        // in login's webflow : we can get the value from context as it has already been stored
+        try {
+            final HttpServletRequest request = WebUtils.getHttpServletRequest(context);
+            final HttpServletResponse response = WebUtils.getHttpServletResponse(context);
+
+            String tgtId = WebUtils.getTicketGrantingTicketId(context);
+            // for logout, we need to get the cookie's value
+            if (tgtId == null) {
+                tgtId = this.ticketGrantingTicketCookieGenerator.retrieveCookieValue(request);
+            }
+            if (tgtId != null) {
+                logger2.debug("Destroying SSO session linked to ticket-granting ticket [{}]", tgtId);
+                final List<LogoutRequest> logoutRequests = this.centralAuthenticationService.destroyTicketGrantingTicket(tgtId);
+                WebUtils.putLogoutRequests(context, logoutRequests);
+            }
+            logger2.debug("Removing CAS cookies");
+            this.ticketGrantingTicketCookieGenerator.removeCookie(response);
+            this.warnCookieGenerator.removeCookie(response);
+
+            // Do NOT destroy the session here. Keep it.
+            return this.eventFactorySupport.success(this);
+        } catch (final Exception e) {
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesAction.java
@@ -76,8 +76,7 @@ public class DestroyTgtAndCookiesAction extends TerminateSessionAction {
             // Do NOT destroy the session here. Keep it.
             return this.eventFactorySupport.success(this);
         } catch (final Exception e) {
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw Throwables.propagate(e);
         }
     }
 

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlAction.java
@@ -1,0 +1,108 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apereo.cas.support.pac4j.util.Pac4JUtils;
+import org.apereo.cas.web.support.WebUtils;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.client.SAML2Client;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.webflow.action.AbstractAction;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+
+
+/**
+ * An action that gives preference to SAML2 Single Logout over a forward to the specified service.
+ * 
+ * Normally, if the "service" parameter is specified for the logout call, the web flow redirects to the service at the end. However, this
+ * means that no SAML2 Single Logout will occur because the view actually used is different. To overcome this issue, this action examines
+ * the client; if it is a SAML2 client and it has at least one SLO service defined, the "service" parameter is completely removed from the
+ * flow scope, no redirect to the service occurs (although the caller wished so) and the SLO can be performed.
+ * 
+ * To be inserted (ideally) to the "on-entry" section of state "finishLogout", either declaratively or programmatically.
+ * 
+ * @author jkacer
+ */
+public class IgnoreServiceRedirectUrlForSamlAction extends AbstractAction {
+
+    
+    /**
+     * Name of the web flow attribute that holds the URL where to redirect after the flow.
+     * 
+     * @see WebUtils#putLogoutRedirectUrl(RequestContext, String)
+     * @see LogoutAction#doExecuteInternal()
+     */
+    public static final String FLOW_ATTR_LOGOUT_REDIR_URL = "logoutRedirectUrl";
+
+    private final Logger logger2 = LoggerFactory.getLogger(IgnoreServiceRedirectUrlForSamlAction.class);
+
+    private final Clients clients;
+
+
+    /**
+     * Creates a new Ignore Service Redirect action.
+     * 
+     * @param clients
+     *            All PAC4J clients.
+     */
+    public IgnoreServiceRedirectUrlForSamlAction(final Clients clients) {
+        super();
+        this.clients = clients;
+    }
+
+
+    @Override
+    protected Event doExecute(RequestContext requestContext) throws Exception {
+        final HttpServletRequest request = WebUtils.getHttpServletRequest(requestContext);
+        final HttpServletResponse response = WebUtils.getHttpServletResponse(requestContext);
+        final J2EContext context = WebUtils.getPac4jJ2EContext(request, response);
+
+        final String currentClientName = Pac4JUtils.findCurrentClientName(context);
+        final Client<?, ?> client = (currentClientName == null) ? null : clients.findClient(currentClientName);
+
+        if (shouldServiceRedirectBeIgnored(client, context)) {
+            requestContext.getFlowScope().remove(FLOW_ATTR_LOGOUT_REDIR_URL);
+            logger2.debug("The Logout Redirection URL has been removed from the web low scope in order to allow for SAML2 SLO.");
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Decides if the "service" parameter should be ignored.
+     * 
+     * It should be ignored for SAML2 clients that have at least one SLO service.
+     * 
+     * @param client
+     *            The currently used client.
+     * @param wc
+     *            The current web context (request + response).
+     * 
+     * @return True if the parameter should be ignored, false otherwise.
+     */
+    private boolean shouldServiceRedirectBeIgnored(final Client<?, ?> client, final WebContext wc) {
+        if (!(client instanceof SAML2Client)) {
+            return false;
+        }
+
+        final SAML2Client saml2Client = (SAML2Client) client;
+        final SAML2MessageContext samlContext = saml2Client.getContextProvider().buildContext(wc);
+        final IDPSSODescriptor idpSsoDescriptor = (samlContext == null) ? null : samlContext.getIDPSSODescriptor();
+        final List<SingleLogoutService> sloServices = (idpSsoDescriptor == null) ? null : idpSsoDescriptor.getSingleLogoutServices();
+
+        return (sloServices != null) && (!sloServices.isEmpty());
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlAction.java
@@ -33,6 +33,8 @@ import org.springframework.webflow.execution.RequestContext;
  * To be inserted (ideally) to the "on-entry" section of state "finishLogout", either declaratively or programmatically.
  * 
  * @author jkacer
+ * 
+ * @since 5.1.6
  */
 public class IgnoreServiceRedirectUrlForSamlAction extends AbstractAction {
 

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
@@ -5,10 +5,7 @@ import org.apereo.cas.web.support.WebUtils;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.context.J2EContext;
-import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.TechnicalException;
-import org.pac4j.core.profile.CommonProfile;
-import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.redirect.RedirectAction;
 import org.pac4j.saml.client.SAML2Client;
 import org.slf4j.Logger;
@@ -16,8 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
-
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SAML2ClientLogoutAction.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.pac4j.web.flow;
 
+import org.apereo.cas.support.pac4j.util.Pac4JUtils;
 import org.apereo.cas.web.support.WebUtils;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
@@ -54,7 +55,7 @@ public class SAML2ClientLogoutAction extends AbstractAction {
 
             Client<?, ?> client;
             try {
-                final String currentClientName = findCurrentClientName(context);
+                final String currentClientName = Pac4JUtils.findCurrentClientName(context);
                 client = (currentClientName == null) ? null : clients.findClient(currentClientName);
             } catch(final TechnicalException e) {
                 // this exception indicates that the SAML2Client is not in the list
@@ -76,22 +77,6 @@ public class SAML2ClientLogoutAction extends AbstractAction {
             LOGGER.warn(e.getMessage(), e);
         }
         return null;
-    }
-
-    /**
-     * Finds the current client name from the context, using the PAC4J Profile Manager. It is assumed that the context has previously been
-     * populated with the profile.
-     * 
-     * @param webContext
-     *            A web context (request + response).
-     * 
-     * @return The currently used client's name or {@code null} if there is no active profile.
-     */
-    private String findCurrentClientName(final WebContext webContext) {
-        @SuppressWarnings("unchecked")
-        final ProfileManager<? extends CommonProfile> pm = WebUtils.getPac4jProfileManager(webContext);
-        final Optional<? extends CommonProfile> profile = pm.get(true);
-        return profile.map(CommonProfile::getClientName).orElse(null);
     }
 
 }

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SingleLogoutPreparationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SingleLogoutPreparationAction.java
@@ -26,6 +26,8 @@ import org.springframework.webflow.execution.RequestContext;
  * This action should be called from the Logout web flow.
  * 
  * @author jkacer
+ * 
+ * @since 5.1.6
  */
 public class SingleLogoutPreparationAction extends AbstractAction {
 

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SingleLogoutPreparationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/SingleLogoutPreparationAction.java
@@ -1,0 +1,75 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
+import org.apereo.cas.web.support.WebUtils;
+import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileManager;
+import org.pac4j.core.profile.service.ProfileService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.webflow.action.AbstractAction;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+
+
+/**
+ * The purpose of this action is to prepare the PAC4J Profile Manager for Single Logout.
+ * 
+ * The Profile Manager keeps the profiles in request + session but the session has already been destroyed. This action should restore the
+ * profile from a long term storage - {@link ProfileService} and populate the PAC4J Profile Manager with it.
+ * 
+ * This action should be called from the Logout web flow.
+ * 
+ * @author jkacer
+ */
+public class SingleLogoutPreparationAction extends AbstractAction {
+
+    private final Logger logger2 = LoggerFactory.getLogger(SingleLogoutPreparationAction.class);
+
+    private final ProfileService<? extends CommonProfile> profileService;
+    private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
+
+
+    public SingleLogoutPreparationAction(final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator,
+            final ProfileService<? extends CommonProfile> profileService) {
+        super();
+        this.profileService = profileService;
+        this.ticketGrantingTicketCookieGenerator = ticketGrantingTicketCookieGenerator;
+    }
+
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    protected Event doExecute(final RequestContext rc) throws Exception {
+        // Get the TGT first. For logout, we need to get the cookie's value, most likely the TGT will not be in the scope anymore.
+        String tgtId = WebUtils.getTicketGrantingTicketId(rc);
+        final HttpServletRequest request = WebUtils.getHttpServletRequest(rc);
+        if (tgtId == null) {
+            tgtId = ticketGrantingTicketCookieGenerator.retrieveCookieValue(request);
+        }
+
+        // Retrieve the user profile previously stored to the long-term storage in PAC4J ClientAction.
+        final CommonProfile profile = (tgtId == null) ? null : profileService.findById(tgtId);
+
+        // And save the profile into the PAC4J Profile Manager for this request + session.
+        if (profile != null) {
+            final HttpServletResponse response = WebUtils.getHttpServletResponse(rc);
+            final WebContext webContext = new J2EContext(request, response);
+            final ProfileManager pm = WebUtils.getPac4jProfileManager(webContext);
+            pm.save(true, profile, false);
+            logger2.debug("User profile restored from a long-term storage and saved in PAC4J Profile Manager.");
+        } else {
+            logger2.debug("No user profile restored from a long-term storage. SAML Single Logout may not work properly."
+                    + " This is normal for non-SAML clients.");
+        }
+
+        return success();
+    }
+
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListener.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListener.java
@@ -36,6 +36,12 @@ public class TerminateSessionFlowExecutionListener extends FlowExecutionListener
     }
 
 
+    /**
+     * Destroys the session on flow termination.
+     * 
+     * @param context
+     *            The flow request context.
+     */
     protected void terminate(final RequestContext context) {
         try {
             final HttpServletRequest request = WebUtils.getHttpServletRequest(context);
@@ -48,6 +54,14 @@ public class TerminateSessionFlowExecutionListener extends FlowExecutionListener
     }
 
 
+    /**
+     * Destroys the session and performs PAC4J logout.
+     * 
+     * @param request
+     *            The HTTP request.
+     * @param response
+     *            The HTTP response.
+     */
     protected void destroyApplicationSession(final HttpServletRequest request, final HttpServletResponse response) {
         logger.debug("Destroying application session");
         final ProfileManager<?> manager = WebUtils.getPac4jProfileManager(request, response);

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListener.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListener.java
@@ -1,0 +1,63 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.apereo.cas.web.support.WebUtils;
+import org.pac4j.core.profile.ProfileManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.webflow.core.collection.AttributeMap;
+import org.springframework.webflow.execution.FlowExecutionListenerAdapter;
+import org.springframework.webflow.execution.FlowSession;
+import org.springframework.webflow.execution.RequestContext;
+
+import com.google.common.base.Throwables;
+
+
+/**
+ * A Spring Flow execution listener that invalidates user session after the flow terminates.
+ * 
+ * Sometimes we need the session until the very last moment of the flow (e.g. during logout, we need the session to render the SAML SLO
+ * request), that's why we invalidate it after the flow terminates.
+ * 
+ * @author jkacer
+ */
+public class TerminateSessionFlowExecutionListener extends FlowExecutionListenerAdapter {
+
+    private final Logger logger = LoggerFactory.getLogger(TerminateSessionFlowExecutionListener.class);
+
+
+    @Override
+    public void sessionEnded(RequestContext context, FlowSession session, String outcome, AttributeMap<?> output) {
+        super.sessionEnded(context, session, outcome, output);
+        terminate(context);
+    }
+
+
+    protected void terminate(final RequestContext context) {
+        try {
+            final HttpServletRequest request = WebUtils.getHttpServletRequest(context);
+            final HttpServletResponse response = WebUtils.getHttpServletResponse(context);
+            destroyApplicationSession(request, response);
+            logger.debug("Terminated the application session successfully.");
+        } catch (final Exception e) {
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    protected void destroyApplicationSession(final HttpServletRequest request, final HttpServletResponse response) {
+        logger.debug("Destroying application session");
+        final ProfileManager<?> manager = WebUtils.getPac4jProfileManager(request, response);
+        manager.logout();
+
+        final HttpSession session = request.getSession();
+        if (session != null) {
+            session.invalidate();
+        }
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListener.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListener.java
@@ -30,7 +30,7 @@ public class TerminateSessionFlowExecutionListener extends FlowExecutionListener
 
 
     @Override
-    public void sessionEnded(RequestContext context, FlowSession session, String outcome, AttributeMap<?> output) {
+    public void sessionEnded(final RequestContext context, final FlowSession session, final String outcome, final AttributeMap<?> output) {
         super.sessionEnded(context, session, outcome, output);
         terminate(context);
     }
@@ -43,8 +43,7 @@ public class TerminateSessionFlowExecutionListener extends FlowExecutionListener
             destroyApplicationSession(request, response);
             logger.debug("Terminated the application session successfully.");
         } catch (final Exception e) {
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw Throwables.propagate(e);
         }
     }
 

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -9,10 +9,21 @@ package org.apereo.cas;
 
 import org.apereo.cas.support.pac4j.authentication.handler.support.ClientAuthenticationHandlerTests;
 import org.apereo.cas.support.pac4j.web.flow.DelegatedClientAuthenticationActionTests;
+import org.apereo.cas.support.pac4j.web.flow.DestroyTgtAndCookiesActionTests;
+import org.apereo.cas.support.pac4j.web.flow.IgnoreServiceRedirectUrlForSamlActionTests;
+import org.apereo.cas.support.pac4j.web.flow.SingleLogoutPreparationActionTests;
+import org.apereo.cas.support.pac4j.web.flow.TerminateSessionFlowExecutionListenerTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ClientAuthenticationHandlerTests.class, DelegatedClientAuthenticationActionTests.class})
+@Suite.SuiteClasses({
+    ClientAuthenticationHandlerTests.class,
+    DelegatedClientAuthenticationActionTests.class,
+    DestroyTgtAndCookiesActionTests.class,
+    IgnoreServiceRedirectUrlForSamlActionTests.class,
+    SingleLogoutPreparationActionTests.class,
+    TerminateSessionFlowExecutionListenerTests.class
+})
 public class AllTestsSuite {
 }

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationActionTests.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationActionTests.java
@@ -84,9 +84,10 @@ public class DelegatedClientAuthenticationActionTests {
         final FacebookClient facebookClient = new FacebookClient(MY_KEY, MY_SECRET);
         final TwitterClient twitterClient = new TwitterClient("3nJPbVTVRZWAyUgoUKQ8UA", "h6LZyZJmcW46Vu8R47MYfeXTSYGI30EqnWaSwVhFkbA");
         final Clients clients = new Clients(MY_LOGIN_URL, facebookClient, twitterClient);
+//        final ProfileService<CommonProfile> profileService = mock(ProfileService.class);
         final DelegatedClientAuthenticationAction action = new DelegatedClientAuthenticationAction(clients,
                 null, mock(CentralAuthenticationService.class),
-                "theme", "locale", false);
+                "theme", "locale", false, null);
 
         final Event event = action.execute(mockRequestContext);
         assertEquals("error", event.getId());
@@ -143,8 +144,10 @@ public class DelegatedClientAuthenticationActionTests {
         final AuthenticationSystemSupport support = mock(AuthenticationSystemSupport.class);
         when(support.getAuthenticationTransactionManager()).thenReturn(transManager);
 
+//        final ProfileService<CommonProfile> profileService = mock(ProfileService.class);
+
         final DelegatedClientAuthenticationAction action = new DelegatedClientAuthenticationAction(clients, support, casImpl,
-                "theme", "locale", false);
+                "theme", "locale", false, null);
 
         final Event event = action.execute(mockRequestContext);
         assertEquals("success", event.getId());

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesActionTests.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DestroyTgtAndCookiesActionTests.java
@@ -1,0 +1,82 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apereo.cas.CentralAuthenticationService;
+import org.apereo.cas.configuration.model.core.logout.LogoutProperties;
+import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.webflow.context.servlet.ServletExternalContext;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.test.MockRequestContext;
+
+
+/**
+ * Unit test of {@link DestroyTgtAndCookiesAction}.
+ * 
+ * Tests only terminate(), which is overridden in the action, not the whole doExecute().
+ * 
+ * @author jkacer
+ */
+public class DestroyTgtAndCookiesActionTests {
+
+    private static final String TGT_ID = "TGT-1";
+
+    private DestroyTgtAndCookiesAction actionUnderTest;
+
+    @Mock
+    private CentralAuthenticationService casMock;
+
+    @Mock
+    private CookieRetrievingCookieGenerator tgtCookieGenMock;
+
+    @Mock
+    private CookieRetrievingCookieGenerator warnCookieGenMock;
+
+
+    @Test
+    public void terminateDeletesCookiesAndTgt() {
+        // Prepare the input
+        MockHttpServletRequest nativeRequest = new MockHttpServletRequest();
+        MockHttpServletResponse nativeResponse = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        nativeRequest.setSession(session);
+        MockServletContext servletContext = new MockServletContext();
+        ServletExternalContext externalContext = new ServletExternalContext(servletContext, nativeRequest, nativeResponse);
+        MockRequestContext rc = new MockRequestContext();
+        rc.setExternalContext(externalContext);
+
+        // Run the tested action
+        Event e = actionUnderTest.terminate(rc);
+        assertNotNull("Null event returned by the action.", e);
+        assertEquals("The result of the action is not success.", "success", e.getId());
+
+        // Did it execute everything needed?
+        verify(casMock).destroyTicketGrantingTicket(TGT_ID);
+        verify(tgtCookieGenMock).removeCookie(nativeResponse);
+        verify(warnCookieGenMock).removeCookie(nativeResponse);
+    }
+
+    @Before
+    public void setUpTestedAction() {
+        MockitoAnnotations.initMocks(this);
+        when(casMock.destroyTicketGrantingTicket(TGT_ID)).thenReturn(emptyList());
+        when(tgtCookieGenMock.retrieveCookieValue(any(HttpServletRequest.class))).thenReturn(TGT_ID);
+        actionUnderTest = new DestroyTgtAndCookiesAction(casMock, tgtCookieGenMock, warnCookieGenMock, new LogoutProperties());
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DummySingleLogoutService.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DummySingleLogoutService.java
@@ -1,0 +1,183 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+
+import org.opensaml.core.xml.Namespace;
+import org.opensaml.core.xml.NamespaceManager;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.schema.XSBooleanValue;
+import org.opensaml.core.xml.util.AttributeMap;
+import org.opensaml.core.xml.util.IDIndex;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.w3c.dom.Element;
+
+import net.shibboleth.utilities.java.support.collection.LockableClassToInstanceMultiMap;
+
+
+/**
+ * Dummy implementation of {@link SingleLogoutService} just for unit tests.
+ * 
+ * Does not do anything.
+ * 
+ * @author jkacer
+ */
+public class DummySingleLogoutService implements SingleLogoutService {
+
+    @Override
+    public String getBinding() {
+        return null;
+    }
+
+    @Override
+    public void setBinding(String binding) {}
+
+    @Override
+    public String getLocation() {
+        return null;
+    }
+
+    @Override
+    public void setLocation(String location) {}
+
+    @Override
+    public String getResponseLocation() {
+        return null;
+    }
+
+    @Override
+    public void setResponseLocation(String location) {}
+
+    @Override
+    public void detach() {}
+
+    @Override
+    public Element getDOM() {
+        return null;
+    }
+
+    @Override
+    public QName getElementQName() {
+        return null;
+    }
+
+    @Override
+    public IDIndex getIDIndex() {
+        return null;
+    }
+
+    @Override
+    public NamespaceManager getNamespaceManager() {
+        return null;
+    }
+
+    @Override
+    public Set<Namespace> getNamespaces() {
+        return null;
+    }
+
+    @Override
+    public String getNoNamespaceSchemaLocation() {
+        return null;
+    }
+
+    @Override
+    public List<XMLObject> getOrderedChildren() {
+        return null;
+    }
+
+    @Override
+    public XMLObject getParent() {
+        return null;
+    }
+
+    @Override
+    public String getSchemaLocation() {
+        return null;
+    }
+
+    @Override
+    public QName getSchemaType() {
+        return null;
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return false;
+    }
+
+    @Override
+    public boolean hasParent() {
+        return false;
+    }
+
+    @Override
+    public void releaseChildrenDOM(boolean propagateRelease) {}
+
+    @Override
+    public void releaseDOM() {}
+
+    @Override
+    public void releaseParentDOM(boolean propagateRelease) {}
+
+    @Override
+    public XMLObject resolveID(String id) {
+        return null;
+    }
+
+    @Override
+    public XMLObject resolveIDFromRoot(String id) {
+        return null;
+    }
+
+    @Override
+    public void setDOM(Element dom) {}
+
+    @Override
+    public void setNoNamespaceSchemaLocation(String location) {}
+
+    @Override
+    public void setParent(XMLObject parent) {}
+
+    @Override
+    public void setSchemaLocation(String location) {}
+
+    @Override
+    public Boolean isNil() {
+        return null;
+    }
+
+    @Override
+    public XSBooleanValue isNilXSBoolean() {
+        return null;
+    }
+
+    @Override
+    public void setNil(Boolean newNil) {}
+
+    @Override
+    public void setNil(XSBooleanValue newNil) {}
+
+    @Override
+    public LockableClassToInstanceMultiMap<Object> getObjectMetadata() {
+        return null;
+    }
+
+    @Override
+    public List<XMLObject> getUnknownXMLObjects() {
+        return null;
+    }
+
+    @Override
+    public List<XMLObject> getUnknownXMLObjects(QName typeOrName) {
+        return null;
+    }
+
+    @Override
+    public AttributeMap getUnknownAttributes() {
+        return null;
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DummySingleLogoutService.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/DummySingleLogoutService.java
@@ -32,7 +32,7 @@ public class DummySingleLogoutService implements SingleLogoutService {
     }
 
     @Override
-    public void setBinding(String binding) {}
+    public void setBinding(final String binding) {}
 
     @Override
     public String getLocation() {
@@ -40,7 +40,7 @@ public class DummySingleLogoutService implements SingleLogoutService {
     }
 
     @Override
-    public void setLocation(String location) {}
+    public void setLocation(final String location) {}
 
     @Override
     public String getResponseLocation() {
@@ -48,7 +48,7 @@ public class DummySingleLogoutService implements SingleLogoutService {
     }
 
     @Override
-    public void setResponseLocation(String location) {}
+    public void setResponseLocation(final String location) {}
 
     @Override
     public void detach() {}
@@ -114,21 +114,21 @@ public class DummySingleLogoutService implements SingleLogoutService {
     }
 
     @Override
-    public void releaseChildrenDOM(boolean propagateRelease) {}
+    public void releaseChildrenDOM(final boolean propagateRelease) {}
 
     @Override
     public void releaseDOM() {}
 
     @Override
-    public void releaseParentDOM(boolean propagateRelease) {}
+    public void releaseParentDOM(final boolean propagateRelease) {}
 
     @Override
-    public XMLObject resolveID(String id) {
+    public XMLObject resolveID(final String id) {
         return null;
     }
 
     @Override
-    public XMLObject resolveIDFromRoot(String id) {
+    public XMLObject resolveIDFromRoot(final String id) {
         return null;
     }
 
@@ -136,13 +136,13 @@ public class DummySingleLogoutService implements SingleLogoutService {
     public void setDOM(Element dom) {}
 
     @Override
-    public void setNoNamespaceSchemaLocation(String location) {}
+    public void setNoNamespaceSchemaLocation(final String location) {}
 
     @Override
     public void setParent(XMLObject parent) {}
 
     @Override
-    public void setSchemaLocation(String location) {}
+    public void setSchemaLocation(final String location) {}
 
     @Override
     public Boolean isNil() {
@@ -155,10 +155,10 @@ public class DummySingleLogoutService implements SingleLogoutService {
     }
 
     @Override
-    public void setNil(Boolean newNil) {}
+    public void setNil(final Boolean newNil) {}
 
     @Override
-    public void setNil(XSBooleanValue newNil) {}
+    public void setNil(final XSBooleanValue newNil) {}
 
     @Override
     public LockableClassToInstanceMultiMap<Object> getObjectMetadata() {
@@ -171,7 +171,7 @@ public class DummySingleLogoutService implements SingleLogoutService {
     }
 
     @Override
-    public List<XMLObject> getUnknownXMLObjects(QName typeOrName) {
+    public List<XMLObject> getUnknownXMLObjects(final QName typeOrName) {
         return null;
     }
 

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlActionTests.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlActionTests.java
@@ -31,7 +31,7 @@ import org.springframework.webflow.test.MockRequestContext;
 
 
 /**
- * Unit test of {@link IgnoreServiceRedirectUrlForSamlActionTests}.
+ * Unit test of {@link IgnoreServiceRedirectUrlForSamlAction}.
  * 
  * Tests these cases:
  * <ul>

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlActionTests.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlActionTests.java
@@ -1,0 +1,169 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apereo.cas.web.support.WebUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
+import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileManager;
+import org.pac4j.http.client.indirect.FormClient;
+import org.pac4j.saml.client.SAML2Client;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.context.SAMLContextProvider;
+import org.pac4j.saml.profile.SAML2Profile;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.webflow.context.servlet.ServletExternalContext;
+import org.springframework.webflow.test.MockRequestContext;
+
+
+/**
+ * Unit test of {@link IgnoreServiceRedirectUrlForSamlActionTests}.
+ * 
+ * Tests these cases:
+ * <ul>
+ * <ol>A non-SAML2 client</ol>
+ * <ol>A SAML2 client without SLO services</ol>
+ * <ol>A SAML2 client with SLO services</ol>
+ * </ul>
+ * 
+ * 
+ * @author jkacer
+ */
+public class IgnoreServiceRedirectUrlForSamlActionTests {
+
+    private static final String CLIENT_NAME_SAML_NO_SLO = "SamlClientNoSlo";
+    private static final String CLIENT_NAME_SAML_WITH_SLO = "SamlClientWithSlo";
+    private static final String CLIENT_NAME_NON_SAML = "AnotherClient";
+
+    private IgnoreServiceRedirectUrlForSamlAction actionUnderTest;   
+
+
+    @Test
+    public void samlClientWithoutSloShouldNotRemoveService() throws Exception {
+        testServiceRemovalForParticularProfile(samlProfile(CLIENT_NAME_SAML_NO_SLO), false);
+    }
+
+
+    @Test
+    public void samlClientWithSloShouldRemoveService() throws Exception {
+        testServiceRemovalForParticularProfile(samlProfile(CLIENT_NAME_SAML_WITH_SLO), true);
+    }
+
+
+    @Test
+    public void otherClientShouldNotRemoveService() throws Exception {
+        testServiceRemovalForParticularProfile(anotherProfile(), false);
+    }
+
+
+    protected void testServiceRemovalForParticularProfile(final CommonProfile profile, boolean shouldBeRemoved) throws Exception {
+        // Prepare the input
+        MockHttpServletRequest nativeRequest = new MockHttpServletRequest();
+        MockHttpServletResponse nativeResponse = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        nativeRequest.setSession(session);
+        MockServletContext servletContext = new MockServletContext();
+        ServletExternalContext externalContext = new ServletExternalContext(servletContext, nativeRequest, nativeResponse);
+        MockRequestContext rc = new MockRequestContext();
+        rc.setExternalContext(externalContext);
+
+        // Simulate that the "service" is in the flow scope
+        rc.getFlowScope().put(IgnoreServiceRedirectUrlForSamlAction.FLOW_ATTR_LOGOUT_REDIR_URL, "http://my-service");
+
+        // Assure the PAC4J profile exist
+        WebContext wc = WebUtils.getPac4jJ2EContext(nativeRequest, nativeResponse);
+        saveMockProfile(wc, profile);
+
+        // Run the tested action
+        actionUnderTest.doExecute(rc);
+        
+        if (shouldBeRemoved) {
+            // Check that the service value has disappeared from the flow
+            assertNull("For SAML clients with SLO services defined, the 'service' parameter should have been removed.",
+                    rc.getFlowScope().get(IgnoreServiceRedirectUrlForSamlAction.FLOW_ATTR_LOGOUT_REDIR_URL));
+        } else {
+            // Check that the service value is still in the flow
+            assertNotNull("For non-SAML2 clients and SAML clients without SLO services defined, the 'service' parameter"
+                    + " should have been retained.",
+                    rc.getFlowScope().get(IgnoreServiceRedirectUrlForSamlAction.FLOW_ATTR_LOGOUT_REDIR_URL));
+        }
+    }
+
+
+    private SAML2Profile samlProfile(String clientName) {
+        SAML2Profile p = new SAML2Profile();
+        p.setClientName(clientName);
+        return p;
+    }
+
+
+    private CommonProfile anotherProfile() {
+        CommonProfile p = new CommonProfile();
+        p.setClientName(CLIENT_NAME_NON_SAML);
+        return p;
+    }
+
+
+    private <T extends CommonProfile> void saveMockProfile(WebContext wc, T profile) {
+        @SuppressWarnings("unchecked")
+        final ProfileManager<T> pm = WebUtils.getPac4jProfileManager(wc);
+        pm.save(true, profile, false);
+    }
+
+
+    @Before
+    public void setUpTestedAction() {
+        SAML2Client samlClientMockNoSlo = mock(SAML2Client.class);
+        mockSamlClientMetadata(samlClientMockNoSlo, false);
+
+        SAML2Client samlClientMockWithSlo = mock(SAML2Client.class);
+        mockSamlClientMetadata(samlClientMockWithSlo, true);
+        
+        FormClient anotherClientMock = mock(FormClient.class);
+
+        Clients clientsMock = mock(Clients.class);
+        when(clientsMock.findClient(CLIENT_NAME_SAML_NO_SLO)).thenReturn(samlClientMockNoSlo);
+        when(clientsMock.findClient(CLIENT_NAME_SAML_WITH_SLO)).thenReturn(samlClientMockWithSlo);
+        when(clientsMock.findClient(CLIENT_NAME_NON_SAML)).thenReturn(anotherClientMock);
+
+        actionUnderTest = new IgnoreServiceRedirectUrlForSamlAction(clientsMock);
+    }
+
+
+    private void mockSamlClientMetadata(SAML2Client client, boolean hasLogoutService) {
+        IDPSSODescriptor idpssoDescriptor = mock(IDPSSODescriptor.class);
+        if (hasLogoutService) {
+            SingleLogoutService logoutService = new DummySingleLogoutService();
+            when(idpssoDescriptor.getSingleLogoutServices()).thenReturn(singletonList(logoutService));
+        }
+
+        SAMLMetadataContext samlMetadataContext = mock(SAMLMetadataContext.class);
+        when(samlMetadataContext.getRoleDescriptor()).thenReturn(idpssoDescriptor);
+
+        SAMLPeerEntityContext peerEntityContext = mock(SAMLPeerEntityContext.class);
+        when(peerEntityContext.getSubcontext(SAMLMetadataContext.class, true)).thenReturn(samlMetadataContext);
+
+        SAML2MessageContext saml2MessageContext = mock(SAML2MessageContext.class);
+        when(saml2MessageContext.getSubcontext(SAMLPeerEntityContext.class, true)).thenReturn(peerEntityContext);
+
+        SAMLContextProvider samlContextProviderMock = mock(SAMLContextProvider.class);
+        when(samlContextProviderMock.buildContext(any(WebContext.class))).thenReturn(saml2MessageContext);
+
+        when(client.getContextProvider()).thenReturn(samlContextProviderMock);
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlActionTests.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/IgnoreServiceRedirectUrlForSamlActionTests.java
@@ -70,7 +70,7 @@ public class IgnoreServiceRedirectUrlForSamlActionTests {
     }
 
 
-    protected void testServiceRemovalForParticularProfile(final CommonProfile profile, boolean shouldBeRemoved) throws Exception {
+    protected void testServiceRemovalForParticularProfile(final CommonProfile profile, final boolean shouldBeRemoved) throws Exception {
         // Prepare the input
         MockHttpServletRequest nativeRequest = new MockHttpServletRequest();
         MockHttpServletResponse nativeResponse = new MockHttpServletResponse();
@@ -104,7 +104,7 @@ public class IgnoreServiceRedirectUrlForSamlActionTests {
     }
 
 
-    private SAML2Profile samlProfile(String clientName) {
+    private SAML2Profile samlProfile(final String clientName) {
         SAML2Profile p = new SAML2Profile();
         p.setClientName(clientName);
         return p;
@@ -118,7 +118,7 @@ public class IgnoreServiceRedirectUrlForSamlActionTests {
     }
 
 
-    private <T extends CommonProfile> void saveMockProfile(WebContext wc, T profile) {
+    private <T extends CommonProfile> void saveMockProfile(final WebContext wc, final T profile) {
         @SuppressWarnings("unchecked")
         final ProfileManager<T> pm = WebUtils.getPac4jProfileManager(wc);
         pm.save(true, profile, false);
@@ -144,7 +144,7 @@ public class IgnoreServiceRedirectUrlForSamlActionTests {
     }
 
 
-    private void mockSamlClientMetadata(SAML2Client client, boolean hasLogoutService) {
+    private void mockSamlClientMetadata(final SAML2Client client, final boolean hasLogoutService) {
         IDPSSODescriptor idpssoDescriptor = mock(IDPSSODescriptor.class);
         if (hasLogoutService) {
             SingleLogoutService logoutService = new DummySingleLogoutService();

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/SingleLogoutPreparationActionTests.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/SingleLogoutPreparationActionTests.java
@@ -1,0 +1,89 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.service.ProfileService;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.webflow.context.servlet.ServletExternalContext;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.test.MockRequestContext;
+
+
+/**
+ * Unit test of {@link SingleLogoutPreparationAction}.
+ * 
+ * @author jkacer
+ */
+public class SingleLogoutPreparationActionTests {
+
+    private static final String TGT_ID = "TGT-1";
+
+    private SingleLogoutPreparationAction actionUnderTest;
+
+    private ProfileService<CommonProfile> profileServiceMock;
+
+    private CookieRetrievingCookieGenerator ticketGrantingTicketCookieGeneratorMock;
+
+    private CommonProfile profile;
+
+
+    /**
+     * Tests that the action properly populates the session and the request with a PAC4J profile.
+     * 
+     * The profile is first retrieved from the long-term profile service, the key used for the store is the TGT ID.
+     * The TGT is retrieved from the cookie generator - the current request should hold an encrypted TGT cookie.
+     */
+    @Test
+    public void actionShouldPopulateRequestAndSessionWithPac4JProfile() throws Exception {
+        // Prepare the input
+        MockHttpServletRequest nativeRequest = new MockHttpServletRequest();
+        MockHttpServletResponse nativeResponse = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        nativeRequest.setSession(session);
+        MockServletContext servletContext = new MockServletContext();
+        ServletExternalContext externalContext = new ServletExternalContext(servletContext, nativeRequest, nativeResponse);
+        MockRequestContext rc = new MockRequestContext();
+        rc.setExternalContext(externalContext);
+
+        // Run the tested action
+        Event e = actionUnderTest.doExecute(rc);
+
+        // Check the result
+        assertEquals("success", e.getId());
+
+        // Check request and session attributes
+        Assert.assertNotNull("No user profile was saved into the request.", nativeRequest.getAttribute(Pac4jConstants.USER_PROFILES));
+        Assert.assertNotNull("No user profile was saved into the session.", session.getAttribute(Pac4jConstants.USER_PROFILES));
+    }
+
+
+    @Before
+    public void setUpTestedObject() {
+        profile = new CommonProfile();
+        profile.setClientName("UnitTestClient");
+        profile.setId("Profile-1");
+
+        profileServiceMock = mock(ProfileService.class);
+        when(profileServiceMock.findById(TGT_ID)).thenReturn(profile);
+
+        ticketGrantingTicketCookieGeneratorMock = mock(CookieRetrievingCookieGenerator.class);
+        when(ticketGrantingTicketCookieGeneratorMock.retrieveCookieValue(any(HttpServletRequest.class))).thenReturn(TGT_ID);
+
+        actionUnderTest = new SingleLogoutPreparationAction(ticketGrantingTicketCookieGeneratorMock, profileServiceMock);
+    }
+
+}

--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListenerTests.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/web/flow/TerminateSessionFlowExecutionListenerTests.java
@@ -1,0 +1,66 @@
+package org.apereo.cas.support.pac4j.web.flow;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.core.context.Pac4jConstants;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.webflow.context.servlet.ServletExternalContext;
+import org.springframework.webflow.core.collection.AttributeMap;
+import org.springframework.webflow.core.collection.LocalAttributeMap;
+import org.springframework.webflow.execution.FlowSession;
+import org.springframework.webflow.test.MockFlowSession;
+import org.springframework.webflow.test.MockRequestContext;
+
+/**
+ * Unit test of {@link TerminateSessionFlowExecutionListener}.
+ * 
+ * @author jkacer
+ */
+public class TerminateSessionFlowExecutionListenerTests {
+
+    private TerminateSessionFlowExecutionListener listenerUnderTest;
+
+
+    @Test
+    public void httpSessionMustBeInvalidatedOnFlowSessionEnd() {
+        // Prepare the input
+        MockHttpServletRequest nativeRequest = new MockHttpServletRequest();
+        MockHttpServletResponse nativeResponse = new MockHttpServletResponse();
+        MockHttpSession session = new MockHttpSession();
+        nativeRequest.setSession(session);
+        MockServletContext servletContext = new MockServletContext();
+        ServletExternalContext externalContext = new ServletExternalContext(servletContext, nativeRequest, nativeResponse);
+        MockRequestContext rc = new MockRequestContext();
+        rc.setExternalContext(externalContext);
+
+        FlowSession flowSession = new MockFlowSession();
+        String outcome = "EndStateId";
+        AttributeMap<?> flowOutput = new LocalAttributeMap<>();
+
+        // Run the tested listener
+        listenerUnderTest.sessionEnded(rc, flowSession, outcome, flowOutput);
+
+        // Check the session state
+        assertTrue("The HTTP session should have been invalidated in the Terminate Session Listener.", session.isInvalid());
+
+        // Check PAC4J state - PAC4J logout removes all user profiles form the request and the session.
+        // The session cannot be checked here because it's already invalidated.
+        Map<?,?> profilesFromRequest = (Map<?,?>) nativeRequest.getAttribute(Pac4jConstants.USER_PROFILES);
+        assertTrue("All PAC4J profiles on the HTTP request should have been cleared in the Terminate Session Listener.",
+                profilesFromRequest.isEmpty());
+    }
+
+
+    @Before
+    public void setUpTestedListener() {
+        listenerUnderTest = new TerminateSessionFlowExecutionListener();
+    }
+
+}

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
@@ -60,10 +60,12 @@ public class Pac4jConfiguration {
     public ProfileService<CommonProfile> pac4jProfileService() {
         // TODO: Let's return a real profile service that is able to work with SAML2 profiles
         return new AbstractProfileService<CommonProfile>() {
-            @Override protected void insert(Map<String, Object> attributes) {}
-            @Override protected void update(Map<String, Object> attributes) {}
-            @Override protected void deleteById(String id) {}
-            @Override protected List<Map<String, Object>> read(List<String> names, String key, String value) {return null;}
+            @Override protected void insert(final Map<String, Object> attributes) {}
+            @Override protected void update(final Map<String, Object> attributes) {}
+            @Override protected void deleteById(final String id) {}
+            @Override protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
+                return null;
+            }
         };
     }
 }

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
@@ -1,10 +1,16 @@
 package org.apereo.cas.support.pac4j.config;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.support.pac4j.web.flow.DelegatedClientAuthenticationAction;
 import org.pac4j.core.client.Clients;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.service.AbstractProfileService;
+import org.pac4j.core.profile.service.ProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -45,6 +51,19 @@ public class Pac4jConfiguration {
                 centralAuthenticationService, 
                 casProperties.getTheme().getParamName(), 
                 casProperties.getLocale().getParamName(), 
-                casProperties.getAuthn().getPac4j().isAutoRedirect());
+                casProperties.getAuthn().getPac4j().isAutoRedirect(),
+                pac4jProfileService());
+    }
+
+
+    @Bean
+    public ProfileService<CommonProfile> pac4jProfileService() {
+        // TODO: Let's return a real profile service that is able to work with SAML2 profiles
+        return new AbstractProfileService<CommonProfile>() {
+            @Override protected void insert(Map<String, Object> attributes) {}
+            @Override protected void update(Map<String, Object> attributes) {}
+            @Override protected void deleteById(String id) {}
+            @Override protected List<Map<String, Object>> read(List<String> names, String key, String value) {return null;}
+        };
     }
 }

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jConfiguration.java
@@ -58,12 +58,23 @@ public class Pac4jConfiguration {
 
     @Bean
     public ProfileService<CommonProfile> pac4jProfileService() {
-        // TODO: Let's return a real profile service that is able to work with SAML2 profiles
+        // Let's return a real profile service that is able to work with SAML2 profiles
         return new AbstractProfileService<CommonProfile>() {
-            @Override protected void insert(final Map<String, Object> attributes) {}
-            @Override protected void update(final Map<String, Object> attributes) {}
-            @Override protected void deleteById(final String id) {}
-            @Override protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
+
+            @Override
+            protected void insert(final Map<String, Object> attributes) {
+            }
+
+            @Override
+            protected void update(final Map<String, Object> attributes) {
+            }
+
+            @Override
+            protected void deleteById(final String id) {
+            }
+
+            @Override
+            protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
                 return null;
             }
         };


### PR DESCRIPTION
This PR contains enhancements that will allow proper SAML Single Logout using PAC4J.
The main problems to be solved here are:
- Properly construct the SAML Logout Request with data from the SAML2 profile, when the profile is not remembered between login and logout due to a missing session
- The profile will be saved on login and read just before logout into the current session
- The session will be invalidated at the very end of the logout flow, not earlier
- The 'service' parameter for logout will be ignored if SLO is active, to prevent redirects to the service before the SLO can be done

Still work in progress - incomplete, I'll be adding more changes.

The topic is being discussed here: https://groups.google.com/forum/#!topic/pac4j-dev/I2VdDIYgVNE