### PR TITLE
Use streams utilities instead of creating intermediate variables

### DIFF
--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
@@ -51,7 +51,7 @@ public class CasDefaultFlowUrlHandler extends DefaultFlowUrlHandler {
 
         return request.getParameterMap().entrySet().stream()
                 .flatMap(entry -> encodeMultiParameter(entry.getKey(), entry.getValue(), encoding))
-                .collect(Collectors.joining(request.getRequestURI() + '?', "&",
+                .collect(Collectors.joining("&", request.getRequestURI() + '?',
                         encodeSingleParameter(this.flowExecutionKeyParameter, flowExecutionKey, encoding)));
     }
 

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
@@ -28,6 +28,7 @@ public class CasDefaultFlowUrlHandler extends DefaultFlowUrlHandler {
      * Same as that used by {@link DefaultFlowUrlHandler}.
      **/
     public static final String DEFAULT_FLOW_EXECUTION_KEY_PARAMETER = "execution";
+    private static final String DELIMITER = "&";
 
     /**
      * Flow execution parameter name.
@@ -51,8 +52,8 @@ public class CasDefaultFlowUrlHandler extends DefaultFlowUrlHandler {
 
         return request.getParameterMap().entrySet().stream()
                 .flatMap(entry -> encodeMultiParameter(entry.getKey(), entry.getValue(), encoding))
-                .collect(Collectors.joining("&", request.getRequestURI() + '?',
-                        encodeSingleParameter(this.flowExecutionKeyParameter, flowExecutionKey, encoding)));
+                .collect(Collectors.joining(DELIMITER, request.getRequestURI() + '?',
+                        encodeSingleParameter(DELIMITER + this.flowExecutionKeyParameter, flowExecutionKey, encoding)));
     }
 
     @Override

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
@@ -53,7 +53,7 @@ public class CasDefaultFlowUrlHandler extends DefaultFlowUrlHandler {
         return request.getParameterMap().entrySet().stream()
                 .flatMap(entry -> encodeMultiParameter(entry.getKey(), entry.getValue(), encoding))
                 .collect(Collectors.joining(DELIMITER, request.getRequestURI() + '?',
-                        encodeSingleParameter(DELIMITER + this.flowExecutionKeyParameter, flowExecutionKey, encoding)));
+                        DELIMITER + encodeSingleParameter(this.flowExecutionKeyParameter, flowExecutionKey, encoding)));
     }
 
     @Override

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/CasDefaultFlowUrlHandler.java
@@ -7,8 +7,7 @@ import org.springframework.webflow.context.servlet.DefaultFlowUrlHandler;
 import org.springframework.webflow.core.collection.AttributeMap;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import lombok.Setter;
@@ -49,14 +48,11 @@ public class CasDefaultFlowUrlHandler extends DefaultFlowUrlHandler {
     @Override
     public String createFlowExecutionUrl(final String flowId, final String flowExecutionKey, final HttpServletRequest request) {
         final String encoding = getEncodingScheme(request);
-        final StringBuilder builder = new StringBuilder(request.getRequestURI()).append('?');
-        final Map<String, String[]> flowParams = new LinkedHashMap<>(request.getParameterMap());
-        flowParams.put(this.flowExecutionKeyParameter, new String[]{flowExecutionKey});
-        final String queryString = flowParams.entrySet().stream()
-            .flatMap(entry -> encodeMultiParameter(entry.getKey(), entry.getValue(), encoding))
-            .reduce((param1, param2) -> param1 + '&' + param2).orElse(StringUtils.EMPTY);
-        builder.append(queryString);
-        return builder.toString();
+
+        return request.getParameterMap().entrySet().stream()
+                .flatMap(entry -> encodeMultiParameter(entry.getKey(), entry.getValue(), encoding))
+                .collect(Collectors.joining(request.getRequestURI() + '?', "&",
+                        encodeSingleParameter(this.flowExecutionKeyParameter, flowExecutionKey, encoding)));
     }
 
     @Override


### PR DESCRIPTION
Closing no issues.

Instead of creating a StringBuilder for storing the prefix and a linkedHashMap for the sufix (flowExecutionKeyParameter) we can use the Collector.joining method.

