### PR TITLE
Make it possible to configure logout flow similarly to login flow

### DIFF
--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
@@ -110,12 +110,22 @@ public abstract class AbstractCasWebflowConfigurer implements CasWebflowConfigur
     protected final FlowBuilderServices flowBuilderServices;
 
     public AbstractCasWebflowConfigurer(final FlowBuilderServices flowBuilderServices,
-                                        final FlowDefinitionRegistry loginFlowDefinitionRegistry, final ApplicationContext applicationContext,
+                                        final FlowDefinitionRegistry loginFlowDefinitionRegistry,
+                                        final ApplicationContext applicationContext,
                                         final CasConfigurationProperties casProperties) {
         this.flowBuilderServices = flowBuilderServices;
         this.loginFlowDefinitionRegistry = loginFlowDefinitionRegistry;
         this.applicationContext = applicationContext;
         this.casProperties = casProperties;
+    }
+
+    public AbstractCasWebflowConfigurer(final FlowBuilderServices flowBuilderServices,
+                                        final FlowDefinitionRegistry loginFlowDefinitionRegistry,
+                                        final FlowDefinitionRegistry logoutFlowDefinitionRegistry,
+                                        final ApplicationContext applicationContext,
+                                        final CasConfigurationProperties casProperties) {
+        this(flowBuilderServices, loginFlowDefinitionRegistry, applicationContext, casProperties);
+        this.logoutFlowDefinitionRegistry = logoutFlowDefinitionRegistry;
     }
 
     @Override


### PR DESCRIPTION
We have in our environment using CAS 4.x, for reasons, modified our flow to add a cookie to the response on login and remove it again on logout. I'm able to register login flow actions in CAS 5.x as suggested in the documentation, but I'm unable to do the same for the logout flow.

As far as I can see, there is no way for me to initialize the logoutFlowDefinitionRegistry similar to loginFlowDefinitionRegistry in AbstractCasWebflowConfigurer, thus making the getLogoutFlow() return null.

Recognizing that I may be misunderstanding how I'm supposed to do this, I suggest adding a constructor to AbstractCasWebflowConfigurer which allows me to initialize logoutFlowDefinitionRegistry as well. Using this I'm able to register logout actions as I expect.