### PR TITLE
fix : remove all actions present in "ActionList", before only first element is removed

### DIFF
--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationEventExecutionPlan.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationEventExecutionPlan.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication;
 
 import org.apereo.cas.authentication.principal.PrincipalResolver;
+import org.apereo.cas.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.OrderComparator;
@@ -71,7 +72,7 @@ public class DefaultAuthenticationEventExecutionPlan implements AuthenticationEv
     public Set<AuthenticationHandler> getAuthenticationHandlersForTransaction(final AuthenticationTransaction transaction) {
         final AuthenticationHandler[] handlers = authenticationHandlerPrincipalResolverMap.keySet().toArray(new AuthenticationHandler[]{});
         OrderComparator.sortIfNecessary(handlers);
-        return new LinkedHashSet<>(Arrays.asList(handlers));
+        return new LinkedHashSet<>(CollectionUtils.wrapList(handlers));
     }
 
     @Override

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationEventExecutionPlan.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationEventExecutionPlan.java
@@ -71,7 +71,7 @@ public class DefaultAuthenticationEventExecutionPlan implements AuthenticationEv
     public Set<AuthenticationHandler> getAuthenticationHandlersForTransaction(final AuthenticationTransaction transaction) {
         final AuthenticationHandler[] handlers = authenticationHandlerPrincipalResolverMap.keySet().toArray(new AuthenticationHandler[]{});
         OrderComparator.sortIfNecessary(handlers);
-        return new LinkedHashSet<>(Arrays.stream(handlers).collect(Collectors.toSet()));
+        return new LinkedHashSet<>(Arrays.asList(handlers));
     }
 
     @Override

--- a/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
+++ b/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
@@ -747,13 +747,13 @@ public abstract class AbstractCasWebflowConfigurer implements CasWebflowConfigur
      * @return the action
      */
     public Action createEvaluateActionForExistingActionState(final Flow flow, final String actionStateId, final String evaluateActionId) {
-		final ActionState action = getState(flow, actionStateId, ActionState.class);
-		final Action[] actions = action.getActionList().toArray();
-		Arrays.stream(actions).forEach(action.getActionList()::remove);
-		final Action evaluateAction = createEvaluateAction(evaluateActionId);
-		action.getActionList().add(evaluateAction);
-		action.getActionList().addAll(actions);
-		return evaluateAction;
+        final ActionState action = getState(flow, actionStateId, ActionState.class);
+        final Action[] actions = action.getActionList().toArray();
+        Arrays.stream(actions).forEach(action.getActionList()::remove);
+        final Action evaluateAction = createEvaluateAction(evaluateActionId);
+        action.getActionList().add(evaluateAction);
+        action.getActionList().addAll(actions);
+        return evaluateAction;
     }
 
     /**

--- a/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
+++ b/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
@@ -746,16 +746,14 @@ public abstract class AbstractCasWebflowConfigurer implements CasWebflowConfigur
      * @param evaluateActionId the evaluate action id
      * @return the action
      */
-    public Action createEvaluateActionForExistingActionState(final Flow flow, final String actionStateId,
-                                                             final String evaluateActionId) {
-        final ActionState action = getState(flow, actionStateId, ActionState.class);
-        final List<Action> actions = StreamSupport.stream(action.getActionList().spliterator(), false)
-                .collect(Collectors.toList());
-        final Action evaluateAction = createEvaluateAction(evaluateActionId);
-        actions.add(0, evaluateAction);
-        action.getActionList().forEach(a -> action.getActionList().remove(a));
-        actions.forEach(action.getActionList()::add);
-        return evaluateAction;
+    public Action createEvaluateActionForExistingActionState(final Flow flow, final String actionStateId, final String evaluateActionId) {
+		final ActionState action = getState(flow, actionStateId, ActionState.class);
+		final Action[] actions = action.getActionList().toArray();
+		Arrays.stream(actions).forEach(action.getActionList()::remove);
+		final Action evaluateAction = createEvaluateAction(evaluateActionId);
+		action.getActionList().add(evaluateAction);
+		action.getActionList().addAll(actions);
+		return evaluateAction;
     }
 
     /**


### PR DESCRIPTION
I change the implementation of "createEvaluateActionForExistingActionState" for fix the issue with the "remove all" action of "ActionList".
The problem was here : "action.getActionList().forEach(a -> action.getActionList().remove(a));".
This line of code remove only the first element but not throws an java.util.ConcurrentModificationException (I don't know why, an idea ?).