### PR TITLE
Fix the REST mfa bypass call

### DIFF
--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/RestMultifactorAuthenticationProviderBypass.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/RestMultifactorAuthenticationProviderBypass.java
@@ -39,8 +39,7 @@ public class RestMultifactorAuthenticationProviderBypass extends DefaultMultifac
                             + "service [{}] and provider [{}] via REST endpoint [{}]",
                     principal.getId(), registeredService, provider, rest.getUrl());
 
-            final Map<String, String> parameters = CollectionUtils.wrap("principal", CollectionUtils.wrap(principal.getId()),
-                    "provider", CollectionUtils.wrap(provider.getId()));
+            final Map<String, String> parameters = CollectionUtils.wrap("principal", principal.getId(), "provider", provider.getId());
             if (registeredService != null) {
                 parameters.put("service", registeredService.getServiceId());
             }


### PR DESCRIPTION
Currently, the parameters are added as lists which generates the following error:

```java
2018-01-03 13:04:13,374 ERROR [org.apereo.cas.util.HttpUtils] - <java.util.ArrayList cannot be cast to java.lang.String>
java.lang.ClassCastException: java.util.ArrayList cannot be cast to java.lang.String
  at java.util.HashMap.forEach(HashMap.java:1280) ~[?:1.8.0_77]
  at org.apereo.cas.util.HttpUtils.buildHttpUri(HttpUtils.java:81) ~[cas-server-core-util-5.2.1.jar:5.2.1]
  at org.apereo.cas.util.HttpUtils.execute(HttpUtils.java:69) ~[cas-server-core-util-5.2.1.jar:5.2.1]
  at org.apereo.cas.authentication.RestMultifactorAuthenticationProviderBypass.shouldMultifactorAuthenticationProviderExecute(RestMultifactorAuthenticationProviderBypass.java:48) ~[cas-server-core-authentication-mfa-5.2.1.
````
This PR fixes this bug.