### PR TITLE
fix bug with oidc

### DIFF
--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/TerminateSessionAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/TerminateSessionAction.java
@@ -106,6 +106,10 @@ public class TerminateSessionAction extends AbstractAction {
         final HttpSession session = request.getSession();
         if (session != null) {
             session.invalidate();
+            final String requestedUrl=request.getSession().getAttribute("pac4jRequestedUrl").toString();        	
+            session.invalidate();
+            // copy pac4jRequestedUrl in  new session 
+            request.getSession(true).setAttribute("pac4jRequestedUrl", requestedUrl);
         }
     }
 


### PR DESCRIPTION
# 1 copy pac4jRequestedUrl  from the old session to the new session  
 when TGC expired and destroy the old session, the callback url will lose  , the controller "callbackAuthorize" will redirect the user to the default url "/"  after reauthentication when use OAuth/OIDC  protocal ,
To solve this problem we need copy pac4jRequestedUrl  from the old session to the new session


# 2 check if CasAuthentication Available 
when TGC expired  the accessToken geneated is invalid，so we need check the CasAuthentication at first


#  3 Comment some code with bugs
```
if (!clearCreds) {
              clearCreds = prompts.contains(OidcConstants.PROMPT_LOGIN);
          }
```
will result in a loop authenitcation


  
  