### PR TITLE
Fix IgniteCheckException on startup due to duplicate cache names

### DIFF
--- a/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/config/IgniteTicketRegistryTicketCatalogConfiguration.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/config/IgniteTicketRegistryTicketCatalogConfiguration.java
@@ -32,7 +32,7 @@ public class IgniteTicketRegistryTicketCatalogConfiguration extends CasCoreTicke
 
     @Override
     protected void buildAndRegisterProxyTicketDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
-        metadata.getProperties().setStorageName("serviceTicketsCache");
+        metadata.getProperties().setStorageName("proxyTicketsCache");
         metadata.getProperties().setStorageTimeout(casProperties.getTicket().getPt().getTimeToKillInSeconds());
         super.buildAndRegisterServiceTicketDefinition(plan, metadata);
     }


### PR DESCRIPTION
Change on ProxyTicketDefinition storage name from "serviceTicketsCache" to "proxyTicketsCache" to fix duplicate cache name issue which raise IgniteCheckException on startup.

Best Regards,
Alexandre de Pellegrin

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
