### PR TITLE
[5.2.x] SAML IdP: change backup file for URL metadata

### DIFF
--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.UUID;
 
 /**
  * This is {@link UrlResourceMetadataResolver}.
@@ -72,7 +71,7 @@ public class UrlResourceMetadataResolver extends BaseSamlRegisteredServiceMetada
         final File backupDirectory = new File(md.getLocation().getFile(), "metadata-backups");
         LOGGER.debug("Metadata backup directory is at [{}]", backupDirectory.getCanonicalPath());
 
-        final String metadataFileName = service.getName().concat("-").concat(UUID.randomUUID().toString()).concat(metadataResource.getFilename());
+        final String metadataFileName = service.getName().concat("-").concat(Long.toString(service.getId())).concat(metadataResource.getFilename());
         final File backupFile = new File(backupDirectory, metadataFileName);
         if (backupFile.exists()) {
             LOGGER.warn("Metadata file designated for service [{}] already exists at path [{}].", service.getName(), backupFile.getCanonicalPath());


### PR DESCRIPTION
I found that each login request by a SAML service triggers a file creation in /etc/cas/saml/metadata-backups/, thus filling up the directory over time. Every file is named `<service name>-<random-number>metadata`. The use of a random component causes the files to never be looked at for new requests (the opensaml resolver refreshes those files after some time) by CAS.

I’ve tried changing the random number to the service id, so that the number of files doesn’t explode. This seems to work fine. The opensaml resolver finds the file, but resolves metadata again nonetheless. I’m not sure if the file backup is actually used, because it gets refreshed for every login attempt. I wouldn’t mind this behavior though.

I’m wondering if this fix, using the service id, could cause any concurrency issues for multiple requests at the same time?

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
