### PR TITLE
Make ErrorViewResolver static to avoid instantiation of all @Autowired beans

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebflowConfiguration.java
@@ -51,6 +51,7 @@ import org.springframework.webflow.execution.Action;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @Slf4j
 public class DelegatedAuthenticationWebflowConfiguration implements CasWebflowExecutionPlanConfigurer {
+
     @Autowired
     @Qualifier("defaultTicketFactory")
     private TicketFactory ticketFactory;
@@ -128,6 +129,16 @@ public class DelegatedAuthenticationWebflowConfiguration implements CasWebflowEx
     @Qualifier("logoutFlowRegistry")
     private FlowDefinitionRegistry logoutFlowDefinitionRegistry;
 
+    /**
+     * This @Bean is static so that it can be instantiated without the @Autowired dependencies
+     * also being instantiated.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "pac4jErrorViewResolver")
+    public static ErrorViewResolver pac4jErrorViewResolver() {
+        return new DelegatedAuthenticationErrorViewResolver();
+    }
+
     @ConditionalOnMissingBean(name = "saml2ClientLogoutAction")
     @Bean
     @Lazy
@@ -156,12 +167,6 @@ public class DelegatedAuthenticationWebflowConfiguration implements CasWebflowEx
     public CasWebflowConfigurer delegatedAuthenticationWebflowConfigurer() {
         return new DelegatedAuthenticationWebflowConfigurer(flowBuilderServices, loginFlowDefinitionRegistry,
             logoutFlowDefinitionRegistry, saml2ClientLogoutAction, applicationContext, casProperties);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean(name = "pac4jErrorViewResolver")
-    public ErrorViewResolver pac4jErrorViewResolver() {
-        return new DelegatedAuthenticationErrorViewResolver();
     }
 
     @Bean


### PR DESCRIPTION
The Spring Boot `EmbeddedServletContainerAutoConfiguration` will attempt to construct all `ErrorViewResolver` `@Bean`s via the `ErrorPageRegistrarBeanPostProcessor` before loading the rest of the `ApplicationContext`.  Because the `DelegatedAuthenticationErrorViewResolver` was defined in a `@Configuration` with `@Autowired` dependencies, this forced the (non-lazy) `@Autowired` dependencies to be constructed before the container startup.  This has implications for CAS components using `DataSource` objects that were supposed to be obtained from JNDI because the components will be constructed before JNDI is setup by the servlet container initialisation.

This patch simply makes the `pac4jErrorViewResolver` static inside the `@Configuration` so that it can be constructed without constructing the rest of the dependencies at the same time.