### PR TITLE
Update GenerateJwtCommand.java

### DIFF
--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/GenerateJwtCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/GenerateJwtCommand.java
@@ -68,7 +68,7 @@ public class GenerateJwtCommand implements CommandMarker {
                     optionContext = "Size of the signing secret",
                     specifiedDefaultValue = "" + DEFAULT_SIGNING_SECRET_SIZE,
                     unspecifiedDefaultValue = "" + DEFAULT_SIGNING_SECRET_SIZE) final int signingSecretSize,
-            @CliOption(key = {"signingSecretSize"},
+            @CliOption(key = {"encryptionSecretSize"},
                     help = "Size of the encryption secret",
                     optionContext = "Size of the encryption secret",
                     specifiedDefaultValue = "" + DEFAULT_ENCRYPTION_SECRET_SIZE,


### PR DESCRIPTION
Minor fix to jwt command line key name duplication bug.

Fix for duplicate signingSecretSize key in cli options.  Changed second entry to encryptionSecretSize to match its description and parameters.

Manifests in the jwt help as repeated keyword "signingSecretSize".

```
cas>help generate-jwt

Keyword:                   generate-jwt
Description:               Generate a JWT with given size and algorithm for signing and encryption.

 Keyword:                  signingSecretSize
   Help:                   Size of the signing secret
   Mandatory:              false
   Default if specified:   '256'
   Default if unspecified: '256'

 Keyword:                  signingSecretSize
   Help:                   Size of the encryption secret
   Mandatory:              false
   Default if specified:   '48'
   Default if unspecified: '48'
```
