### PR TITLE
Fix Docker command path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,4 +69,4 @@ ENV JAVA_HOME /opt/jre-home
 ENV PATH $PATH:$JAVA_HOME/bin:.
 RUN ./mvnw clean package -T 10 -Dcas.version=$CASVERSION
 
-CMD ["cas-overlay/bin/run-cas.sh"]
+CMD ["bin/run-cas.sh"]


### PR DESCRIPTION
Docker command is not valid: `cas-overlay/bin/run-cas.sh` is relative to `/cas-overlay` and is being resolved to `/cas-overlay/cas-overlay/bin/run-cas.sh` file which does not exist.
This should be `bin/run-cas.sh` (which is resolved to `/cas-overlaybin/run-cas.sh`).

Steps to reproduce the issue:
`docker run -p 8080:8080 apereo/cas`
causes:
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:296: starting container process caused "exec: \"cas-overlay/bin/run-cas.sh\": stat cas-overlay/bin/run-cas.sh: no such file or directory": unknown.
ERRO[0000] error waiting for container: context canceled
```

After this fix it works as expected.
