### PR TITLE
Log exceptions for all Redis operations

### DIFF
--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -56,7 +56,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
             this.client.boundValueOps(redisKey)
                     .set(encodeTicket, getTimeout(ticket), TimeUnit.SECONDS);
         } catch (final Exception e) {
-            LOGGER.error("Failed to add [{}]", ticket);
+            LOGGER.error("Failed to add [{}]", ticket, e);
         }
     }
 
@@ -105,7 +105,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
             this.client.boundValueOps(redisKey).set(encodeTicket, getTimeout(ticket), TimeUnit.SECONDS);
             return encodeTicket;
         } catch (final Exception e) {
-            LOGGER.error("Failed to update [{}]", ticket);
+            LOGGER.error("Failed to update [{}]", ticket, e);
         }
         return null;
     }


### PR DESCRIPTION
I encountered some issues with Redis and in case of an addition, the exception is swallowed. Like for update. While it's ok for retrieval and deletion.
I'm not sure if it's done on purpose, otherwise, this PR fixes it.