### PR TITLE
When resolving login request with already present TGT, introduced che…

### DIFF
--- a/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/RankedAuthenticationProviderWebflowEventResolver.java
+++ b/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/RankedAuthenticationProviderWebflowEventResolver.java
@@ -77,11 +77,12 @@ public class RankedAuthenticationProviderWebflowEventResolver extends AbstractCa
         }
         
         if (!service.getRequiredHandlers().isEmpty()) {
-            boolean handlerMatch = authentication.getSuccesses().values().stream()
+            final boolean handlerMatch = authentication.getSuccesses().values().stream()
                     .filter(h -> service.getRequiredHandlers().contains(h.getHandlerName()))
                     .findAny().isPresent();
             if (!handlerMatch) {
-                LOGGER.trace("Current authentication from TGT does not fulfills requirements for service.requiredHandlers; returning weblow event as [{}]", CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE);
+                LOGGER.trace("Current authentication from TGT does not fulfills requirements for service.requiredHandlers; returning weblow event as [{}]",
+                        CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE);
                 return CollectionUtils.wrapSet(new Event(this, CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE));
             }
         }

--- a/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/RankedAuthenticationProviderWebflowEventResolver.java
+++ b/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/resolver/impl/RankedAuthenticationProviderWebflowEventResolver.java
@@ -75,6 +75,16 @@ public class RankedAuthenticationProviderWebflowEventResolver extends AbstractCa
             LOGGER.trace("TGT has no authentication and is blank; proceed with flow normally.");
             return resumeFlow();
         }
+        
+        if (!service.getRequiredHandlers().isEmpty()) {
+            boolean handlerMatch = authentication.getSuccesses().values().stream()
+                    .filter(h -> service.getRequiredHandlers().contains(h.getHandlerName()))
+                    .findAny().isPresent();
+            if (!handlerMatch) {
+                LOGGER.trace("Current authentication from TGT does not fulfills requirements for service.requiredHandlers; returning weblow event as [{}]", CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE);
+                return CollectionUtils.wrapSet(new Event(this, CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE));
+            }
+        }
 
         final Credential credential = WebUtils.getCredential(context);
         final AuthenticationResultBuilder builder = this.authenticationSystemSupport.establishAuthenticationContextFromInitial(authentication, credential);


### PR DESCRIPTION
…ck if auth from TGT fulfills service.requiredHandlers requirements.

# Details

This pull request fixes wrong behaviour at point 5 of below scenario

1. Configure CAS with 2 authentication handlers (eg. 2 LDAPs).  Name one handler "admins" and second handler "minions".
2. Configure regexp service for `https://adminsonly.*` with requiredHandlers = ["admins"]
3. Login to `/cas/login?service=https://adminsonly1` with user data from "minions" handler - you won't be authenticated as expected
4. Login to `/cas/login` (defaut service) with "minions" user. You will be authenticated and gain TGT
5. Login again to `/cas/login?service=https://adminsonly1` - You will be authenticated with your TGT with "minions" account which violates service's requiredHandlers

after patch

5. Login again to `/cas/login?service=https://adminsonly1` - you won't be authenticated with TGT. Login screen will appear.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
