### PR TITLE
support MFA using RSA Securid through PAP protocol

### DIFF
--- a/support/cas-server-support-radius-core-mfa/src/main/java/org/apereo/cas/adaptors/radius/authentication/RadiusMultifactorAuthenticationProvider.java
+++ b/support/cas-server-support-radius-core-mfa/src/main/java/org/apereo/cas/adaptors/radius/authentication/RadiusMultifactorAuthenticationProvider.java
@@ -52,7 +52,7 @@ public class RadiusMultifactorAuthenticationProvider extends AbstractMultifactor
             LOGGER.debug("Attempting to ping RADIUS server [{}] via simulating an authentication request. If the server responds "
                 + "successfully, mock authentication will fail correctly.", server);
             try {
-                server.authenticate(uidPsw, uidPsw);
+                server.authenticate(uidPsw, uidPsw, null);
             } catch (final TimeoutException | SocketTimeoutException e) {
                 LOGGER.debug("Server [{}] is not available", server);
                 continue;

--- a/support/cas-server-support-radius-core-mfa/src/main/java/org/apereo/cas/adaptors/radius/authentication/RadiusTokenCredential.java
+++ b/support/cas-server-support-radius-core-mfa/src/main/java/org/apereo/cas/adaptors/radius/authentication/RadiusTokenCredential.java
@@ -28,6 +28,10 @@ public class RadiusTokenCredential implements Credential, Serializable {
     private static final long serialVersionUID = -7570675701132111037L;
 
     private String token;
+    /** Stores interim state when access is challenged */
+    private Serializable state;
+    /** Describes reason for access challenged */
+    private String message;
 
     @Override
     public String getId() {

--- a/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/AccessChallengedException.java
+++ b/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/AccessChallengedException.java
@@ -1,0 +1,23 @@
+package org.apereo.cas.adaptors.radius;
+
+import javax.security.auth.login.LoginException;
+
+/**
+ * Exception indicating that provided login credentials are not complete and should provided again with changed token.
+ */
+public class AccessChallengedException extends LoginException {
+
+    private static final long serialVersionUID = 0;
+
+    /**
+     * Constructs a {@link AccessChallengedException} with the specified detail message.
+     * A detail message is a String that describes change required from authentication backend.
+     *
+     * <p>
+     *
+     * @param msg instruction for complete authentication.
+     */
+    public AccessChallengedException(final String msg) {
+        super(msg);
+    }
+}

--- a/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/RadiusProtocol.java
+++ b/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/RadiusProtocol.java
@@ -22,7 +22,9 @@ public enum RadiusProtocol {
     MSCHAPv1("mschapv1"), /** The MSCHA pv2. */
     MSCHAPv2("mschapv2"), /** The pap. */
     PAP("pap"), /** The peap. */
-    PEAP("peap");
+    PEAP("peap"),
+    /** Internal protocol to distinguish RSA SecurId challenged communication */
+    SECURID_PAP("securid-pap");
 
     /** The name. */
     private final String name;

--- a/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/RadiusServer.java
+++ b/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/RadiusServer.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.adaptors.radius;
 
+import java.io.Serializable;
+
 /**
  * Interface representing a Radius Server.
  *
@@ -25,11 +27,12 @@ public interface RadiusServer {
      *
      * @param username Non-null username to authenticate.
      * @param password Password to authenticate.
+     * @param state Identification of challenged state
      *
      * @return {@link RadiusResponse} on success, null otherwise.
      *
      * @throws Exception On indeterminate case where authentication was prevented by a system (e.g. IO) error.
      */
-    RadiusResponse authenticate(String username, String password) throws Exception;
+    RadiusResponse authenticate(String username, String password, Serializable state) throws Exception;
 
 }

--- a/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/RadiusUtils.java
+++ b/support/cas-server-support-radius-core/src/main/java/org/apereo/cas/adaptors/radius/RadiusUtils.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.security.auth.login.FailedLoginException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,25 +25,26 @@ public class RadiusUtils {
      * Authenticate pair.
      *
      * @param username                        the username
-     * @param password                        the password
+     * @param password authentication string - PIN, token or both, depending on actual state
+     * @param state identifier of state returned on AccessChallenge response
      * @param servers                         the servers
      * @param failoverOnAuthenticationFailure the failover on authentication failure
      * @param failoverOnException             the failover on exception
      * @return the pair
      * @throws Exception the exception
      */
-    public static Pair<Boolean, Optional<Map<String, Object>>> authenticate(final String username, final String password,
+    public static Pair<Boolean, Optional<Map<String, Object>>> authenticate(final String username, final String password, final Serializable state,
                                                                             final List<RadiusServer> servers,
                                                                             final boolean failoverOnAuthenticationFailure,
                                                                             final boolean failoverOnException) throws Exception {
         for (final RadiusServer radiusServer : servers) {
-            LOGGER.debug("Attempting to authenticate [{}] at [{}]", username, radiusServer);
+            LOGGER.debug("Attempting to authenticate [{}] at [{}] in state [{}]", username, radiusServer, state);
             try {
-                final RadiusResponse response = radiusServer.authenticate(username, password);
+                final RadiusResponse response = radiusServer.authenticate(username, password, state);
                 if (response != null) {
                     final Map<String, Object> attributes = new HashMap<>();
-                    response.getAttributes().forEach(attribute -> attributes.put(attribute.getAttributeName(), attribute.getValue().toString()));
-                    return Pair.of(Boolean.TRUE, Optional.of(attributes));
+                    response.getAttributes().forEach(attribute -> attributes.put(attribute.getAttributeName(), attribute.getValue()));
+                    return Pair.of(response.getCode() == 2, Optional.of(attributes));
                 }
 
                 if (!failoverOnAuthenticationFailure) {

--- a/support/cas-server-support-radius-core/src/test/java/org/apereo/cas/adaptors/radius/JRadiusServerImplTests.java
+++ b/support/cas-server-support-radius-core/src/test/java/org/apereo/cas/adaptors/radius/JRadiusServerImplTests.java
@@ -37,7 +37,7 @@ public class JRadiusServerImplTests {
     public void verifyAuthenticationSuccess() throws Exception {
         final JRadiusServerImpl server = new JRadiusServerImpl(RadiusProtocol.MSCHAPv2,
                 new RadiusClientFactory(ACCOUNTING_PORT, AUTHENTICATION_PORT, INET_ADDRESS, SECRET));
-        final RadiusResponse response = server.authenticate("casuser", "Mellon");
+        final RadiusResponse response = server.authenticate("casuser", "Mellon", null);
         assertEquals(2, response.getCode());
         assertFalse(response.getAttributes().isEmpty());
         assertTrue(response.getAttributes().stream().anyMatch(a -> a.getAttributeName().equals(Attr_MSCHAP2Success.NAME)));
@@ -47,7 +47,7 @@ public class JRadiusServerImplTests {
     public void verifyAuthenticationFails() throws Exception {
         final JRadiusServerImpl server = new JRadiusServerImpl(RadiusProtocol.MSCHAPv2,
                 new RadiusClientFactory(ACCOUNTING_PORT, AUTHENTICATION_PORT, INET_ADDRESS, SECRET));
-        final RadiusResponse response = server.authenticate("casuser", "badpsw");
+        final RadiusResponse response = server.authenticate("casuser", "badpsw", null);
         assertNull(response);
     }
 
@@ -57,7 +57,7 @@ public class JRadiusServerImplTests {
         final JRadiusServerImpl server = new JRadiusServerImpl(RadiusProtocol.MSCHAPv2,
                 new RadiusClientFactory(ACCOUNTING_PORT, AUTHENTICATION_PORT, 1,
                         INET_ADDRESS, "xyz"));
-        server.authenticate("xyz", "xyz");
+        server.authenticate("xyz", "xyz", null);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class JRadiusServerImplTests {
         final JRadiusServerImpl server = new JRadiusServerImpl(RadiusProtocol.MSCHAPv2,
                 new RadiusClientFactory(1234, 4567, 1,
                         INET_ADDRESS, "xyz"));
-        server.authenticate("xyz", "xyz");
+        server.authenticate("xyz", "xyz", null);
     }
 
     @Test
@@ -75,6 +75,6 @@ public class JRadiusServerImplTests {
         final JRadiusServerImpl server = new JRadiusServerImpl(RadiusProtocol.MSCHAPv2,
                 new RadiusClientFactory(1234, 4567, 1,
                         "131.211.138.166", "1234"));
-        server.authenticate("xyz", "xyz");
+        server.authenticate("xyz", "xyz", null);
     }
 }

--- a/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/adaptors/radius/authentication/RadiusTokenAuthenticationHandler.java
+++ b/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/adaptors/radius/authentication/RadiusTokenAuthenticationHandler.java
@@ -2,18 +2,21 @@ package org.apereo.cas.adaptors.radius.authentication;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apereo.cas.adaptors.radius.AccessChallengedException;
 import org.apereo.cas.adaptors.radius.RadiusServer;
 import org.apereo.cas.adaptors.radius.RadiusUtils;
-import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.AuthenticationHandlerExecutionResult;
 import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.handler.support.AbstractPreAndPostProcessingAuthenticationHandler;
-import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.web.support.WebUtils;
+import org.springframework.webflow.execution.RequestContext;
+import org.springframework.webflow.execution.RequestContextHolder;
 
 import javax.security.auth.login.FailedLoginException;
+
+import java.io.Serializable;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,28 +57,31 @@ public class RadiusTokenAuthenticationHandler extends AbstractPreAndPostProcessi
 
     @Override
     protected AuthenticationHandlerExecutionResult doAuthentication(final Credential credential) throws GeneralSecurityException {
+        final RadiusTokenCredential radiusCredential = (RadiusTokenCredential) credential;
+        final String password = radiusCredential.getToken();
+
+        final RequestContext context = RequestContextHolder.getRequestContext();
+        final String username = WebUtils.getAuthentication(context).getPrincipal().getId();
+
+        final Pair<Boolean, Optional<Map<String, Object>>> result;
         try {
-            final RadiusTokenCredential radiusCredential = (RadiusTokenCredential) credential;
-            final String password = radiusCredential.getToken();
-
-            final Authentication authentication = WebUtils.getInProgressAuthentication();
-            if (authentication == null) {
-                throw new IllegalArgumentException("CAS has no reference to an authentication event to locate a principal");
-            }
-            final Principal principal = authentication.getPrincipal();
-            final String username = principal.getId();
-
-            final Pair<Boolean, Optional<Map<String, Object>>> result =
-                    RadiusUtils.authenticate(username, password, this.servers,
-                            this.failoverOnAuthenticationFailure, this.failoverOnException);
-            if (result.getKey()) {
-                return createHandlerResult(credential,
-                        this.principalFactory.createPrincipal(username, result.getValue().get()),
-                        new ArrayList<>());
-            }
-            throw new FailedLoginException("Radius authentication failed for user " + username);
+            final Serializable state = radiusCredential.getState();
+            radiusCredential.setState(null);
+            result = RadiusUtils.authenticate(username, password, state, this.servers,
+                    this.failoverOnAuthenticationFailure, this.failoverOnException);
         } catch (final Exception e) {
             throw new FailedLoginException("Radius authentication failed " + e.getMessage());
         }
+        if (result.getLeft()) {
+            return createHandlerResult(credential, this.principalFactory.createPrincipal(username, result.getRight().get()),
+                    new ArrayList<>());
+        } else if (result.getRight().isPresent()) {
+            final Serializable state = (Serializable) result.getRight().get().getOrDefault("State", null);
+            radiusCredential.setState(state);
+            final String message = result.getRight().get().getOrDefault("Reply-Message", "?").toString();
+            radiusCredential.setMessage(message);
+            throw new AccessChallengedException(message);
+        }
+        throw new FailedLoginException("Radius authentication failed for user " + username);
     }
 }

--- a/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/adaptors/radius/web/flow/RadiusAuthenticationWebflowEventResolver.java
+++ b/support/cas-server-support-radius-mfa/src/main/java/org/apereo/cas/adaptors/radius/web/flow/RadiusAuthenticationWebflowEventResolver.java
@@ -1,13 +1,22 @@
 package org.apereo.cas.adaptors.radius.web.flow;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.CentralAuthenticationService;
+import org.apereo.cas.adaptors.radius.AccessChallengedException;
+import org.apereo.cas.adaptors.radius.authentication.RadiusTokenAuthenticationHandler;
+import org.apereo.cas.adaptors.radius.authentication.RadiusTokenCredential;
+import org.apereo.cas.authentication.AuthenticationException;
+import org.apereo.cas.authentication.AuthenticationResultBuilder;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
+import org.apereo.cas.authentication.Credential;
+import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.MultifactorAuthenticationProviderSelector;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.web.flow.resolver.impl.AbstractCasWebflowEventResolver;
+import org.apereo.cas.web.support.WebUtils;
 import org.apereo.inspektr.audit.annotation.Audit;
 import org.springframework.web.util.CookieGenerator;
 import org.springframework.webflow.execution.Event;
@@ -39,7 +48,32 @@ public class RadiusAuthenticationWebflowEventResolver extends AbstractCasWebflow
 
     @Override
     public Set<Event> resolveInternal(final RequestContext context) {
-        return handleAuthenticationTransactionAndGrantTicketGrantingTicket(context);
+        try {
+            final Credential credential = getCredentialFromContext(context);
+            AuthenticationResultBuilder builder = WebUtils.getAuthenticationResultBuilder(context);
+
+            LOGGER.debug("Handling authentication transaction for credential {}", credential);
+            final Service service = WebUtils.getService(context);
+            builder = this.authenticationSystemSupport.handleAuthenticationTransaction(service, builder, credential);
+
+            LOGGER.debug("Issuing ticket-granting tickets for service {}", service);
+            return ImmutableSet.of(grantTicketGrantingTicketToAuthenticationResult(context, builder, service));
+        } catch (final AuthenticationException e) {
+            final Class<? extends Throwable> error = e.getHandlerErrors().get(RadiusTokenAuthenticationHandler.class.getSimpleName()).getClass();
+            final boolean accessChallenged = error != null && error == AccessChallengedException.class;
+            if (accessChallenged) {
+                // if access attempt was challenged, put message to webflow scope
+                final Credential radiusCredential = getCredentialFromContext(context);
+                final String message = radiusCredential instanceof RadiusTokenCredential ? ((RadiusTokenCredential) radiusCredential).getMessage() : "???:";
+                context.getFlowScope().put("accessChallenged", message);
+                return ImmutableSet.of(newEvent("accessChallenged"));
+            } else {
+                context.getFlowScope().put("accessChallenged", null);
+                return ImmutableSet.of(newEvent("error", e));
+            }
+        } catch (final Exception e) {
+            return ImmutableSet.of(newEvent("error", e));
+        }
     }
 
     @Audit(action = "AUTHENTICATION_EVENT", actionResolverName = "AUTHENTICATION_EVENT_ACTION_RESOLVER",

--- a/support/cas-server-support-radius-mfa/src/main/resources/webflow/mfa-radius/mfa-radius-webflow.xml
+++ b/support/cas-server-support-radius-mfa/src/main/resources/webflow/mfa-radius/mfa-radius-webflow.xml
@@ -29,7 +29,17 @@
     <action-state id="realSubmitRadius">
         <evaluate expression="radiusAuthenticationWebflowAction" />
         <transition on="success" to="success" />
+<<<<<<< HEAD
         <transition on="error" to="initializeLoginForm" />
+=======
+        <transition on="error" to="handleError" />
+        <transition on="accessChallenged" to="viewLoginFormRadius" />
+    </action-state>
+
+    <action-state id="handleError">
+        <evaluate expression="authenticationExceptionHandler.handle(currentEvent.attributes.error, messageContext)"/>
+        <transition to="initializeLoginForm"/>
+>>>>>>> extend radius access challenge with state
     </action-state>
 
     <end-state id="success" />

--- a/support/cas-server-support-radius/src/main/java/org/apereo/cas/adaptors/radius/authentication/handler/support/RadiusAuthenticationHandler.java
+++ b/support/cas-server-support-radius/src/main/java/org/apereo/cas/adaptors/radius/authentication/handler/support/RadiusAuthenticationHandler.java
@@ -71,7 +71,7 @@ public class RadiusAuthenticationHandler extends AbstractUsernamePasswordAuthent
         try {
             final String username = credential.getUsername();
             final Pair<Boolean, Optional<Map<String, Object>>> result =
-                RadiusUtils.authenticate(username, credential.getPassword(), this.servers,
+                RadiusUtils.authenticate(username, credential.getPassword(), null, this.servers,
                     this.failoverOnAuthenticationFailure, this.failoverOnException);
             if (result.getKey()) {
                 return createHandlerResult(credential,

--- a/webapp/resources/templates/casRadiusLoginView.html
+++ b/webapp/resources/templates/casRadiusLoginView.html
@@ -13,6 +13,9 @@
             <div class="alert alert-danger" th:if="${#fields.hasErrors('*')}">
                 <span th:each="err : ${#fields.errors('*')}" th:utext="${err}"/>
             </div>
+            <div class="alert alert-info" th:if="${accessChallenged!=null}">
+                <p th:text="${accessChallenged}"/>
+            </div>
 
             <div class="row fl-controls-left">
                 <label for="password" class="fl-label" th:utext="#{screen.welcome.label.password}"/>
@@ -32,4 +35,3 @@
 </div>
 </body>
 </html>
-


### PR DESCRIPTION

- handle properly AccessChallenge in JRadius implementation - existing implementation ignores response AccessChallenge and invokes again AccessRequest - this causes cca 80k requests to RSA server till AccessReject is send, therefore the default authenticate implementation in JRadius is avoided and replaced with simple call without additional logic
- store state and message in credential for proper communication with SecurId server - these are parts of AccessChallenge response  - state should be used for subsequent call with additional authentication information, this way are handled request for additional/changed token, request for changed pin, ...
- provide accessChallenged variable in webflow context to distinguish info
from error and display it properly as hint on viewLoginForm
- provide error handling state in webflow (as error messages where silently swallowed in processing), anyway I am not sure whether this is required anymore

For distinguishing this Radius handling, new protocol have to be specified. Otherwise old behaviour is preserved.
You have to set

   cas.authn.mfa.radius.server.protocol=SECURID_PAP

