### PR TITLE
SAML IdP: modify attribute names instead of friendly names

### DIFF
--- a/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
@@ -244,11 +244,10 @@ Attribute name formats can be specified per relying party in the service registr
 You may also have the option to define attributes and their relevant name format globally
 via CAS properties. To see the relevant list of CAS properties, please [review this guide](Configuration-Properties.html#saml-idp).
 
-### Attribute Friendly Names
+### Attribute Names
 
-Attribute friendly names can be specified per relying party in the service registry. If there is no friendly name defined for the attribute, the 
-attribute name will be used instead in its place. Note that the name of the attribute is one that is designed to be released to the service provider,
-specially if the original attribute is *mapped* to a different name.
+Attribute names can be specified per relying party in the service registry. If there is no name defined for the attribute, the 
+attribute name known to CAS will be used instead in its place. Note that the name of the attribute is one that is designed to be released to the service provider. In any case, the attribute name known to CAS will be used as the attribute's friendly name.
 
 ```json
 {
@@ -257,12 +256,15 @@ specially if the original attribute is *mapped* to a different name.
   "name": "SAML Service",
   "metadataLocation" : "../../sp-metadata.xml",
   "id": 100001,
-  "attributeFriendlyNames": {
+  "attributeNames": {
     "@class": "java.util.HashMap",
-    "urn:oid:2.5.4.42": "friendly-name-to-use"
+    "cn": "urn:oid:2.5.4.42"
   }
 }
 ```
+
+You also have the option to define attribute names globally
+via CAS properties. To see the relevant list of CAS properties, please [review this guide](Configuration-Properties.html#saml-idp).
 
 ### Attribute Release
 


### PR DESCRIPTION
@mmoayyed, I saw you took up the friendly names topic. First of all thanks for that.

I understand the configuration as follows:
Configure attributes for CAS (e.g. ldap cn -> mapped to uid). Map in SAML service release policy (uid -> urn:oid:1.2.3.4). Specify FriendlyName (urn:oid:1.2.3.4 -> uid). 

I currently see two issues if it's done this way:
1. Attribute names known to CAS have to be mapped twice.
2. Users get presented with the cryptic urn when being asked for consent.

If, instead, the attribute names that appear in the saml response were mapped, then I only need to do it once and users see the friendly name in consent.

Additionally, I would envision the option to do it globally, like nameformats.

I can go ahead and make this change if approved.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
