### PR TITLE
Mongo default writeConcern to ACKNOWLEDGED

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mongo/BaseMongoDbProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mongo/BaseMongoDbProperties.java
@@ -77,7 +77,7 @@ public abstract class BaseMongoDbProperties implements Serializable {
      * mongo db or to replica sets or to sharded clusters. In sharded clusters,
      * mongo db instances will pass the write concern on to the shards.
      */
-    private String writeConcern = "NORMAL";
+    private String writeConcern = "ACKNOWLEDGED";
 
     /**
      * MongoDb database instance name.


### PR DESCRIPTION
http://api.mongodb.com/java/current/com/mongodb/WriteConcern.html

NORMAL is already deprecated, and fallback was UNACKNOWLEDGED, which could case fail in CAS. 
(The application could not find a ticket that was already created.)