### PR TITLE
remove unnecessary DefaultAdvisorAutoProxyCreator

### DIFF
--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasApplicationContextConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasApplicationContextConfiguration.java
@@ -3,7 +3,6 @@ package org.apereo.cas.config;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,17 +26,11 @@ import javax.servlet.http.HttpServletResponse;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @Slf4j
 public class CasApplicationContextConfiguration {
-    
-    @Bean
-    public DefaultAdvisorAutoProxyCreator advisorAutoProxyCreator() {
-        return new DefaultAdvisorAutoProxyCreator();
-    }
-            
     @Bean
     protected UrlFilenameViewController passThroughController() {
         return new UrlFilenameViewController();
     }
-    
+
     @Bean
     protected Controller rootController() {
         return new ParameterizableViewController() {


### PR DESCRIPTION
This bean is actually a duplicate of the bean already created via the
`spring.aop.auto=true` configuration. Because there were 2 AdvisorAutoProxyCreator
beans present in the application context the `@Transactional` advice was being
applied twice to beans.

I discovered the duplicate advice when I was attempting to include some additional advice that I needed to run before the `@Transactional` advice was run. My advice was only being picked up by the other proxy creator, and this proxy creator was wrapping the objects in a second proxy with both proxies applying the `@Transactional` advice.