### PR TITLE
Fix grantServiceTicket permission checks for SAML services

### DIFF
--- a/core/cas-server-core/src/main/java/org/apereo/cas/DefaultCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/DefaultCentralAuthenticationService.java
@@ -140,15 +140,16 @@ public class DefaultCentralAuthenticationService extends AbstractCentralAuthenti
             throws AuthenticationException, AbstractTicketException {
 
         final TicketGrantingTicket ticketGrantingTicket = getTicket(ticketGrantingTicketId, TicketGrantingTicket.class);
-        final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
-        RegisteredServiceAccessStrategyUtils.ensurePrincipalAccessIsAllowedForService(service, registeredService, ticketGrantingTicket);
+        final Service selectedService = resolveServiceFromAuthenticationRequest(service);
+        final RegisteredService registeredService = this.servicesManager.findServiceBy(selectedService);
+        RegisteredServiceAccessStrategyUtils.ensurePrincipalAccessIsAllowedForService(selectedService, registeredService, ticketGrantingTicket);
 
         final Authentication currentAuthentication = evaluatePossibilityOfMixedPrincipals(authenticationResult, ticketGrantingTicket);
-        RegisteredServiceAccessStrategyUtils.ensureServiceSsoAccessIsAllowed(registeredService, service, ticketGrantingTicket);
-        evaluateProxiedServiceIfNeeded(service, ticketGrantingTicket, registeredService);
+        RegisteredServiceAccessStrategyUtils.ensureServiceSsoAccessIsAllowed(registeredService, selectedService, ticketGrantingTicket);
+        evaluateProxiedServiceIfNeeded(selectedService, ticketGrantingTicket, registeredService);
 
         // Perform security policy check by getting the authentication that satisfies the configured policy
-        getAuthenticationSatisfiedByPolicy(currentAuthentication, new ServiceContext(service, registeredService));
+        getAuthenticationSatisfiedByPolicy(currentAuthentication, new ServiceContext(selectedService, registeredService));
 
         final Authentication latestAuthentication = ticketGrantingTicket.getRoot().getAuthentication();
         AuthenticationCredentialsLocalBinder.bindCurrent(latestAuthentication);

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPConfiguration.java
@@ -150,13 +150,12 @@ public class SamlIdPConfiguration {
         return new SamlArtifactTicketExpirationPolicy(casProperties.getTicket().getSt().getTimeToKillInSeconds());
     }
 
-    @Bean
+    @Bean(initMethod = "initialize", destroyMethod = "destroy")
     @RefreshScope
     public SAMLArtifactMap samlArtifactMap() {
         try {
             final CasSamlArtifactMap map = new CasSamlArtifactMap(ticketRegistry, samlArtifactTicketFactory(),
                     ticketGrantingTicketCookieGenerator);
-            map.initialize();
             map.setArtifactLifetime(TimeUnit.SECONDS.toMillis(samlArtifactTicketExpirationPolicy().getTimeToLive()));
             return map;
         } catch (final Exception e) {


### PR DESCRIPTION
When processing `grantServiceTicket()` make sure various access checks are performed against the actual service authenticating, not against the CAS SAML/OAuth intermediate endpoint.