### PR TITLE
Prevent overflow in MongoDbTicketRegistry.getExpireAt

### DIFF
--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -200,7 +200,7 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
      * Makes the assumption that the CAS server date and the Mongo server date are in sync.
      */
     private static Date getExpireAt(final Ticket ticket) {
-        final int ttl = ticket.getExpirationPolicy().getTimeToLive().intValue();
+        final long ttl = ticket.getExpirationPolicy().getTimeToLive();
 
         // expiration policy can specify not to delete automatically
         if (ttl < 1) {


### PR DESCRIPTION
A sufficiently large TTL (eg 30 days in seconds: 2592000) will overflow a 32 bit signed integer when multiplied by 1000, which causes the getExpireAt return value to occur in the past.  By leaving the TTL as a long this class of bug is prevented until a TTL of ~292471208 years is used.
