### PR TITLE
Provides missing configuration to specify SAML2.0 AttributeConsumingServiceIndex

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
@@ -105,7 +105,11 @@ public class Pac4jSamlProperties implements Serializable {
     private boolean wantsAssertionsSigned;
 
     /**
-     * Attribute consuming servie index.
+     * AttributeConsumingServiceIndex attribute of AuthnRequest element.
+     * The given index points out a specific AttributeConsumingService structure, declared into the 
+     * Service Provider (SP)'s metadata, to be used to specify all the attributes that the Service Provider
+     * is asking to be released within the authentication assertion returned by the Identity Provider (IdP).
+     * This attribute won't be sent with the request unless a positive value (including 0) is defined.
      */
     private int attributeConsumingServiceIndex;
 

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
@@ -104,6 +104,11 @@ public class Pac4jSamlProperties implements Serializable {
      */
     private boolean wantsAssertionsSigned;
 
+    /**
+     * Attribute consuming servie index.
+     */
+    private int attributeConsumingServiceIndex;
+
     public String getDestinationBinding() {
         return destinationBinding;
     }
@@ -230,6 +235,14 @@ public class Pac4jSamlProperties implements Serializable {
 
     public void setClientName(final String clientName) {
         this.clientName = clientName;
+    }
+
+    public int getAttributeConsumingServiceIndex() {
+        return attributeConsumingServiceIndex;
+    }
+
+    public void setAttributeConsumingServiceIndex(final int attributeConsumingServiceIndex) {
+        this.attributeConsumingServiceIndex = attributeConsumingServiceIndex;
     }
 }
 

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3801,6 +3801,9 @@ prefixes for the `keystorePath` or `identityProviderMetadataPath` property).
 
 # Define whether metadata requires assertions signed
 # cas.authn.pac4j.saml[0].wantsAssertionsSigned=
+
+# Specifies the AttributeConsumingServiceIndex attribute (positive values to enable)
+# cas.authn.pac4j.saml[0].attributeConsumingServiceIndex=
 ```
 
 Examine the generated metadata after accessing the CAS login screen to ensure all ports and endpoints are correctly adjusted.  

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/support/authentication/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -269,6 +269,7 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration {
                     cfg.setForceAuth(saml.isForceAuth());
                     cfg.setPassive(saml.isPassive());
                     cfg.setWantsAssertionsSigned(saml.isWantsAssertionsSigned());
+                    cfg.setAttributeConsumingServiceIndex(saml.getAttributeConsumingServiceIndex());
 
                     if (StringUtils.isNotBlank(saml.getAuthnContextClassRef())) {
                         cfg.setComparisonType(saml.getAuthnContextComparisonType().toUpperCase());


### PR DESCRIPTION
This PR provides missing configuration parameter to enable SAML2.0 AttributeConsumingServiceIndex
