### PR TITLE
Trap ClassCastExceptions caused by non-String YAML properties

### DIFF
--- a/api/cas-server-core-api-util/src/main/java/org/apereo/cas/CipherExecutor.java
+++ b/api/cas-server-core-api-util/src/main/java/org/apereo/cas/CipherExecutor.java
@@ -51,11 +51,16 @@ public interface CipherExecutor<I, O> {
     default Map<String, Object> decode(Map<String, Object> properties) {
         final Map<String, Object> decrypted = new HashMap<>();
         properties.forEach((key, value) -> {
-            LOGGER.debug("Attempting to decode key [{}]", key);
-            final Object result = decode((I) value);
-            if (result != null) {
-                LOGGER.debug("Decrypted key [{}] successfully", key);
-                decrypted.put(key, result);
+            try {
+                LOGGER.debug("Attempting to decode key [{}]", key);
+                final Object result = decode((I) value);
+                if (result != null) {
+                    LOGGER.debug("Decrypted key [{}] successfully", key);
+                    decrypted.put(key, result);
+                }
+            } catch(ClassCastException e) {
+                LOGGER.debug("Value of key {}, is not the correct type, not decrypting, but using value as-is.", key);
+                decrypted.put(key, value);
             }
         });
         return decrypted;


### PR DESCRIPTION
... or more broadly, ClassCastExceptions thrown when a property value's type doesn't match the decryptor.  In the spirit of #2474, but in a way that will work with the use of Generics that have been included since then.



