### PR TITLE
Consolidate duplicate state id constant

### DIFF
--- a/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
+++ b/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
@@ -115,11 +115,6 @@ public interface CasWebflowConstants {
     String STATE_ID_INITIAL_AUTHN_REQUEST_VALIDATION_CHECK = "initialAuthenticationRequestValidationCheck";
 
     /**
-     * The transition state 'sendTicketGrantingTicket'.
-     */
-    String TRANSITION_ID_SEND_TICKET_GRANTING_TICKET = "sendTicketGrantingTicket";
-
-    /**
      * The state id 'sendTicketGrantingTicket'.
      */
     String STATE_ID_SEND_TICKET_GRANTING_TICKET = "sendTicketGrantingTicket";

--- a/support/cas-server-support-basic/src/main/java/org/apereo/cas/web/flow/BasicAuthenticationWebflowConfigurer.java
+++ b/support/cas-server-support-basic/src/main/java/org/apereo/cas/web/flow/BasicAuthenticationWebflowConfigurer.java
@@ -30,7 +30,7 @@ public class BasicAuthenticationWebflowConfigurer extends AbstractCasWebflowConf
             final ActionState actionState = createActionState(flow, "basicAuthenticationCheck",
                     createEvaluateAction("basicAuthenticationAction"));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_WARN,
                     CasWebflowConstants.TRANSITION_ID_WARN));
             actionState.getExitActionList().add(createEvaluateAction("clearWebflowCredentialsAction"));

--- a/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/web/flow/DigestAuthenticationWebflowConfigurer.java
+++ b/support/cas-server-support-digest-authentication/src/main/java/org/apereo/cas/digest/web/flow/DigestAuthenticationWebflowConfigurer.java
@@ -31,7 +31,7 @@ public class DigestAuthenticationWebflowConfigurer extends AbstractCasWebflowCon
             final ActionState actionState = createActionState(flow, "digestAuthenticationCheck",
                     createEvaluateAction("digestAuthenticationAction"));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_WARN,
                     CasWebflowConstants.TRANSITION_ID_WARN));
             actionState.getExitActionList().add(createEvaluateAction("clearWebflowCredentialsAction"));

--- a/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/web/flow/RemoteAddressWebflowConfigurer.java
+++ b/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/web/flow/RemoteAddressWebflowConfigurer.java
@@ -30,7 +30,7 @@ public class RemoteAddressWebflowConfigurer extends AbstractCasWebflowConfigurer
         if (flow != null) {
             final ActionState actionState = createActionState(flow, "startAuthenticate", createEvaluateAction("remoteAddressCheck"));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, getStartState(flow).getId()));
             actionState.getExitActionList().add(createEvaluateAction("clearWebflowCredentialsAction"));
             registerMultifactorProvidersStateTransitionsIntoWebflow(actionState);

--- a/support/cas-server-support-openid-webflow/src/main/java/org/apereo/cas/web/flow/OpenIdWebflowConfigurer.java
+++ b/support/cas-server-support-openid-webflow/src/main/java/org/apereo/cas/web/flow/OpenIdWebflowConfigurer.java
@@ -41,7 +41,7 @@ public class OpenIdWebflowConfigurer extends AbstractCasWebflowConfigurer {
                     createEvaluateAction(OPEN_ID_SINGLE_SIGN_ON_ACTION));
 
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, getStartState(flow).getId()));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_WARN,
                     CasWebflowConstants.TRANSITION_ID_WARN));

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jWebflowConfigurer.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jWebflowConfigurer.java
@@ -62,7 +62,7 @@ public class Pac4jWebflowConfigurer extends AbstractCasWebflowConfigurer {
         final ActionState actionState = createActionState(flow, DelegatedClientAuthenticationAction.CLIENT_ACTION,
                 createEvaluateAction(DelegatedClientAuthenticationAction.CLIENT_ACTION));
         actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
         actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, getStartState(flow).getId()));
         actionState.getTransitionSet().add(createTransition(DelegatedClientAuthenticationAction.STOP,
                 DelegatedClientAuthenticationAction.STOP_WEBFLOW));

--- a/support/cas-server-support-scim/src/main/java/org/apereo/cas/web/flow/ScimWebflowConfigurer.java
+++ b/support/cas-server-support-scim/src/main/java/org/apereo/cas/web/flow/ScimWebflowConfigurer.java
@@ -26,7 +26,7 @@ public class ScimWebflowConfigurer extends AbstractCasWebflowConfigurer {
     protected void doInitialize() {
         final Flow flow = getLoginFlow();
         if (flow != null) {
-            final ActionState tgtAction = getState(flow, CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET, ActionState.class);
+            final ActionState tgtAction = getState(flow, CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET, ActionState.class);
             tgtAction.getExitActionList().add(createEvaluateAction("principalScimProvisionerAction"));
         }
     }

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpengoWebflowConfigurer.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpengoWebflowConfigurer.java
@@ -58,7 +58,7 @@ public class SpengoWebflowConfigurer extends AbstractCasWebflowConfigurer {
     private ActionState createSpnegoActionState(final Flow flow) {
         final ActionState spnego = createActionState(flow, SPNEGO, createEvaluateAction(SPNEGO));
         final TransitionSet transitions = spnego.getTransitionSet();
-        transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS, CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+        transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS, CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
         transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, CasWebflowConstants.STATE_ID_VIEW_LOGIN_FORM));
         transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, CasWebflowConstants.STATE_ID_VIEW_LOGIN_FORM));
         spnego.getExitActionList().add(createEvaluateAction("clearWebflowCredentialsAction"));

--- a/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/flow/TokenWebflowConfigurer.java
+++ b/support/cas-server-support-token-webflow/src/main/java/org/apereo/cas/web/flow/TokenWebflowConfigurer.java
@@ -32,7 +32,7 @@ public class TokenWebflowConfigurer extends AbstractCasWebflowConfigurer {
             final ActionState actionState = createActionState(flow, "tokenAuthenticationCheck",
                     createEvaluateAction("tokenAuthenticationAction"));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getExitActionList().add(createEvaluateAction("clearWebflowCredentialsAction"));
             registerMultifactorProvidersStateTransitionsIntoWebflow(actionState);
             createStateDefaultTransition(actionState, getStartState(flow).getId());

--- a/support/cas-server-support-trusted-webflow/src/main/java/org/apereo/cas/web/flow/TrustedAuthenticationWebflowConfigurer.java
+++ b/support/cas-server-support-trusted-webflow/src/main/java/org/apereo/cas/web/flow/TrustedAuthenticationWebflowConfigurer.java
@@ -31,7 +31,7 @@ public class TrustedAuthenticationWebflowConfigurer extends AbstractCasWebflowCo
             final ActionState actionState = createActionState(flow, "remoteAuthenticate",
                     createEvaluateAction("remoteUserAuthenticationAction"));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR,
                     getStartState(flow).getId()));
             setStartState(flow, actionState);

--- a/support/cas-server-support-wsfederation-webflow/src/main/java/org/apereo/cas/web/flow/WsFederationWebflowConfigurer.java
+++ b/support/cas-server-support-wsfederation-webflow/src/main/java/org/apereo/cas/web/flow/WsFederationWebflowConfigurer.java
@@ -34,7 +34,7 @@ public class WsFederationWebflowConfigurer extends AbstractCasWebflowConfigurer 
             createEndState(flow, WS_FEDERATION_REDIRECT, "flowScope.WsFederationIdentityProviderUrl", true);
             final ActionState actionState = createActionState(flow, WS_FEDERATION_ACTION, createEvaluateAction(WS_FEDERATION_ACTION));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, WS_FEDERATION_REDIRECT));
 
             final String currentStartState = getStartState(flow).getId();

--- a/support/cas-server-support-x509-webflow/src/main/java/org/apereo/cas/web/flow/X509WebflowConfigurer.java
+++ b/support/cas-server-support-x509-webflow/src/main/java/org/apereo/cas/web/flow/X509WebflowConfigurer.java
@@ -51,7 +51,7 @@ public class X509WebflowConfigurer extends AbstractCasWebflowConfigurer {
         if (flow != null) {
             final ActionState actionState = createActionState(flow, EVENT_ID_START_X509, createEvaluateAction("x509Check"));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS,
-                    CasWebflowConstants.TRANSITION_ID_SEND_TICKET_GRANTING_TICKET));
+                    CasWebflowConstants.STATE_ID_SEND_TICKET_GRANTING_TICKET));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_WARN,
                     CasWebflowConstants.TRANSITION_ID_WARN));
             actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR,


### PR DESCRIPTION
`TRANSITION_ID_SEND_TICKET_GRANTING_TICKET` duplicated `STATE_ID_SEND_TICKET_GRANTING_TICKET`.

The pattern for naming CAS webflow constants is to use `STATE_ID_` for any state id's. So, consolidate the duplicate constants to that.