### PR TITLE
Apply PR#3090 from 5.2.x (fix clientUri handling in MongoDbConnectionFactory)

### DIFF
--- a/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/MongoDbConnectionFactory.java
+++ b/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/MongoDbConnectionFactory.java
@@ -40,7 +40,6 @@ import javax.net.ssl.SSLSocketFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -286,13 +285,8 @@ public class MongoDbConnectionFactory {
     }
 
     private Mongo buildMongoDbClient(final String clientUri, final MongoClientOptions clientOptions) {
-        final MongoClientURI uri = buildMongoClientURI(clientUri);
-        final MongoCredential credential = buildMongoCredential(uri);
-
-        final String hostUri = uri.getHosts().get(0);
-        final String[] host = hostUri.split(":");
-        final ServerAddress addr = new ServerAddress(host[0], host.length > 1 ? Integer.parseInt(host[1]) : DEFAULT_PORT);
-        return new MongoClient(addr, Collections.singletonList(credential), clientOptions);
+        final MongoClientURI uri = buildMongoClientURI(clientUri, clientOptions);
+        return new MongoClient(uri);
     }
 
     private MongoCredential buildMongoCredential(final MongoClientURI uri) {
@@ -306,5 +300,10 @@ public class MongoDbConnectionFactory {
 
     private MongoClientURI buildMongoClientURI(final String clientUri) {
         return new MongoClientURI(clientUri);
+    }
+
+    private MongoClientURI buildMongoClientURI(final String clientUri, final MongoClientOptions clientOptions) {
+        final MongoClientOptions.Builder builder = new MongoClientOptions.Builder(clientOptions);
+        return new MongoClientURI(clientUri, builder);
     }
 }


### PR DESCRIPTION
This patch applies the same fix to MongoDbConnectionFactory that PR#3090 applied in the 5.2.x branch.

Briefly, it corrects the way MongoDbConnectionFactory processes MongoDb connection strings (essentially by removing the code that "messed with" them and instead just passing them to the Mongo java driver to deal with).

Note: I included Misagh's change to the original patch that cleans up the extra import statement that was causing checkstyle to fail.
