### PR TITLE
Couchbase v5

### DIFF
--- a/ci/run-couchbase-server-v5.sh
+++ b/ci/run-couchbase-server-v5.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$PUBLISH_SNAPSHOTS" == "false" ]; then
+if [ "$MATRIX_JOB_TYPE" == "TEST" ]; then
     while sleep 9m; do echo -e '\n=====[ Gradle build is still running ]====='; done &
 
     echo "Pulling Couchbase docker image..."

--- a/ci/run-couchbase-server-v5.sh
+++ b/ci/run-couchbase-server-v5.sh
@@ -7,7 +7,7 @@ if [ "$PUBLISH_SNAPSHOTS" == "false" ]; then
     docker pull couchbase/server:4.6.4
 
     echo "Running Couchbase docker image..."
-    docker run -d --name couchbase -p 8091-8094:8091-8094 -p 11210:11210 couchbase/server:4.6.4
+    docker run -d --name couchbase -p 8091-8094:8091-8094 -p 11210:11210 couchbase/server:5.1.0
 
     docker ps | grep "couchbase"
     retVal=$?
@@ -25,8 +25,11 @@ if [ "$PUBLISH_SNAPSHOTS" == "false" ]; then
     done
 
     echo -e "\nCreating testbucket Couchbase bucket..."
-    curl -X POST -d 'name=testbucket' -d 'bucketType=couchbase' -d 'ramQuotaMB=120' -d 'authType=sasl' -d 'saslPassword=password' -d \
-    'proxyPort=11216' http://localhost:8091/pools/default/buckets
+    curl -X POST -d 'name=testbucket' -d 'bucketType=couchbase' -d 'ramQuotaMB=120' -d 'authType=none' -d 'proxyPort=11216' http://localhost:8091/pools/default/buckets
+
+    curl -X PUT --data "roles=bucket_admin[testbucket]&password=password" \
+                 -H "Content-Type: application/x-www-form-urlencoded" \
+                 http://Administrator:password@127.0.0.1:8091/settings/rbac/users/local/testbucket
 
     echo -e "\nCreating casbucket Couchbase bucket..."
     curl -X POST -d name=casbucket -d bucketType=couchbase -d ramQuotaMB=120 -d authType=none -d proxyPort=11217 http://localhost:8091/pools/default/buckets

--- a/ci/run-couchbase-server-v5.sh
+++ b/ci/run-couchbase-server-v5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$PUBLISH_SNAPSHOTS" == "false" ]; then
-    #while sleep 9m; do echo -e '\n=====[ Gradle build is still running ]====='; done &
+    while sleep 9m; do echo -e '\n=====[ Gradle build is still running ]====='; done &
 
     echo "Pulling Couchbase docker image..."
     docker pull couchbase/server:4.6.4

--- a/ci/run-couchbase-server.sh
+++ b/ci/run-couchbase-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$PUBLISH_SNAPSHOTS" == "false" ]; then
+if [ "$MATRIX_JOB_TYPE" == "TEST" ]; then
     while sleep 9m; do echo -e '\n=====[ Gradle build is still running ]====='; done &
 
     echo "Pulling Couchbase docker image..."

--- a/ci/run-couchbase-server.sh
+++ b/ci/run-couchbase-server.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$PUBLISH_SNAPSHOTS" == "false" ]; then
-    #while sleep 9m; do echo -e '\n=====[ Gradle build is still running ]====='; done &
+    while sleep 9m; do echo -e '\n=====[ Gradle build is still running ]====='; done &
 
     echo "Pulling Couchbase docker image..."
     docker pull couchbase/server:4.6.4

--- a/support/cas-server-support-couchbase-service-registry/src/test/java/org/apereo/cas/services/CouchbaseServiceRegistryDaoTests.java
+++ b/support/cas-server-support-couchbase-service-registry/src/test/java/org/apereo/cas/services/CouchbaseServiceRegistryDaoTests.java
@@ -28,7 +28,9 @@ import static org.junit.Assert.*;
  * @author Misagh Moayyed
  * @since 4.2.0
  */
-@SpringBootTest(classes = {RefreshAutoConfiguration.class, CouchbaseServiceRegistryConfiguration.class})
+@SpringBootTest(classes = {RefreshAutoConfiguration.class, CouchbaseServiceRegistryConfiguration.class},
+        properties = {"cas.serviceRegistry.couchbase.password=password", "cas.serviceRegistry.couchbase.bucket=testbucket"})
+
 @Slf4j
 @RunWith(ConditionalSpringRunner.class)
 @ConditionalIgnore(condition = RunningContinuousIntegrationCondition.class)

--- a/support/cas-server-support-couchbase-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistryTests.java
+++ b/support/cas-server-support-couchbase-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistryTests.java
@@ -60,7 +60,8 @@ import java.util.Collection;
     CasCoreAuthenticationPrincipalConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    RefreshAutoConfiguration.class})
+    RefreshAutoConfiguration.class},
+        properties = {"cas.ticket.registry.couchbase.password=password", "cas.ticket.registry.couchbase.bucket=testbucket"})
 @Slf4j
 public class CouchbaseTicketRegistryTests extends AbstractTicketRegistryTests {
     @Autowired


### PR DESCRIPTION
Verified ticket registry and services registry against both v4 and v5 of Couchbase by making unit tests (integration tests against dockerized Couchbase instance) pass for both versions. No code changes required except the script for docker image to use password for bucket for v4 and user password for v5 (username added must match the bucket name in use), and unit tests to reflect the bucket names and passwords by adding additional properties values right inside the @SpringBootTest annotation.

The separate `ci/run-couchbase-server-v5.sh` is introduced, but I'm not sure how to incorporate that into the travis machinery, etc.