### PR TITLE
Move ErrorViewResolver out of DelegatedAuthenticationWebflowConfiguration

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
  * @author sbearcsiro
  * @since 5.3.0
  */
-@Configuration
+@Configuration("delegatedAuthenticationWebConfiguration")
 public class DelegatedAuthenticationWebConfiguration {
 
     @Bean

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebConfiguration.java
@@ -1,0 +1,26 @@
+package org.apereo.cas.web.flow.config;
+
+import org.apereo.cas.web.flow.DelegatedAuthenticationErrorViewResolver;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.web.ErrorViewResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This configuration is separate from {@link DelegatedAuthenticationWebflowConfiguration} because
+ * {@link ErrorViewResolver} @Beans are requested very early in the {@link org.springframework.boot.context.embedded.EmbeddedServletContainer}
+ * startup process, so it contains 0 {@link org.springframework.beans.factory.annotation.Autowired} dependencies.
+ *
+ * @author sbearcsiro
+ * @since 5.3.0
+ */
+@Configuration
+public class DelegatedAuthenticationWebConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "pac4jErrorViewResolver")
+    public ErrorViewResolver pac4jErrorViewResolver() {
+        return new DelegatedAuthenticationErrorViewResolver();
+    }
+
+}

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebflowConfiguration.java
@@ -159,12 +159,6 @@ public class DelegatedAuthenticationWebflowConfiguration implements CasWebflowEx
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "pac4jErrorViewResolver")
-    public ErrorViewResolver pac4jErrorViewResolver() {
-        return new DelegatedAuthenticationErrorViewResolver();
-    }
-
-    @Bean
     public DelegatedClientWebflowManager delegatedClientWebflowManager() {
         return new DelegatedClientWebflowManager(ticketRegistry,
             ticketFactory,

--- a/support/cas-server-support-pac4j-webflow/src/main/resources/META-INF/spring.factories
+++ b/support/cas-server-support-pac4j-webflow/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.web.flow.config.DelegatedAuthenticationWebflowConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.web.flow.config.DelegatedAuthenticationWebflowConfiguration,org.apereo.cas.web.flow.config.DelegatedAuthenticationWebConfiguration


### PR DESCRIPTION
The Spring Boot `EmbeddedServletContainerAutoConfiguration` will attempt to construct all `ErrorViewResolver` `@Bean`s via the `ErrorPageRegistrarBeanPostProcessor` before loading the rest of the `ApplicationContext`.  Because the `DelegatedAuthenticationErrorViewResolver` was defined in a `@Configuration` with `@Autowired` dependencies, this forced the (non-lazy) `@Autowired` dependencies to be constructed before the container startup.  This has implications for CAS components using `DataSource` objects that were supposed to be obtained from JNDI because the components will be constructed before JNDI is setup by the servlet container initialisation.

This patch simply separates the `pac4jErrorViewResolver` out into its own `@Configuration` so that it can be constructed without constructing the rest of CAS as the same time.