### PR TITLE
fix TGC generation

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -145,6 +145,11 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator {
     }
 
     @Override
+    public void setCookieDomain(final String cookieDomain) {
+        super.setCookieDomain(StringUtils.defaultIfEmpty(cookieDomain, null));
+    }
+
+    @Override
     protected Cookie createCookie(final String cookieValue) {
         final Cookie c = super.createCookie(cookieValue);
         c.setComment("CAS Cookie");


### PR DESCRIPTION
we need to sanitize the cookie domain to be null if it is not set so that the TGC will actually be tracked by a web browser. This behavior existed existed in CAS pre-5.3.0, it looks like it got dropped when implementing lombok setters

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
