### PR TITLE
the v2 serviceValidate controller should use the proxy20Handler

### DIFF
--- a/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
+++ b/support/cas-server-support-validation/src/main/java/org/apereo/cas/web/config/CasValidationConfiguration.java
@@ -263,7 +263,7 @@ public class CasValidationConfiguration {
         if (casProperties.getView().getCas2().isV3ForwardCompatible()) {
             return new ServiceValidateController(
                     cas20WithoutProxyProtocolValidationSpecification, authenticationSystemSupport,
-                    servicesManager, centralAuthenticationService, proxy10Handler, argumentExtractor,
+                    servicesManager, centralAuthenticationService, proxy20Handler, argumentExtractor,
                     multifactorTriggerSelectionStrategy, authenticationContextValidator,
                     cas3ServiceJsonView(), cas3ServiceSuccessView(), cas3ServiceFailureView,
                     casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(), serviceValidationAuthorizers()
@@ -272,7 +272,7 @@ public class CasValidationConfiguration {
 
         return new ServiceValidateController(
                 cas20WithoutProxyProtocolValidationSpecification, authenticationSystemSupport,
-                servicesManager, centralAuthenticationService, proxy10Handler, argumentExtractor,
+                servicesManager, centralAuthenticationService, proxy20Handler, argumentExtractor,
                 multifactorTriggerSelectionStrategy, authenticationContextValidator,
                 cas3ServiceJsonView(), cas2ServiceSuccessView(), cas2ServiceFailureView,
                 casProperties.getAuthn().getMfa().getAuthenticationContextAttribute(), serviceValidationAuthorizers()


### PR DESCRIPTION
Without this a PGT is not delivered for /cas/serviceValidate?pgtUrl=url

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
