### PR TITLE
Allow OAuth tokens to participate in TGT deletion (5.2.x)

### DIFF
--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
@@ -13,6 +13,7 @@ import org.apereo.cas.ticket.TicketCatalog;
 import org.apereo.cas.ticket.registry.JpaTicketRegistry;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.registry.support.JpaLockingStrategy;
+import org.apereo.cas.ticket.registry.support.JpaTgtDeleteHandler;
 import org.apereo.cas.ticket.registry.support.LockingStrategy;
 import org.apereo.cas.util.InetAddressUtils;
 import org.reflections.Reflections;
@@ -33,7 +34,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -50,6 +53,9 @@ public class JpaTicketRegistryConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
+
+    @Autowired
+    private Optional<List<JpaTgtDeleteHandler>> jpaTgtDeleteHandlers;
 
     @Bean
     public List<String> ticketPackagesToScan() {
@@ -95,7 +101,8 @@ public class JpaTicketRegistryConfiguration {
     public TicketRegistry ticketRegistry(@Qualifier("ticketCatalog")
                                             final TicketCatalog ticketCatalog) {
         final JpaTicketRegistryProperties jpa = casProperties.getTicket().getRegistry().getJpa();
-        final JpaTicketRegistry bean = new JpaTicketRegistry(jpa.getTicketLockType(), ticketCatalog);
+        final JpaTicketRegistry bean = new JpaTicketRegistry(jpa.getTicketLockType(), ticketCatalog,
+                jpaTgtDeleteHandlers.orElseGet(ArrayList::new));
         bean.setCipherExecutor(Beans.newTicketRegistryCipherExecutor(jpa.getCrypto(), "jpa"));
         return bean;
     }

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
@@ -5,6 +5,7 @@ import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketCatalog;
 import org.apereo.cas.ticket.TicketDefinition;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.registry.support.JpaTgtDeleteHandler;
 import org.hibernate.LockOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,12 +41,15 @@ public class JpaTicketRegistry extends AbstractTicketRegistry {
     private final TicketCatalog ticketCatalog;
     private final LockModeType lockType;
 
+    private final List<JpaTgtDeleteHandler> tgtDeleteHandlers;
+
     @PersistenceContext(unitName = "ticketEntityManagerFactory")
     private EntityManager entityManager;
 
-    public JpaTicketRegistry(final LockModeType lockType, final TicketCatalog ticketCatalog) {
+    public JpaTicketRegistry(final LockModeType lockType, final TicketCatalog ticketCatalog, final List<JpaTgtDeleteHandler> tgtDeleteHandlers) {
         this.lockType = lockType;
         this.ticketCatalog = ticketCatalog;
+        this.tgtDeleteHandlers = tgtDeleteHandlers;
     }
 
     @Override
@@ -162,10 +166,11 @@ public class JpaTicketRegistry extends AbstractTicketRegistry {
      * @return the int
      */
     private int deleteTicketGrantingTickets(final String ticketId) {
-        int totalCount = 0;
+        int totalCount = tgtDeleteHandlers.stream()
+                .mapToInt(handler -> handler.deleteSingleTgt(entityManager, ticketId))
+                .sum();
 
         final TicketDefinition st = this.ticketCatalog.find(ServiceTicket.PREFIX);
-
         Query query = entityManager.createQuery("delete from " + getTicketEntityName(st) + " s where s.ticketGrantingTicket.id = :id");
 
         query.setParameter("id", ticketId);

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/DefaultJpaTgtDeleteHandler.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/DefaultJpaTgtDeleteHandler.java
@@ -1,0 +1,46 @@
+package org.apereo.cas.ticket.registry.support;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apereo.cas.ticket.TicketCatalog;
+import org.apereo.cas.ticket.TicketDefinition;
+
+/**
+ * Simple implentation of the JpaTgtDeleteHandler that takes a ticket prefix and
+ * looks up the ticket definition.
+ * 
+ * @author sbearcsiro
+ * @since 5.2.3
+ *
+ */
+public class DefaultJpaTgtDeleteHandler implements JpaTgtDeleteHandler {
+
+    private static final String DEFAULT_TICKET_GRANTING_TICKET_FIELD_NAME = "ticketGrantingTicket";
+
+    private final TicketCatalog ticketCatalog;
+    private final String prefix;
+    private final String ticketGrantingTicketFieldName;
+
+    public DefaultJpaTgtDeleteHandler(final TicketCatalog ticketCatalog, final String prefix) {
+        this(ticketCatalog, prefix, DEFAULT_TICKET_GRANTING_TICKET_FIELD_NAME);
+    }
+
+    public DefaultJpaTgtDeleteHandler(final TicketCatalog ticketCatalog, final String prefix,
+            final String ticketGrantingTicketFieldName) {
+        this.ticketCatalog = ticketCatalog;
+        this.prefix = prefix;
+        this.ticketGrantingTicketFieldName = ticketGrantingTicketFieldName;
+    }
+
+    @Override
+    public int deleteSingleTgt(final EntityManager entityManager, final String ticketId) {
+        final TicketDefinition ot = ticketCatalog.find(prefix);
+        final String entityName = ot.getImplementationClass().getSimpleName();
+        final Query query = entityManager
+                .createQuery("delete from " + entityName + " c where c." + ticketGrantingTicketFieldName + ".id = :id");
+        query.setParameter("id", ticketId);
+        return query.executeUpdate();
+    }
+
+}

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/JpaTgtDeleteHandler.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/support/JpaTgtDeleteHandler.java
@@ -1,0 +1,24 @@
+package org.apereo.cas.ticket.registry.support;
+
+import javax.persistence.EntityManager;
+
+/**
+ * Allows other support libraries to particpate in JPA TGT deletion (eg oauth).
+ * 
+ * @author sbearcsiro
+ * @since 5.2.3
+ *
+ */
+public interface JpaTgtDeleteHandler {
+
+    /**
+     * Called when a single cascading ticket is being deleted.
+     * 
+     * @param entityManager
+     *            The entity manager
+     * @param ticketId
+     *            The TGT ticket id being deleted
+     * @return the number of entities deleted
+     */
+    int deleteSingleTgt(EntityManager entityManager, String ticketId);
+}

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JpaTicketRegistryTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JpaTicketRegistryTests.java
@@ -24,17 +24,24 @@ import org.apereo.cas.config.JpaTicketRegistryConfiguration;
 import org.apereo.cas.config.JpaTicketRegistryTicketCatalogConfiguration;
 import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
 import org.apereo.cas.config.support.EnvironmentConversionServiceInitializer;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.ticket.AbstractTicketException;
+import org.apereo.cas.ticket.BaseTicketCatalogConfigurer;
 import org.apereo.cas.ticket.ExpirationPolicy;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
+import org.apereo.cas.ticket.TicketCatalog;
+import org.apereo.cas.ticket.TicketDefinition;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.UniqueTicketIdGenerator;
 import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.proxy.ProxyTicket;
+import org.apereo.cas.ticket.registry.support.DefaultJpaTgtDeleteHandler;
+import org.apereo.cas.ticket.registry.support.JpaTgtDeleteHandler;
+import org.apereo.cas.ticket.registry.support.TestTicket;
 import org.apereo.cas.ticket.support.HardTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.MultiTimeUseOrTimeoutExpirationPolicy;
 import org.apereo.cas.util.DefaultUniqueTicketIdGenerator;
@@ -49,6 +56,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -56,6 +65,7 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -65,7 +75,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.junit.Assert.*;
-
+import static org.mockito.Mockito.*;
 
 /**
  * Unit test for {@link JpaTicketRegistry} class.
@@ -114,6 +124,8 @@ public class JpaTicketRegistryTests {
 
     private static final ExpirationPolicy EXP_POLICY_PT = new MultiTimeUseOrTimeoutExpirationPolicy(1, 2000);
 
+    private static final ExpirationPolicy EXP_POLICY_TT = new HardTimeoutExpirationPolicy(1000);
+
     private static final Logger LOGGER = LoggerFactory.getLogger(JpaTicketRegistryTests.class);
 
     @Autowired
@@ -124,10 +136,39 @@ public class JpaTicketRegistryTests {
     @Qualifier("ticketRegistry")
     private TicketRegistry ticketRegistry;
 
+    @Autowired
+    @Qualifier("mockHandler")
+    private JpaTgtDeleteHandler mockHandler;
+
     @TestConfiguration
     public static class JpaTestConfiguration {
         @Autowired
         protected ApplicationContext applicationContext;
+
+        @Bean
+        public JpaTgtDeleteHandler testHandler(final TicketCatalog catalog) {
+            return new DefaultJpaTgtDeleteHandler(catalog, TestTicket.PREFIX);
+        }
+
+        @Bean
+        public JpaTgtDeleteHandler mockHandler() {
+            final JpaTgtDeleteHandler mockHandler = mock(JpaTgtDeleteHandler.class);
+            when(mockHandler.deleteSingleTgt((EntityManager) any(EntityManager.class), anyString())).thenReturn(0);
+            return mockHandler;
+        }
+
+        @Configuration("testTicketMetadataRegistrationConfiguration")
+        public static class TestTicketCatalogConfiguration extends BaseTicketCatalogConfigurer {
+
+            @Override
+            public void configureTicketCatalog(final TicketCatalog plan) {
+                final TicketDefinition metadata = buildTicketDefinition(plan, TestTicket.PREFIX, TestTicket.class);
+                metadata.getProperties().setStorageName("testTokensCache");
+                final long timeout = Beans.newDuration("PT1S").toMillis();
+                metadata.getProperties().setStorageTimeout(timeout);
+                registerTicketDefinition(plan, metadata);
+            }
+        }
 
         @PostConstruct
         public void init() {
@@ -145,8 +186,10 @@ public class JpaTicketRegistryTests {
         final ProxyGrantingTicket newPgt = grantProxyGrantingTicketInTransaction(stFromDb);
         final ProxyGrantingTicket pgtFromDb = (ProxyGrantingTicket) getTicketInTransaction(newPgt.getId());
         final ProxyTicket newPt = grantProxyTicketInTransaction(pgtFromDb);
+        final TestTicket newTt = grantTestTicketInTransaction(tgtFromDb);
 
         getTicketInTransaction(newPt.getId());
+        getTicketInTransaction(newTt.getId());
         deleteTicketsInTransaction();
     }
 
@@ -218,6 +261,27 @@ public class JpaTicketRegistryTests {
     }
 
     @Test
+    public void verifyTgtDeleteHandlerExecuted() {
+        // TGT
+        final TicketGrantingTicket newTgt = newTGT();
+        addTicketInTransaction(newTgt);
+        final TicketGrantingTicket tgtFromDb = (TicketGrantingTicket) getTicketInTransaction(newTgt.getId());
+        assertNotNull(tgtFromDb);
+
+        final TestTicket newTt = grantTestTicketInTransaction(tgtFromDb);
+        final TestTicket ttFromDb = (TestTicket) getTicketInTransaction(newTt.getId());
+        assertNotNull(ttFromDb);
+        assertEquals(newTt.getId(), ttFromDb.getId());
+
+        deleteTicketInTransaction(tgtFromDb.getId());
+
+        // verify test ticket delete handler is executed
+        assertNull(getTicketInTransaction(ttFromDb.getId()));
+        // verify second tgt delete handler is executed
+        verify(mockHandler).deleteSingleTgt(isA(EntityManager.class), eq(tgtFromDb.getId()));
+    }
+
+    @Test
     public void verifyConcurrentServiceTicketGeneration() {
         final TicketGrantingTicket newTgt = newTGT();
         addTicketInTransaction(newTgt);
@@ -280,6 +344,13 @@ public class JpaTicketRegistryTests {
                 false);
     }
 
+    static TestTicket newTT(final TicketGrantingTicket parent) {
+        final TestTicket tt = new TestTicket(ID_GENERATOR.getNewTicketId(TestTicket.PREFIX), EXP_POLICY_TT);
+        tt.setGrantingTicket(parent);
+
+        return tt;
+    }
+
     private void addTicketInTransaction(final Ticket ticket) {
         new TransactionTemplate(txManager).execute(status -> {
             ticketRegistry.addTicket(ticket);
@@ -333,6 +404,14 @@ public class JpaTicketRegistryTests {
             final ProxyTicket st = newPT(parent);
             ticketRegistry.addTicket(st);
             return st;
+        });
+    }
+
+    private TestTicket grantTestTicketInTransaction(final TicketGrantingTicket parent) {
+        return new TransactionTemplate(txManager).execute(status -> {
+            final TestTicket tt = newTT(parent);
+            ticketRegistry.addTicket(tt);
+            return tt;
         });
     }
 

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/TestTicket.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/TestTicket.java
@@ -1,0 +1,62 @@
+package org.apereo.cas.ticket.registry.support;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.apereo.cas.authentication.Authentication;
+import org.apereo.cas.ticket.AbstractTicket;
+import org.apereo.cas.ticket.ExpirationPolicy;
+import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.TicketGrantingTicketImpl;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+/**
+ * Mock ticket type for testing ticket types outside this project can be deleted
+ * too.
+ * 
+ * @author sbearcsiro
+ * @since 5.2.3
+ *
+ */
+@Entity
+@Table(name = "TEST")
+public class TestTicket extends AbstractTicket {
+
+    public static final String PREFIX = "TEST";
+
+    /**
+     * The {@link TicketGrantingTicket} this is associated with.
+     */
+    @ManyToOne(targetEntity = TicketGrantingTicketImpl.class)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private TicketGrantingTicket ticketGrantingTicket;
+
+    public TestTicket() {
+    }
+
+    public TestTicket(final String id, final ExpirationPolicy expirationPolicy) {
+        super(id, expirationPolicy);
+    }
+
+    @Override
+    public TicketGrantingTicket getGrantingTicket() {
+        return ticketGrantingTicket;
+    }
+
+    public void setGrantingTicket(final TicketGrantingTicket ticketGrantingTicket) {
+        this.ticketGrantingTicket = ticketGrantingTicket;
+    }
+
+    @Override
+    public Authentication getAuthentication() {
+        return getGrantingTicket().getAuthentication();
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+}

--- a/support/cas-server-support-oauth-core/build.gradle
+++ b/support/cas-server-support-oauth-core/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(":core:cas-server-core-web")
     implementation project(":core:cas-server-core-authentication-attributes")
     compileOnly project(":core:cas-server-core-tickets")
+    compileOnly project(":support:cas-server-support-jpa-ticket-registry")
     implementation project(":support:cas-server-support-oauth-api")
     implementation project(":support:cas-server-support-oauth-services")
     implementation project(":core:cas-server-core-configuration")

--- a/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/config/CasOAuthJdbcConfiguration.java
+++ b/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/config/CasOAuthJdbcConfiguration.java
@@ -1,0 +1,28 @@
+package org.apereo.cas.config;
+
+import org.apereo.cas.ticket.TicketCatalog;
+import org.apereo.cas.ticket.code.OAuthCode;
+import org.apereo.cas.ticket.registry.JpaTicketRegistry;
+import org.apereo.cas.ticket.registry.support.JpaTgtDeleteHandler;
+import org.apereo.cas.ticket.registry.support.DefaultJpaTgtDeleteHandler;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This is {@link CasOauthJdbcConfiguration}.
+ *
+ * @author sbearcsiro
+ * @since 5.2.3
+ */
+@Configuration("casOauthJdbcConfiguration")
+@ConditionalOnClass(JpaTicketRegistry.class)
+public class CasOAuthJdbcConfiguration {
+
+    @Bean
+    public JpaTgtDeleteHandler oauthJpaTgtDeleteHandler(@Qualifier("ticketCatalog") final TicketCatalog ticketCatalog) {
+        return new DefaultJpaTgtDeleteHandler(ticketCatalog, OAuthCode.PREFIX);
+    }
+
+}

--- a/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/ticket/code/OAuthCodeImpl.java
+++ b/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/ticket/code/OAuthCodeImpl.java
@@ -8,6 +8,8 @@ import org.apereo.cas.ticket.ExpirationPolicy;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
 import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.util.Assert;
 
 import javax.persistence.Column;
@@ -36,6 +38,7 @@ public class OAuthCodeImpl extends AbstractTicket implements OAuthCode {
      * The {@link TicketGrantingTicket} this is associated with.
      */
     @ManyToOne(targetEntity = TicketGrantingTicketImpl.class)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JsonProperty("grantingTicket")
     private TicketGrantingTicket ticketGrantingTicket;
 

--- a/support/cas-server-support-oauth-core/src/main/resources/META-INF/spring.factories
+++ b/support/cas-server-support-oauth-core/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.config.OAuthProtocolTicketCatalogConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.config.OAuthProtocolTicketCatalogConfiguration,org.apereo.cas.config.CasOAuthJdbcConfiguration


### PR DESCRIPTION
Currently with both OAuth server support enabled and a JPA ticket registry in use, deleting a single TGT from the repo fails due to a foreign key constraint.

This patch adds allows external libs to add synchronous handlers that can participate in the deletion of a single TGT and in particular adds an OAuth TGT delete handler that is only added when the JpaTicketRegistry is available.  It also adds cascade deletes from the TGT to the OAuth token at the DB level when Hibernate creates the DB tables.