### PR TITLE
Don't initialize DefaultLoginWebflowConfigurer twice

### DIFF
--- a/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/config/CasWebflowContextConfiguration.java
+++ b/core/cas-server-core-webflow/src/main/java/org/apereo/cas/web/flow/config/CasWebflowContextConfiguration.java
@@ -216,7 +216,6 @@ public class CasWebflowContextConfiguration implements CasWebflowExecutionPlanCo
         final DefaultLoginWebflowConfigurer c = new DefaultLoginWebflowConfigurer(builder(), loginFlowRegistry(), applicationContext, casProperties);
         c.setLogoutFlowDefinitionRegistry(logoutFlowRegistry());
         c.setOrder(Ordered.HIGHEST_PRECEDENCE);
-        c.initialize();
         return c;
     }
 


### PR DESCRIPTION
Without this change the `DefaultLoginWebflowConfigurer.initialize()` method is run twice, which causes the `genericSuccessViewAction` Action to be added twice and crash on the second run when a default redirect url is defined.
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
