### PR TITLE
bug fix OIDC errors

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20CasCallbackUrlResolver.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/OAuth20CasCallbackUrlResolver.java
@@ -34,7 +34,7 @@ public class OAuth20CasCallbackUrlResolver implements UrlResolver {
     @Override
     public String compute(final String url, final WebContext context) {
         if (url.startsWith(callbackUrl)) {
-            final URIBuilder builder = new URIBuilder(url);
+            final URIBuilder builder = new URIBuilder(url, true);
 
             Optional<URIBuilder.BasicNameValuePair> parameter = getQueryParameter(context, OAuth20Constants.CLIENT_ID);
             parameter.ifPresent(basicNameValuePair -> builder.addParameter(basicNameValuePair.getName(), basicNameValuePair.getValue()));

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcAuthorizeEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcAuthorizeEndpointController.java
@@ -80,7 +80,7 @@ public class OidcAuthorizeEndpointController extends OAuth20AuthorizeEndpointCon
 
     @PostMapping(value = '/' + OidcConstants.BASE_OIDC_URL + '/' + OAuth20Constants.AUTHORIZE_URL)
     @Override
-    public ModelAndView handleRequestPost(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public ModelAndView handleRequestPost(final HttpServletRequest request, final HttpServletResponse response) throws Exception {
         return handleRequest(request, response);
     }
 

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcAuthorizeEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcAuthorizeEndpointController.java
@@ -26,6 +26,7 @@ import org.pac4j.core.context.J2EContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
 
@@ -75,6 +76,12 @@ public class OidcAuthorizeEndpointController extends OAuth20AuthorizeEndpointCon
         }
 
         return super.handleRequest(request, response);
+    }
+
+    @PostMapping(value = '/' + OidcConstants.BASE_OIDC_URL + '/' + OAuth20Constants.AUTHORIZE_URL)
+    @Override
+    public ModelAndView handleRequestPost(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return handleRequest(request, response);
     }
 
     @Override


### PR DESCRIPTION
Fix OIDC errors

- on statup when OIDC dependency is added 

```
Caused by: java.lang.IllegalStateException: Ambiguous mapping. Cannot map 'oidcAuthorizeController' method
public org.springframework.web.servlet.ModelAndView org.apereo.cas.support.oauth.web.endpoints.OAuth20AuthorizeEndpointController.handleRequestPost(javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse) throws java.lang.Exception
to {[/oauth2.0/authorize],methods=[POST]}: There is already 'authorizeController' bean method
public org.springframework.web.servlet.ModelAndView org.apereo.cas.support.oauth.web.endpoints.OAuth20AuthorizeEndpointController.handleRequestPost(javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse) throws java.lang.Exception mapped.
```

Commit [Allow POST for oauth](https://github.com/apereo/cas/commit/2e8b5243aa379731b727076cf7901a02e6ad5e37#diff-ff9c0e780f8f2389ad4e305d16d80c8b) seems to be the cause of this issue. 
The new POST mapping in `OAuth20AuthorizeEndpointController` requires to do the same in the child class `OidcAuthorizeEndpointController` to resolve the duplicate Spring MVC mapping.


- when `response_type` parameter contains blank (ex : .`response_type=id_token token`)

```
java.net.URISyntaxException: Illegal character in query at index 151: https://localhost:8443/cas/oauth2.0/callbackAuthorize?client_name=CasOAuthClient&client_id=client&redirect_uri=http://127.0.0.1/&response_type=id_token token] with root cause>
java.net.URISyntaxException: Illegal character in query at index 151: https://localhost:8443/cas/oauth2.0/callbackAuthorize?client_name=CasOAuthClient&client_id=client&redirect_uri=http://127.0.0.1/&response_type=id_token token
        at java.net.URI$Parser.fail(Unknown Source) ~[?:1.8.0_151]
        at java.net.URI$Parser.checkChars(Unknown Source) ~[?:1.8.0_151]
        at java.net.URI$Parser.parseHierarchical(Unknown Source) ~[?:1.8.0_151]
        at java.net.URI$Parser.parse(Unknown Source) ~[?:1.8.0_151]
        at java.net.URI.<init>(Unknown Source) ~[?:1.8.0_151]
        at org.jasig.cas.client.util.URIBuilder.build(URIBuilder.java:137) ~[cas-client-core-3.4.1.jar!/:3.4.1]
        at org.apereo.cas.support.oauth.web.OAuth20CasCallbackUrlResolver.compute(OAuth20CasCallbackUrlResolver.java:54) ~[cas-server-support-oauth-5.2.0-SNAPSHOT.jar!/:5.2.0-SNAPSHOT]
```

`OAuth20CasCallbackUrlResolver` should escape query parameters when it builds callback URL 