### PR TITLE
Fix NPE on surrogate mail notification

### DIFF
--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/SurrogateAuthenticationEventListener.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/SurrogateAuthenticationEventListener.java
@@ -61,9 +61,14 @@ public class SurrogateAuthenticationEventListener {
         }
         if (communicationsManager.isMailSenderDefined()) {
             final EmailProperties mail = casProperties.getAuthn().getSurrogate().getMail();
-            final String to = principal.getAttributes().get(mail.getAttributeName()).toString();
-            final String text = mail.getText().concat("\n").concat(eventDetails);
-            this.communicationsManager.email(text, mail.getFrom(), mail.getSubject(), to, mail.getCc(), mail.getBcc());
+            final String emailAttribute = mail.getAttributeName();
+            final Object to = principal.getAttributes().get(emailAttribute);
+            if (to != null) {
+                final String text = mail.getText().concat("\n").concat(eventDetails);
+                this.communicationsManager.email(text, mail.getFrom(), mail.getSubject(), to.toString(), mail.getCc(), mail.getBcc());
+            } else {
+                LOGGER.trace("The principal has no {} attribute, cannot send email notification", emailAttribute);
+            }
         } else {
             LOGGER.trace("CAS is unable to send surrogate-authentication email messages given no settings are defined to account for servers, etc");
         }


### PR DESCRIPTION
When the principal has no email attribute, the `SurrogateAuthenticationEventListener` throws a NPE:


```java
2018-01-10 08:06:23,205 WARN [org.apereo.cas.web.flow.resolver.impl.InitialAuthenticationAttemptWebflowEventResolver] - <null>
java.lang.NullPointerException: null
  at org.apereo.cas.authentication.event.SurrogateAuthenticationEventListener.notify(SurrogateAuthenticationEventListener.java:64) ~[cas-server-support-surrogate-authentication-5.2.1.jar:5.2.1]
  at org.apereo.cas.authentication.event.SurrogateAuthenticationEventListener.handleSurrogateAuthenticationFailureEvent(SurrogateAuthenticationEventListener.java:40) ~[cas-server-support-surrogate-authentication-5.2.1.jar:5.2.1]

```