### PR TITLE
Fix the TGC cookie expiration when remember me is enabled

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -104,7 +104,7 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
     private boolean isRememberMeAuthentication(final RequestContext requestContext) {
         final HttpServletRequest request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
         final String value = request.getParameter(RememberMeCredential.REQUEST_PARAMETER_REMEMBER_ME);
-        return StringUtils.isNotBlank(value) || WebUtils.isRememberMeAuthenticationEnabled(requestContext);
+        return StringUtils.isNotBlank(value) && WebUtils.isRememberMeAuthenticationEnabled(requestContext);
     }
 
     /**


### PR DESCRIPTION
At the moment the CAS ticket granting cookie max age is set to cas.tgc.rememberMeMaxAge whenever remember me is enabled (and also when remember me is disabled but a remember me form parameter is passed).  This change will only apply the remember me max age cookie expiry when both tgt remember me is enabled and remember me is checked.