### PR TITLE
Fix on PublicKeyFactoryBean and PrivateKeyFactoryBean used to load Google Apps certificates (cas-server-core-util-5.2.1) 

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/PrivateKeyFactoryBean.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/PrivateKeyFactoryBean.java
@@ -66,7 +66,7 @@ public class PrivateKeyFactoryBean extends AbstractFactoryBean<PrivateKey> {
     private PrivateKey readDERPrivateKey() {
         LOGGER.debug("Attempting to read key as DER [{}]", this.location);
         try (InputStream privKey = this.location.getInputStream()) {
-            final byte[] bytes = new byte[privKey.available()];
+            final byte[] bytes = new byte[(int) this.location.contentLength()];
             privKey.read(bytes);
             final PKCS8EncodedKeySpec privSpec = new PKCS8EncodedKeySpec(bytes);
             final KeyFactory factory = KeyFactory.getInstance(this.algorithm);

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/PublicKeyFactoryBean.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/PublicKeyFactoryBean.java
@@ -32,7 +32,7 @@ public class PublicKeyFactoryBean extends AbstractFactoryBean<PublicKey> {
     protected PublicKey createInstance() throws Exception {
         LOGGER.debug("Creating public key instance from [{}] using [{}]", this.resource.getFilename(), this.algorithm);
         try (InputStream pubKey = this.resource.getInputStream()) {
-            final byte[] bytes = new byte[pubKey.available()];
+            final byte[] bytes = new byte[(int) this.resource.contentLength()];
             pubKey.read(bytes);
             final X509EncodedKeySpec pubSpec = new X509EncodedKeySpec(bytes);
             final KeyFactory factory = KeyFactory.getInstance(this.algorithm);


### PR DESCRIPTION
Hi, 

I want to submit a small patch for an issue I met on Google Apps integration on CAS 5.2.1. FYI, I already have the Google Apps integration working on our old CAS 3.4.5.

Best regards,
Alex

Main reason for this fix : 
--------------------------------

Server is not able to load Google Apps Public/Private keys on startup because it puts resource inputstream into a byte array which size is always 0.

Details :
-----------

org.springframework.boot.loader.data.RandomAccessDataFile$DataInputStream extends InputStream but doesn't override available() which returns 0 by default (and should be overriden according to java.io.InputStream javadoc). An alternative solution consists on using Spring Resource class contentLength() method instead.


Proof of the issue : 
-------------------------

Here is the raised exception :

```
java.security.InvalidKeyException: IOException: DerInputStream.getLength(): lengthTag=127, too big.
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:599)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1173)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1067)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:513)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:483)
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:306)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:302)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeansOfType(DefaultListableBeanFactory.java:519)
	at org.springframework.context.support.AbstractApplicationContext.getBeansOfType(AbstractApplicationContext.java:1194)
	at org.apereo.cas.authentication.principal.DefaultWebApplicationResponseBuilderLocator.<init>(DefaultWebApplicationResponseBuilderLocator.java:22)
	at org.apereo.cas.config.CasCoreServicesConfiguration.webApplicationResponseBuilderLocator(CasCoreServicesConfiguration.java:83)
	at org.apereo.cas.config.CasCoreServicesConfiguration$$EnhancerBySpringCGLIB$$7bd3e8a.CGLIB$webApplicationResponseBuilderLocator$2(<generated>)
	at org.apereo.cas.config.CasCoreServicesConfiguration$$EnhancerBySpringCGLIB$$7bd3e8a$$FastClassBySpringCGLIB$$28c55774.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:358)
	at org.apereo.cas.config.CasCoreServicesConfiguration$$EnhancerBySpringCGLIB$$7bd3e8a.webApplicationResponseBuilderLocator(<generated>)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162)
	... 26 more
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.apereo.cas.authentication.principal.ResponseBuilder]: Factory method 'googleAccountsServiceResponseBuilder' threw exception; nested exception is java.lang.RuntimeException: java.security.InvalidKeyException: IOException: DerInputStream.getLength(): lengthTag=127, too big.
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588)
	... 48 more
Caused by: java.lang.RuntimeException: java.security.InvalidKeyException: IOException: DerInputStream.getLength(): lengthTag=127, too big.
	at org.apereo.cas.support.saml.authentication.principal.GoogleAccountsServiceResponseBuilder.<init>(GoogleAccountsServiceResponseBuilder.java:129)
	at org.apereo.cas.support.saml.authentication.principal.GoogleAccountsServiceResponseBuilder.<init>(GoogleAccountsServiceResponseBuilder.java:100)
	at org.apereo.cas.support.saml.config.SamlGoogleAppsConfiguration.googleAccountsServiceResponseBuilder(SamlGoogleAppsConfiguration.java:77)
	at org.apereo.cas.support.saml.config.SamlGoogleAppsConfiguration$$EnhancerBySpringCGLIB$$8feb0e2e.CGLIB$googleAccountsServiceResponseBuilder$3(<generated>)
	at org.apereo.cas.support.saml.config.SamlGoogleAppsConfiguration$$EnhancerBySpringCGLIB$$8feb0e2e$$FastClassBySpringCGLIB$$75d4db8f.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:358)
	at org.apereo.cas.support.saml.config.SamlGoogleAppsConfiguration$$EnhancerBySpringCGLIB$$8feb0e2e.googleAccountsServiceResponseBuilder(<generated>)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162)
	... 49 more
Caused by: java.security.spec.InvalidKeySpecException: java.security.InvalidKeyException: IOException: DerInputStream.getLength(): lengthTag=127, too big.
	at sun.security.rsa.RSAKeyFactory.engineGeneratePublic(RSAKeyFactory.java:205)
	at java.security.KeyFactory.generatePublic(KeyFactory.java:334)
	at org.apereo.cas.util.crypto.PublicKeyFactoryBean.createInstance(PublicKeyFactoryBean.java:37)
	at org.apereo.cas.util.crypto.PublicKeyFactoryBean.createInstance(PublicKeyFactoryBean.java:21)
	at org.springframework.beans.factory.config.AbstractFactoryBean.afterPropertiesSet(AbstractFactoryBean.java:134)
	at org.apereo.cas.support.saml.authentication.principal.GoogleAccountsServiceResponseBuilder.createGoogleAppsPublicKey(GoogleAccountsServiceResponseBuilder.java:256)
	at org.apereo.cas.support.saml.authentication.principal.GoogleAccountsServiceResponseBuilder.<init>(GoogleAccountsServiceResponseBuilder.java:127)
	... 61 more
Caused by: java.security.InvalidKeyException: IOException: DerInputStream.getLength(): lengthTag=127, too big.
	at sun.security.x509.X509Key.decode(X509Key.java:398)
	at sun.security.x509.X509Key.decode(X509Key.java:403)
	at sun.security.rsa.RSAPublicKeyImpl.<init>(RSAPublicKeyImpl.java:84)
	at sun.security.rsa.RSAKeyFactory.generatePublic(RSAKeyFactory.java:298)
	at sun.security.rsa.RSAKeyFactory.engineGeneratePublic(RSAKeyFactory.java:201)
	... 67 more
```


