### PR TITLE
Attempt to fix an IllegalArgumentException in the MemcachedTicketRegistry

### DIFF
--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
@@ -24,6 +24,7 @@ import org.apereo.cas.authentication.DefaultAuthentication;
 import org.apereo.cas.authentication.DefaultAuthenticationHandlerExecutionResult;
 import org.apereo.cas.authentication.PreventedException;
 import org.apereo.cas.authentication.UsernamePasswordCredential;
+import org.apereo.cas.authentication.RememberMeUsernamePasswordCredential;
 import org.apereo.cas.authentication.exceptions.AccountDisabledException;
 import org.apereo.cas.authentication.exceptions.InvalidLoginLocationException;
 import org.apereo.cas.authentication.exceptions.InvalidLoginTimeException;
@@ -188,6 +189,7 @@ public class CloseableKryoFactory implements KryoFactory {
         kryo.register(DefaultAuthenticationHandlerExecutionResult.class);
         kryo.register(DefaultAuthentication.class);
         kryo.register(UsernamePasswordCredential.class);
+        kryo.register(RememberMeUsernamePasswordCredential.class);
         kryo.register(SimplePrincipal.class);
         kryo.register(PublicKeyFactoryBean.class);
         kryo.register(ReturnAllowedAttributeReleasePolicy.class);


### PR DESCRIPTION
Kryo throws an IllegalArgumentException when RememberMe has been enabled, since a RememberMeUsernamePasswordCredential object is being stored instead of a UsernamePasswordCredential object.

I've imported the `RememberMeUsernamePasswordCredential` class and made the `CloseableKryoFactory` register the class along with the `UsernamePasswordCredential`

Since CAS does not register the classes with an associated int ID, I don't see any bad consequences.

The original stacktrace: 
```
2018-01-31 10:50:45,606 ERROR [org.apereo.cas.ticket.registry.MemcachedTicketRegistry] - <Failed adding [TGT-***************************************************************EDBwrsQ734-AndersMacBookPro]>
com.esotericsoftware.kryo.KryoException: com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: org.apereo.cas.authentication.RememberMeUsernamePasswordCredential
Note: To register this class use: kryo.register(org.apereo.cas.authentication.RememberMeUsernamePasswordCredential.class);
Serialization trace:
credentialClass (org.apereo.cas.authentication.BasicCredentialMetaData)
credentials (org.apereo.cas.authentication.DefaultAuthentication)
authentication (org.apereo.cas.ticket.TicketGrantingTicketImpl)
	at org.apereo.cas.memcached.kryo.CasKryoTranscoder.encode(CasKryoTranscoder.java:66) ~[cas-server-support-memcached-core-5.2.2.jar!/:5.2.2]
	at net.spy.memcached.MemcachedClient.asyncStore(MemcachedClient.java:304) ~[spymemcached-2.12.3.jar!/:2.12.3]
	at net.spy.memcached.MemcachedClient.set(MemcachedClient.java:928) ~[spymemcached-2.12.3.jar!/:2.12.3]
	at net.spy.memcached.MemcachedClient.set(MemcachedClient.java:139) ~[spymemcached-2.12.3.jar!/:2.12.3]
	at org.apereo.cas.ticket.registry.MemcachedTicketRegistry.addTicket(MemcachedTicketRegistry.java:58) ~[cas-server-support-memcached-ticket-registry-5.2.2.jar!/:5.2.2]
	at org.apereo.cas.DefaultCentralAuthenticationService.createTicketGrantingTicket(DefaultCentralAuthenticationService.java:375) ~[cas-server-core-5.2.2.jar!/:5.2.2]
	at org.apereo.cas.DefaultCentralAuthenticationService$$FastClassBySpringCGLIB$$b02e48f2.invoke(<generated>) ~[cas-server-core-5.2.2.jar!/:5.2.2]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204) ~[spring-core-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:738) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:85) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apereo.inspektr.audit.AuditTrailManagementAspect.handleAuditTrail(AuditTrailManagementAspect.java:134) ~[inspektr-audit-1.8.0.GA.jar!/:1.8.0.GA]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_91]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_91]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_91]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_91]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:629) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:618) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:70) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:168) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99) ~[spring-tx-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:282) ~[spring-tx-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96) ~[spring-tx-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:92) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:673) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apereo.cas.DefaultCentralAuthenticationService$$EnhancerBySpringCGLIB$$430d6107.createTicketGrantingTicket(<generated>) ~[cas-server-core-5.2.2.jar!/:5.2.2]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_91]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_91]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_91]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_91]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99) ~[spring-tx-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:282) ~[spring-tx-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96) ~[spring-tx-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at com.sun.proxy.$Proxy133.createTicketGrantingTicket(Unknown Source) ~[?:?]
	at org.apereo.cas.web.flow.resolver.impl.AbstractCasWebflowEventResolver.createOrUpdateTicketGrantingTicket(AbstractCasWebflowEventResolver.java:229) ~[cas-server-core-webflow-5.2.2.jar!/:5.2.2]
	at org.apereo.cas.web.flow.resolver.impl.AbstractCasWebflowEventResolver.grantTicketGrantingTicketToAuthenticationResult(AbstractCasWebflowEventResolver.java:212) ~[cas-server-core-webflow-5.2.2.jar!/:5.2.2]
	at org.apereo.cas.web.flow.resolver.impl.InitialAuthenticationAttemptWebflowEventResolver.resolveInternal(InitialAuthenticationAttemptWebflowEventResolver.java:95) ~[cas-server-core-webflow-5.2.2.jar!/:5.2.2]
	at org.apereo.cas.web.flow.resolver.impl.AbstractCasWebflowEventResolver.resolve(AbstractCasWebflowEventResolver.java:512) ~[cas-server-core-webflow-5.2.2.jar!/:5.2.2]
	at org.apereo.cas.web.flow.resolver.impl.AbstractCasWebflowEventResolver.resolveSingle(AbstractCasWebflowEventResolver.java:517) ~[cas-server-core-webflow-5.2.2.jar!/:5.2.2]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_91]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_91]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_91]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_91]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:133) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:121) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at com.sun.proxy.$Proxy191.resolveSingle(Unknown Source) ~[?:?]
	at org.apereo.cas.web.flow.actions.AbstractAuthenticationAction.doExecute(AbstractAuthenticationAction.java:61) ~[cas-server-core-webflow-5.2.2.jar!/:5.2.2]
	at org.springframework.webflow.action.AbstractAction.execute(AbstractAction.java:188) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_91]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_91]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_91]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_91]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:133) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:121) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at com.sun.proxy.$Proxy188.execute(Unknown Source) ~[?:?]
	at org.springframework.webflow.execution.ActionExecutor.execute(ActionExecutor.java:51) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.action.EvaluateAction.doExecute(EvaluateAction.java:77) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.action.AbstractAction.execute(AbstractAction.java:188) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.execution.AnnotatedAction.execute(AnnotatedAction.java:145) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.execution.ActionExecutor.execute(ActionExecutor.java:51) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.ActionState.doEnter(ActionState.java:101) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.State.enter(State.java:194) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.Transition.execute(Transition.java:228) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.impl.FlowExecutionImpl.execute(FlowExecutionImpl.java:395) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.impl.RequestControlContextImpl.execute(RequestControlContextImpl.java:214) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.TransitionableState.handleEvent(TransitionableState.java:116) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.Flow.handleEvent(Flow.java:547) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.impl.FlowExecutionImpl.handleEvent(FlowExecutionImpl.java:390) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.impl.RequestControlContextImpl.handleEvent(RequestControlContextImpl.java:210) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.ViewState.handleEvent(ViewState.java:231) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.ViewState.resume(ViewState.java:195) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.Flow.resume(Flow.java:537) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.engine.impl.FlowExecutionImpl.resume(FlowExecutionImpl.java:259) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.webflow.executor.FlowExecutorImpl.resumeExecution(FlowExecutorImpl.java:169) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_91]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_91]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_91]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_91]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.doProceed(DelegatingIntroductionInterceptor.java:133) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.support.DelegatingIntroductionInterceptor.invoke(DelegatingIntroductionInterceptor.java:121) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213) ~[spring-aop-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at com.sun.proxy.$Proxy143.resumeExecution(Unknown Source) ~[?:?]
	at org.springframework.webflow.mvc.servlet.FlowHandlerAdapter.handle(FlowHandlerAdapter.java:253) ~[spring-webflow-2.4.6.RELEASE.jar!/:2.4.6.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:967) ~[spring-webmvc-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:901) ~[spring-webmvc-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:970) ~[spring-webmvc-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:872) ~[spring-webmvc-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707) ~[javax.servlet-api-3.1.0.jar!/:3.1.0]
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:846) ~[spring-webmvc-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[javax.servlet-api-3.1.0.jar!/:3.1.0]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52) ~[tomcat-embed-websocket-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apereo.cas.web.support.AuthenticationCredentialsLocalBinderClearingFilter.doFilter(AuthenticationCredentialsLocalBinderClearingFilter.java:28) ~[cas-server-core-web-5.2.2.jar!/:5.2.2]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apereo.cas.security.RequestParameterPolicyEnforcementFilter.doFilter(RequestParameterPolicyEnforcementFilter.java:261) ~[cas-server-security-filter-2.0.7.jar!/:2.0.7]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apereo.cas.security.ResponseHeadersEnforcementFilter.doFilter(ResponseHeadersEnforcementFilter.java:245) ~[cas-server-security-filter-2.0.7.jar!/:2.0.7]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.springframework.boot.actuate.trace.WebRequestTraceFilter.doFilterInternal(WebRequestTraceFilter.java:110) ~[spring-boot-actuator-1.5.8.RELEASE.jar!/:1.5.8.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:99) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.springframework.web.filter.HttpPutFormContentFilter.doFilterInternal(HttpPutFormContentFilter.java:108) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.springframework.web.filter.HiddenHttpMethodFilter.doFilterInternal(HiddenHttpMethodFilter.java:81) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apereo.cas.logging.web.ThreadContextMDCServletFilter.doFilter(ThreadContextMDCServletFilter.java:93) ~[cas-server-core-logging-5.2.2.jar!/:5.2.2]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.springframework.boot.actuate.autoconfigure.MetricsFilter.doFilterInternal(MetricsFilter.java:106) ~[spring-boot-actuator-1.5.8.RELEASE.jar!/:1.5.8.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:197) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:107) ~[spring-web-4.3.12.RELEASE.jar!/:4.3.12.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apereo.inspektr.common.web.ClientInfoThreadLocalFilter.doFilter(ClientInfoThreadLocalFilter.java:66) ~[inspektr-common-1.8.0.GA.jar!/:1.8.0.GA]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:504) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:650) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:677) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:803) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:790) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1459) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_91]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_91]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-8.5.24.jar!/:8.5.24]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_91]
Caused by: com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: org.apereo.cas.authentication.RememberMeUsernamePasswordCredential
Note: To register this class use: kryo.register(org.apereo.cas.authentication.RememberMeUsernamePasswordCredential.class);
Serialization trace:
credentialClass (org.apereo.cas.authentication.BasicCredentialMetaData)
credentials (org.apereo.cas.authentication.DefaultAuthentication)
authentication (org.apereo.cas.ticket.TicketGrantingTicketImpl)
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:101) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:508) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeClassAndObject(Kryo.java:651) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:100) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:40) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:575) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:79) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:508) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:575) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:79) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:508) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeClassAndObject(Kryo.java:651) ~[kryo-4.0.1.jar!/:?]
	at org.apereo.cas.memcached.kryo.CasKryoTranscoder.encode(CasKryoTranscoder.java:61) ~[cas-server-support-memcached-core-5.2.2.jar!/:5.2.2]
	... 172 more
Caused by: java.lang.IllegalArgumentException: Class is not registered: org.apereo.cas.authentication.RememberMeUsernamePasswordCredential
Note: To register this class use: kryo.register(org.apereo.cas.authentication.RememberMeUsernamePasswordCredential.class);
	at com.esotericsoftware.kryo.Kryo.getRegistration(Kryo.java:503) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.util.DefaultClassResolver.writeClass(DefaultClassResolver.java:97) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeClass(Kryo.java:540) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.DefaultSerializers$ClassSerializer.write(DefaultSerializers.java:325) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.DefaultSerializers$ClassSerializer.write(DefaultSerializers.java:318) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeObjectOrNull(Kryo.java:629) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:86) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:508) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeClassAndObject(Kryo.java:651) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:100) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.CollectionSerializer.write(CollectionSerializer.java:40) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:575) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:79) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:508) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeObject(Kryo.java:575) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.ObjectField.write(ObjectField.java:79) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.serializers.FieldSerializer.write(FieldSerializer.java:508) ~[kryo-4.0.1.jar!/:?]
	at com.esotericsoftware.kryo.Kryo.writeClassAndObject(Kryo.java:651) ~[kryo-4.0.1.jar!/:?]
	at org.apereo.cas.memcached.kryo.CasKryoTranscoder.encode(CasKryoTranscoder.java:61) ~[cas-server-support-memcached-core-5.2.2.jar!/:5.2.2]
	... 172 more
```