### PR TITLE
Delete spring.factories from api/cas-server-core-api-configuration

### DIFF
--- a/api/cas-server-core-api-configuration/src/main/resources/META-INF/spring.factories
+++ b/api/cas-server-core-api-configuration/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.cloud.bootstrap.BootstrapConfiguration=org.apereo.cas.configuration.config.CasCoreBootstrapStandaloneConfiguration


### PR DESCRIPTION
This is duplicated in the core/cas-server-core-configuration