### PR TITLE
PasswordValidator routine added

### DIFF
--- a/docs/cas-server-documentation/installation/Installing-ServicesMgmt-Webapp.md
+++ b/docs/cas-server-documentation/installation/Installing-ServicesMgmt-Webapp.md
@@ -42,6 +42,9 @@ The management web application is primarily controlled by a `management.yml|prop
 
 The [persistence storage](Service-Management.html) for services **MUST** be the same as that of the CAS server. The same service registry component that is configured for the CAS server, including module and settings, needs to be configured in the same exact way for the management web application.
 
+## User Attributes
+The set of user attributes defined in the CAS Server's [authentication attributes](Configuration-Properties.html#authentication-attributes) or [attribute resolution](Attribute-Resolution.html) configurations should be mapped in the Service Management webapp's configuration using the [stub-based attribute repository](Configuration-Properties.html#attributes). This will make the attributes available for selction in the management webapp's various user attributes-related dropdowns.
+
 ## Authentication
 
 Access to the management webapp can be configured via the following strategies.

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/config/PasswordManagementConfiguration.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/config/PasswordManagementConfiguration.java
@@ -21,7 +21,7 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
-
+import org.springframework.util.StringUtils;
 import javax.annotation.PostConstruct;
 
 /**
@@ -62,7 +62,12 @@ public class PasswordManagementConfiguration {
     @RefreshScope
     @Bean
     public PasswordValidationService passwordValidationService() {
-        return (c, bean) -> true;
+        final String policyPattern = casProperties.getAuthn().getPm().getPolicyPattern();
+        return (credential, bean) -> {
+            return StringUtils.hasText(bean.getPassword())
+                && bean.getPassword().equals(bean.getConfirmedPassword())
+                && bean.getPassword().matches(policyPattern);
+        };
     }
     
     @ConditionalOnMissingBean(name = "passwordChangeService")

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
@@ -19,6 +19,7 @@ import org.apereo.cas.config.CasPersonDirectoryConfiguration;
 import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
 import org.apereo.cas.pm.PasswordChangeBean;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordValidationService;
 import org.apereo.cas.pm.config.PasswordManagementConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,7 +52,7 @@ import static org.junit.Assert.*;
         CasCoreTicketCatalogConfiguration.class,
         CasCoreTicketsConfiguration.class,
         CasPersonDirectoryConfiguration.class,
-        CasCoreAuthenticationConfiguration.class, 
+        CasCoreAuthenticationConfiguration.class,
         CasCoreServicesAuthenticationConfiguration.class,
         CasCoreServicesConfiguration.class,
         CasCoreWebConfiguration.class,
@@ -64,6 +65,10 @@ public class JsonResourcePasswordManagementServiceTests {
     @Autowired
     @Qualifier("passwordChangeService")
     private PasswordManagementService passwordChangeService;
+
+    @Autowired
+    @Qualifier("passwordChangeService")
+    private PasswordValidationService passwordValidationService;
 
     @Test
     public void verifyUserEmailCanBeFound() {
@@ -91,5 +96,15 @@ public class JsonResourcePasswordManagementServiceTests {
         bean.setPassword("newPassword");
         final boolean res = passwordChangeService.change(c, bean);
         assertTrue(res);
+    }
+
+    @Test
+    public void verifyPasswordValidationService() {
+        final UsernamePasswordCredential c = new UsernamePasswordCredential("casuser", "password");
+        final PasswordChangeBean bean = new PasswordChangeBean();
+        bean.setConfirmedPassword("newPassword");
+        bean.setPassword("newPassword");
+        boolean isValid = passwordValidationService.isValid(c, bean);
+        assertTrue(isValid);
     }
 }

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
@@ -102,8 +102,8 @@ public class JsonResourcePasswordManagementServiceTests {
     public void verifyPasswordValidationService() {
         final UsernamePasswordCredential c = new UsernamePasswordCredential("casuser", "password");
         final PasswordChangeBean bean = new PasswordChangeBean();
-        bean.setConfirmedPassword("newPassword");
-        bean.setPassword("newPassword");
+        bean.setConfirmedPassword("Test@1234");
+        bean.setPassword("Test@1234");
         final boolean isValid = passwordValidationService.isValid(c, bean);
         assertTrue(isValid);
     }

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
@@ -104,7 +104,7 @@ public class JsonResourcePasswordManagementServiceTests {
         final PasswordChangeBean bean = new PasswordChangeBean();
         bean.setConfirmedPassword("newPassword");
         bean.setPassword("newPassword");
-        boolean isValid = passwordValidationService.isValid(c, bean);
+        final boolean isValid = passwordValidationService.isValid(c, bean);
         assertTrue(isValid);
     }
 }

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
@@ -67,7 +67,7 @@ public class JsonResourcePasswordManagementServiceTests {
     private PasswordManagementService passwordChangeService;
 
     @Autowired
-    @Qualifier("passwordChangeService")
+    @Qualifier("passwordValidationService")
     private PasswordValidationService passwordValidationService;
 
     @Test

--- a/support/cas-server-support-pm/src/test/resources/pm.properties
+++ b/support/cas-server-support-pm/src/test/resources/pm.properties
@@ -1,2 +1,3 @@
 cas.authn.pm.json.location=classpath:jsonResourcePassword.json
 cas.authn.pm.enabled=true
+cas.authn.pm.policyPattern=^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%#?&])[A-Za-z\\d@$!%#?&]{8,}$

--- a/webapp/resources/templates/fragments/pwdupdateform.html
+++ b/webapp/resources/templates/fragments/pwdupdateform.html
@@ -56,7 +56,8 @@
                    accesskey="s"
                    th:value="#{screen.pm.button.submit}"
                    id="submit"
-                   type="submit"/>
+                   type="submit" 
+                   disabled="true"/>
             &nbsp;
             <input
                     class="btn btn-danger btn-lg"


### PR DESCRIPTION
This PR is a followup to [#3067](https://github.com/apereo/cas/pull/3067). It will add Password Validation routine which will validate password against following rules;
- Password should not be empty
- It should match to the configured Password Policy Pattern