### PR TITLE
RestfulAttribute case string exception

### DIFF
--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
@@ -47,7 +47,7 @@ public class ReturnRestfulAttributeReleasePolicy extends AbstractRegisteredServi
         try (StringWriter writer = new StringWriter()) {
             MAPPER.writer(new MinimalPrettyPrinter()).writeValue(writer, attributes);
             final HttpResponse response = HttpUtils.executePost(this.endpoint, writer.toString(),
-                    CollectionUtils.wrap("principal", principal.getId(), "service", service.getId()));
+                    CollectionUtils.wrap("principal", principal.getId(), "service", String.valueOf(service.getId())));
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
                 return MAPPER.readValue(response.getEntity().getContent(),
                         new TypeReference<Map<String, Object>>() {

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
@@ -47,7 +47,7 @@ public class ReturnRestfulAttributeReleasePolicy extends AbstractRegisteredServi
         try (StringWriter writer = new StringWriter()) {
             MAPPER.writer(new MinimalPrettyPrinter()).writeValue(writer, attributes);
             final HttpResponse response = HttpUtils.executePost(this.endpoint, writer.toString(),
-                    CollectionUtils.wrap("principal", principal.getId(), "service", String.valueOf(service.getId())));
+                    CollectionUtils.wrap("principal", principal.getId(), "service", service.getServiceId()));
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
                 return MAPPER.readValue(response.getEntity().getContent(),
                         new TypeReference<Map<String, Object>>() {


### PR DESCRIPTION
https://github.com/apereo/cas/blob/3c23af44fcb69e4918fcea8da8f86738acd75702/core/cas-server-core-util/src/main/java/org/apereo/cas/util/HttpUtils.java#L81

---
`service.getId()` is long type. 
There will be case string exception, there require string type.

It is require string before append params to url.



<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
