### PR TITLE
Fix to prevent an exception when an invalid username is used during the password reset flow

### DIFF
--- a/support/cas-server-support-pm-jdbc/src/main/java/org/apereo/cas/pm/jdbc/JdbcPasswordManagementService.java
+++ b/support/cas-server-support-pm-jdbc/src/main/java/org/apereo/cas/pm/jdbc/JdbcPasswordManagementService.java
@@ -58,7 +58,7 @@ public class JdbcPasswordManagementService extends BasePasswordManagementService
             }
             LOGGER.debug("Username {} not found when searching for email", username);
             return null;
-        } catch (EmptyResultDataAccessException e) {
+        } catch (final EmptyResultDataAccessException e) {
             LOGGER.debug("Username {} not found when searching for email", username);
             return null;
         }

--- a/support/cas-server-support-pm-jdbc/src/main/java/org/apereo/cas/pm/jdbc/JdbcPasswordManagementService.java
+++ b/support/cas-server-support-pm-jdbc/src/main/java/org/apereo/cas/pm/jdbc/JdbcPasswordManagementService.java
@@ -51,12 +51,17 @@ public class JdbcPasswordManagementService extends BasePasswordManagementService
 
     @Override
     public String findEmail(final String username) {
-        final String query = properties.getJdbc().getSqlFindEmail();
-        final String email = this.jdbcTemplate.queryForObject(query, String.class, username);
-        if (StringUtils.isNotBlank(email) && EmailValidator.getInstance().isValid(email)) {
-            return email;
+        try {
+            final String email = this.jdbcTemplate.queryForObject(passwordManagementProperties.getJdbc().getSqlFindEmail(), String.class, username);
+            if (StringUtils.isNotBlank(email) && EmailValidator.getInstance().isValid(email)) {
+                return email;
+            }
+            LOGGER.debug("Username {} not found when searching for email", username);
+            return null;
+        } catch (EmptyResultDataAccessException e) {
+            LOGGER.debug("Username {} not found when searching for email", username);
+            return null;
         }
-        return null;
     }
 
     @Override

--- a/support/cas-server-support-pm-jdbc/src/test/java/org/apereo/cas/pm/jdbc/JdbcPasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm-jdbc/src/test/java/org/apereo/cas/pm/jdbc/JdbcPasswordManagementServiceTests.java
@@ -33,7 +33,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.sql.DataSource;
-
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -46,24 +45,24 @@ import static org.junit.Assert.*;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {RefreshAutoConfiguration.class,
-        CasCoreAuthenticationPrincipalConfiguration.class,
-        CasCoreAuthenticationPolicyConfiguration.class,
-        CasCoreAuthenticationMetadataConfiguration.class,
-        CasCoreAuthenticationSupportConfiguration.class,
-        CasCoreAuthenticationHandlersConfiguration.class,
-        CasWebApplicationServiceFactoryConfiguration.class,
-        CasCoreHttpConfiguration.class,
-        CasCoreTicketCatalogConfiguration.class,
-        CasCoreTicketsConfiguration.class,
-        CasPersonDirectoryConfiguration.class,
-        CasCoreAuthenticationConfiguration.class, 
-        CasCoreServicesAuthenticationConfiguration.class,
-        CasCoreWebConfiguration.class,
-        CasWebApplicationServiceFactoryConfiguration.class,
-        CasCoreServicesConfiguration.class,
-        CasCoreUtilConfiguration.class,
-        JdbcPasswordManagementConfiguration.class,
-        PasswordManagementConfiguration.class})
+    CasCoreAuthenticationPrincipalConfiguration.class,
+    CasCoreAuthenticationPolicyConfiguration.class,
+    CasCoreAuthenticationMetadataConfiguration.class,
+    CasCoreAuthenticationSupportConfiguration.class,
+    CasCoreAuthenticationHandlersConfiguration.class,
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasCoreHttpConfiguration.class,
+    CasCoreTicketCatalogConfiguration.class,
+    CasCoreTicketsConfiguration.class,
+    CasPersonDirectoryConfiguration.class,
+    CasCoreAuthenticationConfiguration.class,
+    CasCoreServicesAuthenticationConfiguration.class,
+    CasCoreWebConfiguration.class,
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasCoreServicesConfiguration.class,
+    CasCoreUtilConfiguration.class,
+    JdbcPasswordManagementConfiguration.class,
+    PasswordManagementConfiguration.class})
 @TestPropertySource(locations = {"classpath:/pm.properties"})
 public class JdbcPasswordManagementServiceTests {
     @Autowired
@@ -79,34 +78,40 @@ public class JdbcPasswordManagementServiceTests {
     @Before
     public void before() {
         jdbcTemplate = new JdbcTemplate(this.jdbcPasswordManagementDataSource);
-        
+
         jdbcTemplate.execute("drop table pm_table_accounts if exists;");
         jdbcTemplate.execute("create table pm_table_accounts (id int, userid varchar(255),"
-                + "password varchar(255), email varchar(255));");
+            + "password varchar(255), email varchar(255));");
         jdbcTemplate.execute("insert into pm_table_accounts values (100, 'casuser', 'password', 'casuser@example.org');");
 
         jdbcTemplate.execute("drop table pm_table_questions if exists;");
         jdbcTemplate.execute("create table pm_table_questions (id int, userid varchar(255),"
-                + " question varchar(255), answer varchar(255));");
+            + " question varchar(255), answer varchar(255));");
         jdbcTemplate.execute("insert into pm_table_questions values (100, 'casuser', 'question1', 'answer1');");
         jdbcTemplate.execute("insert into pm_table_questions values (200, 'casuser', 'question2', 'answer2');");
-        
+
     }
 
     @Test
     public void verifyUserEmailCanBeFound() {
         final String email = passwordChangeService.findEmail("casuser");
-        assertEquals(email, "casuser@example.org");
+        assertEquals("casuser@example.org", email);
+    }
+
+    @Test
+    public void verifyNullReturnedIfUserEmailCannotBeFound() {
+        final String email = passwordChangeService.findEmail("unknown");
+        assertNull(email);
     }
 
     @Test
     public void verifyUserQuestionsCanBeFound() {
         final Map questions = passwordChangeService.getSecurityQuestions("casuser");
-        assertEquals(questions.size(), 2);
+        assertEquals(2, questions.size());
         assertTrue(questions.containsKey("question1"));
         assertTrue(questions.containsKey("question2"));
     }
-    
+
     @Test
     public void verifyUserPasswordChange() {
         final Credential c = new UsernamePasswordCredential("casuser", "password");
@@ -116,6 +121,6 @@ public class JdbcPasswordManagementServiceTests {
         final boolean res = passwordChangeService.change(c, bean);
         assertTrue(res);
     }
-    
+
 
 }


### PR DESCRIPTION
Fix to prevent an exception when an invalid username is used during the password reset flow