### PR TITLE
Fix o auth refresh token

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -242,7 +242,7 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
         } else {
             final HandlerInterceptor throttledInterceptor = this.applicationContext.getBean(throttler, HandlerInterceptor.class);
             final String throttledUrl = BASE_OAUTH20_URL.concat("/").concat(ACCESS_TOKEN_URL);
-            HandlerInterceptorAdapter throttledInceptorAdapter = new HandlerInterceptorAdapter() {
+            return new HandlerInterceptorAdapter() {
                 @Override
                 public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl) && !throttledInterceptor.preHandle(request, response, handler)) {
@@ -252,13 +252,13 @@ public class CasOAuthConfiguration extends WebMvcConfigurerAdapter {
                 }
 
                 @Override
-                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final ModelAndView modelAndView) throws Exception {
+                public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler,
+                                       final ModelAndView modelAndView) throws Exception {
                     if (request.getServletPath().startsWith(throttledUrl)) {
                         throttledInterceptor.postHandle(request, response, handler, modelAndView);
                     }
                 }
             };
-            return throttledInceptorAdapter;
         }
     }
 

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/ticket/code/OAuthCodeExpirationPolicy.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/ticket/code/OAuthCodeExpirationPolicy.java
@@ -15,10 +15,10 @@ public class OAuthCodeExpirationPolicy extends MultiTimeUseOrTimeoutExpirationPo
      * Instantiates a new O auth code expiration policy.
      *
      * @param numberOfUses             the number of uses
-     * @param timeToKillInMilliSeconds the time to kill in milli seconds
+     * @param timeToKillInSeconds the time to kill in seconds
      */
     public OAuthCodeExpirationPolicy(final int numberOfUses,
-                                     final long timeToKillInMilliSeconds) {
-        super(numberOfUses, timeToKillInMilliSeconds);
+                                     final long timeToKillInSeconds) {
+        super(numberOfUses, timeToKillInSeconds);
     }
 }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuthRefreshTokenExpirationPolicy.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuthRefreshTokenExpirationPolicy.java
@@ -19,7 +19,7 @@ public class OAuthRefreshTokenExpirationPolicy extends AbstractCasExpirationPoli
     private static final long serialVersionUID = -7144233906843566234L;
 
     /** The time to kill in milliseconds. */
-    private long timeToKillInMilliSeconds;
+    private long timeToKillInSeconds;
 
     /** No-arg constructor for serialization support. */
     public OAuthRefreshTokenExpirationPolicy() {}
@@ -27,21 +27,22 @@ public class OAuthRefreshTokenExpirationPolicy extends AbstractCasExpirationPoli
     /**
      * Instantiates a new OAuth refresh token expiration policy.
      *
-     * @param timeToKillInMilliSeconds the time to kill in milli seconds
+     * @param timeToKillInSeconds the time to kill in seconds
      */
-    public OAuthRefreshTokenExpirationPolicy(final long timeToKillInMilliSeconds) {
-        this.timeToKillInMilliSeconds = timeToKillInMilliSeconds;
+    public OAuthRefreshTokenExpirationPolicy(final long timeToKillInSeconds) {
+        this.timeToKillInSeconds = timeToKillInSeconds;
     }
 
     @Override
     public boolean isExpired(final TicketState ticketState) {
         return ticketState == null || ticketState.getCreationTime()
-                .plus(this.timeToKillInMilliSeconds, ChronoUnit.MILLIS).isBefore(ZonedDateTime.now(ZoneOffset.UTC));
+                .plus(this.timeToKillInSeconds, ChronoUnit.SECONDS)
+                .isBefore(ZonedDateTime.now(ZoneOffset.UTC));
     }
 
     @Override
     public Long getTimeToLive() {
-        return this.timeToKillInMilliSeconds;
+        return this.timeToKillInSeconds;
     }
 
     @Override

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/OAuthTestSuite.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/OAuthTestSuite.java
@@ -3,12 +3,13 @@ package org.apereo.cas.support.oauth;
 import org.apereo.cas.support.oauth.web.OAuth20ProfileControllerTests;
 import org.apereo.cas.support.oauth.web.OAuth20AccessTokenControllerTests;
 import org.apereo.cas.support.oauth.web.OAuth20AuthorizeControllerTests;
+import org.apereo.cas.ticket.refreshtoken.OAuthRefreshTokenExpirationPolicy;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({OAuth20AccessTokenControllerTests.class, OAuth20AuthorizeControllerTests.class,
-                     OAuth20ProfileControllerTests.class})
+                     OAuth20ProfileControllerTests.class, OAuthRefreshTokenExpirationPolicy.class})
 /**
  * OAuth test suite that runs all test in a batch.
  * @author Misagh Moayyed

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuthRefreshTokenExpirationPolicyTest.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuthRefreshTokenExpirationPolicyTest.java
@@ -1,0 +1,52 @@
+package org.apereo.cas.ticket.refreshtoken;
+
+import org.apereo.cas.authentication.Authentication;
+import org.apereo.cas.authentication.principal.Service;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.*;
+
+/**
+ * Adding test to check expired refresh token.
+ *
+ * @author Phillip Rower
+ * @since 5.0.0
+ */
+public class OAuthRefreshTokenExpirationPolicyTest {
+    @Mock
+    private Service mockService;
+
+    @Mock
+    private Authentication mockAuthentication;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void isExpiredTrueTest() {
+        final OAuthRefreshTokenExpirationPolicy policy = new OAuthRefreshTokenExpirationPolicy(-1L);
+        DefaultRefreshTokenFactory defaultRefreshTokenFactory = new DefaultRefreshTokenFactory();
+        defaultRefreshTokenFactory.setExpirationPolicy(policy);
+        final RefreshTokenImpl refreshToken = (RefreshTokenImpl) defaultRefreshTokenFactory.create(mockService, mockAuthentication );
+
+        assertNotNull(refreshToken.getCreationTime());
+        assertTrue(policy.isExpired(refreshToken));
+    }
+
+    @Test
+    public void isExpiredFalseTest() {
+        final OAuthRefreshTokenExpirationPolicy policy = new OAuthRefreshTokenExpirationPolicy(10L);
+        DefaultRefreshTokenFactory defaultRefreshTokenFactory = new DefaultRefreshTokenFactory();
+        defaultRefreshTokenFactory.setExpirationPolicy(policy);
+        final RefreshTokenImpl refreshToken = (RefreshTokenImpl) defaultRefreshTokenFactory.create(mockService, mockAuthentication );
+
+        assertNotNull(refreshToken.getCreationTime());
+        assertFalse(policy.isExpired(refreshToken));
+    }
+
+}


### PR DESCRIPTION
Fix Bug with OAuth Refresh Token policy.  CAS properties set the time for the refresh token in seconds but the OAuthRefreshTokenExpirationPolicy attempted to use these values as milliseconds.  Result being a bug where policy expires 1000 times faster than set in the configuration.  I update policy to use seconds instead of milliseconds.  Update the OAuthCodeExpirationPolicy parameter name to use seconds too as this is actually how it treats the parameter as seconds even though the name of parameter uses milliseconds.  All the OAuth*ExpirationPolicy classes are consistently using seconds.  OAuthAccessTokenExpirationPolicy was already using seconds.
