### PR TITLE
Move anonymous TomcatEmbeddedServletContainerFactory to separate class

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/tomcat/CasEmbeddedApacheTomcatClusteringProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/tomcat/CasEmbeddedApacheTomcatClusteringProperties.java
@@ -3,6 +3,7 @@ package org.apereo.cas.configuration.model.core.web.tomcat;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.configuration.support.RequiredProperty;
 import org.apereo.cas.configuration.support.RequiresModule;
 
@@ -138,4 +139,8 @@ public class CasEmbeddedApacheTomcatClusteringProperties implements Serializable
      * Enable tomcat session clustering.
      */
     private boolean enabled;
+
+    public boolean isSessionClusteringEnabled() {
+        return isEnabled() && StringUtils.isNotBlank(getClusterMembers());
+    }
 }

--- a/webapp/cas-server-webapp-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
+++ b/webapp/cas-server-webapp-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
@@ -1,29 +1,10 @@
 package org.apereo.cas.config;
 
-import lombok.Getter;
 import lombok.SneakyThrows;
-import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.authenticator.BasicAuthenticator;
 import org.apache.catalina.connector.Connector;
-import org.apache.catalina.ha.session.BackupManager;
-import org.apache.catalina.ha.session.ClusterManagerBase;
-import org.apache.catalina.ha.session.ClusterSessionListener;
-import org.apache.catalina.ha.session.DeltaManager;
-import org.apache.catalina.ha.session.JvmRouteBinderValve;
-import org.apache.catalina.ha.tcp.ReplicationValve;
-import org.apache.catalina.ha.tcp.SimpleTcpCluster;
 import org.apache.catalina.startup.Tomcat;
-import org.apache.catalina.tribes.group.GroupChannel;
-import org.apache.catalina.tribes.group.interceptors.MessageDispatchInterceptor;
-import org.apache.catalina.tribes.group.interceptors.StaticMembershipInterceptor;
-import org.apache.catalina.tribes.group.interceptors.TcpFailureDetector;
-import org.apache.catalina.tribes.group.interceptors.TcpPingInterceptor;
-import org.apache.catalina.tribes.membership.McastService;
-import org.apache.catalina.tribes.membership.StaticMember;
-import org.apache.catalina.tribes.transport.ReplicationTransmitter;
-import org.apache.catalina.tribes.transport.nio.NioReceiver;
-import org.apache.catalina.tribes.transport.nio.PooledParallelSender;
 import org.apache.catalina.valves.ExtendedAccessLogValve;
 import org.apache.catalina.valves.SSLValve;
 import org.apache.catalina.valves.rewrite.RewriteValve;
@@ -36,7 +17,6 @@ import org.apereo.cas.CasEmbeddedContainerUtils;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatAjpProperties;
 import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatBasicAuthenticationProperties;
-import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatClusteringProperties;
 import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatExtendedAccessLogProperties;
 import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatHttpProperties;
 import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatHttpProxyProperties;
@@ -53,8 +33,6 @@ import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoCo
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -92,13 +70,7 @@ public class CasEmbeddedContainerTomcatConfiguration {
     @ConditionalOnMissingBean(name = "casServletContainerFactory")
     @Bean
     public EmbeddedServletContainerFactory casServletContainerFactory() {
-        return new TomcatEmbeddedServletContainerFactory() {
-            @Override
-            protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(final Tomcat tomcat) {
-                configureSessionClustering(tomcat);
-                return super.getTomcatEmbeddedServletContainer(tomcat);
-            }
-        };
+        return new CasTomcatEmbeddedServletContainerFactory(casProperties.getServer().getClustering());
     }
 
     @ConditionalOnMissingBean(name = "casTomcatEmbeddedServletContainerCustomizer")
@@ -114,40 +86,10 @@ public class CasEmbeddedContainerTomcatConfiguration {
                 configureRewriteValve(tomcat);
                 configureSSLValve(tomcat);
                 configureBasicAuthn(tomcat);
-                configureContextForSessionClustering(tomcat);
             } else {
                 LOGGER.error("EmbeddedServletContainer [{}] does not support Tomcat!", configurableEmbeddedServletContainer);
             }
         };
-    }
-
-    private void configureContextForSessionClustering(final TomcatEmbeddedServletContainerFactory tomcat) {
-        if (!isSessionClusteringEnabled()) {
-            LOGGER.debug("Tomcat session clustering/replication is turned off");
-            return;
-        }
-
-        tomcat.addContextCustomizers((TomcatContextCustomizer) context -> {
-            final ClusterManagerBase manager = getClusteringManagerInstance();
-            context.setManager(manager);
-            context.setDistributable(true);
-        });
-    }
-
-    private ClusterManagerBase getClusteringManagerInstance() {
-        final CasEmbeddedApacheTomcatClusteringProperties props = casProperties.getServer().getClustering();
-        switch (props.getManagerType().toUpperCase()) {
-            case "DELTA":
-                final DeltaManager manager = new DeltaManager();
-                manager.setExpireSessionsOnShutdown(props.isExpireSessionsOnShutdown());
-                manager.setNotifyListenersOnReplication(true);
-                return manager;
-            default:
-                final BackupManager backupManager = new BackupManager();
-                backupManager.setNotifyListenersOnReplication(true);
-                return backupManager;
-        }
-
     }
 
     private void configureBasicAuthn(final TomcatEmbeddedServletContainerFactory tomcat) {
@@ -316,99 +258,5 @@ public class CasEmbeddedContainerTomcatConfiguration {
             valve.setSslSessionIdHeader(valveConfig.getSslSessionIdHeader());
             tomcat.addContextValves(valve);
         }
-    }
-
-    private void configureSessionClustering(final Tomcat tomcat) {
-        if (!isSessionClusteringEnabled()) {
-            LOGGER.debug("Tomcat session clustering/replication is turned off");
-            return;
-        }
-
-        final CasEmbeddedApacheTomcatClusteringProperties props = casProperties.getServer().getClustering();
-        final SimpleTcpCluster cluster = new SimpleTcpCluster();
-        cluster.setChannelSendOptions(props.getChannelSendOptions());
-
-        final ClusterManagerBase manager = getClusteringManagerInstance();
-        cluster.setManagerTemplate(manager);
-
-        final GroupChannel channel = new GroupChannel();
-
-        final NioReceiver receiver = new NioReceiver();
-        receiver.setPort(props.getReceiverPort());
-        receiver.setTimeout(props.getReceiverTimeout());
-        receiver.setMaxThreads(props.getReceiverMaxThreads());
-        receiver.setAddress(props.getReceiverAddress());
-        receiver.setAutoBind(props.getReceiverAutoBind());
-        channel.setChannelReceiver(receiver);
-
-        final McastService membershipService = new McastService();
-        membershipService.setPort(props.getMembershipPort());
-        membershipService.setAddress(props.getMembershipAddress());
-        membershipService.setFrequency(props.getMembershipFrequency());
-        membershipService.setDropTime(props.getMembershipDropTime());
-        membershipService.setRecoveryEnabled(props.isMembershipRecoveryEnabled());
-        membershipService.setRecoveryCounter(props.getMembershipRecoveryCounter());
-        membershipService.setLocalLoopbackDisabled(props.isMembershipLocalLoopbackDisabled());
-        channel.setMembershipService(membershipService);
-
-        final ReplicationTransmitter sender = new ReplicationTransmitter();
-        sender.setTransport(new PooledParallelSender());
-        channel.setChannelSender(sender);
-
-        channel.addInterceptor(new TcpPingInterceptor());
-        channel.addInterceptor(new TcpFailureDetector());
-        channel.addInterceptor(new MessageDispatchInterceptor());
-
-        final StaticMembershipInterceptor membership = new StaticMembershipInterceptor();
-        final String[] memberSpecs = props.getClusterMembers().split(",", -1);
-        for (final String spec : memberSpecs) {
-            final ClusterMemberDesc memberDesc = new ClusterMemberDesc(spec);
-            final StaticMember member = new StaticMember();
-            member.setHost(memberDesc.getAddress());
-            member.setPort(memberDesc.getPort());
-            member.setDomain("CAS");
-            member.setUniqueId(memberDesc.getUniqueId());
-            membership.addStaticMember(member);
-            channel.addInterceptor(membership);
-            cluster.setChannel(channel);
-        }
-        cluster.addValve(new ReplicationValve());
-        cluster.addValve(new JvmRouteBinderValve());
-        cluster.addClusterListener(new ClusterSessionListener());
-
-        tomcat.getEngine().setCluster(cluster);
-    }
-
-    @Getter
-    @ToString
-    private static class ClusterMemberDesc {
-        private static final int UNIQUE_ID_LIMIT = 255;
-        private static final int UNIQUE_ID_ITERATIONS = 16;
-        private String address;
-        private int port;
-        private String uniqueId;
-
-        ClusterMemberDesc(final String spec) {
-            final String[] values = spec.split(":", -1);
-            address = values[0];
-            port = Integer.parseInt(values[1]);
-            int index = Integer.parseInt(values[2]);
-            if ((index < 0) || (index > UNIQUE_ID_LIMIT)) {
-                throw new IllegalArgumentException("invalid unique index: must be >= 0 and < 256");
-            }
-            uniqueId = "{";
-            for (int i = 0; i < UNIQUE_ID_ITERATIONS; i++, index++) {
-                if (i != 0) {
-                    uniqueId += ',';
-                }
-                uniqueId += index % (UNIQUE_ID_LIMIT + 1);
-            }
-            uniqueId += '}';
-        }
-    }
-
-    private boolean isSessionClusteringEnabled() {
-        final CasEmbeddedApacheTomcatClusteringProperties props = casProperties.getServer().getClustering();
-        return props.isEnabled() && StringUtils.isNotBlank(props.getClusterMembers());
     }
 }

--- a/webapp/cas-server-webapp-tomcat/src/main/java/org/apereo/cas/config/CasTomcatEmbeddedServletContainerFactory.java
+++ b/webapp/cas-server-webapp-tomcat/src/main/java/org/apereo/cas/config/CasTomcatEmbeddedServletContainerFactory.java
@@ -1,0 +1,169 @@
+package org.apereo.cas.config;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.ha.session.BackupManager;
+import org.apache.catalina.ha.session.ClusterManagerBase;
+import org.apache.catalina.ha.session.ClusterSessionListener;
+import org.apache.catalina.ha.session.DeltaManager;
+import org.apache.catalina.ha.session.JvmRouteBinderValve;
+import org.apache.catalina.ha.tcp.ReplicationValve;
+import org.apache.catalina.ha.tcp.SimpleTcpCluster;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.tribes.group.GroupChannel;
+import org.apache.catalina.tribes.group.interceptors.MessageDispatchInterceptor;
+import org.apache.catalina.tribes.group.interceptors.StaticMembershipInterceptor;
+import org.apache.catalina.tribes.group.interceptors.TcpFailureDetector;
+import org.apache.catalina.tribes.group.interceptors.TcpPingInterceptor;
+import org.apache.catalina.tribes.membership.McastService;
+import org.apache.catalina.tribes.membership.StaticMember;
+import org.apache.catalina.tribes.transport.ReplicationTransmitter;
+import org.apache.catalina.tribes.transport.nio.NioReceiver;
+import org.apache.catalina.tribes.transport.nio.PooledParallelSender;
+import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatClusteringProperties;
+import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+
+/**
+ * A {@link TomcatEmbeddedServletContainerFactory} that will configure Tomcat with clustering support based on the
+ * provided {@link CasEmbeddedApacheTomcatClusteringProperties}.
+ *
+ * CAS Implementations may use this as a base for further {@link Tomcat} customisation (eg to enable JNDI).
+ *
+ * @since 5.3.0
+ * @author sbearcsiro
+ */
+@Slf4j
+public class CasTomcatEmbeddedServletContainerFactory extends TomcatEmbeddedServletContainerFactory {
+
+    private final CasEmbeddedApacheTomcatClusteringProperties clusteringProperties;
+
+    public CasTomcatEmbeddedServletContainerFactory(final CasEmbeddedApacheTomcatClusteringProperties clusteringProperties) {
+        this.clusteringProperties = clusteringProperties;
+        configureContextForSessionClustering();
+    }
+
+    @Override
+    protected TomcatEmbeddedServletContainer getTomcatEmbeddedServletContainer(final Tomcat tomcat) {
+        configureSessionClustering(tomcat);
+        return super.getTomcatEmbeddedServletContainer(tomcat);
+    }
+
+    private void configureSessionClustering(final Tomcat tomcat) {
+        if (!clusteringProperties.isSessionClusteringEnabled()) {
+            LOGGER.debug("Tomcat session clustering/replication is turned off");
+            return;
+        }
+
+        final SimpleTcpCluster cluster = new SimpleTcpCluster();
+        cluster.setChannelSendOptions(clusteringProperties.getChannelSendOptions());
+
+        final ClusterManagerBase manager = getClusteringManagerInstance();
+        cluster.setManagerTemplate(manager);
+
+        final GroupChannel channel = new GroupChannel();
+
+        final NioReceiver receiver = new NioReceiver();
+        receiver.setPort(clusteringProperties.getReceiverPort());
+        receiver.setTimeout(clusteringProperties.getReceiverTimeout());
+        receiver.setMaxThreads(clusteringProperties.getReceiverMaxThreads());
+        receiver.setAddress(clusteringProperties.getReceiverAddress());
+        receiver.setAutoBind(clusteringProperties.getReceiverAutoBind());
+        channel.setChannelReceiver(receiver);
+
+        final McastService membershipService = new McastService();
+        membershipService.setPort(clusteringProperties.getMembershipPort());
+        membershipService.setAddress(clusteringProperties.getMembershipAddress());
+        membershipService.setFrequency(clusteringProperties.getMembershipFrequency());
+        membershipService.setDropTime(clusteringProperties.getMembershipDropTime());
+        membershipService.setRecoveryEnabled(clusteringProperties.isMembershipRecoveryEnabled());
+        membershipService.setRecoveryCounter(clusteringProperties.getMembershipRecoveryCounter());
+        membershipService.setLocalLoopbackDisabled(clusteringProperties.isMembershipLocalLoopbackDisabled());
+        channel.setMembershipService(membershipService);
+
+        final ReplicationTransmitter sender = new ReplicationTransmitter();
+        sender.setTransport(new PooledParallelSender());
+        channel.setChannelSender(sender);
+
+        channel.addInterceptor(new TcpPingInterceptor());
+        channel.addInterceptor(new TcpFailureDetector());
+        channel.addInterceptor(new MessageDispatchInterceptor());
+
+        final StaticMembershipInterceptor membership = new StaticMembershipInterceptor();
+        final String[] memberSpecs = clusteringProperties.getClusterMembers().split(",", -1);
+        for (final String spec : memberSpecs) {
+            final ClusterMemberDesc memberDesc = new ClusterMemberDesc(spec);
+            final StaticMember member = new StaticMember();
+            member.setHost(memberDesc.getAddress());
+            member.setPort(memberDesc.getPort());
+            member.setDomain("CAS");
+            member.setUniqueId(memberDesc.getUniqueId());
+            membership.addStaticMember(member);
+            channel.addInterceptor(membership);
+            cluster.setChannel(channel);
+        }
+        cluster.addValve(new ReplicationValve());
+        cluster.addValve(new JvmRouteBinderValve());
+        cluster.addClusterListener(new ClusterSessionListener());
+
+        tomcat.getEngine().setCluster(cluster);
+    }
+
+    private void configureContextForSessionClustering() {
+        if (!clusteringProperties.isSessionClusteringEnabled()) {
+            LOGGER.debug("Tomcat session clustering/replication is turned off");
+            return;
+        }
+
+        addContextCustomizers((TomcatContextCustomizer) context -> {
+            final ClusterManagerBase manager = getClusteringManagerInstance();
+            context.setManager(manager);
+            context.setDistributable(true);
+        });
+    }
+
+    private ClusterManagerBase getClusteringManagerInstance() {
+        switch (clusteringProperties.getManagerType().toUpperCase()) {
+            case "DELTA":
+                final DeltaManager manager = new DeltaManager();
+                manager.setExpireSessionsOnShutdown(clusteringProperties.isExpireSessionsOnShutdown());
+                manager.setNotifyListenersOnReplication(true);
+                return manager;
+            default:
+                final BackupManager backupManager = new BackupManager();
+                backupManager.setNotifyListenersOnReplication(true);
+                return backupManager;
+        }
+
+    }
+
+    @Getter
+    @ToString
+    private static class ClusterMemberDesc {
+        private static final int UNIQUE_ID_LIMIT = 255;
+        private static final int UNIQUE_ID_ITERATIONS = 16;
+        private String address;
+        private int port;
+        private String uniqueId;
+
+        ClusterMemberDesc(final String spec) {
+            final String[] values = spec.split(":", -1);
+            address = values[0];
+            port = Integer.parseInt(values[1]);
+            int index = Integer.parseInt(values[2]);
+            if ((index < 0) || (index > UNIQUE_ID_LIMIT)) {
+                throw new IllegalArgumentException("invalid unique index: must be >= 0 and < 256");
+            }
+            uniqueId = "{";
+            for (int i = 0; i < UNIQUE_ID_ITERATIONS; i++, index++) {
+                if (i != 0) {
+                    uniqueId += ',';
+                }
+                uniqueId += index % (UNIQUE_ID_LIMIT + 1);
+            }
+            uniqueId += '}';
+        }
+    }
+}


### PR DESCRIPTION
This should be logically the same as it was previously but extracts the anonymous `TomcatEmbeddedServletContainerFactory` into a separate class so that CAS implementations can use it as a base for their own `EmbeddedServletContainerFactory` customisation.