### PR TITLE
Fix handling of MongoDB connection string (clientUri) in MongoDbConnectionFactory

### DIFF
--- a/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/MongoDbConnectionFactory.java
+++ b/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/MongoDbConnectionFactory.java
@@ -286,13 +286,8 @@ public class MongoDbConnectionFactory {
     }
 
     private Mongo buildMongoDbClient(final String clientUri, final MongoClientOptions clientOptions) {
-        final MongoClientURI uri = buildMongoClientURI(clientUri);
-        final MongoCredential credential = buildMongoCredential(uri);
-
-        final String hostUri = uri.getHosts().get(0);
-        final String[] host = hostUri.split(":");
-        final ServerAddress addr = new ServerAddress(host[0], host.length > 1 ? Integer.parseInt(host[1]) : DEFAULT_PORT);
-        return new MongoClient(addr, Collections.singletonList(credential), clientOptions);
+        final MongoClientURI uri = buildMongoClientURI(clientUri, clientOptions);
+        return new MongoClient(uri);
     }
 
     private MongoCredential buildMongoCredential(final MongoClientURI uri) {
@@ -306,5 +301,10 @@ public class MongoDbConnectionFactory {
 
     private MongoClientURI buildMongoClientURI(final String clientUri) {
         return new MongoClientURI(clientUri);
+    }
+
+    private MongoClientURI buildMongoClientURI(final String clientUri, final MongoClientOptions clientOptions) {
+        final MongoClientOptions.Builder builder = new MongoClientOptions.Builder(clientOptions);
+        return new MongoClientURI(clientUri, builder);
     }
 }


### PR DESCRIPTION
This patch corrects the handling of MongoDB connection strings in the **MongoDbConnectionFactory**.

## Background

When configuring CAS to work with MongoDB, you have a choice of

1. Using several properties of the form **${configurationKey}.mongo._whatever_** to specify the username, password, host(s), port(s), database name, replica set name, etc.  of the MongoDB instance, or
2. Specifying all of those values in the form of a [MongoDB connection string](https://docs.mongodb.com/v3.4/reference/connection-string/) to the **${configurationKey}.mongo.clientUri** property.

The MongoDB documentation recommends using a replica set in production. To configure a Mongo client (in this case, the java driver used by CAS) to use a replica set, you give it a comma-separated list of hosts (and ports, if non-standard ports are used) to connect to, so that it can reliably locate the replica set member currently operating as primary (which is the only member that can write to, and usually read from, the database).

CAS seems to work correctly when using the several properties approach (the list of hosts is set in the **${configurationKey}.mongo.host** property). But, when using the connection string approach, it only works if the first host in the list is the primary member--i.e., if the list is _primaryhost,secondaryhost1,secondaryhost2_. If the first server in the list is not the primary, i.e., if the list is  _secondaryhost1,primaryhost,secondaryhost2_ or _secondaryhost1,secondaryhost2,primaryhost_, CAS will fail because it is unable to locate the primary server. (I discovered this after accidentally causing my MongoDB replica set to elect a new primary--all of a sudden, the CAS server that had been working just fine an hour before wouldn't even start up.)

## The problem

In the **MongoDbConnectionFactory**, the code that handles the separate properties specification correctly splits the list of hosts (in **${configurationKey}.mongo.host**) at the commas, puts them into an array, and passes them all to the Mongo java driver to create the **MongoClient**.

But, the code that handles the connection string (**${configurationKey}.mongo.clientUri** property) doesn't do this. Instead, it takes only the first host in the list (discarding everything after the first comma), and passes that to the Mongo java driver to create the **MongoClient**. Since the driver is never told about the other servers in the replica set, it has no way to locate the primary member if the one host it was told about doesn't happen to be serving in that role.

## The fix

The incorrect code, in the version of **buildMongoDbClient()** that takes both a **MongoClientURI** (connection string) object and a **MongoClientOptions** object as arguments, does three things:
1. Extracts the list of hosts from the connection string and discards all but the first one.
2. Extracts the database access credentials from the connection string.
3. Calls **MongoClient()** with the (single) host, the credentials, and the client options as arguments.

I replaced (1) and (2) with a single call to a new version of **buildMongoClientUri()** that takes both a **MongoClientURI** object and a **MongoClientOptions** object (the original version only takes the **MongoClientURI**). This version uses a **MongoClientOptions.Builder** to pass those options to **MongoClientURI()** and return an "updated" object.

I replaced (3) with a different call to **MongoClient()** that takes the updated **MongoClientURI** object as its sole argument.

## Testing

I've tested this against my MongoDB setup and it seems to work correctly. I think it should be fine for all the CAS-specific uses of MongoDB that are controlled by [common properties](https://apereo.github.io/cas/development/installation/Configuration-Properties-Common.html#mongodb-configuration), since they're all handled by this code. The only bit I'm not so sure about would be whether this change would matter to Spring--e.g., for the  **cas.spring.cloud.mongo.uri** property. I can't imagine why it would matter, but I don't know enough about Spring to say for sure. 

## NOTE

I'm offering this patch against the 5.2.x branch because that's where the **MongoDbConnectionFactory** was introduced, and because I'm hoping I'm early enough to get it included in the 5.2.1 release. It probably also needs to be put into the master branch so that it's there for v5.3.0 and beyond, but I'm not sure if I'm supposed to do that as a separate pull request or it's something you guys will take care of without me doing anything.


