### PR TITLE
Upgrade pac4j to version 2.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -122,7 +122,7 @@ guavaVersion=23.0
 
 
 pac4jSpringWebmvcVersion=2.0.0
-pac4jVersion=2.2.0
+pac4jVersion=2.3.1
 
 dropwizardMetricsSpringVersion=3.1.3
 statsdVersion=3.1.0


### PR DESCRIPTION
This is the latest v2.x pac4j release.

This especially fixes the issue with the SAML support brought by the version 2.2.0. That said, for that, we could just upgrade to pac4j v2.2.1.
