### PR TITLE
LDAP Tests - parallel issue?

### DIFF
--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
@@ -43,7 +43,7 @@ public class CasConfigurationJasyptCipherExecutorTests {
     public void verifyDecryptionEncryptionPairNotNeeded() {
         final String result = jasypt.decryptValue("keyValue");
         assertNotNull(result);
-        assertEquals(result, "keyValue");
+        assertEquals("keyValue", result);
 
     }
 

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/adaptors/ldap/AbstractLdapTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/adaptors/ldap/AbstractLdapTests.java
@@ -1,12 +1,12 @@
 package org.apereo.cas.adaptors.ldap;
 
-import org.apereo.cas.util.ldap.uboundid.InMemoryTestLdapDirectoryServer;
-import org.ldaptive.LdapEntry;
-import org.springframework.core.io.ClassPathResource;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apereo.cas.util.ldap.uboundid.InMemoryTestLdapDirectoryServer;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * Base class for LDAP tests that provision and de-provision DIRECTORY data as part of test setup/teardown.
@@ -16,16 +16,17 @@ import java.util.Collection;
  */
 public abstract class AbstractLdapTests {
 
-    protected static InMemoryTestLdapDirectoryServer DIRECTORY;
+    private static Map<Integer, InMemoryTestLdapDirectoryServer> DIRECTORY_MAP = new HashMap<>();
 
     public static synchronized void initDirectoryServer(final InputStream ldifFile,
                                                         final int port) {
         try {
-            final boolean createInstance = DIRECTORY == null || !DIRECTORY.isAlive();
+            final InMemoryTestLdapDirectoryServer directory = DIRECTORY_MAP.get(port);
+            final boolean createInstance = directory == null || !directory.isAlive();
             if (createInstance) {
                 final ClassPathResource properties = new ClassPathResource("ldapserver.properties");
                 final ClassPathResource schema = new ClassPathResource("schema/standard-ldap.schema");
-                DIRECTORY = new InMemoryTestLdapDirectoryServer(properties.getInputStream(), ldifFile, schema.getInputStream(), port);
+                DIRECTORY_MAP.put(port, new InMemoryTestLdapDirectoryServer(properties.getInputStream(), ldifFile, schema.getInputStream(), port));
             }
         } catch (final Exception e) {
             throw new IllegalArgumentException(e.getMessage(), e);
@@ -36,15 +37,11 @@ public abstract class AbstractLdapTests {
         initDirectoryServer(new ClassPathResource("ldif/ldap-base.ldif").getInputStream(), port);
     }
 
-    public static void initDirectoryServer() throws IOException {
-        initDirectoryServer(1389);
+    protected static InMemoryTestLdapDirectoryServer getDirectory(final int port) {
+        return getLdapDirectory(port);
     }
 
-    protected static InMemoryTestLdapDirectoryServer getDirectory() {
-        return DIRECTORY;
-    }
-
-    protected Collection<LdapEntry> getEntries() {
-        return DIRECTORY.getLdapEntries();
+    protected static InMemoryTestLdapDirectoryServer getLdapDirectory(final int port) {
+        return DIRECTORY_MAP.get(port);
     }
 }

--- a/support/cas-server-support-throttle-jdbc/src/main/java/org/apereo/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
+++ b/support/cas-server-support-throttle-jdbc/src/main/java/org/apereo/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapter.java
@@ -36,7 +36,6 @@ public class InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptor
     private static final double NUMBER_OF_MILLISECONDS_IN_SECOND = 1000.0;
 
     private static final String INSPEKTR_ACTION_THROTTLED = "THROTTLED_LOGIN_ATTEMPT";
-    private static final String INSPEKTR_ACTION_FAILED = "FAILED_LOGIN_ATTEMPT";
     
     private final AuditTrailManager auditTrailManager;
     private final DataSource dataSource;
@@ -106,7 +105,7 @@ public class InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptor
     @Override
     public void recordSubmissionFailure(final HttpServletRequest request) {
         super.recordSubmissionFailure(request);
-        recordAnyAction(request, INSPEKTR_ACTION_FAILED, "recordSubmissionFailure()");
+        recordAnyAction(request, this.authenticationFailureCode, "recordSubmissionFailure()");
     }
 
     @Override

--- a/support/cas-server-support-throttle-jdbc/src/test/java/org/apereo/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapterTests.java
+++ b/support/cas-server-support-throttle-jdbc/src/test/java/org/apereo/cas/web/support/InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapterTests.java
@@ -91,6 +91,7 @@ public class InspektrThrottledSubmissionByIpAddressAndUsernameHandlerInterceptor
         request.setMethod("POST");
         request.setParameter("username", username);
         request.setRemoteAddr(fromAddress);
+        request.setRequestURI("/cas/login");
         final MockRequestContext context = new MockRequestContext();
         context.setCurrentEvent(new Event(StringUtils.EMPTY, "error"));
         request.setAttribute("flowRequestContext", context);

--- a/support/cas-server-support-throttle-jdbc/src/test/resources/casthrottle.properties
+++ b/support/cas-server-support-throttle-jdbc/src/test/resources/casthrottle.properties
@@ -1,3 +1,4 @@
 cas.authn.throttle.failure.rangeSeconds=5
 cas.authn.throttle.failure.threshold=10
 cas.authn.throttle.usernameParameter=username
+cas.authn.throttle.failure.code=AUTHENTICATION_FAILED

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/handler/support/AbstractX509LdapTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/handler/support/AbstractX509LdapTests.java
@@ -19,10 +19,10 @@ public abstract class AbstractX509LdapTests extends AbstractLdapTests {
 
     private static final String DN = "CN=x509,ou=people,dc=example,dc=org";
     
-    public static void bootstrap() {
+    public static void bootstrap(final int port) {
         try {
-            getDirectory().populateEntries(new ClassPathResource("ldif/users-x509.ldif").getInputStream());
-            populateCertificateRevocationListAttribute();
+            getDirectory(port).populateEntries(new ClassPathResource("ldif/users-x509.ldif").getInputStream());
+            populateCertificateRevocationListAttribute(port);
         } catch (final Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -36,8 +36,8 @@ public abstract class AbstractX509LdapTests extends AbstractLdapTests {
      * without dependencies on the classpath and or filesystem.
      * @throws Exception the exception
      */
-    private static void populateCertificateRevocationListAttribute() throws Exception {
-        final Collection<LdapEntry> col = getDirectory().getLdapEntries();
+    private static void populateCertificateRevocationListAttribute(final int port) throws Exception {
+        final Collection<LdapEntry> col = getDirectory(port).getLdapEntries();
         for (final LdapEntry ldapEntry : col) {
             if (ldapEntry.getDn().equals(DN)) {
                 final LdapAttribute attr = new LdapAttribute(true);
@@ -47,7 +47,7 @@ public abstract class AbstractX509LdapTests extends AbstractLdapTests {
                 value = EncodingUtils.encodeBase64ToByteArray(value);
                 attr.setName("certificateRevocationList");
                 attr.addBinaryValue(value);
-                LdapTestUtils.modifyLdapEntry(getDirectory().getConnection(), ldapEntry, attr);
+                LdapTestUtils.modifyLdapEntry(getDirectory(port).getConnection(), ldapEntry, attr);
 
             }
         }

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/ldap/LdaptiveResourceCRLFetcherTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/authentication/ldap/LdaptiveResourceCRLFetcherTests.java
@@ -69,7 +69,9 @@ import java.security.cert.X509Certificate;
 @TestPropertySource(locations = {"classpath:/x509.properties"})
 @EnableScheduling
 public class LdaptiveResourceCRLFetcherTests extends AbstractX509LdapTests {
-    
+
+    private static final int LDAP_PORT = 1389;
+
     @Autowired
     @Qualifier("crlFetcher")
     private CRLFetcher fetcher;
@@ -84,8 +86,8 @@ public class LdaptiveResourceCRLFetcherTests extends AbstractX509LdapTests {
     
     @BeforeClass
     public static void bootstrapTests() throws Exception {
-        initDirectoryServer();
-        AbstractX509LdapTests.bootstrap();
+        initDirectoryServer(LDAP_PORT);
+        AbstractX509LdapTests.bootstrap(LDAP_PORT);
     }
 
     @Test


### PR DESCRIPTION
I looked into the ldap tests having issues when running in parallel and I made a change thinking that the tests were running in parallel in the same JVM (where static variables might be issue) but I realize now they are running in parallel in different JVMs. I think there may still be a case where if two different LDAP tests (using different servers running on different ports) both happened to run in same JVM then the initDirectoryServer() method wouldn't create a new server (with new port) if there was already another server running (DIRECTORY !=null). This change keeps DIRECTORYs in a map with the port as key so as long as different test classes use different ports for their servers then there should be no risk of them using the wrong one. If this isn't the issue then please ignore.  This change includes my other pull request regarding throttling. 