### PR TITLE
Issue - 5.1.x => NullPointerException when Empty passwords are given on Password Update Form

### DIFF
--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordValidator.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordValidator.java
@@ -27,7 +27,7 @@ public class PasswordValidator {
     public void validateCasMustChangePassView(final PasswordChangeBean bean, final ValidationContext context) {
         final MessageContext messages = context.getMessageContext();
 
-        if(!StringUtils.hasText(bean.getPassword())) {
+        if (!StringUtils.hasText(bean.getPassword())) {
             messages.addMessage(new MessageBuilder().error().source("pm.passwordFailedCriteria").
                     defaultText("Password policy rejected empty password.").build());
             return;

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordValidator.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/PasswordValidator.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.binding.message.MessageBuilder;
 import org.springframework.binding.message.MessageContext;
 import org.springframework.binding.validation.ValidationContext;
+import org.springframework.util.StringUtils;
 
 /**
  * This is {@link PasswordValidator}.
@@ -25,6 +26,13 @@ public class PasswordValidator {
      */
     public void validateCasMustChangePassView(final PasswordChangeBean bean, final ValidationContext context) {
         final MessageContext messages = context.getMessageContext();
+
+        if(!StringUtils.hasText(bean.getPassword())) {
+            messages.addMessage(new MessageBuilder().error().source("pm.passwordFailedCriteria").
+                    defaultText("Password policy rejected empty password.").build());
+            return;
+        }
+        
         if (!bean.getPassword().equals(bean.getConfirmedPassword())) {
             messages.addMessage(new MessageBuilder().error().source("pm.passwordsMustMatch").
                     defaultText("Provided passwords do not match.").build());

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
@@ -58,7 +58,6 @@ public class PasswordManagementWebflowConfigurer extends AbstractCasWebflowConfi
             createEndState(flow, CasWebflowConstants.STATE_ID_PASSWORD_UPDATE_SUCCESS, CasWebflowConstants.VIEW_ID_PASSWORD_UPDATE_SUCCESS);
 
             if (casProperties.getAuthn().getPm().isEnabled()) {
-                configure(flow, CasWebflowConstants.VIEW_ID_ACCOUNT_DISABLED);
                 configure(flow, CasWebflowConstants.VIEW_ID_EXPIRED_PASSWORD);
                 configure(flow, CasWebflowConstants.VIEW_ID_MUST_CHANGE_PASSWORD);
                 configurePasswordReset();

--- a/webapp/resources/templates/casExpiredPassView.html
+++ b/webapp/resources/templates/casExpiredPassView.html
@@ -3,6 +3,7 @@
 
 <head>
     <title th:text="#{screen.expiredpass.heading}"></title>
+    <script type="text/javascript" th:src="@{/js/pm.js}"></script>
 </head>
 
 <body id="cas">

--- a/webapp/resources/templates/fragments/pwdupdateform.html
+++ b/webapp/resources/templates/fragments/pwdupdateform.html
@@ -50,7 +50,8 @@
                accesskey="s"
                th:value="#{screen.pm.button.submit}"
                id="submit"
-               type="submit"/>
+               type="submit"
+               disabled="true"/>
         <input
                 class="btn-reset"
                 name="cancel"


### PR DESCRIPTION
This PR will fix `NullPointerExcetion` which is raised when on Password Update page (`casMustChangePassView` and `casExpiredPassView`), user submits the form with empty passwords.

Following changes were made;
- Added empty text check into `PasswordValidator`
- Disabled submit button on form load
- Added missing `pm.js` on expired password view page
