### PR TITLE
Fixes samlAttributeName formats options from not appearing in dropdown

### DIFF
--- a/webapp-mgmt/cas-management-webapp/src/app/form/samlservicespane/samlservicespane.component.html
+++ b/webapp-mgmt/cas-management-webapp/src/app/form/samlservicespane/samlservicespane.component.html
@@ -16,7 +16,7 @@
     <mat-cell *cdkCellDef="let row" [ngClass]="'valueWidth'">
       <mat-form-field>
         <mat-select [(ngModel)]="data.service.attributeNameFormats[row.key]">
-          <mat-option *ngFor="let item of data.formData.attributeNameFormats" [value]="item">
+          <mat-option *ngFor="let item of data.formData.samlAttributeNameFormats" [value]="item">
             {{item}}
           </mat-option>
         </mat-select>

--- a/webapp-mgmt/cas-management-webapp/src/domain/form-data.ts
+++ b/webapp-mgmt/cas-management-webapp/src/domain/form-data.ts
@@ -9,7 +9,7 @@ export class FormData {
     serviceTypes: String[];
     samlRoles: String[];
     samlDirections: String[];
-    attributeNameFormats: String[];
+    samlAttributeNameFormats: String[];
     samlCredentialTypes: String[];
     wsFederationClaims: String[];
     mfaProviders: PropertyEnum[];


### PR DESCRIPTION
This PR will fix a bug described by David Curry in the cas-user email list.  There was a naming difference between the field sending the options in FormData from the server and the name of the field that was being used in the front end client.  This change fixes the client to match the field name sent from the server.