### PR TITLE
fixed dynamic theme

### DIFF
--- a/support/cas-server-support-themes/src/main/java/org/apereo/cas/services/web/ServiceThemeResolver.java
+++ b/support/cas-server-support-themes/src/main/java/org/apereo/cas/services/web/ServiceThemeResolver.java
@@ -133,7 +133,7 @@ public class ServiceThemeResolver extends AbstractThemeResolver {
             LOGGER.debug("Service [{}] is configured to use a custom theme [{}]", rService, rService.getTheme());
             
             final Resource resource = ResourceUtils.getRawResourceFrom(rService.getTheme());
-            if (resource instanceof FileSystemResource) {
+            if (resource instanceof FileSystemResource && resource.exists()) {
                 LOGGER.debug("Executing groovy script to determine theme for [{}]", service.getId());
                 final String result = ScriptingUtils.executeGroovyScript(resource, new Object[]{service, rService,
                         request.getQueryString(), HttpRequestUtils.getRequestHeaders(request), LOGGER}, String.class);


### PR DESCRIPTION
fixed dynamic theme, execute grovvy script if it exists.

by default, `ResourceUtils.getRawResourceFrom(rService.getTheme())` is return a `FileSystemResource `, But  do not want to a `FileSystemResource` that is a ordinary theme name. so execute groovy script if it is exists.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
