### PR TITLE
Fix packages names (again) on REST surrogation support

### DIFF
--- a/support/cas-server-support-surrogate-authentication-rest/src/main/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationService.java
+++ b/support/cas-server-support-surrogate-authentication-rest/src/main/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationService.java
@@ -1,11 +1,10 @@
-package cas.authentication.surrogate;
+package org.apereo.cas.authentication.surrogate;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
-import org.apereo.cas.authentication.surrogate.BaseSurrogateAuthenticationService;
 import org.apereo.cas.configuration.model.support.surrogate.SurrogateAuthenticationProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.util.CollectionUtils;

--- a/support/cas-server-support-surrogate-authentication-rest/src/main/java/org/apereo/cas/config/SurrogateRestAuthenticationConfiguration.java
+++ b/support/cas-server-support-surrogate-authentication-rest/src/main/java/org/apereo/cas/config/SurrogateRestAuthenticationConfiguration.java
@@ -1,7 +1,7 @@
-package cas.config;
+package org.apereo.cas.config;
 
-import cas.authentication.surrogate.SurrogateRestAuthenticationService;
 import org.apereo.cas.authentication.surrogate.SurrogateAuthenticationService;
+import org.apereo.cas.authentication.surrogate.SurrogateRestAuthenticationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.surrogate.SurrogateAuthenticationProperties;
 import org.apereo.cas.services.ServicesManager;


### PR DESCRIPTION
My previous fix was not very good. I moved the classes without changing the package names inside the classes :-(
Notice that it did compile though, which lead me to think it was ok.

This time, it compiles and I tested it successfully.

Will submit the same PR for the master.
