### PR TITLE
Add generic parameter to principalAttributeList

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jdbc/QueryJdbcAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jdbc/QueryJdbcAuthenticationProperties.java
@@ -62,7 +62,7 @@ public class QueryJdbcAuthenticationProperties extends AbstractJpaProperties {
     /**
      * List of column names to fetch as user attributes.
      */
-    private List principalAttributeList = new ArrayList();
+    private List<String> principalAttributeList = new ArrayList<>();
 
     /**
      * Principal transformation settings for this authentication.


### PR DESCRIPTION
Without a generic parameter, attempting to assign the principalAttributeList via a YAML config file fails with a NullPointerException
