### PR TITLE
JWT validation

### DIFF
--- a/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTServiceTicketResourceEntityResponseFactory.java
+++ b/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTServiceTicketResourceEntityResponseFactory.java
@@ -8,7 +8,6 @@ import org.apereo.cas.services.RegisteredServiceAccessStrategyUtils;
 import org.apereo.cas.services.RegisteredServiceProperty;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.rest.factory.DefaultServiceTicketResourceEntityResponseFactory;
-import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.token.TokenTicketBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,17 +26,13 @@ public class JWTServiceTicketResourceEntityResponseFactory extends DefaultServic
      */
     private final TokenTicketBuilder tokenTicketBuilder;
 
-    private final TicketRegistrySupport ticketRegistrySupport;
-
     private final ServicesManager servicesManager;
 
     public JWTServiceTicketResourceEntityResponseFactory(final CentralAuthenticationService centralAuthenticationService,
                                                          final TokenTicketBuilder tokenTicketBuilder,
-                                                         final TicketRegistrySupport ticketRegistrySupport,
                                                          final ServicesManager servicesManager) {
         super(centralAuthenticationService);
         this.tokenTicketBuilder = tokenTicketBuilder;
-        this.ticketRegistrySupport = ticketRegistrySupport;
         this.servicesManager = servicesManager;
     }
 

--- a/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTTicketGrantingTicketResourceEntityResponseFactory.java
+++ b/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTTicketGrantingTicketResourceEntityResponseFactory.java
@@ -2,7 +2,6 @@ package org.apereo.cas.tokens;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.rest.factory.DefaultTicketGrantingTicketResourceEntityResponseFactory;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.token.TokenConstants;
@@ -25,15 +24,12 @@ import javax.servlet.http.HttpServletRequest;
 public class JWTTicketGrantingTicketResourceEntityResponseFactory extends DefaultTicketGrantingTicketResourceEntityResponseFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(JWTTicketGrantingTicketResourceEntityResponseFactory.class);
     
-    private final ServicesManager servicesManager;
-
     /**
      * The ticket builder that produces tokens.
      */
     private final TokenTicketBuilder tokenTicketBuilder;
     
-    public JWTTicketGrantingTicketResourceEntityResponseFactory(final ServicesManager servicesManager, final TokenTicketBuilder tokenTicketBuilder) {
-        this.servicesManager = servicesManager;
+    public JWTTicketGrantingTicketResourceEntityResponseFactory(final TokenTicketBuilder tokenTicketBuilder) {
         this.tokenTicketBuilder = tokenTicketBuilder;
     }
 

--- a/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTTicketStatusResourcePreprocessor.java
+++ b/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTTicketStatusResourcePreprocessor.java
@@ -1,0 +1,52 @@
+package org.apereo.cas.tokens;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.CipherExecutor;
+import org.apereo.cas.support.rest.factory.TicketStatusResourcePreprocessor;
+import org.apereo.cas.token.TokenConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is {@link JWTTicketStatusResourcePreprocessor}.
+ *
+ * @author Francesco Chicchiriccò
+ * @since 5.2.2
+ */
+public class JWTTicketStatusResourcePreprocessor implements TicketStatusResourcePreprocessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JWTTicketStatusResourcePreprocessor.class);
+
+    private final CipherExecutor<String, String> tokenCipherExecutor;
+
+    public JWTTicketStatusResourcePreprocessor(final CipherExecutor<String, String> tokenCipherExecutor) {
+        this.tokenCipherExecutor = tokenCipherExecutor;
+    }
+
+    @Override
+    public String preprocess(final String id, final HttpServletRequest request) {
+        String tokenParam = request.getParameter(TokenConstants.PARAMETER_NAME_TOKEN);
+        if (StringUtils.isBlank(tokenParam)) {
+            tokenParam = request.getHeader(TokenConstants.PARAMETER_NAME_TOKEN);
+        }
+        if (StringUtils.isBlank(tokenParam) || !BooleanUtils.toBoolean(tokenParam)) {
+            LOGGER.debug("The request indicates that ticket-granting ticket should not be extracted from JWT");
+            return id;
+        }
+
+        JWTClaimsSet claimsSet;
+        try {
+            String jwtJson = tokenCipherExecutor.decode(id);
+            claimsSet = JWTClaimsSet.parse(jwtJson);
+        } catch (Exception e) {
+            LOGGER.error("Could not extract JWT from {}", id, e);
+            return id;
+        }
+
+        return claimsSet.getJWTID();
+    }
+
+}

--- a/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTTicketStatusResourcePreprocessor.java
+++ b/support/cas-server-support-rest-tokens/src/main/java/org/apereo/cas/tokens/JWTTicketStatusResourcePreprocessor.java
@@ -37,11 +37,11 @@ public class JWTTicketStatusResourcePreprocessor implements TicketStatusResource
             return id;
         }
 
-        JWTClaimsSet claimsSet;
+        final JWTClaimsSet claimsSet;
         try {
-            String jwtJson = tokenCipherExecutor.decode(id);
+            final String jwtJson = tokenCipherExecutor.decode(id);
             claimsSet = JWTClaimsSet.parse(jwtJson);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             LOGGER.error("Could not extract JWT from {}", id, e);
             return id;
         }

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/config/CasRestConfiguration.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/config/CasRestConfiguration.java
@@ -29,6 +29,8 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apereo.cas.support.rest.factory.DefaultTicketStatusResourcePreprocessor;
+import org.apereo.cas.support.rest.factory.TicketStatusResourcePreprocessor;
 
 /**
  * This is {@link CasRestConfiguration}.
@@ -72,7 +74,15 @@ public class CasRestConfiguration extends WebMvcConfigurerAdapter {
 
     @Bean
     public TicketStatusResource ticketStatusResource() {
-        return new TicketStatusResource(centralAuthenticationService);
+        return new TicketStatusResource(
+                centralAuthenticationService,
+                applicationContext.getBean("ticketStatusResourcePreprocessor", TicketStatusResourcePreprocessor.class));
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "ticketStatusResourcePreprocessor")
+    public TicketStatusResourcePreprocessor ticketStatusResourcePreprocessor() {
+        return new DefaultTicketStatusResourcePreprocessor();
     }
 
     @Bean
@@ -96,7 +106,8 @@ public class CasRestConfiguration extends WebMvcConfigurerAdapter {
     @Bean
     public TicketGrantingTicketResource ticketResourceRestController() {
         return new TicketGrantingTicketResource(authenticationSystemSupport, credentialFactory,
-                centralAuthenticationService, webApplicationServiceFactory, ticketGrantingTicketResourceEntityResponseFactory());
+                centralAuthenticationService, webApplicationServiceFactory,
+                ticketGrantingTicketResourceEntityResponseFactory());
     }
 
     @ConditionalOnMissingBean(name = "restAuthenticationThrottle")
@@ -107,10 +118,11 @@ public class CasRestConfiguration extends WebMvcConfigurerAdapter {
             return this.applicationContext.getBean(throttler, HandlerInterceptor.class);
         }
         return new HandlerInterceptorAdapter() {
+
             @Override
             public boolean preHandle(final HttpServletRequest request,
-                                     final HttpServletResponse response,
-                                     final Object handler) {
+                    final HttpServletResponse response,
+                    final Object handler) {
                 return true;
             }
         };

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/factory/DefaultTicketStatusResourcePreprocessor.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/factory/DefaultTicketStatusResourcePreprocessor.java
@@ -1,0 +1,18 @@
+package org.apereo.cas.support.rest.factory;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This is {@link DefaultTicketStatusResourcePreprocessor}.
+ *
+ * @author Francesco Chicchiriccò
+ * @since 5.2.2
+ */
+public class DefaultTicketStatusResourcePreprocessor implements TicketStatusResourcePreprocessor {
+
+    @Override
+    public String preprocess(final String id, final HttpServletRequest request) {
+        return id;
+    }
+
+}

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/factory/TicketStatusResourcePreprocessor.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/factory/TicketStatusResourcePreprocessor.java
@@ -1,0 +1,22 @@
+package org.apereo.cas.support.rest.factory;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This is {@link TicketStatusResourcePreprocessor}.
+ *
+ * @author Francesco Chicchiriccò
+ * @since 5.2.2
+ */
+@FunctionalInterface
+public interface TicketStatusResourcePreprocessor {
+
+    /**
+     * Preprocess the ticket id before validation.
+     *
+     * @param id ticket id
+     * @param request raw HttpServletRequest used to call this method
+     * @return the ticket id after preprocessing
+     */
+    String preprocess(String id, HttpServletRequest request);
+}


### PR DESCRIPTION
`cas-server-support-rest-tokens` allows to enhance the REST resources provided by `cas-server-support-rest` with JWT support.
This works fine for creating TGTs and STs, but not for validation since `TicketStatusResource` is token-unaware.

This PR provides support for usage of a `TicketStatusResourcePreprocessor` instance before actual validation takes place; in case of JWT, `JWTTicketStatusResourcePreprocessor` is provided, which extracts the token id from the provided JWT.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
