### PR TITLE
Add known bugs section

### DIFF
--- a/docs/cas-server-documentation/installation/Surrogate-Authentication.md
+++ b/docs/cas-server-documentation/installation/Surrogate-Authentication.md
@@ -27,6 +27,10 @@ Surrogate authentication is enabled by including the following dependencies in t
 </dependency>
 ```
 
+## Known bugs
+
+Surrogate authentication doesn't play well with multifactor authentication, as implementation is intercepting actual webflow.
+
 ## Account Storage
 
 The following account stores may be configured and used to locate surrogates authorized for a particular user.


### PR DESCRIPTION
I understand reasoning behind disabling issues for project CAS, yet I am missing channel to signaling known bugs/shortcommings to configurators of CAS. 

I propose to use documentation pages for improving such situation.

As surrogate authentication is intercepting usual handling of login flow and provided is Credential object is different from expected in MFA webflow screens - for example missing token field.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
