### PR TITLE
Add 'unauthorizedRedirectUrl' usable for pac4j module

### DIFF
--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/InitialFlowSetupAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/InitialFlowSetupAction.java
@@ -37,12 +37,12 @@ public class InitialFlowSetupAction extends AbstractAction {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InitialFlowSetupAction.class);
 
-    private final CasConfigurationProperties casProperties;
-    private final ServicesManager servicesManager;
-    private final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
-    private final CookieRetrievingCookieGenerator warnCookieGenerator;
-    private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
-    private final List<ArgumentExtractor> argumentExtractors;
+    protected CasConfigurationProperties casProperties;
+    protected ServicesManager servicesManager;
+    protected AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
+    protected CookieRetrievingCookieGenerator warnCookieGenerator;
+    protected CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
+    protected List<ArgumentExtractor> argumentExtractors;
 
     public InitialFlowSetupAction(final List<ArgumentExtractor> argumentExtractors,
                                   final ServicesManager servicesManager,
@@ -66,7 +66,7 @@ public class InitialFlowSetupAction extends AbstractAction {
         return success();
     }
 
-    private void configureWebflowContextForService(final RequestContext context) {
+    protected void configureWebflowContextForService(final RequestContext context) {
         final Service service = WebUtils.getService(this.argumentExtractors, context);
         if (service != null) {
             LOGGER.debug("Placing service in context scope: [{}]", service.getId());
@@ -96,7 +96,7 @@ public class InitialFlowSetupAction extends AbstractAction {
         WebUtils.putService(context, service);
     }
 
-    private void configureWebflowContext(final RequestContext context) {
+    protected void configureWebflowContext(final RequestContext context) {
         final HttpServletRequest request = WebUtils.getHttpServletRequestFromExternalWebflowContext(context);
         WebUtils.putTicketGrantingTicketInScopes(context, this.ticketGrantingTicketCookieGenerator.retrieveCookieValue(request));
         WebUtils.putGoogleAnalyticsTrackingIdIntoFlowScope(context, casProperties.getGoogleAnalytics().getGoogleAnalyticsTrackingId());
@@ -110,7 +110,7 @@ public class InitialFlowSetupAction extends AbstractAction {
         WebUtils.putRememberMeAuthenticationEnabled(context, casProperties.getTicket().getTgt().getRememberMe().isEnabled());
     }
 
-    private void configureCookieGenerators(final RequestContext context) {
+    protected void configureCookieGenerators(final RequestContext context) {
         final String contextPath = context.getExternalContext().getContextPath();
         final String cookiePath = StringUtils.isNotBlank(contextPath) ? contextPath + '/' : "/";
 

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java
@@ -153,7 +153,7 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
                     final TicketGrantingTicket tgt = this.centralAuthenticationService.createTicketGrantingTicket(authenticationResult);
                     WebUtils.putTicketGrantingTicketInScopes(context, tgt);
                 } catch (final PrincipalException e) {
-                    LOGGER.warn("Could not grant service ticket [{}]. Routing to [{}]", e.getMessage(), CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE);
+                    LOGGER.warn("PrincipalException caught on service [{}]", e.getMessage());
                     return newEvent(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, e);
                 }
                 return success();

--- a/support/cas-server-support-pac4j-webflow/build.gradle
+++ b/support/cas-server-support-pac4j-webflow/build.gradle
@@ -7,4 +7,7 @@ dependencies {
     implementation project(":support:cas-server-support-pac4j")
     implementation project(":support:cas-server-support-pac4j-core-clients")
     implementation project(":core:cas-server-core-web")
+    implementation project(":core:cas-server-core-util")
+    implementation project(":support:cas-server-support-cookie")
+    implementation project(":support:cas-server-support-actions")
 }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jInitialFlowSetupAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jInitialFlowSetupAction.java
@@ -8,11 +8,12 @@ import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceAccessStrategy;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.services.UnauthorizedServiceException;
+import org.apereo.cas.web.flow.InitialFlowSetupAction;
 import org.apereo.cas.web.support.ArgumentExtractor;
+import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.apereo.cas.web.support.WebUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.repository.NoSuchFlowExecutionException;
@@ -26,22 +27,31 @@ import java.util.List;
  * @author Francis Le Coq
  * @since 5.2
  */
-public class Pac4jInitialFlowSetupAction extends AbstractAction {
+public class Pac4jInitialFlowSetupAction extends InitialFlowSetupAction {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Pac4jInitialFlowSetupAction.class);
 
     private final CasConfigurationProperties casProperties;
     private final ServicesManager servicesManager;
     private final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
+    private final CookieRetrievingCookieGenerator warnCookieGenerator;
+    private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
     private final List<ArgumentExtractor> argumentExtractors;
 
     public Pac4jInitialFlowSetupAction(final List<ArgumentExtractor> argumentExtractors,
                                   final ServicesManager servicesManager,
                                   final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionPlan,
+                                  final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator,
+                                  final CookieRetrievingCookieGenerator warnCookieGenerator,
                                   final CasConfigurationProperties casProperties) {
+
+        super(argumentExtractors, servicesManager, authenticationRequestServiceSelectionPlan, ticketGrantingTicketCookieGenerator, warnCookieGenerator, casProperties);
+
         this.argumentExtractors = argumentExtractors;
         this.servicesManager = servicesManager;
         this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionPlan;
+        this.ticketGrantingTicketCookieGenerator = ticketGrantingTicketCookieGenerator;
+        this.warnCookieGenerator = warnCookieGenerator;
         this.casProperties = casProperties;
     }
 
@@ -79,9 +89,5 @@ public class Pac4jInitialFlowSetupAction extends AbstractAction {
                     new UnauthorizedServiceException("screen.service.required.message", "Service is required"));
         }
         WebUtils.putService(context, service);
-    }
-
-    public ServicesManager getServicesManager() {
-        return servicesManager;
     }
 }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jInitialFlowSetupAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jInitialFlowSetupAction.java
@@ -31,13 +31,6 @@ public class Pac4jInitialFlowSetupAction extends InitialFlowSetupAction {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Pac4jInitialFlowSetupAction.class);
 
-    private final CasConfigurationProperties casProperties;
-    private final ServicesManager servicesManager;
-    private final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
-    private final CookieRetrievingCookieGenerator warnCookieGenerator;
-    private final CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
-    private final List<ArgumentExtractor> argumentExtractors;
-
     public Pac4jInitialFlowSetupAction(final List<ArgumentExtractor> argumentExtractors,
                                   final ServicesManager servicesManager,
                                   final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionPlan,
@@ -46,48 +39,11 @@ public class Pac4jInitialFlowSetupAction extends InitialFlowSetupAction {
                                   final CasConfigurationProperties casProperties) {
 
         super(argumentExtractors, servicesManager, authenticationRequestServiceSelectionPlan, ticketGrantingTicketCookieGenerator, warnCookieGenerator, casProperties);
-
-        this.argumentExtractors = argumentExtractors;
-        this.servicesManager = servicesManager;
-        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionPlan;
-        this.ticketGrantingTicketCookieGenerator = ticketGrantingTicketCookieGenerator;
-        this.warnCookieGenerator = warnCookieGenerator;
-        this.casProperties = casProperties;
     }
 
     @Override
     protected Event doExecute(final RequestContext context) {
         configureWebflowContextForService(context);
         return success();
-    }
-
-    private void configureWebflowContextForService(final RequestContext context) {
-        final Service service = WebUtils.getService(this.argumentExtractors, context);
-        if (service != null) {
-            LOGGER.debug("Placing service in context scope: [{}]", service.getId());
-
-            final Service selectedService = authenticationRequestServiceSelectionStrategies.resolveService(service);
-            final RegisteredService registeredService = this.servicesManager.findServiceBy(selectedService);
-            if (registeredService != null && registeredService.getAccessStrategy().isServiceAccessAllowed()) {
-                LOGGER.debug("Placing registered service [{}] with id [{}] in context scope",
-                        registeredService.getServiceId(),
-                        registeredService.getId());
-                WebUtils.putRegisteredService(context, registeredService);
-
-                final RegisteredServiceAccessStrategy accessStrategy = registeredService.getAccessStrategy();
-                if (accessStrategy.getUnauthorizedRedirectUrl() != null) {
-                    LOGGER.debug("Placing registered service's unauthorized redirect url [{}] with id [{}] in context scope",
-                            accessStrategy.getUnauthorizedRedirectUrl(),
-                            registeredService.getServiceId());
-                    WebUtils.putUnauthorizedRedirectUrl(context, accessStrategy.getUnauthorizedRedirectUrl());
-                }
-            }
-        } else if (!casProperties.getSso().isMissingService()) {
-            LOGGER.warn("No service authentication request is available at [{}]. CAS is configured to disable the flow.",
-                    WebUtils.getHttpServletRequestFromExternalWebflowContext(context).getRequestURL());
-            throw new NoSuchFlowExecutionException(context.getFlowExecutionContext().getKey(),
-                    new UnauthorizedServiceException("screen.service.required.message", "Service is required"));
-        }
-        WebUtils.putService(context, service);
     }
 }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jInitialFlowSetupAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jInitialFlowSetupAction.java
@@ -9,7 +9,6 @@ import org.apereo.cas.services.RegisteredServiceAccessStrategy;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.services.UnauthorizedServiceException;
 import org.apereo.cas.web.support.ArgumentExtractor;
-import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.apereo.cas.web.support.WebUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,18 +24,18 @@ import java.util.List;
  * Class to set up variables at webflow action initialisation
  *
  * @author Francis Le Coq
- * @since 3.1
+ * @since 5.2
  */
-public class initialFlowSetupP4jAction extends AbstractAction {
+public class Pac4jInitialFlowSetupAction extends AbstractAction {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(initialFlowSetupP4jAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Pac4jInitialFlowSetupAction.class);
 
     private final CasConfigurationProperties casProperties;
     private final ServicesManager servicesManager;
     private final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
     private final List<ArgumentExtractor> argumentExtractors;
 
-    public initialFlowSetupP4jAction(final List<ArgumentExtractor> argumentExtractors,
+    public Pac4jInitialFlowSetupAction(final List<ArgumentExtractor> argumentExtractors,
                                   final ServicesManager servicesManager,
                                   final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionPlan,
                                   final CasConfigurationProperties casProperties) {

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jWebflowConfigurer.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jWebflowConfigurer.java
@@ -1,7 +1,9 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.authentication.adaptive.UnauthorizedAuthenticationException;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.support.pac4j.web.flow.DelegatedClientAuthenticationAction;
+import org.apereo.cas.web.flow.CasWebflowConstants;
 import org.apereo.cas.web.flow.configurer.AbstractCasWebflowConfigurer;
 import org.apereo.cas.web.support.WebUtils;
 import org.springframework.context.ApplicationContext;
@@ -31,8 +33,8 @@ import java.util.Optional;
 public class Pac4jWebflowConfigurer extends AbstractCasWebflowConfigurer {
 
     private final Action saml2ClientLogoutAction;
-    
-    public Pac4jWebflowConfigurer(final FlowBuilderServices flowBuilderServices, 
+
+    public Pac4jWebflowConfigurer(final FlowBuilderServices flowBuilderServices,
                                   final FlowDefinitionRegistry loginFlowDefinitionRegistry,
                                   final FlowDefinitionRegistry logoutFlowDefinitionRegistry,
                                   final Action saml2ClientLogoutAction, final ApplicationContext applicationContext,
@@ -49,6 +51,8 @@ public class Pac4jWebflowConfigurer extends AbstractCasWebflowConfigurer {
             createClientActionActionState(flow);
             createStopWebflowViewState(flow);
             createSaml2ClientLogoutAction();
+
+            createAuthnFailureAction(flow);
         }
     }
 
@@ -66,7 +70,21 @@ public class Pac4jWebflowConfigurer extends AbstractCasWebflowConfigurer {
         actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, getStartState(flow).getId()));
         actionState.getTransitionSet().add(createTransition(DelegatedClientAuthenticationAction.STOP,
                 DelegatedClientAuthenticationAction.STOP_WEBFLOW));
+        createTransitionForState(actionState, CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, "P4jFailure");
+
         setStartState(flow, actionState);
+    }
+
+    private void createAuthnFailureAction(final Flow flow){
+        final ActionState actionState = createActionState(flow, "P4jFailure",
+                createEvaluateAction(CasWebflowConstants.ACTION_ID_AUTHENTICATION_EXCEPTION_HANDLER));
+
+        actionState.getEntryActionList().add(createEvaluateAction("initialFlowSetupP4jAction"));
+
+        createTransitionForState(actionState, UnauthorizedAuthenticationException.class.getSimpleName(), CasWebflowConstants.VIEW_ID_AUTHENTICATION_BLOCKED);
+        createTransitionForState(actionState, CasWebflowConstants.STATE_ID_SERVICE_UNAUTHZ_CHECK, CasWebflowConstants.STATE_ID_SERVICE_UNAUTHZ_CHECK);
+        createStateDefaultTransition(actionState, CasWebflowConstants.STATE_ID_INIT_LOGIN_FORM);
+
     }
 
     private void createStopWebflowViewState(final Flow flow) {

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jWebflowConfigurer.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/Pac4jWebflowConfigurer.java
@@ -70,16 +70,16 @@ public class Pac4jWebflowConfigurer extends AbstractCasWebflowConfigurer {
         actionState.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, getStartState(flow).getId()));
         actionState.getTransitionSet().add(createTransition(DelegatedClientAuthenticationAction.STOP,
                 DelegatedClientAuthenticationAction.STOP_WEBFLOW));
-        createTransitionForState(actionState, CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, "P4jFailure");
+        createTransitionForState(actionState, CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, "Pac4jFailure");
 
         setStartState(flow, actionState);
     }
 
     private void createAuthnFailureAction(final Flow flow){
-        final ActionState actionState = createActionState(flow, "P4jFailure",
+        final ActionState actionState = createActionState(flow, "Pac4jFailure",
                 createEvaluateAction(CasWebflowConstants.ACTION_ID_AUTHENTICATION_EXCEPTION_HANDLER));
 
-        actionState.getEntryActionList().add(createEvaluateAction("initialFlowSetupP4jAction"));
+        actionState.getEntryActionList().add(createEvaluateAction("Pac4jInitialFlowSetupAction"));
 
         createTransitionForState(actionState, UnauthorizedAuthenticationException.class.getSimpleName(), CasWebflowConstants.VIEW_ID_AUTHENTICATION_BLOCKED);
         createTransitionForState(actionState, CasWebflowConstants.STATE_ID_SERVICE_UNAUTHZ_CHECK, CasWebflowConstants.STATE_ID_SERVICE_UNAUTHZ_CHECK);

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/Pac4jWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/Pac4jWebflowConfiguration.java
@@ -6,8 +6,10 @@ import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
 import org.apereo.cas.web.flow.Pac4jErrorViewResolver;
+import org.apereo.cas.web.flow.Pac4jInitialFlowSetupAction;
 import org.apereo.cas.web.flow.Pac4jWebflowConfigurer;
 import org.apereo.cas.web.support.ArgumentExtractor;
+import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -21,7 +23,6 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
 import org.springframework.webflow.execution.Action;
-import org.apereo.cas.web.flow.initialFlowSetupP4jAction;
 
 /**
  * This is {@link Pac4jWebflowConfiguration}.
@@ -62,6 +63,14 @@ public class Pac4jWebflowConfiguration {
     @Qualifier("servicesManager")
     private ServicesManager servicesManager;
 
+    @Autowired
+    @Qualifier("ticketGrantingTicketCookieGenerator")
+    private CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator;
+
+    @Autowired
+    @Qualifier("warnCookieGenerator")
+    private CookieRetrievingCookieGenerator warnCookieGenerator;
+
     @ConditionalOnMissingBean(name = "pac4jWebflowConfigurer")
     @Bean
     @DependsOn("defaultWebflowConfigurer")
@@ -86,7 +95,7 @@ public class Pac4jWebflowConfiguration {
             CollectionUtils.wrap(argumentExtractor),
             servicesManager,
             authenticationRequestServiceSelectionStrategies,
-            casProperties
-        );
+            ticketGrantingTicketCookieGenerator,
+            warnCookieGenerator, casProperties);
     }
 }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/Pac4jWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/Pac4jWebflowConfiguration.java
@@ -1,14 +1,19 @@
 package org.apereo.cas.web.flow.config;
 
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
 import org.apereo.cas.web.flow.Pac4jErrorViewResolver;
 import org.apereo.cas.web.flow.Pac4jWebflowConfigurer;
+import org.apereo.cas.web.support.ArgumentExtractor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ErrorViewResolver;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +21,7 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
 import org.springframework.webflow.execution.Action;
+import org.apereo.cas.web.flow.initialFlowSetupP4jAction;
 
 /**
  * This is {@link Pac4jWebflowConfiguration}.
@@ -39,7 +45,7 @@ public class Pac4jWebflowConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
-    
+
     @Autowired
     @Qualifier("saml2ClientLogoutAction")
     private Action saml2ClientLogoutAction;
@@ -47,7 +53,15 @@ public class Pac4jWebflowConfiguration {
     @Autowired
     @Qualifier("logoutFlowRegistry")
     private FlowDefinitionRegistry logoutFlowDefinitionRegistry;
-    
+
+    @Autowired
+    @Qualifier("authenticationServiceSelectionPlan")
+    private AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
+
+    @Autowired
+    @Qualifier("servicesManager")
+    private ServicesManager servicesManager;
+
     @ConditionalOnMissingBean(name = "pac4jWebflowConfigurer")
     @Bean
     @DependsOn("defaultWebflowConfigurer")
@@ -61,5 +75,18 @@ public class Pac4jWebflowConfiguration {
     @Bean
     public ErrorViewResolver pac4jErrorViewResolver() {
         return new Pac4jErrorViewResolver();
+    }
+
+    @RefreshScope
+    @Bean
+    @Autowired
+    @ConditionalOnMissingBean(name = "initialFlowSetupP4jAction")
+    public Action initialFlowSetupP4jAction(@Qualifier("argumentExtractor") final ArgumentExtractor argumentExtractor) {
+        return new initialFlowSetupP4jAction(
+            CollectionUtils.wrap(argumentExtractor),
+            servicesManager,
+            authenticationRequestServiceSelectionStrategies,
+            casProperties
+        );
     }
 }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/Pac4jWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/Pac4jWebflowConfiguration.java
@@ -80,9 +80,9 @@ public class Pac4jWebflowConfiguration {
     @RefreshScope
     @Bean
     @Autowired
-    @ConditionalOnMissingBean(name = "initialFlowSetupP4jAction")
-    public Action initialFlowSetupP4jAction(@Qualifier("argumentExtractor") final ArgumentExtractor argumentExtractor) {
-        return new initialFlowSetupP4jAction(
+    @ConditionalOnMissingBean(name = "Pac4jInitialFlowSetupAction")
+    public Action Pac4jInitialFlowSetupAction(@Qualifier("argumentExtractor") final ArgumentExtractor argumentExtractor) {
+        return new Pac4jInitialFlowSetupAction(
             CollectionUtils.wrap(argumentExtractor),
             servicesManager,
             authenticationRequestServiceSelectionStrategies,

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/initialFlowSetupP4jAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/initialFlowSetupP4jAction.java
@@ -1,0 +1,88 @@
+package org.apereo.cas.web.flow;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
+import org.apereo.cas.authentication.principal.Service;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.services.RegisteredServiceAccessStrategy;
+import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.UnauthorizedServiceException;
+import org.apereo.cas.web.support.ArgumentExtractor;
+import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
+import org.apereo.cas.web.support.WebUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.webflow.action.AbstractAction;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+import org.springframework.webflow.execution.repository.NoSuchFlowExecutionException;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+/**
+ * Class to set up variables at webflow action initialisation
+ *
+ * @author Francis Le Coq
+ * @since 3.1
+ */
+public class initialFlowSetupP4jAction extends AbstractAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(initialFlowSetupP4jAction.class);
+
+    private final CasConfigurationProperties casProperties;
+    private final ServicesManager servicesManager;
+    private final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies;
+    private final List<ArgumentExtractor> argumentExtractors;
+
+    public initialFlowSetupP4jAction(final List<ArgumentExtractor> argumentExtractors,
+                                  final ServicesManager servicesManager,
+                                  final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionPlan,
+                                  final CasConfigurationProperties casProperties) {
+        this.argumentExtractors = argumentExtractors;
+        this.servicesManager = servicesManager;
+        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionPlan;
+        this.casProperties = casProperties;
+    }
+
+    @Override
+    protected Event doExecute(final RequestContext context) {
+        configureWebflowContextForService(context);
+        return success();
+    }
+
+    private void configureWebflowContextForService(final RequestContext context) {
+        final Service service = WebUtils.getService(this.argumentExtractors, context);
+        if (service != null) {
+            LOGGER.debug("Placing service in context scope: [{}]", service.getId());
+
+            final Service selectedService = authenticationRequestServiceSelectionStrategies.resolveService(service);
+            final RegisteredService registeredService = this.servicesManager.findServiceBy(selectedService);
+            if (registeredService != null && registeredService.getAccessStrategy().isServiceAccessAllowed()) {
+                LOGGER.debug("Placing registered service [{}] with id [{}] in context scope",
+                        registeredService.getServiceId(),
+                        registeredService.getId());
+                WebUtils.putRegisteredService(context, registeredService);
+
+                final RegisteredServiceAccessStrategy accessStrategy = registeredService.getAccessStrategy();
+                if (accessStrategy.getUnauthorizedRedirectUrl() != null) {
+                    LOGGER.debug("Placing registered service's unauthorized redirect url [{}] with id [{}] in context scope",
+                            accessStrategy.getUnauthorizedRedirectUrl(),
+                            registeredService.getServiceId());
+                    WebUtils.putUnauthorizedRedirectUrl(context, accessStrategy.getUnauthorizedRedirectUrl());
+                }
+            }
+        } else if (!casProperties.getSso().isMissingService()) {
+            LOGGER.warn("No service authentication request is available at [{}]. CAS is configured to disable the flow.",
+                    WebUtils.getHttpServletRequestFromExternalWebflowContext(context).getRequestURL());
+            throw new NoSuchFlowExecutionException(context.getFlowExecutionContext().getKey(),
+                    new UnauthorizedServiceException("screen.service.required.message", "Service is required"));
+        }
+        WebUtils.putService(context, service);
+    }
+
+    public ServicesManager getServicesManager() {
+        return servicesManager;
+    }
+}


### PR DESCRIPTION
P4j had a crash when trying to use the service option 'unauthorizedRedirectUrl'.

I had to :
- manage execption into DelegatedClientAuthenticationAction.java in order to be able to catch an exception event in the webflow
- add a new webflow transition catching this event
- add a new action handling the new exception and redirect to 'unauthorizedRedirectUrl'
- add a 'initialFlowSetupP4jAction', the goal is to setup variables when entering the 'P4jFailure' action. The default initLoginForm action is not working because of the exit of the webflow when communicating with tiers application.

How to test it :
 - add a new 'cas.authn.pac4j.oidc[0]' client
 - setup a new access strategy for your service :

 ``` javascript
  "accessStrategy": {
       "@class" : "org.apereo.cas.services.DefaultRegisteredServiceAccessStrategy",
       "unauthorizedRedirectUrl" : "https://google.com",
       "requiredAttributes" : {
         "@class" : "java.util.HashMap",
         // fake parameter forcing CAS to redirect
         "uids" : [ "java.util.HashSet", [ ".*" ] ]
       }
    }

```
What should happen :
 - On OIDC validation, CAS should redirect to google if it doesn't find the 'uids' when logging

What is happening :
 - CAS crash and display an issue that it doesn't find webflow action to apply on clientLogin webflow action
 - However works fine on form default login

Where to find the example code used in this modifications :
 - org.apereo.cas.web.flow.configurer.DefaultWebflowConfigurer
 - org.apereo.cas.web.flow.GenerateServiceTicketAction
