### PR TITLE
Improve OAuth token checks

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
@@ -1,7 +1,9 @@
 package org.apereo.cas.support.oauth.web.response.accesstoken.ext;
 
 import org.apereo.cas.CentralAuthenticationService;
+import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.configuration.model.support.oauth.OAuthProperties;
+import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.services.UnauthorizedServiceException;
 import org.apereo.cas.support.oauth.OAuth20Constants;
@@ -11,11 +13,15 @@ import org.apereo.cas.support.oauth.util.OAuth20Utils;
 import org.apereo.cas.ticket.InvalidTicketException;
 import org.apereo.cas.ticket.OAuthToken;
 import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.util.Pac4jUtils;
+import org.pac4j.core.profile.ProfileManager;
+import org.pac4j.core.profile.UserProfile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -40,18 +46,26 @@ public class AccessTokenAuthorizationCodeGrantRequestExtractor extends BaseAcces
 
         LOGGER.debug("OAuth grant type is [{}]", grantType);
 
-        final String clientId = request.getParameter(OAuth20Constants.CLIENT_ID);
-        final OAuthRegisteredService registeredService = OAuth20Utils.getRegisteredOAuthService(this.servicesManager, clientId);
-        if (registeredService == null) {
+        final ProfileManager manager = Pac4jUtils.getPac4jProfileManager(request, response);
+        final Optional<UserProfile> profile = manager.get(true);
+        final String clientId = profile.get().getId();
+        final OAuthRegisteredService clientRegisteredService = OAuth20Utils.getRegisteredOAuthService(this.servicesManager, clientId);
+        if (clientRegisteredService == null) {
             throw new UnauthorizedServiceException("Unable to locate OAuth service in registry for client " + clientId);
         }
-        LOGGER.debug("Located OAuth registered service [{}]", registeredService);
+        LOGGER.debug("Located OAuth client registered service [{}]", clientRegisteredService);
 
         final OAuthToken token = getOAuthTokenFromRequest(request);
         if (token == null) {
             throw new InvalidTicketException(getOAuthParameter(request));
         }
-        return new AccessTokenRequestDataHolder(token, registeredService, getGrantType(), isAllowedToGenerateRefreshToken(), scopes);
+        final Service codeService = token.getService();
+        final RegisteredService codeRegisteredService = OAuth20Utils.getRegisteredOAuthService(this.servicesManager, codeService.getId());
+        LOGGER.debug("Located OAuth code registered service [{}]", codeRegisteredService);
+        if (!clientRegisteredService.equals(codeRegisteredService)) {
+            throw new UnauthorizedServiceException("Code and client registered services do not match");
+        }
+        return new AccessTokenRequestDataHolder(token, clientRegisteredService, getGrantType(), isAllowedToGenerateRefreshToken(), scopes);
     }
 
     /**


### PR DESCRIPTION
Two changes:

- the `client_id` parameter is replaced by the current pac4j user profile to know the current authenticated OAuth client
- the service of the OAuth code must match the service used to call the token endpoint.