### PR TITLE
Fix registeredService in webflow for SAML auth

### DIFF
--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/config/CasSupportActionsConfiguration.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/config/CasSupportActionsConfiguration.java
@@ -162,6 +162,7 @@ public class CasSupportActionsConfiguration {
     public Action initialFlowSetupAction(@Qualifier("argumentExtractor") final ArgumentExtractor argumentExtractor) {
         return new InitialFlowSetupAction(CollectionUtils.wrap(argumentExtractor),
                 servicesManager,
+                authenticationRequestServiceSelectionStrategies,
                 ticketGrantingTicketCookieGenerator,
                 warnCookieGenerator, casProperties);
     }

--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/config/CasSupportActionsConfiguration.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/config/CasSupportActionsConfiguration.java
@@ -186,7 +186,11 @@ public class CasSupportActionsConfiguration {
     @RefreshScope
     @ConditionalOnMissingBean(name = "generateServiceTicketAction")
     public Action generateServiceTicketAction() {
-        return new GenerateServiceTicketAction(authenticationSystemSupport, centralAuthenticationService, ticketRegistrySupport, servicesManager);
+        return new GenerateServiceTicketAction(authenticationSystemSupport,
+                centralAuthenticationService,
+                ticketRegistrySupport,
+                servicesManager,
+                authenticationRequestServiceSelectionStrategies);
     }
 
     @Bean

--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/GenerateServiceTicketAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/GenerateServiceTicketAction.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.AuthenticationException;
 import org.apereo.cas.authentication.AuthenticationResult;
 import org.apereo.cas.authentication.AuthenticationResultBuilder;
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.principal.Service;
@@ -35,6 +36,7 @@ import org.springframework.webflow.execution.RequestContext;
 public class GenerateServiceTicketAction extends AbstractAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenerateServiceTicketAction.class);
     private final CentralAuthenticationService centralAuthenticationService;
+    private final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
     private final AuthenticationSystemSupport authenticationSystemSupport;
     private final TicketRegistrySupport ticketRegistrySupport;
     private final ServicesManager servicesManager;
@@ -42,11 +44,13 @@ public class GenerateServiceTicketAction extends AbstractAction {
     public GenerateServiceTicketAction(final AuthenticationSystemSupport authenticationSystemSupport,
                                        final CentralAuthenticationService authenticationService,
                                        final TicketRegistrySupport ticketRegistrySupport,
-                                       final ServicesManager servicesManager) {
+                                       final ServicesManager servicesManager,
+                                       final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies) {
         this.authenticationSystemSupport = authenticationSystemSupport;
         this.centralAuthenticationService = authenticationService;
         this.ticketRegistrySupport = ticketRegistrySupport;
         this.servicesManager = servicesManager;
+        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionStrategies;
     }
 
     /**
@@ -75,7 +79,8 @@ public class GenerateServiceTicketAction extends AbstractAction {
                         + ticketGrantingTicket), ticketGrantingTicket);
             }
 
-            final RegisteredService registeredService = servicesManager.findServiceBy(service);
+            final Service selectedService = authenticationRequestServiceSelectionStrategies.resolveService(service);
+            final RegisteredService registeredService = servicesManager.findServiceBy(selectedService);
             LOGGER.debug("Registered service asking for service ticket is [{}]", registeredService);
             WebUtils.putRegisteredService(context, registeredService);
             WebUtils.putService(context, service);

--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/InitialFlowSetupAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/InitialFlowSetupAction.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.RegisteredService;
@@ -38,17 +39,20 @@ public class InitialFlowSetupAction extends AbstractAction {
 
     private final CasConfigurationProperties casProperties;
     private final ServicesManager servicesManager;
+    private final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
     private final CookieRetrievingCookieGenerator warnCookieGenerator;
     private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
     private final List<ArgumentExtractor> argumentExtractors;
 
     public InitialFlowSetupAction(final List<ArgumentExtractor> argumentExtractors,
                                   final ServicesManager servicesManager,
+                                  final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionPlan,
                                   final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator,
                                   final CookieRetrievingCookieGenerator warnCookieGenerator,
                                   final CasConfigurationProperties casProperties) {
         this.argumentExtractors = argumentExtractors;
         this.servicesManager = servicesManager;
+        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionPlan;
         this.ticketGrantingTicketCookieGenerator = ticketGrantingTicketCookieGenerator;
         this.warnCookieGenerator = warnCookieGenerator;
         this.casProperties = casProperties;
@@ -67,7 +71,8 @@ public class InitialFlowSetupAction extends AbstractAction {
         if (service != null) {
             LOGGER.debug("Placing service in context scope: [{}]", service.getId());
 
-            final RegisteredService registeredService = this.servicesManager.findServiceBy(service);
+            final Service selectedService = authenticationRequestServiceSelectionStrategies.resolveService(service);
+            final RegisteredService registeredService = this.servicesManager.findServiceBy(selectedService);
             if (registeredService != null && registeredService.getAccessStrategy().isServiceAccessAllowed()) {
                 LOGGER.debug("Placing registered service [{}] with id [{}] in context scope",
                         registeredService.getServiceId(),

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionCookieTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionCookieTests.java
@@ -64,7 +64,8 @@ public class InitialFlowSetupActionCookieTests extends AbstractCentralAuthentica
         final List<ArgumentExtractor> argExtractors = Collections.singletonList(new DefaultArgumentExtractor(new WebApplicationServiceFactory()));
         final ServicesManager servicesManager = mock(ServicesManager.class);
         when(servicesManager.findServiceBy(any(Service.class))).thenReturn(RegisteredServiceTestUtils.getRegisteredService("test"));
-        this.action = new InitialFlowSetupAction(argExtractors, servicesManager, authenticationRequestServiceSelectionStrategies, tgtCookieGenerator, warnCookieGenerator, casProperties);
+        this.action = new InitialFlowSetupAction(argExtractors, servicesManager, authenticationRequestServiceSelectionStrategies, tgtCookieGenerator,
+                warnCookieGenerator, casProperties);
 
         this.action.afterPropertiesSet();
     }

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionCookieTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionCookieTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.web.flow;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.AbstractCentralAuthenticationServiceTests;
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
 import org.apereo.cas.configuration.CasConfigurationProperties;
@@ -44,6 +45,9 @@ public class InitialFlowSetupActionCookieTests extends AbstractCentralAuthentica
     @Autowired
     private CasConfigurationProperties casProperties;
 
+    @Autowired
+    private AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
+
     private InitialFlowSetupAction action;
     private CookieRetrievingCookieGenerator warnCookieGenerator;
     private CookieRetrievingCookieGenerator tgtCookieGenerator;
@@ -56,11 +60,11 @@ public class InitialFlowSetupActionCookieTests extends AbstractCentralAuthentica
         this.tgtCookieGenerator = new CookieRetrievingCookieGenerator("tgt", "", 2, 
                 false, null, false);
         this.tgtCookieGenerator.setCookiePath(StringUtils.EMPTY);
-        
+
         final List<ArgumentExtractor> argExtractors = Collections.singletonList(new DefaultArgumentExtractor(new WebApplicationServiceFactory()));
         final ServicesManager servicesManager = mock(ServicesManager.class);
         when(servicesManager.findServiceBy(any(Service.class))).thenReturn(RegisteredServiceTestUtils.getRegisteredService("test"));
-        this.action = new InitialFlowSetupAction(argExtractors, servicesManager, tgtCookieGenerator, warnCookieGenerator, casProperties);
+        this.action = new InitialFlowSetupAction(argExtractors, servicesManager, authenticationRequestServiceSelectionStrategies, tgtCookieGenerator, warnCookieGenerator, casProperties);
 
         this.action.afterPropertiesSet();
     }


### PR DESCRIPTION
the `registeredService` that was present in the webflow (and accessed inside Thymeleaf templates) wasn't taking `ServiceSelectionStrategies` into account.

I also found some unnecessary duplicate logic in the process. (at least as far as I can tell)