### PR TITLE
Add support for alternateClientAddr and alternateServerAddr MDC variables

### DIFF
--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/config/CasLoggingConfiguration.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/config/CasLoggingConfiguration.java
@@ -33,15 +33,12 @@ public class CasLoggingConfiguration {
     @Autowired
     @Qualifier("defaultTicketRegistrySupport")
     private TicketRegistrySupport ticketRegistrySupport;
-
-    @Autowired
-    private CasConfigurationProperties casProperties;
     
     @Bean
     public FilterRegistrationBean threadContextMDCServletFilter() {
         final Map<String, String> initParams = new HashMap<>();
         final FilterRegistrationBean bean = new FilterRegistrationBean();
-        bean.setFilter(new ThreadContextMDCServletFilter(ticketRegistrySupport, this.ticketGrantingTicketCookieGenerator, casProperties));
+        bean.setFilter(new ThreadContextMDCServletFilter(ticketRegistrySupport, this.ticketGrantingTicketCookieGenerator));
         bean.setUrlPatterns(CollectionUtils.wrap("/*"));
         bean.setInitParameters(initParams);
         bean.setName("threadContextMDCServletFilter");

--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/config/CasLoggingConfiguration.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/config/CasLoggingConfiguration.java
@@ -33,12 +33,15 @@ public class CasLoggingConfiguration {
     @Autowired
     @Qualifier("defaultTicketRegistrySupport")
     private TicketRegistrySupport ticketRegistrySupport;
+
+    @Autowired
+    private CasConfigurationProperties casProperties;
     
     @Bean
     public FilterRegistrationBean threadContextMDCServletFilter() {
         final Map<String, String> initParams = new HashMap<>();
         final FilterRegistrationBean bean = new FilterRegistrationBean();
-        bean.setFilter(new ThreadContextMDCServletFilter(ticketRegistrySupport, this.ticketGrantingTicketCookieGenerator));
+        bean.setFilter(new ThreadContextMDCServletFilter(ticketRegistrySupport, this.ticketGrantingTicketCookieGenerator, casProperties));
         bean.setUrlPatterns(CollectionUtils.wrap("/*"));
         bean.setInitParameters(initParams);
         bean.setName("threadContextMDCServletFilter");

--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
+import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.slf4j.MDC;
 
 import javax.servlet.Filter;
@@ -29,11 +30,14 @@ public class ThreadContextMDCServletFilter implements Filter {
 
     private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
     private final TicketRegistrySupport ticketRegistrySupport;
+    private final CasConfigurationProperties casProperties;
 
     public ThreadContextMDCServletFilter(final TicketRegistrySupport ticketRegistrySupport,
-                                         final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator) {
+                                         final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator,
+                                         final CasConfigurationProperties casProperties) {
         this.ticketGrantingTicketCookieGenerator = ticketGrantingTicketCookieGenerator;
         this.ticketRegistrySupport = ticketRegistrySupport;
+        this.casProperties = casProperties;
     }
 
     /**
@@ -70,6 +74,14 @@ public class ThreadContextMDCServletFilter implements Filter {
             addContextAttribute("requestUri", request.getRequestURI());
             addContextAttribute("scheme", request.getScheme());
             addContextAttribute("timezone", TimeZone.getDefault().getDisplayName());
+
+            if (StringUtils.isNotBlank(casProperties.getAudit().getAlternateClientAddrHeaderName())) {
+                addContextAttribute("alternateClientAddr", request.getHeader(casProperties.getAudit().getAlternateClientAddrHeaderName()));
+            }
+
+            if (StringUtils.isNotBlank(casProperties.getAudit().getAlternateServerAddrHeaderName())) {
+                addContextAttribute("alternateServerAddr", request.getHeader(casProperties.getAudit().getAlternateServerAddrHeaderName()));
+            }
 
             final Map<String, String[]> params = request.getParameterMap();
             params.keySet().forEach(k -> {

--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
-import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.slf4j.MDC;
 
 import javax.servlet.Filter;
@@ -30,14 +29,11 @@ public class ThreadContextMDCServletFilter implements Filter {
 
     private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
     private final TicketRegistrySupport ticketRegistrySupport;
-    private final CasConfigurationProperties casProperties;
 
     public ThreadContextMDCServletFilter(final TicketRegistrySupport ticketRegistrySupport,
-                                         final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator,
-                                         final CasConfigurationProperties casProperties) {
+                                         final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator) {
         this.ticketGrantingTicketCookieGenerator = ticketGrantingTicketCookieGenerator;
         this.ticketRegistrySupport = ticketRegistrySupport;
-        this.casProperties = casProperties;
     }
 
     /**
@@ -74,14 +70,6 @@ public class ThreadContextMDCServletFilter implements Filter {
             addContextAttribute("requestUri", request.getRequestURI());
             addContextAttribute("scheme", request.getScheme());
             addContextAttribute("timezone", TimeZone.getDefault().getDisplayName());
-
-            if (StringUtils.isNotBlank(casProperties.getAudit().getAlternateClientAddrHeaderName())) {
-                addContextAttribute("alternateClientAddr", request.getHeader(casProperties.getAudit().getAlternateClientAddrHeaderName()));
-            }
-
-            if (StringUtils.isNotBlank(casProperties.getAudit().getAlternateServerAddrHeaderName())) {
-                addContextAttribute("alternateServerAddr", request.getHeader(casProperties.getAudit().getAlternateServerAddrHeaderName()));
-            }
 
             final Map<String, String[]> params = request.getParameterMap();
             params.keySet().forEach(k -> {

--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
@@ -83,10 +83,8 @@ public class ThreadContextMDCServletFilter implements Filter {
 
             final Enumeration<String> requestHeaderNames = request.getHeaderNames();
             if (requestHeaderNames != null) {
-                while (requestHeaderNames.hasMoreElements()) {
-                    String requestHeaderName = requestHeaderNames.nextElement();
-                    addContextAttribute(requestHeaderName, request.getHeader(requestHeaderName));
-                }
+                Collections.list(requestHeaderNames)
+                    .forEach(h -> addContextAttribute(h, request.getHeader(h)));
             }
 
             final String cookieValue = this.ticketGrantingTicketCookieGenerator.retrieveCookieValue(request);

--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
@@ -81,7 +81,7 @@ public class ThreadContextMDCServletFilter implements Filter {
             Collections.list(request.getAttributeNames())
                     .forEach(a -> addContextAttribute(a, request.getAttribute(a)));
 
-			final Enumeration<String> requestHeaderNames = request.getHeaderNames();
+            final Enumeration<String> requestHeaderNames = request.getHeaderNames();
             if (requestHeaderNames != null) {
                 while (requestHeaderNames.hasMoreElements()) {
                     String requestHeaderName = requestHeaderNames.nextElement();

--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.Enumeration;
 
 /**
  * This is {@link ThreadContextMDCServletFilter}.
@@ -79,6 +80,14 @@ public class ThreadContextMDCServletFilter implements Filter {
 
             Collections.list(request.getAttributeNames())
                     .forEach(a -> addContextAttribute(a, request.getAttribute(a)));
+
+			final Enumeration<String> requestHeaderNames = request.getHeaderNames();
+            if (requestHeaderNames != null) {
+                while (requestHeaderNames.hasMoreElements()) {
+                    String requestHeaderName = requestHeaderNames.nextElement();
+                    addContextAttribute(requestHeaderName, request.getHeader(requestHeaderName));
+                }
+            }
 
             final String cookieValue = this.ticketGrantingTicketCookieGenerator.retrieveCookieValue(request);
             if (StringUtils.isNotBlank(cookieValue)) {

--- a/docs/cas-server-documentation/installation/Logging.md
+++ b/docs/cas-server-documentation/installation/Logging.md
@@ -317,7 +317,7 @@ may convey additional information about the nature of the request or the authent
 | `timezone`                          | Timezone of the HTTP request.
 | `principal`                         | CAS authenticated principal id.
 
-Additionally, all available request attributes and parameters are exposed as variables.
+Additionally, all available request attributes, headers, and parameters are exposed as variables.
 
 The above variables may be used in logging patterns:
 

--- a/docs/cas-server-documentation/installation/Logging.md
+++ b/docs/cas-server-documentation/installation/Logging.md
@@ -316,8 +316,6 @@ may convey additional information about the nature of the request or the authent
 | `scheme`                            | Scheme of the HTTP request.
 | `timezone`                          | Timezone of the HTTP request.
 | `principal`                         | CAS authenticated principal id.
-| `alternateClientAddr`               | Client address for header defined in `cas.audit.alternateClientAddrHeaderName`.
-| `alternateServerAddr`               | Server address for header defined in `cas.audit.alternateServerAddrHeaderName`.
 
 Additionally, all available request attributes and parameters are exposed as variables.
 

--- a/docs/cas-server-documentation/installation/Logging.md
+++ b/docs/cas-server-documentation/installation/Logging.md
@@ -316,6 +316,8 @@ may convey additional information about the nature of the request or the authent
 | `scheme`                            | Scheme of the HTTP request.
 | `timezone`                          | Timezone of the HTTP request.
 | `principal`                         | CAS authenticated principal id.
+| `alternateClientAddr`               | Client address for header defined in `cas.audit.alternateClientAddrHeaderName`.
+| `alternateServerAddr`               | Server address for header defined in `cas.audit.alternateServerAddrHeaderName`.
 
 Additionally, all available request attributes and parameters are exposed as variables.
 


### PR DESCRIPTION
Closes #3032 

Add `alternateClientAddr` and `alternateServerAddr` [MDC](https://apereo.github.io/cas/development/installation/Logging.html#mapped-diagnostic-context) variables to support alternative headers defined for the `cas.audit.alternateClientAddrHeaderName` and `cas.audit.alternateServerAddrHeaderName` properties.

The above mentioned MDC variables will only return a value if `cas.audit.alternateClientAddrHeaderName` or `cas.audit.alternateServerAddrHeaderName` are defined. Otherwise, null will be returned. This is the same behavior if attempting to call a nonexistent MDC variable (ex. `%X{foo}`).

This implemented was tested by setting `cas.audit.alternateClientAddrHeaderName` to `X-FORWARDED-FOR` . After initiating a request  to CAS, the `alternateClientAddr` MDC variable contained the client IP address in the `X-FORWARDED-FOR` header.

I am fairly certain this change can be back ported as-is to the 5.0.x and 5.1.x branches as well.