### PR TITLE
Allowing SAML binding HTTP-POST by supporting RedirectAction SUCCESS

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
@@ -27,6 +27,7 @@ import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.exception.HttpAction;
+import org.pac4j.core.redirect.RedirectAction;
 import org.pac4j.core.profile.CommonProfile;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.ModelAndView;
@@ -194,7 +195,13 @@ public class DelegatedClientAuthenticationAction extends AbstractAction {
                     final String name = client.getName();
                     final Matcher matcher = PAC4J_CLIENT_SUFFIX_PATTERN.matcher(client.getClass().getSimpleName());
                     final String type = matcher.replaceAll(StringUtils.EMPTY).toLowerCase();
-                    final String redirectionUrl = indirectClient.getRedirectAction(webContext).getLocation();
+                    final String redirectionUrl;
+                    final RedirectAction action = indirectClient.getRedirectAction(webContext);
+                    if (RedirectAction.RedirectType.SUCCESS.equals(action.getType())) {
+                        redirectionUrl = String.format("javascript:document.write('%1$s');document.close()", action.getContent().replaceAll("\n", ""));
+                    } else {
+                        redirectionUrl = action.getLocation();
+                    }
                     LOGGER.debug("[{}] -> [{}]", name, redirectionUrl);
                     urls.add(new ProviderLoginPageConfiguration(name, redirectionUrl, type, getCssClass(name)));
                 } catch (final HttpAction e) {


### PR DESCRIPTION
Adds support for SAML binding HTTP-POST as configured by:

```
cas.authn.pac4j.saml[0].destinationBinding=urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
```

This was not supported because [pac4j creates a redirect action of type SUCCESS](https://github.com/pac4j/pac4j/blob/400cec0c94a93ba80dc43208c9e5d179dfd70af4/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectActionBuilder.java) with no location but with content. 

The content contains the result of Velocity template which has an HTML with a form that does the POST action and a script that executes the form automatically. 

But the [cas-pac4j integration code](https://github.com/apereo/cas/blob/fb21bd0045590c821d5f588276409a74f062e4f4/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/web/flow/DelegatedClientAuthenticationAction.java#L199) only expects redirects, looking only to location that will be empty.

Fixed this by creating a redirection URL that executes a javascript that will substitute the current page content by the content that comes from pac4j/opensaml velocity template. 

This solution was tested on Chrome, Firefox and IE. Tested with CAS 5.2.2 but changes should be compatible with master (which was failing to compile at the time of this pull request).

There is no configuration needed (actually supporting current configuration options) and no foreseen side effects.
