### PR TITLE
DynamoDb naming tables and prevent table creation on startup (5.2.x)

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/AbstractDynamoDbProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/AbstractDynamoDbProperties.java
@@ -61,7 +61,7 @@ public abstract class AbstractDynamoDbProperties implements Serializable {
     /**
      * Flag that indicates whether to prevent CAS from creating tables.
      */
-    private boolean preventTableCreationOnStartup = false;
+    private boolean preventTableCreationOnStartup;
 
     /**
      * Time offset.

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/AbstractDynamoDbProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/AbstractDynamoDbProperties.java
@@ -59,6 +59,11 @@ public abstract class AbstractDynamoDbProperties implements Serializable {
     private boolean dropTablesOnStartup;
 
     /**
+     * Flag that indicates whether to prevent CAS from creating tables.
+     */
+    private boolean preventTableCreationOnStartup = false;
+
+    /**
      * Time offset.
      */
     private int timeOffset;
@@ -155,6 +160,14 @@ public abstract class AbstractDynamoDbProperties implements Serializable {
 
     public void setDropTablesOnStartup(final boolean dropTablesOnStartup) {
         this.dropTablesOnStartup = dropTablesOnStartup;
+    }
+
+    public boolean isPreventTableCreationOnStartup() {
+        return preventTableCreationOnStartup;
+    }
+
+    public void setPreventTableCreationOnStartup(final boolean PreventTableCreationOnStartup) {
+        this.preventTableCreationOnStartup = preventTableCreationOnStartup;
     }
 
     public String getEndpoint() {

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/AbstractDynamoDbProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/AbstractDynamoDbProperties.java
@@ -166,7 +166,7 @@ public abstract class AbstractDynamoDbProperties implements Serializable {
         return preventTableCreationOnStartup;
     }
 
-    public void setPreventTableCreationOnStartup(final boolean PreventTableCreationOnStartup) {
+    public void setPreventTableCreationOnStartup(final boolean preventTableCreationOnStartup) {
         this.preventTableCreationOnStartup = preventTableCreationOnStartup;
     }
 

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/DynamoDbTicketRegistryProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/DynamoDbTicketRegistryProperties.java
@@ -15,6 +15,58 @@ public class DynamoDbTicketRegistryProperties extends AbstractDynamoDbProperties
     private static final long serialVersionUID = 699497009058965681L;
 
     /**
+     * The table name used and created by CAS to hold service tickets in DynamoDb.
+     */
+    private String serviceTicketsTableName = "serviceTicketsTable";
+
+    public String getServiceTicketsTableName() {
+        return serviceTicketsTableName;
+    }
+
+    public void setServiceTicketsTableName(final String serviceTicketsTableName) {
+        this.serviceTicketsTableName = serviceTicketsTableName;
+    }
+
+    /**
+     * The table name used and created by CAS to hold proxy tickets in DynamoDb.
+     */
+    private String proxyTicketsTableName = "proxyTicketsTable";
+
+    public String getProxyTicketsTableName() {
+        return proxyTicketsTableName;
+    }
+
+    public void setProxyTicketsTableName(final String proxyTicketsTableName) {
+        this.proxyTicketsTableName = proxyTicketsTableName;
+    }
+
+    /**
+     * The table name used and created by CAS to hold ticket granting tickets in DynamoDb.
+     */
+    private String ticketGrantingTicketsTableName = "ticketGrantingTicketsTable";
+
+    public String getTicketGrantingTicketsTableName() {
+        return ticketGrantingTicketsTableName;
+    }
+
+    public void setTicketGrantingTicketsTableName(final String ticketGrantingTicketsTableName) {
+        this.ticketGrantingTicketsTableName = ticketGrantingTicketsTableName;
+    }
+
+    /**
+     * The table name used and created by CAS to hold proxy ticket granting tickets in DynamoDb.
+     */
+    private String proxyGrantingTicketsTableName = "proxyGrantingTicketsTable";
+
+    public String getProxyGrantingTicketsTableName() {
+        return proxyGrantingTicketsTableName;
+    }
+
+    public void setProxyGrantingTicketsTableName(final String proxyGrantingTicketsTableName) {
+        this.proxyGrantingTicketsTableName = proxyGrantingTicketsTableName;
+    }
+
+    /**
      * Crypto settings for the registry.
      */
     @NestedConfigurationProperty

--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/DynamoDbTicketRegistryProperties.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/model/support/dynamodb/DynamoDbTicketRegistryProperties.java
@@ -19,52 +19,20 @@ public class DynamoDbTicketRegistryProperties extends AbstractDynamoDbProperties
      */
     private String serviceTicketsTableName = "serviceTicketsTable";
 
-    public String getServiceTicketsTableName() {
-        return serviceTicketsTableName;
-    }
-
-    public void setServiceTicketsTableName(final String serviceTicketsTableName) {
-        this.serviceTicketsTableName = serviceTicketsTableName;
-    }
-
     /**
      * The table name used and created by CAS to hold proxy tickets in DynamoDb.
      */
     private String proxyTicketsTableName = "proxyTicketsTable";
-
-    public String getProxyTicketsTableName() {
-        return proxyTicketsTableName;
-    }
-
-    public void setProxyTicketsTableName(final String proxyTicketsTableName) {
-        this.proxyTicketsTableName = proxyTicketsTableName;
-    }
 
     /**
      * The table name used and created by CAS to hold ticket granting tickets in DynamoDb.
      */
     private String ticketGrantingTicketsTableName = "ticketGrantingTicketsTable";
 
-    public String getTicketGrantingTicketsTableName() {
-        return ticketGrantingTicketsTableName;
-    }
-
-    public void setTicketGrantingTicketsTableName(final String ticketGrantingTicketsTableName) {
-        this.ticketGrantingTicketsTableName = ticketGrantingTicketsTableName;
-    }
-
     /**
      * The table name used and created by CAS to hold proxy ticket granting tickets in DynamoDb.
      */
     private String proxyGrantingTicketsTableName = "proxyGrantingTicketsTable";
-
-    public String getProxyGrantingTicketsTableName() {
-        return proxyGrantingTicketsTableName;
-    }
-
-    public void setProxyGrantingTicketsTableName(final String proxyGrantingTicketsTableName) {
-        this.proxyGrantingTicketsTableName = proxyGrantingTicketsTableName;
-    }
 
     /**
      * Crypto settings for the registry.
@@ -75,9 +43,41 @@ public class DynamoDbTicketRegistryProperties extends AbstractDynamoDbProperties
     public DynamoDbTicketRegistryProperties() {
         this.crypto.setEnabled(false);
     }
-    
+
+    public String getServiceTicketsTableName() {
+        return this.serviceTicketsTableName;
+    }
+
+    public String getProxyTicketsTableName() {
+        return this.proxyTicketsTableName;
+    }
+
+    public String getTicketGrantingTicketsTableName() {
+        return this.ticketGrantingTicketsTableName;
+    }
+
+    public String getProxyGrantingTicketsTableName() {
+        return this.proxyGrantingTicketsTableName;
+    }
+
     public EncryptionRandomizedSigningJwtCryptographyProperties getCrypto() {
-        return crypto;
+        return this.crypto;
+    }
+
+    public void setServiceTicketsTableName(final String serviceTicketsTableName) {
+        this.serviceTicketsTableName = serviceTicketsTableName;
+    }
+
+    public void setProxyTicketsTableName(final String proxyTicketsTableName) {
+        this.proxyTicketsTableName = proxyTicketsTableName;
+    }
+
+    public void setTicketGrantingTicketsTableName(final String ticketGrantingTicketsTableName) {
+        this.ticketGrantingTicketsTableName = ticketGrantingTicketsTableName;
+    }
+
+    public void setProxyGrantingTicketsTableName(final String proxyGrantingTicketsTableName) {
+        this.proxyGrantingTicketsTableName = proxyGrantingTicketsTableName;
     }
 
     public void setCrypto(final EncryptionRandomizedSigningJwtCryptographyProperties crypto) {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -4561,6 +4561,7 @@ To learn more about this topic, [please review this guide](DynamoDb-Service-Mana
 # cas.serviceRegistry.dynamoDb.serviceNameIntern=
 
 # cas.serviceRegistry.dynamoDb.dropTablesOnStartup=false
+# cas.serviceRegistry.dynamoDb.preventTableCreationOnStartup=true
 # cas.serviceRegistry.dynamoDb.timeOffset=0
 
 # cas.serviceRegistry.dynamoDb.readCapacity=10
@@ -5022,6 +5023,11 @@ To learn more about this topic, [please review this guide](Memcached-Ticket-Regi
 To learn more about this topic, [please review this guide](DynamoDb-Ticket-Registry.html).
 
 ```properties
+# cas.ticket.registry.dynamoDb.serviceTicketsTableName=serviceTicketsTable
+# cas.ticket.registry.dynamoDb.proxyTicketsTableName=proxyTicketsTable
+# cas.ticket.registry.dynamoDb.ticketGrantingTicketsTableName=ticketGrantingTicketsTable
+# cas.ticket.registry.dynamoDb.proxyGrantingTicketsTableName=proxyGrantingTicketsTable
+
 # Path to an external properties file that contains 'accessKey' and 'secretKey' fields.
 # cas.ticket.registry.dynamoDb.credentialsPropertiesFile=file:/path/to/file.properties
 
@@ -5035,6 +5041,7 @@ To learn more about this topic, [please review this guide](DynamoDb-Ticket-Regis
 # cas.ticket.registry.dynamoDb.serviceNameIntern=
 
 # cas.ticket.registry.dynamoDb.dropTablesOnStartup=false
+# cas.ticket.registry.dynamoDb.preventTableCreationOnStartup=true
 # cas.ticket.registry.dynamoDb.timeOffset=0
 
 # cas.ticket.registry.dynamoDb.readCapacity=10

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -4561,7 +4561,7 @@ To learn more about this topic, [please review this guide](DynamoDb-Service-Mana
 # cas.serviceRegistry.dynamoDb.serviceNameIntern=
 
 # cas.serviceRegistry.dynamoDb.dropTablesOnStartup=false
-# cas.serviceRegistry.dynamoDb.preventTableCreationOnStartup=true
+# cas.serviceRegistry.dynamoDb.preventTableCreationOnStartup=false
 # cas.serviceRegistry.dynamoDb.timeOffset=0
 
 # cas.serviceRegistry.dynamoDb.readCapacity=10
@@ -5041,7 +5041,7 @@ To learn more about this topic, [please review this guide](DynamoDb-Ticket-Regis
 # cas.ticket.registry.dynamoDb.serviceNameIntern=
 
 # cas.ticket.registry.dynamoDb.dropTablesOnStartup=false
-# cas.ticket.registry.dynamoDb.preventTableCreationOnStartup=true
+# cas.ticket.registry.dynamoDb.preventTableCreationOnStartup=false
 # cas.ticket.registry.dynamoDb.timeOffset=0
 
 # cas.ticket.registry.dynamoDb.readCapacity=10

--- a/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/services/DynamoDbServiceRegistryFacilitator.java
+++ b/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/services/DynamoDbServiceRegistryFacilitator.java
@@ -71,7 +71,8 @@ public class DynamoDbServiceRegistryFacilitator {
                                               final AmazonDynamoDBClient amazonDynamoDBClient) {
         this.dynamoDbProperties = dynamoDbProperties;
         this.amazonDynamoDBClient = amazonDynamoDBClient;
-        createServicesTable(dynamoDbProperties.isDropTablesOnStartup());
+        if(!dynamoDbProperties.isPreventTableCreationOnStartup())
+            createServicesTable(dynamoDbProperties.isDropTablesOnStartup());
     }
 
     /**

--- a/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/services/DynamoDbServiceRegistryFacilitator.java
+++ b/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/services/DynamoDbServiceRegistryFacilitator.java
@@ -71,8 +71,9 @@ public class DynamoDbServiceRegistryFacilitator {
                                               final AmazonDynamoDBClient amazonDynamoDBClient) {
         this.dynamoDbProperties = dynamoDbProperties;
         this.amazonDynamoDBClient = amazonDynamoDBClient;
-        if(!dynamoDbProperties.isPreventTableCreationOnStartup())
+        if (!dynamoDbProperties.isPreventTableCreationOnStartup()){
             createServicesTable(dynamoDbProperties.isDropTablesOnStartup());
+        }
     }
 
     /**

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/config/DynamoDbTicketRegistryTicketCatalogConfiguration.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/config/DynamoDbTicketRegistryTicketCatalogConfiguration.java
@@ -25,28 +25,28 @@ public class DynamoDbTicketRegistryTicketCatalogConfiguration extends CasCoreTic
 
     @Override
     protected void buildAndRegisterServiceTicketDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
-        metadata.getProperties().setStorageName("serviceTicketsTable");
+        metadata.getProperties().setStorageName(casProperties.getTicket().getRegistry().getDynamoDb().getServiceTicketsTableName());
         metadata.getProperties().setStorageTimeout(casProperties.getTicket().getSt().getTimeToKillInSeconds());
         super.buildAndRegisterServiceTicketDefinition(plan, metadata);
     }
 
     @Override
     protected void buildAndRegisterProxyTicketDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
-        metadata.getProperties().setStorageName("proxyTicketsTable");
+        metadata.getProperties().setStorageName(casProperties.getTicket().getRegistry().getDynamoDb().getProxyTicketsTableName());
         metadata.getProperties().setStorageTimeout(casProperties.getTicket().getPt().getTimeToKillInSeconds());
         super.buildAndRegisterProxyTicketDefinition(plan, metadata);
     }
 
     @Override
     protected void buildAndRegisterTicketGrantingTicketDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
-        metadata.getProperties().setStorageName("ticketGrantingTicketsTable");
+        metadata.getProperties().setStorageName(casProperties.getTicket().getRegistry().getDynamoDb().getTicketGrantingTicketsTableName());
         metadata.getProperties().setStorageTimeout(casProperties.getTicket().getTgt().getMaxTimeToLiveInSeconds());
         super.buildAndRegisterTicketGrantingTicketDefinition(plan, metadata);
     }
 
     @Override
     protected void buildAndRegisterProxyGrantingTicketDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
-        metadata.getProperties().setStorageName("proxyGrantingTicketsTable");
+        metadata.getProperties().setStorageName(casProperties.getTicket().getRegistry().getDynamoDb().getProxyGrantingTicketsTableName());
         metadata.getProperties().setStorageTimeout(casProperties.getTicket().getTgt().getMaxTimeToLiveInSeconds());
         super.buildAndRegisterProxyGrantingTicketDefinition(plan, metadata);
     }

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryFacilitator.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryFacilitator.java
@@ -77,7 +77,8 @@ public class DynamoDbTicketRegistryFacilitator {
         this.dynamoDbProperties = dynamoDbProperties;
         this.amazonDynamoDBClient = amazonDynamoDBClient;
 
-        createTicketTables(dynamoDbProperties.isDropTablesOnStartup());
+        if(!dynamoDbProperties.isPreventTableCreationOnStartup())
+            createTicketTables(dynamoDbProperties.isDropTablesOnStartup());
     }
 
     /**

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryFacilitator.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryFacilitator.java
@@ -77,8 +77,9 @@ public class DynamoDbTicketRegistryFacilitator {
         this.dynamoDbProperties = dynamoDbProperties;
         this.amazonDynamoDBClient = amazonDynamoDBClient;
 
-        if(!dynamoDbProperties.isPreventTableCreationOnStartup())
+        if (!dynamoDbProperties.isPreventTableCreationOnStartup()) {
             createTicketTables(dynamoDbProperties.isDropTablesOnStartup());
+        }
     }
 
     /**


### PR DESCRIPTION
Added the ability to specify the name of the DynamoDb tables and also the ability to skip table creation on startup (This way if CAS doesn't have permissions to create tables your AWS account it won't throw an error on the 'create table if not exist' method).

Already added the info to Configuration-Properties.md the values are:

```
cas.serviceRegistry.dynamoDb.preventTableCreationOnStartup

cas.ticket.registry.dynamoDb.preventTableCreationOnStartup
cas.ticket.registry.dynamoDb.serviceTicketsTableName
cas.ticket.registry.dynamoDb.proxyTicketsTableName
cas.ticket.registry.dynamoDb.ticketGrantingTicketsTableName
cas.ticket.registry.dynamoDb.proxyGrantingTicketsTableName
```

Note: They have default values of what the behavior is expected before this change

This is my first time contributing so any issues for new contributers are probably present. Changes were made in both cas-server-core-configuration, cas-server-support-dynamodb-ticket-registry, and cas-server-support-dynamodb-service-registry. I was building it as 5.2.4-SNAPSHOT and was copying the appropriate maven repos over into my cas-overlay for testing.  So I'm assuming that some mysterious entity out there will update the cas version or that it doesn't matter. If I need to update it let me know.

I don't think it'll be effecting any other pull requests from the brief time I looked at them. I didn't go into incredible detail on each of them though. 

