### PR TITLE
Changes to support OAuth1RequestToken deserialisation for SessionStoreCookie

### DIFF
--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/pac4j/DelegatedSessionCookieManager.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/pac4j/DelegatedSessionCookieManager.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.util.EncodingUtils;
+import org.apereo.cas.util.serialization.StringSerializer;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.pac4j.core.context.J2EContext;
 
@@ -21,7 +22,7 @@ import java.util.Map;
 public class DelegatedSessionCookieManager {
 
     private final CookieRetrievingCookieGenerator cookieGenerator;
-    private final SessionStoreCookieSerializer serializer = new SessionStoreCookieSerializer();
+    private final StringSerializer<Map<String, Object>> serializer;
 
     /**
      * Store.

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/pac4j/SessionStoreCookieSerializer.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/pac4j/SessionStoreCookieSerializer.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.pac4j;
 
 import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
+import com.fasterxml.jackson.databind.Module;
 import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
 
 import java.util.Map;
@@ -11,15 +12,20 @@ import java.util.Map;
  * @author Misagh Moayyed
  * @since 5.3.0
  */
-public class SessionStoreCookieSerializer extends AbstractJacksonBackedStringSerializer<Map> {
+public class SessionStoreCookieSerializer extends AbstractJacksonBackedStringSerializer<Map<String, Object>> {
     private static final long serialVersionUID = -1152522695984638020L;
 
-    public SessionStoreCookieSerializer() {
+
+    public SessionStoreCookieSerializer(final Module... additionalModules) {
         super(new MinimalPrettyPrinter());
+        for (Module module: additionalModules) {
+            getObjectMapper().registerModule(module);
+        }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    protected Class<Map> getTypeToSerialize() {
-        return Map.class;
+    protected Class<Map<String, Object>> getTypeToSerialize() {
+        return (Class<Map<String,Object>>)(Class<?>) Map.class;
     }
 }

--- a/support/cas-server-support-pac4j-webflow/src/test/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationActionTests.java
+++ b/support/cas-server-support-pac4j-webflow/src/test/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationActionTests.java
@@ -37,6 +37,7 @@ import org.apereo.cas.web.DelegatedClientWebflowManager;
 import org.apereo.cas.web.flow.resolver.CasDelegatingWebflowEventResolver;
 import org.apereo.cas.web.flow.resolver.CasWebflowEventResolver;
 import org.apereo.cas.web.pac4j.DelegatedSessionCookieManager;
+import org.apereo.cas.web.pac4j.SessionStoreCookieSerializer;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.junit.Test;
 import org.pac4j.core.client.BaseClient;
@@ -228,7 +229,7 @@ public class DelegatedClientAuthenticationActionTests {
             getServicesManagerWith(service, client),
             enforcer,
             manager,
-            new DelegatedSessionCookieManager(mock(CookieRetrievingCookieGenerator.class)),
+            new DelegatedSessionCookieManager(mock(CookieRetrievingCookieGenerator.class), mock(SessionStoreCookieSerializer.class)),
             support);
 
     }

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jDelegatedAuthenticationConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/support/pac4j/config/Pac4jDelegatedAuthenticationConfiguration.java
@@ -1,5 +1,11 @@
 package org.apereo.cas.support.pac4j.config;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.github.scribejava.core.model.OAuth1RequestToken;
 import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.CipherExecutor;
 import org.apereo.cas.audit.AuditableExecution;
@@ -7,6 +13,7 @@ import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.util.EncryptionJwtSigningJwtCryptographyProperties;
 import org.apereo.cas.configuration.model.support.pac4j.Pac4jDelegatedSessionCookieProperties;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.util.serialization.StringSerializer;
 import org.apereo.cas.validation.Pac4jServiceTicketValidationAuthorizer;
 import org.apereo.cas.validation.RegisteredServiceDelegatedAuthenticationPolicyAuditableEnforcer;
 import org.apereo.cas.validation.ServiceTicketValidationAuthorizer;
@@ -15,6 +22,7 @@ import org.apereo.cas.validation.ServiceTicketValidationAuthorizersExecutionPlan
 import org.apereo.cas.web.pac4j.DelegatedSessionCookieCipherExecutor;
 import org.apereo.cas.web.pac4j.DelegatedSessionCookieManager;
 import org.apereo.cas.web.pac4j.SessionStoreCookieGenerator;
+import org.apereo.cas.web.pac4j.SessionStoreCookieSerializer;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.apereo.cas.web.support.DefaultCasCookieValueManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +32,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
 
 /**
  * This is {@link Pac4jDelegatedAuthenticationConfiguration}.
@@ -53,7 +63,21 @@ public class Pac4jDelegatedAuthenticationConfiguration implements ServiceTicketV
     @Bean
     @ConditionalOnMissingBean(name = "pac4jDelegatedSessionCookieManager")
     public DelegatedSessionCookieManager pac4jDelegatedSessionCookieManager() {
-        return new DelegatedSessionCookieManager(pac4jSessionStoreCookieGenerator());
+        return new DelegatedSessionCookieManager(pac4jSessionStoreCookieGenerator(), pac4jDelegatedSessionStoreCookieSerializer());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "pac4jDelegatedSessionStoreCookieSerializer")
+    public StringSerializer<Map<String,Object>> pac4jDelegatedSessionStoreCookieSerializer() {
+        return new SessionStoreCookieSerializer(pac4jJacksonModule());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "pac4jJacksonModule")
+    public Module pac4jJacksonModule() {
+        SimpleModule module = new SimpleModule();
+        module.setMixInAnnotation(OAuth1RequestToken.class, OAuth1RequestTokenMixin.class);
+        return module;
     }
 
     @Bean
@@ -89,5 +113,19 @@ public class Pac4jDelegatedAuthenticationConfiguration implements ServiceTicketV
     @Override
     public void configureAuthorizersExecutionPlan(final ServiceTicketValidationAuthorizersExecutionPlan plan) {
         plan.registerAuthorizer(pac4jServiceTicketValidationAuthorizer());
+    }
+
+    public abstract static class OAuth1RequestTokenMixin extends OAuth1RequestToken {
+        @JsonCreator
+        public OAuth1RequestTokenMixin(@JsonProperty("token") final String token,
+                                       @JsonProperty("tokenSecret") final String tokenSecret,
+                                       @JsonProperty("oauthCallbackConfirmed") final boolean oauthCallbackConfirmed,
+                                       @JsonProperty("rawResponse") final String rawResponse) {
+            super(token, tokenSecret, oauthCallbackConfirmed, rawResponse);
+        }
+
+        @JsonIgnore
+        @Override
+        public abstract boolean isEmpty();
     }
 }


### PR DESCRIPTION
@mmoayyed this patch adds twitter (and oauth1 request token in general) support to the DelegatedSessionCookieManager.  It also makes the SessionStoreCookieSerialiser an overridable @Bean.

Note that the Jackson mixin is currently stored in the @Configuration class for want of a better place to put it, happy to takes suggestions of a more appropriate place for it.
