### PR TITLE
Ticket serialization performance fix

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/BaseTicketSerializers.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/BaseTicketSerializers.java
@@ -28,13 +28,8 @@ public abstract class BaseTicketSerializers {
     private static final Map<String, Class> TICKET_TYPE_CACHE = new ConcurrentHashMap<>();
     private static final PrettyPrinter MINIMAL_PRETTY_PRINTER = new MinimalPrettyPrinter();
 
-    /**
-     * Gets proxy granting ticket serializer.
-     *
-     * @return the proxy granting ticket serializer
-     */
-    public static StringSerializer<ProxyGrantingTicket> getProxyGrantingTicketSerializer() {
-        return new AbstractJacksonBackedStringSerializer<ProxyGrantingTicket>(MINIMAL_PRETTY_PRINTER) {
+    private static final StringSerializer<ProxyGrantingTicket> PROXY_GRANTING_TICKET_SERIALIZER
+        = new AbstractJacksonBackedStringSerializer<ProxyGrantingTicket>(MINIMAL_PRETTY_PRINTER) {
             private static final long serialVersionUID = 7089208351327601379L;
 
             @Override
@@ -42,6 +37,54 @@ public abstract class BaseTicketSerializers {
                 return ProxyGrantingTicket.class;
             }
         };
+
+    private static final StringSerializer<ProxyTicket> PROXY_TICKET_SERIALIZER
+        = new AbstractJacksonBackedStringSerializer<ProxyTicket>(MINIMAL_PRETTY_PRINTER) {
+            private static final long serialVersionUID = -6343596853082798477L;
+
+            @Override
+            protected Class<ProxyTicket> getTypeToSerialize() {
+                return ProxyTicket.class;
+            }
+        };
+
+    private static final StringSerializer<TicketGrantingTicket> TICKET_GRANTING_TICKET_SERIALIZER
+        = new AbstractJacksonBackedStringSerializer<TicketGrantingTicket>(MINIMAL_PRETTY_PRINTER) {
+            private static final long serialVersionUID = 1527874389457723545L;
+
+            @Override
+            protected Class<TicketGrantingTicket> getTypeToSerialize() {
+                return TicketGrantingTicket.class;
+            }
+        };
+
+    private static final StringSerializer<ServiceTicket> SERVICE_TICKET_SERIALIZER
+        = new AbstractJacksonBackedStringSerializer<ServiceTicket>(MINIMAL_PRETTY_PRINTER) {
+            private static final long serialVersionUID = 8959617299162115085L;
+
+            @Override
+            protected Class<ServiceTicket> getTypeToSerialize() {
+                return ServiceTicket.class;
+            }
+        };
+
+    private static final StringSerializer<EncodedTicket> ENCODED_TICKET_SERIALIZER
+        = new AbstractJacksonBackedStringSerializer<EncodedTicket>(MINIMAL_PRETTY_PRINTER) {
+            private static final long serialVersionUID = 8959835299162115085L;
+
+            @Override
+            protected Class<EncodedTicket> getTypeToSerialize() {
+                return EncodedTicket.class;
+            }
+        };
+
+    /**
+     * Gets proxy granting ticket serializer.
+     *
+     * @return the proxy granting ticket serializer
+     */
+    public static StringSerializer<ProxyGrantingTicket> getProxyGrantingTicketSerializer() {
+        return PROXY_GRANTING_TICKET_SERIALIZER;
     }
 
     /**
@@ -50,14 +93,7 @@ public abstract class BaseTicketSerializers {
      * @return the proxy ticket serializer
      */
     public static StringSerializer<ProxyTicket> getProxyTicketSerializer() {
-        return new AbstractJacksonBackedStringSerializer<ProxyTicket>(MINIMAL_PRETTY_PRINTER) {
-            private static final long serialVersionUID = -6343596853082798477L;
-
-            @Override
-            protected Class<ProxyTicket> getTypeToSerialize() {
-                return ProxyTicket.class;
-            }
-        };
+        return PROXY_TICKET_SERIALIZER;
     }
 
     /**
@@ -66,14 +102,7 @@ public abstract class BaseTicketSerializers {
      * @return the ticket granting ticket serializer
      */
     public static StringSerializer<TicketGrantingTicket> getTicketGrantingTicketSerializer() {
-        return new AbstractJacksonBackedStringSerializer<TicketGrantingTicket>(MINIMAL_PRETTY_PRINTER) {
-            private static final long serialVersionUID = 1527874389457723545L;
-
-            @Override
-            protected Class<TicketGrantingTicket> getTypeToSerialize() {
-                return TicketGrantingTicket.class;
-            }
-        };
+        return TICKET_GRANTING_TICKET_SERIALIZER;
     }
 
     /**
@@ -82,25 +111,11 @@ public abstract class BaseTicketSerializers {
      * @return the service ticket serializer
      */
     public static StringSerializer<ServiceTicket> getServiceTicketSerializer() {
-        return new AbstractJacksonBackedStringSerializer<ServiceTicket>(MINIMAL_PRETTY_PRINTER) {
-            private static final long serialVersionUID = 8959617299162115085L;
-
-            @Override
-            protected Class<ServiceTicket> getTypeToSerialize() {
-                return ServiceTicket.class;
-            }
-        };
+        return SERVICE_TICKET_SERIALIZER;
     }
 
     public static StringSerializer<EncodedTicket> getEncodedTicketSerializer() {
-        return new AbstractJacksonBackedStringSerializer<EncodedTicket>(MINIMAL_PRETTY_PRINTER) {
-            private static final long serialVersionUID = 8959835299162115085L;
-
-            @Override
-            protected Class<EncodedTicket> getTypeToSerialize() {
-                return EncodedTicket.class;
-            }
-        };
+        return ENCODED_TICKET_SERIALIZER;
     }
 
     /**


### PR DESCRIPTION
We've experienced performance issues with ticket serialization in `MongoDbTicketRegistry`.
Turned out the bottleneck is the continuous instantiation of `ObjectMapper`.