### PR TITLE
Provides missing configuration to specify SAML2.0 AttributeConsumingServiceIndex

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
@@ -118,4 +118,9 @@ public class Pac4jSamlProperties implements Serializable {
      * Whether metadata should be marked to request sign assertions.
      */
     private boolean wantsAssertionsSigned;
+
+    /**
+     * Attribute consuming servie index.
+     */
+    private int attributeConsumingServiceIndex;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jSamlProperties.java
@@ -120,7 +120,11 @@ public class Pac4jSamlProperties implements Serializable {
     private boolean wantsAssertionsSigned;
 
     /**
-     * Attribute consuming servie index.
+     * AttributeConsumingServiceIndex attribute of AuthnRequest element.
+     * The given index points out a specific AttributeConsumingService structure, declared into the 
+     * Service Provider (SP)'s metadata, to be used to specify all the attributes that the Service Provider
+     * is asking to be released within the authentication assertion returned by the Identity Provider (IdP).
+     * This attribute won't be sent with the request unless a positive value (including 0) is defined.
      */
     private int attributeConsumingServiceIndex;
 }

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -2540,6 +2540,9 @@ prefixes for the `keystorePath` or `identityProviderMetadataPath` property).
 
 # Define whether metadata requires assertions signed
 # cas.authn.pac4j.saml[0].wantsAssertionsSigned=
+
+# Specifies the AttributeConsumingServiceIndex attribute (positive values to enable)
+# cas.authn.pac4j.saml[0].attributeConsumingServiceIndex=
 ```
 
 Examine the generated metadata after accessing the CAS login screen to ensure all ports and endpoints are correctly adjusted.  Finally, share the CAS SP metadata with the delegated IdP and register CAS as an authorized relying party.

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
@@ -324,6 +324,7 @@ public class DelegatedClientFactory {
                 cfg.setForceAuth(saml.isForceAuth());
                 cfg.setPassive(saml.isPassive());
                 cfg.setWantsAssertionsSigned(saml.isWantsAssertionsSigned());
+                cfg.setAttributeConsumingServiceIndex(saml.getAttributeConsumingServiceIndex());
 
                 if (StringUtils.isNotBlank(saml.getAuthnContextClassRef())) {
                     cfg.setComparisonType(saml.getAuthnContextComparisonType().toUpperCase());


### PR DESCRIPTION
This PR provides missing configuration parameter to enable SAML2.0 AttributeConsumingServiceIndex