### PR TITLE
Fix some instances of passing milliseconds where seconds were expected.

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/JpaBeans.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/JpaBeans.java
@@ -76,7 +76,7 @@ public class JpaBeans {
         bean.setJdbcUrl(jpaProperties.getUrl());
         bean.setUsername(jpaProperties.getUser());
         bean.setPassword(jpaProperties.getPassword());
-        bean.setLoginTimeout((int) Beans.newDuration(jpaProperties.getPool().getMaxWait()).toMillis());
+        bean.setLoginTimeout((int) Beans.newDuration(jpaProperties.getPool().getMaxWait()).getSeconds());
         bean.setMaximumPoolSize(jpaProperties.getPool().getMaxSize());
         bean.setMinimumIdle(jpaProperties.getPool().getMinSize());
         bean.setIdleTimeout((int) Beans.newDuration(jpaProperties.getIdleTimeout()).toMillis());

--- a/core/cas-server-core-cookie/src/main/java/org/apereo/cas/web/config/CasCookieConfiguration.java
+++ b/core/cas-server-core-cookie/src/main/java/org/apereo/cas/web/config/CasCookieConfiguration.java
@@ -85,7 +85,7 @@ public class CasCookieConfiguration {
     @RefreshScope
     public CookieRetrievingCookieGenerator ticketGrantingTicketCookieGenerator(@Qualifier("cookieCipherExecutor") final CipherExecutor cipherExecutor) {
         final TicketGrantingCookieProperties tgc = casProperties.getTgc();
-        final int rememberMeMaxAge = (int) Beans.newDuration(tgc.getRememberMeMaxAge()).toMillis();
+        final int rememberMeMaxAge = (int) Beans.newDuration(tgc.getRememberMeMaxAge()).getSeconds();
         return new TGCCookieRetrievingCookieGenerator(cookieValueManager(cipherExecutor),
             tgc.getName(),
             tgc.getPath(),

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/WebflowExecutorFactory.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/WebflowExecutorFactory.java
@@ -46,7 +46,7 @@ public class WebflowExecutorFactory {
     private FlowExecutor buildFlowExecutorViaServerSessionBindingExecution() {
         final SessionBindingConversationManager conversationManager = new SessionBindingConversationManager();
         final WebflowSessionManagementProperties session = webflowProperties.getSession();
-        conversationManager.setLockTimeoutSeconds((int) Beans.newDuration(session.getLockTimeout()).toMillis());
+        conversationManager.setLockTimeoutSeconds((int) Beans.newDuration(session.getLockTimeout()).getSeconds());
         conversationManager.setMaxConversations(session.getMaxConversations());
 
         final FlowExecutionImplFactory executionFactory = new FlowExecutionImplFactory();

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
@@ -108,6 +108,6 @@ public class JpaTicketRegistryConfiguration {
         final TicketRegistryProperties registry = casProperties.getTicket().getRegistry();
         final String uniqueId = StringUtils.defaultIfEmpty(casProperties.getHost().getName(), InetAddressUtils.getCasServerHostName());
         return new JpaLockingStrategy("cas-ticket-registry-cleaner", uniqueId,
-            Beans.newDuration(registry.getJpa().getJpaLockingTimeout()).toMillis());
+            Beans.newDuration(registry.getJpa().getJpaLockingTimeout()).getSeconds());
     }
 }

--- a/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/config/OAuthProtocolTicketCatalogConfiguration.java
+++ b/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/config/OAuthProtocolTicketCatalogConfiguration.java
@@ -42,14 +42,14 @@ public class OAuthProtocolTicketCatalogConfiguration extends BaseTicketCatalogCo
 
     protected void buildAndRegisterAccessTokenDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
         metadata.getProperties().setStorageName("oauthAccessTokensCache");
-        final long timeout = Beans.newDuration(casProperties.getAuthn().getOauth().getAccessToken().getMaxTimeToLiveInSeconds()).toMillis();
+        final long timeout = Beans.newDuration(casProperties.getAuthn().getOauth().getAccessToken().getMaxTimeToLiveInSeconds()).getSeconds();
         metadata.getProperties().setStorageTimeout(timeout);
         registerTicketDefinition(plan, metadata);
     }
 
     protected void buildAndRegisterRefreshTokenDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
         metadata.getProperties().setStorageName("oauthRefreshTokensCache");
-        final long timeout = Beans.newDuration(casProperties.getAuthn().getOauth().getRefreshToken().getTimeToKillInSeconds()).toMillis();
+        final long timeout = Beans.newDuration(casProperties.getAuthn().getOauth().getRefreshToken().getTimeToKillInSeconds()).getSeconds();
         metadata.getProperties().setStorageTimeout(timeout);
         registerTicketDefinition(plan, metadata);
     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -271,8 +271,8 @@ public class CasOAuthConfiguration implements AuditTrailRecordResolutionPlanConf
     public ExpirationPolicy accessTokenExpirationPolicy() {
         final OAuthAccessTokenProperties oauth = casProperties.getAuthn().getOauth().getAccessToken();
         return new OAuthAccessTokenExpirationPolicy(
-            Beans.newDuration(oauth.getMaxTimeToLiveInSeconds()).toMillis(),
-            Beans.newDuration(oauth.getTimeToKillInSeconds()).toMillis()
+            Beans.newDuration(oauth.getMaxTimeToLiveInSeconds()).getSeconds(),
+            Beans.newDuration(oauth.getTimeToKillInSeconds()).getSeconds()
         );
     }
 
@@ -514,7 +514,7 @@ public class CasOAuthConfiguration implements AuditTrailRecordResolutionPlanConf
 
     private ExpirationPolicy refreshTokenExpirationPolicy() {
         final OAuthRefreshTokenProperties rtProps = casProperties.getAuthn().getOauth().getRefreshToken();
-        final long timeout = Beans.newDuration(rtProps.getTimeToKillInSeconds()).toMillis();
+        final long timeout = Beans.newDuration(rtProps.getTimeToKillInSeconds()).getSeconds();
         return new OAuthRefreshTokenExpirationPolicy(timeout);
     }
 

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasMetricsConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasMetricsConfiguration.java
@@ -79,7 +79,7 @@ public class CasMetricsConfiguration extends MetricsConfigurerAdapter {
                 .convertRatesTo(TimeUnit.MILLISECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .build())
-                .start(Beans.newDuration(casProperties.getMetrics().getRefreshInterval()).toMillis(), TimeUnit.SECONDS);
+                .start(Beans.newDuration(casProperties.getMetrics().getRefreshInterval()).getSeconds(), TimeUnit.SECONDS);
 
         registerReporter(JmxReporter.forRegistry(metricRegistry).build());
     }


### PR DESCRIPTION
Commit 0953eb3958d2ae4482b7053ad894c1fde62f2210 added duration support for a number of properties, however in some cases it converted the durations to milliseconds where seconds were expected.  This PR fixes those cases.