### PR TITLE
Fix JDBC Bind Authenticator

### DIFF
--- a/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/adaptors/jdbc/BindModeSearchDatabaseAuthenticationHandler.java
+++ b/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/adaptors/jdbc/BindModeSearchDatabaseAuthenticationHandler.java
@@ -1,9 +1,12 @@
 package org.apereo.cas.adaptors.jdbc;
 
+import com.zaxxer.hikari.util.DriverDataSource;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.authentication.AuthenticationHandlerExecutionResult;
 import org.apereo.cas.authentication.PreventedException;
 import org.apereo.cas.authentication.UsernamePasswordCredential;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
+import org.apereo.cas.configuration.model.support.jpa.AbstractJpaProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 
@@ -12,6 +15,8 @@ import javax.sql.DataSource;
 import java.security.GeneralSecurityException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
+
 
 /**
  * This class attempts to authenticate the user by opening a connection to the
@@ -26,9 +31,12 @@ import java.sql.SQLException;
  */
 public class BindModeSearchDatabaseAuthenticationHandler extends AbstractJdbcUsernamePasswordAuthenticationHandler {
 
+    private final AbstractJpaProperties connectionProps;
+
     public BindModeSearchDatabaseAuthenticationHandler(final String name, final ServicesManager servicesManager, final PrincipalFactory principalFactory,
-                                                       final Integer order, final DataSource dataSource) {
+                                                       final Integer order, final DataSource dataSource, final AbstractJpaProperties connectionProps) {
         super(name, servicesManager, principalFactory, order, dataSource);
+        this.connectionProps = connectionProps;
     }
 
     @Override
@@ -36,15 +44,26 @@ public class BindModeSearchDatabaseAuthenticationHandler extends AbstractJdbcUse
                                                                                         final String originalPassword)
         throws GeneralSecurityException, PreventedException {
 
-        if (getDataSource() == null) {
+        if (this.connectionProps.getUrl() == null) {
             throw new GeneralSecurityException("Authentication handler is not configured correctly");
         }
 
+        DriverDataSource dataSource = null;
         Connection connection = null;
         try {
+            final Properties properties = new Properties();
             final String username = credential.getUsername();
             final String password = credential.getPassword();
-            connection = this.getDataSource().getConnection(username, password);
+            String driverClass = null;
+
+            if (StringUtils.isNotBlank(this.connectionProps.getDriverClass())) {
+                driverClass = this.connectionProps.getDriverClass();
+            }
+            // Load the driver if not already loaded
+            Class.forName(driverClass);
+            dataSource = new DriverDataSource(this.connectionProps.getUrl(), driverClass, properties, username, password);
+            connection = dataSource.getConnection();
+
             return createHandlerResult(credential, this.principalFactory.createPrincipal(username), null);
         } catch (final SQLException e) {
             throw new FailedLoginException(e.getMessage());
@@ -52,7 +71,7 @@ public class BindModeSearchDatabaseAuthenticationHandler extends AbstractJdbcUse
             throw new PreventedException("Unexpected SQL connection error", e);
         } finally {
             if (connection != null) {
-                DataSourceUtils.releaseConnection(connection, this.getDataSource());
+                DataSourceUtils.releaseConnection(connection, dataSource);
             }
         }
     }

--- a/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
+++ b/support/cas-server-support-jdbc/src/main/java/org/apereo/cas/adaptors/jdbc/config/CasJdbcAuthenticationConfiguration.java
@@ -91,7 +91,7 @@ public class CasJdbcAuthenticationConfiguration {
 
     private AuthenticationHandler bindModeSearchDatabaseAuthenticationHandler(final BindJdbcAuthenticationProperties b) {
         final BindModeSearchDatabaseAuthenticationHandler h = new BindModeSearchDatabaseAuthenticationHandler(b.getName(), servicesManager,
-                jdbcPrincipalFactory(), b.getOrder(), JpaBeans.newDataSource(b));
+                jdbcPrincipalFactory(), b.getOrder(), JpaBeans.newDataSource(b), b);
         h.setPasswordEncoder(PasswordEncoderUtils.newPasswordEncoder(b.getPasswordEncoder()));
         h.setPrincipalNameTransformer(PrincipalNameTransformerUtils.newPrincipalNameTransformer(b.getPrincipalTransformation()));
 


### PR DESCRIPTION
If the underlying `DataSource` for `BindModeSearchDatabaseAuthenticationHandler` is a `HikariDataSource` then getConnection(user,pass) throws a `SQLFeatureNotSupportedException`.

Rework the code to avoid using `this.dataSource` and instead initialize it's own `DataSource`.