### PR TITLE
Provide a mechanism to limit authentication protocol attributes released

### DIFF
--- a/api/cas-server-core-api-web/src/main/java/org/apereo/cas/services/web/support/AuthenticationAttributeReleasePolicy.java
+++ b/api/cas-server-core-api-web/src/main/java/org/apereo/cas/services/web/support/AuthenticationAttributeReleasePolicy.java
@@ -8,8 +8,16 @@ import java.util.Map;
 /**
  * This component is used to handle release of protocol attributes in validation responses.
  *
+ * @author Daniel Frett
  * @since 5.2.0
  */
+@FunctionalInterface
 public interface AuthenticationAttributeReleasePolicy {
+    /**
+     * This method will return the Authentication attributes that should be released.
+     *
+     * @param authentication The authentication object we are processing.
+     * @return The attributes to be released
+     */
     Map<String, Object> getAuthenticationAttributesForRelease(@Nonnull Authentication authentication);
 }

--- a/api/cas-server-core-api-web/src/main/java/org/apereo/cas/services/web/support/AuthenticationAttributeReleasePolicy.java
+++ b/api/cas-server-core-api-web/src/main/java/org/apereo/cas/services/web/support/AuthenticationAttributeReleasePolicy.java
@@ -1,0 +1,15 @@
+package org.apereo.cas.services.web.support;
+
+import org.apereo.cas.authentication.Authentication;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * This component is used to handle release of protocol attributes in validation responses.
+ *
+ * @since 5.2.0
+ */
+public interface AuthenticationAttributeReleasePolicy {
+    Map<String, Object> getAuthenticationAttributesForRelease(@Nonnull Authentication authentication);
+}

--- a/api/cas-server-core-api-web/src/main/java/org/apereo/cas/services/web/support/AuthenticationAttributeReleasePolicy.java
+++ b/api/cas-server-core-api-web/src/main/java/org/apereo/cas/services/web/support/AuthenticationAttributeReleasePolicy.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
- * This component is used to handle release of protocol attributes in validation responses.
+ * This component is used to handle release of authentication attributes in validation responses.
  *
  * @author Daniel Frett
  * @since 5.2.0

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationAttributeReleaseProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationAttributeReleaseProperties.java
@@ -5,10 +5,23 @@ import org.apereo.cas.configuration.support.RequiresModule;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Authentication attribute release properties.
+ *
+ * @author Daniel Frett
+ * @since 5.2.0
+ */
 @RequiresModule(name = "cas-server-support-validation", automated = true)
 public class AuthenticationAttributeReleaseProperties {
+    /**
+     * List of authentication attributes that should never be released.
+     */
     private List<String> neverRelease = new ArrayList<>();
 
+    /**
+     * List of authentication attributes that should be the only ones released. An empty list indicates all attributes
+     * should be released.
+     */
     private List<String> onlyRelease = new ArrayList<>();
 
     public List<String> getNeverRelease() {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationAttributeReleaseProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationAttributeReleaseProperties.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RequiresModule(name = "cas-server-support-validation", automated = true)
-public class ProtocolAttributeReleaseProperties {
+public class AuthenticationAttributeReleaseProperties {
     private List<String> neverRelease = new ArrayList<>();
 
     private List<String> onlyRelease = new ArrayList<>();

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationProperties.java
@@ -281,6 +281,12 @@ public class AuthenticationProperties implements Serializable {
     private FortressAuthenticationProperties fortress = new FortressAuthenticationProperties();
 
     /**
+     * Authentication/protocol attribute release settings.
+     */
+    @NestedConfigurationProperty
+    private ProtocolAttributeReleaseProperties protocolAttributeRelease = new ProtocolAttributeReleaseProperties();
+
+    /**
      * Whether CAS authentication/protocol attributes
      * should be released as part of ticket validation.
      */
@@ -300,6 +306,14 @@ public class AuthenticationProperties implements Serializable {
 
     public void setSurrogate(final SurrogateAuthenticationProperties surrogate) {
         this.surrogate = surrogate;
+    }
+
+    public ProtocolAttributeReleaseProperties getProtocolAttributeRelease() {
+        return protocolAttributeRelease;
+    }
+
+    public void setProtocolAttributeRelease(final ProtocolAttributeReleaseProperties protocolAttributeRelease) {
+        this.protocolAttributeRelease = protocolAttributeRelease;
     }
 
     public boolean isReleaseProtocolAttributes() {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/AuthenticationProperties.java
@@ -281,10 +281,10 @@ public class AuthenticationProperties implements Serializable {
     private FortressAuthenticationProperties fortress = new FortressAuthenticationProperties();
 
     /**
-     * Authentication/protocol attribute release settings.
+     * Authentication attribute release settings.
      */
     @NestedConfigurationProperty
-    private ProtocolAttributeReleaseProperties protocolAttributeRelease = new ProtocolAttributeReleaseProperties();
+    private AuthenticationAttributeReleaseProperties authenticationAttributeRelease = new AuthenticationAttributeReleaseProperties();
 
     /**
      * Whether CAS authentication/protocol attributes
@@ -308,12 +308,12 @@ public class AuthenticationProperties implements Serializable {
         this.surrogate = surrogate;
     }
 
-    public ProtocolAttributeReleaseProperties getProtocolAttributeRelease() {
-        return protocolAttributeRelease;
+    public AuthenticationAttributeReleaseProperties getAuthenticationAttributeRelease() {
+        return authenticationAttributeRelease;
     }
 
-    public void setProtocolAttributeRelease(final ProtocolAttributeReleaseProperties protocolAttributeRelease) {
-        this.protocolAttributeRelease = protocolAttributeRelease;
+    public void setAuthenticationAttributeRelease(final AuthenticationAttributeReleaseProperties authenticationAttributeRelease) {
+        this.authenticationAttributeRelease = authenticationAttributeRelease;
     }
 
     public boolean isReleaseProtocolAttributes() {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/ProtocolAttributeReleaseProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/core/authentication/ProtocolAttributeReleaseProperties.java
@@ -1,0 +1,29 @@
+package org.apereo.cas.configuration.model.core.authentication;
+
+import org.apereo.cas.configuration.support.RequiresModule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiresModule(name = "cas-server-support-validation", automated = true)
+public class ProtocolAttributeReleaseProperties {
+    private List<String> neverRelease = new ArrayList<>();
+
+    private List<String> onlyRelease = new ArrayList<>();
+
+    public List<String> getNeverRelease() {
+        return neverRelease;
+    }
+
+    public void setNeverRelease(final List<String> neverRelease) {
+        this.neverRelease = neverRelease;
+    }
+
+    public List<String> getOnlyRelease() {
+        return onlyRelease;
+    }
+
+    public void setOnlyRelease(final List<String> onlyRelease) {
+        this.onlyRelease = onlyRelease;
+    }
+}

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
@@ -44,7 +44,7 @@ public class DefaultAuthenticationAttributeReleasePolicy implements Authenticati
      * Return authentications attributes that we are allowed to release to client systems.
      *
      * @param authentication The authentication object we are processing.
-     * @return
+     * @return The attributes to be released
      */
     @Override
     public Map<String, Object> getAuthenticationAttributesForRelease(@Nonnull final Authentication authentication) {

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
@@ -1,0 +1,50 @@
+package org.apereo.cas.services.web.support;
+
+import org.apereo.cas.authentication.Authentication;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * Default AuthenticationAttributeReleasePolicy implementation.
+ *
+ * @since 5.2.0
+ */
+public class DefaultAuthenticationAttributeReleasePolicy implements AuthenticationAttributeReleasePolicy {
+    private Collection<String> attributesToRelease;
+
+    @Nonnull
+    private HashSet<String> attributesToNeverRelease = new HashSet<>();
+
+    public void setAttributesToRelease(final Collection<String> attrs) {
+        attributesToRelease = attrs;
+    }
+
+    public void setAttributesToNeverRelease(final Collection<String> attrs) {
+        attributesToNeverRelease = attrs != null ? new HashSet<>(attrs) : new HashSet<>();
+    }
+
+    public void addAttributesToNeverRelease(final Collection<String> attrs) {
+        if (attrs != null) {
+            attributesToNeverRelease.addAll(attrs);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getAuthenticationAttributesForRelease(@Nonnull final Authentication authentication) {
+        final HashMap<String, Object> attrs = new HashMap<>(authentication.getAttributes());
+
+        // remove any attributes explicitly prohibited
+        attrs.keySet().removeAll(attributesToNeverRelease);
+
+        // only apply whitelist if it contains attributes
+        if (attributesToRelease != null && !attributesToRelease.isEmpty()) {
+            attrs.keySet().retainAll(attributesToRelease);
+        }
+
+        return attrs;
+    }
+}

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
@@ -11,6 +11,7 @@ import java.util.Map;
 /**
  * Default AuthenticationAttributeReleasePolicy implementation.
  *
+ * @author Daniel Frett
  * @since 5.2.0
  */
 public class DefaultAuthenticationAttributeReleasePolicy implements AuthenticationAttributeReleasePolicy {
@@ -27,12 +28,23 @@ public class DefaultAuthenticationAttributeReleasePolicy implements Authenticati
         attributesToNeverRelease = attrs != null ? new HashSet<>(attrs) : new HashSet<>();
     }
 
+    /**
+     * Add additional attributes that should never be released in a validation response.
+     *
+     * @param attrs Additional attributes to never release
+     */
     public void addAttributesToNeverRelease(final Collection<String> attrs) {
         if (attrs != null) {
             attributesToNeverRelease.addAll(attrs);
         }
     }
 
+    /**
+     * Return authentications attributes that we are allowed to release to client systems.
+     *
+     * @param authentication The authentication object we are processing.
+     * @return
+     */
     @Override
     public Map<String, Object> getAuthenticationAttributesForRelease(@Nonnull final Authentication authentication) {
         final HashMap<String, Object> attrs = new HashMap<>(authentication.getAttributes());

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/support/DefaultAuthenticationAttributeReleasePolicy.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Default AuthenticationAttributeReleasePolicy implementation.
@@ -18,7 +19,7 @@ public class DefaultAuthenticationAttributeReleasePolicy implements Authenticati
     private Collection<String> attributesToRelease;
 
     @Nonnull
-    private HashSet<String> attributesToNeverRelease = new HashSet<>();
+    private Set<String> attributesToNeverRelease = new HashSet<>();
 
     public void setAttributesToRelease(final Collection<String> attrs) {
         attributesToRelease = attrs;

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractCasView.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractCasView.java
@@ -11,6 +11,7 @@ import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceAttributeReleasePolicy;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.validation.Assertion;
 import org.slf4j.Logger;
@@ -20,7 +21,6 @@ import org.springframework.web.servlet.view.AbstractView;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -58,21 +58,18 @@ public abstract class AbstractCasView extends AbstractView {
      */
     protected final String authenticationContextAttribute;
 
-    private final Collection<String> authnAttrsToRelease;
-    private final Collection<String> authnAttrsToNeverRelease;
+    protected final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy;
 
     public AbstractCasView(final boolean successResponse,
                            final ProtocolAttributeEncoder protocolAttributeEncoder,
                            final ServicesManager servicesManager,
                            final String authenticationContextAttribute,
-                           final Collection<String> authnAttrsToRelease,
-                           final Collection<String> authnAttrsToNeverRelease) {
+                           final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy) {
         this.successResponse = successResponse;
         this.protocolAttributeEncoder = protocolAttributeEncoder;
         this.servicesManager = servicesManager;
         this.authenticationContextAttribute = authenticationContextAttribute;
-        this.authnAttrsToRelease = authnAttrsToRelease;
-        this.authnAttrsToNeverRelease = authnAttrsToNeverRelease;
+        this.authenticationAttributeReleasePolicy = authenticationAttributeReleasePolicy;
     }
 
     /**
@@ -168,27 +165,6 @@ public abstract class AbstractCasView extends AbstractView {
     protected String getAuthenticationAttribute(final Map<String, Object> model, final String attributeName) {
         final Authentication authn = getPrimaryAuthenticationFrom(model);
         return (String) authn.getAttributes().get(attributeName);
-    }
-
-    /**
-     * Filter the authentication attributes for release in validation responses.
-     *
-     * @param rawAttributes the attributes to filter
-     * @return The filtered authentication attributes
-     * @since 5.2.0
-     */
-    protected Map<String, Object> filterAuthenticationAttributesForRelease(final Map<String, Object> rawAttributes) {
-        final Map<String, Object> attrs = new HashMap<>(rawAttributes);
-
-        // remove any attributes explicitly prohibited
-        attrs.keySet().removeAll(authnAttrsToNeverRelease);
-
-        // only apply whitelist if it contains attributes
-        if (!authnAttrsToRelease.isEmpty()) {
-            attrs.keySet().retainAll(authnAttrsToRelease);
-        }
-
-        return attrs;
     }
 
     /**

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractCasView.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractCasView.java
@@ -58,6 +58,9 @@ public abstract class AbstractCasView extends AbstractView {
      */
     protected final String authenticationContextAttribute;
 
+    /**
+     * Authentication attribute release policy.
+     */
     protected final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy;
 
     public AbstractCasView(final boolean successResponse,

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractCasView.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractCasView.java
@@ -174,6 +174,8 @@ public abstract class AbstractCasView extends AbstractView {
      * Filter the authentication attributes for release in validation responses.
      *
      * @param rawAttributes the attributes to filter
+     * @return The filtered authentication attributes
+     * @since 5.2.0
      */
     protected Map<String, Object> filterAuthenticationAttributesForRelease(final Map<String, Object> rawAttributes) {
         final Map<String, Object> attrs = new HashMap<>(rawAttributes);

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractDelegatingCasView.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractDelegatingCasView.java
@@ -2,13 +2,13 @@ package org.apereo.cas.services.web.view;
 
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.View;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -32,10 +32,9 @@ public abstract class AbstractDelegatingCasView extends AbstractCasView {
                                      final ServicesManager servicesManager,
                                      final String authenticationContextAttribute,
                                      final View view,
-                                     final Collection<String> authnAttrsToRelease,
-                                     final Collection<String> authnAttrsToNeverRelease) {
+                                     final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                authnAttrsToRelease, authnAttrsToNeverRelease);
+                authenticationAttributeReleasePolicy);
         this.view = view;
     }
 

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractDelegatingCasView.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/services/web/view/AbstractDelegatingCasView.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.View;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -30,8 +31,11 @@ public abstract class AbstractDelegatingCasView extends AbstractCasView {
                                      final ProtocolAttributeEncoder protocolAttributeEncoder,
                                      final ServicesManager servicesManager,
                                      final String authenticationContextAttribute,
-                                     final View view) {
-        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute);
+                                     final View view,
+                                     final Collection<String> authnAttrsToRelease,
+                                     final Collection<String> authnAttrsToNeverRelease) {
+        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
+                authnAttrsToRelease, authnAttrsToNeverRelease);
         this.view = view;
     }
 

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1059,10 +1059,16 @@ To learn more about this topic, [please review this guide](../integration/Attrib
 
 ### Protocol Attributes
 
-Defines whether CAS should include and release protocol attributes defined in the specification in addition to the principal attribute.
+Defines whether CAS should include and release protocol attributes defined in the specification in addition to the
+principal attributes. By default all authentication attributes are released when protocol attributes are enabled for
+release. If you wish to restrict which authentication attributes get released, you can use the onlyRelease and
+neverRelease properties.
 
 ```properties
 # cas.authn.releaseProtocolAttributes=true
+
+# cas.authn.authenticationAttributeRelease.onlyRelease=authenticationDate,isFromNewLogin
+# cas.authn.authenticationAttributeRelease.neverRelease=
 ```
 
 ## Principal Resolution

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
@@ -7,6 +7,7 @@ import org.apereo.cas.authentication.MultifactorTriggerSelectionStrategy;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.ResponseBuilder;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.core.authentication.AuthenticationAttributeReleaseProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
 import org.apereo.cas.support.saml.authentication.principal.SamlServiceFactory;
@@ -93,12 +94,14 @@ public class SamlConfiguration {
     @RefreshScope
     @Bean
     public View casSamlServiceSuccessView() {
+        final AuthenticationAttributeReleaseProperties authenticationAttributeRelease = casProperties.getAuthn().getAuthenticationAttributeRelease();
         return new Saml10SuccessResponseView(protocolAttributeEncoder,
                 servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(),
                 saml10ObjectBuilder(), new DefaultArgumentExtractor(new SamlServiceFactory()),
                 StandardCharsets.UTF_8.name(), casProperties.getSamlCore().getSkewAllowance(),
                 casProperties.getSamlCore().getIssueLength(), casProperties.getSamlCore().getIssuer(),
-                casProperties.getSamlCore().getAttributeNamespace());
+                casProperties.getSamlCore().getAttributeNamespace(), authenticationAttributeRelease.getOnlyRelease(),
+                authenticationAttributeRelease.getNeverRelease());
     }
 
     @ConditionalOnMissingBean(name = "casSamlServiceFailureView")

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
@@ -7,7 +7,6 @@ import org.apereo.cas.authentication.MultifactorTriggerSelectionStrategy;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.ResponseBuilder;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.configuration.model.core.authentication.AuthenticationAttributeReleaseProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
@@ -99,7 +98,6 @@ public class SamlConfiguration {
     @RefreshScope
     @Bean
     public View casSamlServiceSuccessView() {
-        final AuthenticationAttributeReleaseProperties authenticationAttributeRelease = casProperties.getAuthn().getAuthenticationAttributeRelease();
         return new Saml10SuccessResponseView(protocolAttributeEncoder,
                 servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(),
                 saml10ObjectBuilder(), new DefaultArgumentExtractor(new SamlServiceFactory()),

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
@@ -9,6 +9,7 @@ import org.apereo.cas.authentication.principal.ResponseBuilder;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.authentication.AuthenticationAttributeReleaseProperties;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
 import org.apereo.cas.support.saml.authentication.principal.SamlServiceFactory;
 import org.apereo.cas.support.saml.authentication.principal.SamlServiceResponseBuilder;
@@ -71,6 +72,10 @@ public class SamlConfiguration {
     private CentralAuthenticationService centralAuthenticationService;
 
     @Autowired
+    @Qualifier("authenticationAttributeReleasePolicy")
+    private AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy;
+
+    @Autowired
     @Qualifier("authenticationContextValidator")
     private AuthenticationContextValidator authenticationContextValidator;
 
@@ -100,8 +105,7 @@ public class SamlConfiguration {
                 saml10ObjectBuilder(), new DefaultArgumentExtractor(new SamlServiceFactory()),
                 StandardCharsets.UTF_8.name(), casProperties.getSamlCore().getSkewAllowance(),
                 casProperties.getSamlCore().getIssueLength(), casProperties.getSamlCore().getIssuer(),
-                casProperties.getSamlCore().getAttributeNamespace(), authenticationAttributeRelease.getOnlyRelease(),
-                authenticationAttributeRelease.getNeverRelease());
+                casProperties.getSamlCore().getAttributeNamespace(), authenticationAttributeReleasePolicy);
     }
 
     @ConditionalOnMissingBean(name = "casSamlServiceFailureView")

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
@@ -116,7 +116,7 @@ public class SamlConfiguration {
                 servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(),
                 saml10ObjectBuilder(), new DefaultArgumentExtractor(new SamlServiceFactory()),
                 StandardCharsets.UTF_8.name(), casProperties.getSamlCore().getSkewAllowance(),
-                casProperties.getSamlCore().getIssueLength());
+                casProperties.getSamlCore().getIssueLength(), authenticationAttributeReleasePolicy);
     }
 
 

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -77,6 +77,9 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
      *                                       to adjust their server time configuration.
      * @param issueLength                    Sets the length of time in seconds between the {@code NotBefore}
      *                                       and {@code NotOnOrAfter} attributes in the SAML assertion. Default 30s.
+     * @param authnAttrsToRelease            The Authentication attributes to release in the response. If this
+     *                                       collection is empty, all attributes are released.
+     * @param authnAttrsToNeverRelease       The Authentication attributes to never release in the response.
      */
     public AbstractSaml10ResponseView(final boolean successResponse,
                                       final ProtocolAttributeEncoder protocolAttributeEncoder,

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -17,6 +17,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -85,8 +86,11 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
                                       final ArgumentExtractor samlArgumentExtractor,
                                       final String encoding,
                                       final int skewAllowance,
-                                      final int issueLength) {
-        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute);
+                                      final int issueLength,
+                                      final Collection<String> authnAttrsToRelease,
+                                      final Collection<String> authnAttrsToNeverRelease) {
+        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
+                authnAttrsToRelease, authnAttrsToNeverRelease);
         this.samlObjectBuilder = samlObjectBuilder;
         this.samlArgumentExtractor = samlArgumentExtractor;
         this.encoding = encoding;

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.services.web.view.AbstractCasView;
 import org.apereo.cas.support.saml.util.Saml10ObjectBuilder;
 import org.apereo.cas.web.support.ArgumentExtractor;
@@ -90,10 +91,9 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
                                       final String encoding,
                                       final int skewAllowance,
                                       final int issueLength,
-                                      final Collection<String> authnAttrsToRelease,
-                                      final Collection<String> authnAttrsToNeverRelease) {
+                                      final AuthenticationAttributeReleasePolicy authAttrReleasePolicy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                authnAttrsToRelease, authnAttrsToNeverRelease);
+                authAttrReleasePolicy);
         this.samlObjectBuilder = samlObjectBuilder;
         this.samlArgumentExtractor = samlArgumentExtractor;
         this.encoding = encoding;

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -18,7 +18,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -78,9 +77,8 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
      *                                       to adjust their server time configuration.
      * @param issueLength                    Sets the length of time in seconds between the {@code NotBefore}
      *                                       and {@code NotOnOrAfter} attributes in the SAML assertion. Default 30s.
-     * @param authnAttrsToRelease            The Authentication attributes to release in the response. If this
-     *                                       collection is empty, all attributes are released.
-     * @param authnAttrsToNeverRelease       The Authentication attributes to never release in the response.
+     * @param authAttrReleasePolicy          This policy controls which authentication attributes get released in a
+     *                                       validation response.
      */
     public AbstractSaml10ResponseView(final boolean successResponse,
                                       final ProtocolAttributeEncoder protocolAttributeEncoder,

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseView.java
@@ -8,6 +8,7 @@ import org.apereo.cas.web.support.ArgumentExtractor;
 import org.opensaml.saml.saml1.core.Response;
 import org.opensaml.saml.saml1.core.StatusCode;
 
+import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -28,8 +29,8 @@ public class Saml10FailureResponseView extends AbstractSaml10ResponseView {
             final String encoding, 
             final int skewAllowance,
             final int issueLength) {
-        super(false, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, 
-                samlObjectBuilder, samlArgumentExtractor, encoding, skewAllowance, issueLength);
+        super(false, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, samlObjectBuilder,
+                samlArgumentExtractor, encoding, skewAllowance, issueLength, new HashSet<>(), new HashSet<>());
     }
 
     @Override

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseView.java
@@ -3,12 +3,12 @@ package org.apereo.cas.support.saml.web.view;
 
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.support.saml.util.Saml10ObjectBuilder;
 import org.apereo.cas.web.support.ArgumentExtractor;
 import org.opensaml.saml.saml1.core.Response;
 import org.opensaml.saml.saml1.core.StatusCode;
 
-import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -28,9 +28,10 @@ public class Saml10FailureResponseView extends AbstractSaml10ResponseView {
             final ArgumentExtractor samlArgumentExtractor, 
             final String encoding, 
             final int skewAllowance,
-            final int issueLength) {
+            final int issueLength,
+            final AuthenticationAttributeReleasePolicy authAttrReleasePolicy) {
         super(false, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, samlObjectBuilder,
-                samlArgumentExtractor, encoding, skewAllowance, issueLength, new HashSet<>(), new HashSet<>());
+                samlArgumentExtractor, encoding, skewAllowance, issueLength, authAttrReleasePolicy);
     }
 
     @Override

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseView.java
@@ -1,17 +1,17 @@
 package org.apereo.cas.support.saml.web.view;
 
+import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
+import org.apereo.cas.authentication.RememberMeCredential;
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.support.saml.authentication.SamlAuthenticationMetaDataPopulator;
 import org.apereo.cas.support.saml.util.Saml10ObjectBuilder;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.DateTimeUtils;
-import org.apereo.cas.CasProtocolConstants;
-import org.apereo.cas.authentication.RememberMeCredential;
-import org.apereo.cas.authentication.principal.Service;
-import org.apereo.cas.support.saml.authentication.SamlAuthenticationMetaDataPopulator;
 import org.apereo.cas.web.support.ArgumentExtractor;
 import org.opensaml.saml.saml1.core.Assertion;
 import org.opensaml.saml.saml1.core.AuthenticationStatement;
@@ -58,9 +58,12 @@ public class Saml10SuccessResponseView extends AbstractSaml10ResponseView {
                                      final int skewAllowance,
                                      final int issueLength,
                                      final String issuer,
-                                     final String defaultAttributeNamespace) {
-        super(true, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                samlObjectBuilder, samlArgumentExtractor, encoding, skewAllowance, issueLength);
+                                     final String defaultAttributeNamespace,
+                                     final Collection<String> authnAttrsToRelease,
+                                     final Collection<String> authnAttrsToNeverRelease) {
+        super(true, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, samlObjectBuilder,
+                samlArgumentExtractor, encoding, skewAllowance, issueLength, authnAttrsToRelease,
+                authnAttrsToNeverRelease);
         this.issuer = issuer;
         this.rememberMeAttributeName = CasProtocolConstants.VALIDATION_REMEMBER_ME_ATTRIBUTE_NAME;
         this.defaultAttributeNamespace = defaultAttributeNamespace;
@@ -129,7 +132,7 @@ public class Saml10SuccessResponseView extends AbstractSaml10ResponseView {
         final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
         final Map<String, Object> attributesToReturn = new HashMap<>();
         attributesToReturn.putAll(getPrincipalAttributesAsMultiValuedAttributes(model));
-        attributesToReturn.putAll(authnAttributes);
+        attributesToReturn.putAll(filterAuthenticationAttributesForRelease(authnAttributes));
 
         decideIfCredentialPasswordShouldBeReleasedAsAttribute(attributesToReturn, model, registeredService);
         decideIfProxyGrantingTicketShouldBeReleasedAsAttribute(attributesToReturn, model, registeredService);

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseView.java
@@ -3,11 +3,11 @@ package org.apereo.cas.support.saml.web.view;
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
-import org.apereo.cas.authentication.RememberMeCredential;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.support.saml.authentication.SamlAuthenticationMetaDataPopulator;
 import org.apereo.cas.support.saml.util.Saml10ObjectBuilder;
 import org.apereo.cas.util.CollectionUtils;
@@ -59,11 +59,9 @@ public class Saml10SuccessResponseView extends AbstractSaml10ResponseView {
                                      final int issueLength,
                                      final String issuer,
                                      final String defaultAttributeNamespace,
-                                     final Collection<String> authnAttrsToRelease,
-                                     final Collection<String> authnAttrsToNeverRelease) {
+                                     final AuthenticationAttributeReleasePolicy authAttrReleasePolicy) {
         super(true, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, samlObjectBuilder,
-                samlArgumentExtractor, encoding, skewAllowance, issueLength, authnAttrsToRelease,
-                authnAttrsToNeverRelease);
+                samlArgumentExtractor, encoding, skewAllowance, issueLength, authAttrReleasePolicy);
         this.issuer = issuer;
         this.rememberMeAttributeName = CasProtocolConstants.VALIDATION_REMEMBER_ME_ATTRIBUTE_NAME;
         this.defaultAttributeNamespace = defaultAttributeNamespace;
@@ -122,9 +120,9 @@ public class Saml10SuccessResponseView extends AbstractSaml10ResponseView {
      * @since 4.1.0
      */
     private Map<String, Object> prepareSamlAttributes(final Map<String, Object> model, final Service service) {
-        final Map<String, Object> authnAttributes = new HashMap<>(getAuthenticationAttributesAsMultiValuedAttributes(model));        
+        final Map<String, Object> authnAttributes = authenticationAttributeReleasePolicy
+                .getAuthenticationAttributesForRelease(getPrimaryAuthenticationFrom(model));
         if (isRememberMeAuthentication(model)) {
-            authnAttributes.remove(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
             authnAttributes.put(this.rememberMeAttributeName, Boolean.TRUE.toString());
         }
         LOGGER.debug("Retrieved authentication attributes [{}] from the model", authnAttributes);
@@ -132,7 +130,7 @@ public class Saml10SuccessResponseView extends AbstractSaml10ResponseView {
         final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
         final Map<String, Object> attributesToReturn = new HashMap<>();
         attributesToReturn.putAll(getPrincipalAttributesAsMultiValuedAttributes(model));
-        attributesToReturn.putAll(filterAuthenticationAttributesForRelease(authnAttributes));
+        attributesToReturn.putAll(authnAttributes);
 
         decideIfCredentialPasswordShouldBeReleasedAsAttribute(attributesToReturn, model, registeredService);
         decideIfProxyGrantingTicketShouldBeReleasedAsAttribute(attributesToReturn, model, registeredService);

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseViewTests.java
@@ -31,7 +31,7 @@ public class Saml10FailureResponseViewTests extends AbstractOpenSamlTests {
         final Saml10ObjectBuilder builder = new Saml10ObjectBuilder(this.configBean);
         view = new Saml10FailureResponseView(null, null, "attribute",
                 builder, new DefaultArgumentExtractor(new SamlServiceFactory()),
-                StandardCharsets.UTF_8.name(), 0, 30);
+                StandardCharsets.UTF_8.name(), 0, 30, null);
     }
 
     @Test

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
@@ -12,6 +12,7 @@ import org.apereo.cas.services.InMemoryServiceRegistry;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.DefaultAuthenticationAttributeReleasePolicy;
 import org.apereo.cas.support.saml.AbstractOpenSamlTests;
 import org.apereo.cas.support.saml.authentication.SamlAuthenticationMetaDataPopulator;
 import org.apereo.cas.support.saml.authentication.principal.SamlServiceFactory;
@@ -31,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -64,8 +64,8 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
 
         this.response = new Saml10SuccessResponseView(new DefaultCasProtocolAttributeEncoder(mgmr, NoOpCipherExecutor.getInstance()),
                 mgmr, "attribute", new Saml10ObjectBuilder(configBean),
-                new DefaultArgumentExtractor(new SamlServiceFactory()), StandardCharsets.UTF_8.name(),
-                1000, 30, "testIssuer", "whatever", new HashSet<>(), new HashSet<>());
+                new DefaultArgumentExtractor(new SamlServiceFactory()), StandardCharsets.UTF_8.name(), 1000, 30,
+                "testIssuer", "whatever", new DefaultAuthenticationAttributeReleasePolicy());
     }
 
     @Test

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -64,7 +65,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
         this.response = new Saml10SuccessResponseView(new DefaultCasProtocolAttributeEncoder(mgmr, NoOpCipherExecutor.getInstance()),
                 mgmr, "attribute", new Saml10ObjectBuilder(configBean),
                 new DefaultArgumentExtractor(new SamlServiceFactory()), StandardCharsets.UTF_8.name(),
-                1000, 30, "testIssuer", "whatever");
+                1000, 30, "testIssuer", "whatever", new HashSet<>(), new HashSet<>());
     }
 
     @Test

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
@@ -9,8 +9,8 @@ import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.configuration.model.core.authentication.AuthenticationAttributeReleaseProperties;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.ticket.proxy.ProxyHandler;
 import org.apereo.cas.validation.CasProtocolValidationSpecification;
 import org.apereo.cas.validation.ValidationAuthorizer;
@@ -56,6 +56,10 @@ public class CasValidationConfiguration {
     @Autowired
     @Qualifier("cas3SuccessView")
     private View cas3SuccessView;
+
+    @Autowired
+    @Qualifier("authenticationAttributeReleasePolicy")
+    private AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy;
 
     @Autowired
     @Qualifier("authenticationContextValidator")
@@ -125,14 +129,15 @@ public class CasValidationConfiguration {
     @ConditionalOnMissingBean(name = "cas1ServiceSuccessView")
     public View cas1ServiceSuccessView() {
         return new Cas10ResponseView(true, protocolAttributeEncoder, servicesManager,
-                casProperties.getAuthn().getMfa().getAuthenticationContextAttribute());
+                casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(), authenticationAttributeReleasePolicy);
     }
 
     @Bean
     @ConditionalOnMissingBean(name = "cas1ServiceFailureView")
     public View cas1ServiceFailureView() {
         return new Cas10ResponseView(false, protocolAttributeEncoder,
-                servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute());
+                servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(),
+                authenticationAttributeReleasePolicy);
     }
 
     @Bean
@@ -140,13 +145,12 @@ public class CasValidationConfiguration {
     public View cas2ServiceSuccessView() {
         return new Cas20ResponseView(true, protocolAttributeEncoder,
                 servicesManager, casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(),
-                this.cas2SuccessView, selectionStrategies);
+                cas2SuccessView, authenticationAttributeReleasePolicy, selectionStrategies);
     }
 
     @Bean
     @ConditionalOnMissingBean(name = "cas3ServiceJsonView")
     public View cas3ServiceJsonView() {
-        final AuthenticationAttributeReleaseProperties authenticationAttributeRelease = casProperties.getAuthn().getAuthenticationAttributeRelease();
         final String authenticationContextAttribute = casProperties.getAuthn().getMfa().getAuthenticationContextAttribute();
         final boolean isReleaseProtocolAttributes = casProperties.getAuthn().isReleaseProtocolAttributes();
         return new Cas30JsonResponseView(true,
@@ -154,15 +158,13 @@ public class CasValidationConfiguration {
                 servicesManager,
                 authenticationContextAttribute,
                 isReleaseProtocolAttributes,
-                authenticationAttributeRelease.getOnlyRelease(),
-                authenticationAttributeRelease.getNeverRelease(),
+                authenticationAttributeReleasePolicy,
                 selectionStrategies);
     }
 
     @Bean
     @ConditionalOnMissingBean(name = "cas3ServiceSuccessView")
     public View cas3ServiceSuccessView() {
-        final AuthenticationAttributeReleaseProperties protocolAttributeRelease = casProperties.getAuthn().getAuthenticationAttributeRelease();
         final String authenticationContextAttribute = casProperties.getAuthn().getMfa().getAuthenticationContextAttribute();
         final boolean isReleaseProtocolAttributes = casProperties.getAuthn().isReleaseProtocolAttributes();
         return new Cas30ResponseView(true,
@@ -171,8 +173,7 @@ public class CasValidationConfiguration {
                 authenticationContextAttribute,
                 cas3SuccessView,
                 isReleaseProtocolAttributes,
-                protocolAttributeRelease.getOnlyRelease(),
-                protocolAttributeRelease.getNeverRelease(),
+                authenticationAttributeReleasePolicy,
                 selectionStrategies);
     }
 

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
@@ -9,6 +9,7 @@ import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.core.authentication.ProtocolAttributeReleaseProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.proxy.ProxyHandler;
 import org.apereo.cas.validation.CasProtocolValidationSpecification;
@@ -145,23 +146,34 @@ public class CasValidationConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = "cas3ServiceJsonView")
     public View cas3ServiceJsonView() {
+        final ProtocolAttributeReleaseProperties protocolAttributeRelease = casProperties.getAuthn().getProtocolAttributeRelease();
         final String authenticationContextAttribute = casProperties.getAuthn().getMfa().getAuthenticationContextAttribute();
         final boolean isReleaseProtocolAttributes = casProperties.getAuthn().isReleaseProtocolAttributes();
         return new Cas30JsonResponseView(true,
                 protocolAttributeEncoder,
                 servicesManager,
                 authenticationContextAttribute,
-                isReleaseProtocolAttributes, selectionStrategies);
+                isReleaseProtocolAttributes,
+                protocolAttributeRelease.getOnlyRelease(),
+                protocolAttributeRelease.getNeverRelease(),
+                selectionStrategies);
     }
 
     @Bean
     @ConditionalOnMissingBean(name = "cas3ServiceSuccessView")
     public View cas3ServiceSuccessView() {
+        final ProtocolAttributeReleaseProperties protocolAttributeRelease = casProperties.getAuthn().getProtocolAttributeRelease();
         final String authenticationContextAttribute = casProperties.getAuthn().getMfa().getAuthenticationContextAttribute();
         final boolean isReleaseProtocolAttributes = casProperties.getAuthn().isReleaseProtocolAttributes();
-        return new Cas30ResponseView(true, protocolAttributeEncoder,
-                servicesManager, authenticationContextAttribute, 
-                cas3SuccessView, isReleaseProtocolAttributes, selectionStrategies);
+        return new Cas30ResponseView(true,
+                protocolAttributeEncoder,
+                servicesManager,
+                authenticationContextAttribute,
+                cas3SuccessView,
+                isReleaseProtocolAttributes,
+                protocolAttributeRelease.getOnlyRelease(),
+                protocolAttributeRelease.getNeverRelease(),
+                selectionStrategies);
     }
 
     @Bean

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
@@ -9,7 +9,7 @@ import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.configuration.model.core.authentication.ProtocolAttributeReleaseProperties;
+import org.apereo.cas.configuration.model.core.authentication.AuthenticationAttributeReleaseProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.proxy.ProxyHandler;
 import org.apereo.cas.validation.CasProtocolValidationSpecification;
@@ -146,7 +146,7 @@ public class CasValidationConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = "cas3ServiceJsonView")
     public View cas3ServiceJsonView() {
-        final ProtocolAttributeReleaseProperties protocolAttributeRelease = casProperties.getAuthn().getProtocolAttributeRelease();
+        final AuthenticationAttributeReleaseProperties authenticationAttributeRelease = casProperties.getAuthn().getAuthenticationAttributeRelease();
         final String authenticationContextAttribute = casProperties.getAuthn().getMfa().getAuthenticationContextAttribute();
         final boolean isReleaseProtocolAttributes = casProperties.getAuthn().isReleaseProtocolAttributes();
         return new Cas30JsonResponseView(true,
@@ -154,15 +154,15 @@ public class CasValidationConfiguration {
                 servicesManager,
                 authenticationContextAttribute,
                 isReleaseProtocolAttributes,
-                protocolAttributeRelease.getOnlyRelease(),
-                protocolAttributeRelease.getNeverRelease(),
+                authenticationAttributeRelease.getOnlyRelease(),
+                authenticationAttributeRelease.getNeverRelease(),
                 selectionStrategies);
     }
 
     @Bean
     @ConditionalOnMissingBean(name = "cas3ServiceSuccessView")
     public View cas3ServiceSuccessView() {
-        final ProtocolAttributeReleaseProperties protocolAttributeRelease = casProperties.getAuthn().getProtocolAttributeRelease();
+        final AuthenticationAttributeReleaseProperties protocolAttributeRelease = casProperties.getAuthn().getAuthenticationAttributeRelease();
         final String authenticationContextAttribute = casProperties.getAuthn().getMfa().getAuthenticationContextAttribute();
         final boolean isReleaseProtocolAttributes = casProperties.getAuthn().isReleaseProtocolAttributes();
         return new Cas30ResponseView(true,

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas10ResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas10ResponseView.java
@@ -2,11 +2,11 @@ package org.apereo.cas.web.view;
 
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.services.web.view.AbstractCasView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -19,12 +19,13 @@ import java.util.Map;
  */
 public class Cas10ResponseView extends AbstractCasView {
 
-    public Cas10ResponseView(final boolean successResponse, 
-                             final ProtocolAttributeEncoder protocolAttributeEncoder, 
-                             final ServicesManager servicesManager, 
-                             final String authenticationContextAttribute) {
+    public Cas10ResponseView(final boolean successResponse,
+                             final ProtocolAttributeEncoder protocolAttributeEncoder,
+                             final ServicesManager servicesManager,
+                             final String authenticationContextAttribute,
+                             final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                new HashSet<>(), new HashSet<>());
+                authenticationAttributeReleasePolicy);
     }
 
     @Override

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas10ResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas10ResponseView.java
@@ -6,6 +6,7 @@ import org.apereo.cas.services.web.view.AbstractCasView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -22,7 +23,8 @@ public class Cas10ResponseView extends AbstractCasView {
                              final ProtocolAttributeEncoder protocolAttributeEncoder, 
                              final ServicesManager servicesManager, 
                              final String authenticationContextAttribute) {
-        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute);
+        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
+                new HashSet<>(), new HashSet<>());
     }
 
     @Override

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas20ResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas20ResponseView.java
@@ -4,6 +4,7 @@ import org.apereo.cas.CasViewConstants;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.services.web.view.AbstractDelegatingCasView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,8 +12,6 @@ import org.springframework.web.servlet.View;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -36,21 +35,10 @@ public class Cas20ResponseView extends AbstractDelegatingCasView {
                              final ServicesManager servicesManager, 
                              final String authenticationContextAttribute, 
                              final View view,
+                             final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy,
                              final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
-        this(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, view,
-                new HashSet<>(), new HashSet<>(), serviceSelectionStrategy);
-    }
-
-    protected Cas20ResponseView(final boolean successResponse,
-                                final ProtocolAttributeEncoder protocolAttributeEncoder,
-                                final ServicesManager servicesManager,
-                                final String authenticationContextAttribute,
-                                final View view,
-                                final Collection<String> authnAttrsToRelease,
-                                final Collection<String> authnAttrsToNeverRelease,
-                                final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, view,
-                authnAttrsToRelease, authnAttrsToNeverRelease);
+                authenticationAttributeReleasePolicy);
         this.authenticationRequestServiceSelectionStrategies = serviceSelectionStrategy;
     }
 

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas20ResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas20ResponseView.java
@@ -11,6 +11,8 @@ import org.springframework.web.servlet.View;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -28,14 +30,27 @@ public class Cas20ResponseView extends AbstractDelegatingCasView {
      * The Service selection strategy.
      */
     protected final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
-    
-    public Cas20ResponseView(final boolean successResponse, 
+
+    public Cas20ResponseView(final boolean successResponse,
                              final ProtocolAttributeEncoder protocolAttributeEncoder, 
                              final ServicesManager servicesManager, 
                              final String authenticationContextAttribute, 
                              final View view,
                              final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
-        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, view);
+        this(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, view,
+                new HashSet<>(), new HashSet<>(), serviceSelectionStrategy);
+    }
+
+    protected Cas20ResponseView(final boolean successResponse,
+                                final ProtocolAttributeEncoder protocolAttributeEncoder,
+                                final ServicesManager servicesManager,
+                                final String authenticationContextAttribute,
+                                final View view,
+                                final Collection<String> authnAttrsToRelease,
+                                final Collection<String> authnAttrsToNeverRelease,
+                                final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
+        super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, view,
+                authnAttrsToRelease, authnAttrsToNeverRelease);
         this.authenticationRequestServiceSelectionStrategies = serviceSelectionStrategy;
     }
 

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30JsonResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30JsonResponseView.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,12 +36,11 @@ public class Cas30JsonResponseView extends Cas30ResponseView {
                                  final ServicesManager servicesManager,
                                  final String authenticationContextAttribute,
                                  final boolean releaseProtocolAttributes,
-                                 final Collection<String> authnAttrsToRelease,
-                                 final Collection<String> authnAttrsToNeverRelease,
+                                 final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy,
                                  final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                createDelegatedView(), releaseProtocolAttributes, authnAttrsToRelease,
-                authnAttrsToNeverRelease, serviceSelectionStrategy);
+                createDelegatedView(), releaseProtocolAttributes, authenticationAttributeReleasePolicy,
+                serviceSelectionStrategy);
     }
 
     private static MappingJackson2JsonView createDelegatedView() {

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30JsonResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30JsonResponseView.java
@@ -35,12 +35,12 @@ public class Cas30JsonResponseView extends Cas30ResponseView {
                                  final ServicesManager servicesManager,
                                  final String authenticationContextAttribute,
                                  final boolean releaseProtocolAttributes,
-                                 final Collection<String> onlyReleaseProtocolAttributes,
-                                 final Collection<String> neverReleaseProtocolAttributes,
+                                 final Collection<String> authnAttrsToRelease,
+                                 final Collection<String> authnAttrsToNeverRelease,
                                  final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                createDelegatedView(), releaseProtocolAttributes, onlyReleaseProtocolAttributes,
-                neverReleaseProtocolAttributes, serviceSelectionStrategy);
+                createDelegatedView(), releaseProtocolAttributes, authnAttrsToRelease,
+                authnAttrsToNeverRelease, serviceSelectionStrategy);
     }
 
     private static MappingJackson2JsonView createDelegatedView() {

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30JsonResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30JsonResponseView.java
@@ -35,9 +35,12 @@ public class Cas30JsonResponseView extends Cas30ResponseView {
                                  final ServicesManager servicesManager,
                                  final String authenticationContextAttribute,
                                  final boolean releaseProtocolAttributes,
+                                 final Collection<String> onlyReleaseProtocolAttributes,
+                                 final Collection<String> neverReleaseProtocolAttributes,
                                  final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute,
-                createDelegatedView(), releaseProtocolAttributes, serviceSelectionStrategy);
+                createDelegatedView(), releaseProtocolAttributes, onlyReleaseProtocolAttributes,
+                neverReleaseProtocolAttributes, serviceSelectionStrategy);
     }
 
     private static MappingJackson2JsonView createDelegatedView() {

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30ResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30ResponseView.java
@@ -16,6 +16,7 @@ import org.springframework.web.servlet.View;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -35,15 +36,22 @@ public class Cas30ResponseView extends Cas20ResponseView {
     
     private final boolean releaseProtocolAttributes;
 
+    private final Collection<String> onlyReleaseProtocolAttributes;
+    private final Collection<String> neverReleaseProtocolAttributes;
+
     public Cas30ResponseView(final boolean successResponse,
                              final ProtocolAttributeEncoder protocolAttributeEncoder,
                              final ServicesManager servicesManager,
                              final String authenticationContextAttribute,
                              final View view,
                              final boolean releaseProtocolAttributes,
+                             final Collection<String> onlyReleaseProtocolAttributes,
+                             final Collection<String> neverReleaseProtocolAttributes,
                              final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, view, serviceSelectionStrategy);
         this.releaseProtocolAttributes = releaseProtocolAttributes;
+        this.onlyReleaseProtocolAttributes = onlyReleaseProtocolAttributes;
+        this.neverReleaseProtocolAttributes = neverReleaseProtocolAttributes;
     }
 
     @Override
@@ -101,6 +109,9 @@ public class Cas30ResponseView extends Cas20ResponseView {
         if (StringUtils.isNotBlank(contextProvider) && StringUtils.isNotBlank(authenticationContextAttribute)) {
             filteredAuthenticationAttributes.put(this.authenticationContextAttribute, CollectionUtils.wrap(contextProvider));
         }        
+
+        filterAuthenticationAttributesByReleaseVisibility(filteredAuthenticationAttributes);
+
         return filteredAuthenticationAttributes;
     }
 
@@ -148,5 +159,12 @@ public class Cas30ResponseView extends Cas20ResponseView {
             });
         });
         super.putIntoModel(model, CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_FORMATTED_ATTRIBUTES, formattedAttributes);
+    }
+
+    private void filterAuthenticationAttributesByReleaseVisibility(final Map<String, Object> attributes) {
+        attributes.keySet().removeAll(neverReleaseProtocolAttributes);
+        if (!onlyReleaseProtocolAttributes.isEmpty()) {
+            attributes.keySet().retainAll(onlyReleaseProtocolAttributes);
+        }
     }
 }

--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30ResponseView.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/view/Cas30ResponseView.java
@@ -8,6 +8,7 @@ import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.AuthenticationAttributeReleasePolicy;
 import org.apereo.cas.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +17,6 @@ import org.springframework.web.servlet.View;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -42,11 +42,10 @@ public class Cas30ResponseView extends Cas20ResponseView {
                              final String authenticationContextAttribute,
                              final View view,
                              final boolean releaseProtocolAttributes,
-                             final Collection<String> authnAttrsToRelease,
-                             final Collection<String> authnAttrsToNeverRelease,
+                             final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy,
                              final AuthenticationServiceSelectionPlan serviceSelectionStrategy) {
         super(successResponse, protocolAttributeEncoder, servicesManager, authenticationContextAttribute, view,
-                authnAttrsToRelease, authnAttrsToNeverRelease, serviceSelectionStrategy);
+                authenticationAttributeReleasePolicy, serviceSelectionStrategy);
         this.releaseProtocolAttributes = releaseProtocolAttributes;
     }
 
@@ -93,8 +92,11 @@ public class Cas30ResponseView extends Cas20ResponseView {
             return new LinkedHashMap<>(0);
         }
 
-        final Map<String, Object> filteredAuthenticationAttributes =
-                new HashMap<>(filterAuthenticationAttributesForRelease(getAuthenticationAttributes(model)));
+        // Authentication Attributes
+        final Map<String, Object> filteredAuthenticationAttributes = authenticationAttributeReleasePolicy
+                .getAuthenticationAttributesForRelease(getPrimaryAuthenticationFrom(model));
+
+        // CAS 3.0 specific protocol attributes
         filteredAuthenticationAttributes.put(CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_AUTHENTICATION_DATE,
                 CollectionUtils.wrap(getAuthenticationDate(model)));
         filteredAuthenticationAttributes.put(CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_FROM_NEW_LOGIN,

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas10ResponseViewTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas10ResponseViewTests.java
@@ -40,7 +40,7 @@ public class Cas10ResponseViewTests {
     public void verifySuccessView() throws Exception {
         final MockHttpServletResponse response = new MockHttpServletResponse();
         final Cas10ResponseView view = new Cas10ResponseView(true, null,
-                null, null);
+                null, null, null);
         view.render(this.model, new MockHttpServletRequest(), response);
         assertEquals("yes\ntest\n", response.getContentAsString());
     }
@@ -49,7 +49,7 @@ public class Cas10ResponseViewTests {
     public void verifyFailureView() throws Exception {
         final MockHttpServletResponse response = new MockHttpServletResponse();
         final Cas10ResponseView view = new Cas10ResponseView(false, null,
-                null, null);
+                null, null, null);
         view.render(this.model, new MockHttpServletRequest(), response);
         assertEquals("no\n\n", response.getContentAsString());
     }

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas20ResponseViewTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas20ResponseViewTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.CasViewConstants;
 import org.apereo.cas.authentication.DefaultAuthenticationContextValidator;
 import org.apereo.cas.authentication.DefaultAuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.DefaultMultifactorTriggerSelectionStrategy;
+import org.apereo.cas.services.web.support.DefaultAuthenticationAttributeReleasePolicy;
 import org.apereo.cas.web.AbstractServiceValidateController;
 import org.apereo.cas.web.AbstractServiceValidateControllerTests;
 import org.apereo.cas.web.ServiceValidateController;
@@ -25,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 
 import static org.junit.Assert.*;
-
 
 /**
  * Unit tests for {@link Cas20ResponseView}.
@@ -82,7 +82,7 @@ public class Cas20ResponseViewTests extends AbstractServiceValidateControllerTes
             }
         };
         final Cas20ResponseView view = new Cas20ResponseView(true, null,
-                null, "attribute", delegatedView, 
+                null, "attribute", delegatedView, new DefaultAuthenticationAttributeReleasePolicy(),
                 new DefaultAuthenticationServiceSelectionPlan());
         view.render(modelAndView.getModel(), req, resp);
 

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas30ResponseViewTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas30ResponseViewTests.java
@@ -38,6 +38,7 @@ import javax.crypto.Cipher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.security.PrivateKey;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
@@ -109,7 +110,7 @@ public class Cas30ResponseViewTests extends AbstractServiceValidateControllerTes
         };
 
         final Cas30ResponseView view = new Cas30ResponseView(true, encoder, servicesManager,
-                "attribute", viewDelegated, true,
+                "attribute", viewDelegated, true, new HashSet<>(), new HashSet<>(),
                 new DefaultAuthenticationServiceSelectionPlan(new DefaultAuthenticationServiceSelectionStrategy()));
         final MockHttpServletResponse resp = new MockHttpServletResponse();
         view.render(modelAndView.getModel(), req, resp);

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas30ResponseViewTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas30ResponseViewTests.java
@@ -11,6 +11,7 @@ import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.UsernamePasswordCredential;
 import org.apereo.cas.authentication.support.DefaultCasProtocolAttributeEncoder;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.support.DefaultAuthenticationAttributeReleasePolicy;
 import org.apereo.cas.util.EncodingUtils;
 import org.apereo.cas.util.cipher.NoOpCipherExecutor;
 import org.apereo.cas.util.crypto.PrivateKeyFactoryBean;
@@ -38,12 +39,10 @@ import javax.crypto.Cipher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.security.PrivateKey;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
 import static org.junit.Assert.*;
-
 
 /**
  * Unit tests for {@link Cas30ResponseView}.
@@ -109,8 +108,8 @@ public class Cas30ResponseViewTests extends AbstractServiceValidateControllerTes
             }
         };
 
-        final Cas30ResponseView view = new Cas30ResponseView(true, encoder, servicesManager,
-                "attribute", viewDelegated, true, new HashSet<>(), new HashSet<>(),
+        final Cas30ResponseView view = new Cas30ResponseView(true, encoder, servicesManager, "attribute",
+                viewDelegated, true, new DefaultAuthenticationAttributeReleasePolicy(),
                 new DefaultAuthenticationServiceSelectionPlan(new DefaultAuthenticationServiceSelectionStrategy()));
         final MockHttpServletResponse resp = new MockHttpServletResponse();
         view.render(modelAndView.getModel(), req, resp);


### PR DESCRIPTION
Currently it's an all or nothing approach when including authentication protocol attributes in the CAS validation response. This causes problems when an `AuthenticationMetaDataPopulator` puts data in the Authentication attributes that is meant for internal use only within AuthenticationPolicies. 

This PR is designed to provide more fine grained control over which authentication protocol attributes can be released.

There are 2 new configuration parameters:
`cas.authn.authenticationAttributeRelease.neverRelease`
`cas.authn.authenticationAttributeRelease.onlyRelease`

the `neverRelease` configuration property indicates authentication attributes that should never be released.

the `onlyRelease` configuration property will allow only the specified authentication attributes to be released. the `onlyRelease` restriction only applies if it is a non-empty list.