### PR TITLE
Avoid serializing objects that shouldn't be part of oidc well-known endpoint

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
@@ -1,13 +1,15 @@
 package org.apereo.cas.oidc.discovery;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.support.oauth.OAuth20Constants;
+
 import java.util.List;
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * This is {@link OidcServerDiscoverySettings}.
@@ -44,10 +46,13 @@ public class OidcServerDiscoverySettings {
     @JsonProperty("introspection_endpoint_auth_methods_supported")
     private List<String> introspectionSupportedAuthenticationMethods;
 
+    @JsonIgnore
     private final CasConfigurationProperties casProperties;
 
+    @JsonIgnore
     private final String issuer;
 
+    @JsonIgnore
     private final String serverPrefix;
 
     public OidcServerDiscoverySettings(final CasConfigurationProperties casProperties, final String issuer) {


### PR DESCRIPTION
Adding the @Getter lombok annotation made is so Jackson tried to dump the entire cas config to JSON, it didn't get all the way through but it dumped part of the config to the browser before it got an exception and stopped.
