### PR TITLE
5.2.x Mgmt App Fixes

### DIFF
--- a/webapp-mgmt/cas-management-webapp/src/app/form/access-strategy/access-strategy.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/access-strategy/access-strategy.component.html
@@ -43,7 +43,9 @@
     <h5>Required Attributes</h5>
   </mat-card-title>
   <div class="cardContent">
-    <app-rejectedattributes [attributes]="data.service.accessStrategy.requiredAttributes"></app-rejectedattributes>
+    <app-rejectedattributes [attributes]="data.service.accessStrategy.requiredAttributes"
+                            [attributeNames]="data.formData.availableAttributes">
+    </app-rejectedattributes>
     <div>
       <mat-checkbox [(ngModel)]="data.service.accessStrategy.caseInsensitive">
         <ng-container i18n="services.form.label.sas.caseinsensitive">

--- a/webapp-mgmt/cas-management-webapp/src/app/form/access-strategy/access-strategy.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/access-strategy/access-strategy.component.ts
@@ -6,7 +6,6 @@ import {
   TimeBasedRegisteredServiceAccessStrategy
 } from '../../../domain/access-strategy';
 import {FormData} from '../../../domain/form-data';
-import {AbstractRegisteredService} from '../../../domain/registered-service';
 import {Util} from '../../util/util';
 import {Data} from '../data';
 
@@ -45,9 +44,9 @@ export class AccessStrategyComponent implements OnInit {
       service.accessStrategy.requiredAttributes = new Map();
     }
 
-    this.formData.availableAttributes.forEach((item: any) => {
-      service.accessStrategy.requiredAttributes[item] = service.accessStrategy.requiredAttributes[item] || [item];
-    });
+    if (Util.isEmpty(service.accessStrategy.requiredAttributes)) {
+      service.accessStrategy.requiredAttributes = new Map();
+    }
 
     if (RemoteEndpointServiceAccessStrategy.instanceOf(service.accessStrategy)) {
       this.type = Type.REMOTE;

--- a/webapp-mgmt/cas-management-webapp/src/app/form/attribute-release-policies/attribute-release-policies.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/attribute-release-policies/attribute-release-policies.component.html
@@ -54,8 +54,10 @@
   </mat-icon>
 </div>
 
-<div *ngIf="type == TYPE.RETURN_MAPPED && !isEmpty( formData.availableAttributes )">
-  <app-mappedattributes [attributes]="data.service.attributeReleasePolicy.allowedAttributes"></app-mappedattributes>
+<div *ngIf="type == TYPE.RETURN_MAPPED">
+  <app-rejectedattributes [attributes]="data.service.attributeReleasePolicy.allowedAttributes"
+                          [attributeNames]="data.formData.availableAttributes">
+  </app-rejectedattributes>
 </div>
 
 <div *ngIf="type == TYPE.METADATA" style="padding-top:25px;">

--- a/webapp-mgmt/cas-management-webapp/src/app/form/attribute-release-policies/attribute-release-policies.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/attribute-release-policies/attribute-release-policies.component.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../domain/attribute-release';
 import {Data} from '../data';
 import {SamlRegisteredService} from '../../../domain/saml-service';
+import {Util} from '../../util/util';
 
 enum Type {
   RETURN_ALL,
@@ -56,9 +57,9 @@ export class AttributeReleasePoliciesComponent implements OnInit {
       this.type = Type.DENY_ALL;
     } else if (ReturnMappedAttributeReleasePolicy.instanceOf(this.data.service.attributeReleasePolicy)) {
       const mapped: ReturnMappedAttributeReleasePolicy = this.data.service.attributeReleasePolicy as ReturnMappedAttributeReleasePolicy;
-      this.formData.availableAttributes.forEach((item: any) => {
-        mapped.allowedAttributes[item] = mapped.allowedAttributes[item] || [item];
-      });
+      if (Util.isEmpty(mapped.allowedAttributes)) {
+        mapped.allowedAttributes = new Map();
+      }
       this.type = Type.RETURN_MAPPED;
     } else if (ReturnAllowedAttributeReleasePolicy.instanceOf(this.data.service.attributeReleasePolicy)) {
       this.type = Type.RETURN_ALLOWED;
@@ -112,9 +113,6 @@ export class AttributeReleasePoliciesComponent implements OnInit {
       case Type.RETURN_MAPPED :
         const mapped: ReturnMappedAttributeReleasePolicy = new ReturnMappedAttributeReleasePolicy(this.data.service.attributeReleasePolicy);
         mapped.allowedAttributes = new Map();
-        this.formData.availableAttributes.forEach((item: any) => {
-          mapped.allowedAttributes[item] = [item];
-        });
         this.data.service.attributeReleasePolicy = mapped;
         break;
       case Type.RETURN_ALLOWED :

--- a/webapp-mgmt/cas-management-webapp/src/app/form/form.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/form.component.html
@@ -88,6 +88,6 @@
     </mat-tab>
   </mat-tab-group>
 </div>
-<div style="position:relative;top:90px;margin-bottom:75px;">
+<div style="position:relative;top:90px;padding-bottom:75px;">
   <router-outlet name="form"></router-outlet>
 </div>

--- a/webapp-mgmt/cas-management-webapp/src/app/form/rejectedattributes/rejectedattributes.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/rejectedattributes/rejectedattributes.component.html
@@ -5,8 +5,8 @@
       <mat-header-cell *cdkHeaderCellDef [ngClass]="'nameWidth'">Name</mat-header-cell>
       <mat-cell *cdkCellDef="let row" [ngClass]="'nameWidth'">
         <mat-form-field>
-          <input matInput #text
-                 [ngModel]="row.key"
+          <input matInput #text [matAutocomplete]="auto"
+                 [ngModel]="row.key" (click)="selectedRow = row"
                  (change)="doChange(row,$event.target.value)">
         </mat-form-field>
       </mat-cell>
@@ -38,3 +38,7 @@
     <button mat-mini-fab (click)="addRow()" style="float:right;">+</button>
   </div>
 </div>
+
+<mat-autocomplete #auto="matAutocomplete" (optionSelected)="selection($event)">
+  <mat-option *ngFor="let opt of attributeNames" [value]="opt">{{ opt }}</mat-option>
+</mat-autocomplete>

--- a/webapp-mgmt/cas-management-webapp/src/app/form/rejectedattributes/rejectedattributes.component.ts
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/rejectedattributes/rejectedattributes.component.ts
@@ -5,6 +5,7 @@ import 'rxjs/add/operator/startWith';
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/operator/map';
 import {Row, RowDataSource} from '../row';
+import {MatAutocompleteSelectedEvent} from '@angular/material';
 
 @Component({
   selector: 'app-rejectedattributes',
@@ -18,6 +19,11 @@ export class RejectedattributesComponent implements OnInit {
 
   @Input()
   attributes: Map<String, String[]>;
+
+  @Input()
+  attributeNames: String[];
+
+  selectedRow;
 
   constructor(public messages: Messages,
               public data: Data) {
@@ -44,5 +50,10 @@ export class RejectedattributesComponent implements OnInit {
   delete(row: Row) {
     delete this.attributes[row.key as string];
     this.dataSource.removeRow(row);
+  }
+
+  selection(val: MatAutocompleteSelectedEvent) {
+    const opt =  val.option.value;
+    this.doChange(this.selectedRow, opt)
   }
 }

--- a/webapp-mgmt/cas-management-webapp/src/app/services/services.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/services/services.component.html
@@ -10,7 +10,7 @@
   <div style="flex: 1 1 auto">
   </div>
   <div>
-    <app-controls></app-controls>
+    <app-controls showEdit="true"></app-controls>
   </div>
 </div>
 


### PR DESCRIPTION
This PR fixes the following issues in the CAS Management App reported by Arnold Bergner form the cas-user mailing list:

- editing or creating a service, “Access Strategy” tab, “Required Attribues” is pre-filled with name = value = attribute name for all available attributes. Before saving, I have to delete all these lines, or service access is not possible. It would be better if these lines were not there.

- duplicating a service, there is no “save” button, and the “require all attributes” flag is checked (this was a bug when creating a new service, too)

- the footer line is cutting off part of the forms. for some tabs, this makes it impossible to edit certain fields. (using firefox)
  