### PR TITLE
Use id instead of name when adding properties to property file in cli shell

### DIFF
--- a/api/cas-server-core-api-configuration/src/main/java/org/apereo/cas/configuration/model/core/CasServerProperties.java
+++ b/api/cas-server-core-api-configuration/src/main/java/org/apereo/cas/configuration/model/core/CasServerProperties.java
@@ -349,7 +349,7 @@ public class CasServerProperties implements Serializable {
         /**
          * String representing extended log pattern.
          */
-        private String pattern = "c-ip s-ip cs-uri sc-status time X-threadname x-H(secure) x-H(remoteUser)";
+        private String pattern = "c-ip s-ip cs-uri sc-status time x-threadname x-H(secure) x-H(remoteUser)";
 
         /**
          * File name suffix for extended log.

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -354,7 +354,7 @@ for the embedded Tomcat container.
 
 ```properties
 # cas.server.extAccessLog.enabled=false
-# cas.server.extAccessLog.pattern=c-ip s-ip cs-uri sc-status time X-threadname x-H(secure) x-H(remoteUser)
+# cas.server.extAccessLog.pattern=c-ip s-ip cs-uri sc-status time x-threadname x-H(secure) x-H(remoteUser)
 # cas.server.extAccessLog.suffix=.log
 # cas.server.extAccessLog.prefix=localhost_access_extended
 # cas.server.extAccessLog.directory=

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/AddPropertiesToConfigurationCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/AddPropertiesToConfigurationCommand.java
@@ -131,8 +131,8 @@ public class AddPropertiesToConfigurationCommand implements CommandMarker {
             } else {
                 value = v.getDefaultValue().toString();
             }
-            LOGGER.info("Adding property [{}={}]", v.getName(), value);
-            p.put("# " + v.getName(), value);
+            LOGGER.info("Adding property [{}={}]", v.getId(), value);
+            p.put("# " + v.getId(), value);
         });
     }
 


### PR DESCRIPTION
When you use the shell with a non-cas property, the name is usually not the full property name but the id is correct so this uses the id instead. 

build.cmd cli -sh 
add-property -group tomcat

If you try that without this patch you will see the results aren't useful. 


