### PR TITLE
Ensure external property sources have higher priority in standalone mode

### DIFF
--- a/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
+++ b/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
@@ -46,8 +46,11 @@ public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfig
     public PropertySource<?> locate(final Environment environment, final ResourceLoader resourceLoader) {
         final CompositePropertySource compositePropertySource = new CompositePropertySource("casCompositePropertySource");
 
-        final PropertySource<?> sourceYaml = loadEmbeddedYamlOverriddenProperties(resourceLoader);
-        compositePropertySource.addPropertySource(sourceYaml);
+        final File configFile = casConfigurationPropertiesEnvironmentManager.getStandaloneProfileConfigurationFile();
+        if (configFile != null) {
+            final PropertySource<?> sourceStandalone = loadSettingsFromStandaloneConfigFile(configFile);
+            compositePropertySource.addPropertySource(sourceStandalone);
+        }
 
         final File config = casConfigurationPropertiesEnvironmentManager.getStandaloneProfileConfigurationDirectory();
         LOGGER.debug("Located CAS standalone configuration directory at [{}]", config);
@@ -58,11 +61,9 @@ public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfig
             LOGGER.info("Configuration directory [{}] is not a directory or cannot be found at the specific path", config);
         }
 
-        final File configFile = casConfigurationPropertiesEnvironmentManager.getStandaloneProfileConfigurationFile();
-        if (configFile != null) {
-            final PropertySource<?> sourceStandalone = loadSettingsFromStandaloneConfigFile(configFile);
-            compositePropertySource.addFirstPropertySource(sourceStandalone);
-        }
+        final PropertySource<?> sourceYaml = loadEmbeddedYamlOverriddenProperties(resourceLoader);
+        compositePropertySource.addPropertySource(sourceYaml);
+
         return compositePropertySource;
     }
 

--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/DefaultCasConfigurationPropertiesSourceLocatorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/DefaultCasConfigurationPropertiesSourceLocatorTests.java
@@ -45,6 +45,7 @@ public class DefaultCasConfigurationPropertiesSourceLocatorTests {
 
     static {
         System.setProperty("spring.profiles.active", "standalone");
+        System.setProperty("cas.standalone.configurationDirectory", "src/test/resources/directory");
         System.setProperty("cas.standalone.configurationFile", "src/test/resources/standalone.properties");
     }
 
@@ -56,5 +57,23 @@ public class DefaultCasConfigurationPropertiesSourceLocatorTests {
         final CompositePropertySource composite = (CompositePropertySource) source;
         assertEquals("https://cas.example.org:9999", composite.getProperty("cas.server.name"));
         assertEquals("https://cas.example.org/something", composite.getProperty("cas.server.prefix"));
+    }
+
+    @Test
+    public void verifyPriority() {
+        final PropertySource source = casConfigurationPropertiesSourceLocator.locate(environment, resourceLoader);
+        assertTrue(source instanceof CompositePropertySource);
+
+        // Ensure standalone property sources priority order is:
+        // 1. file
+        // 2. dir cas.props
+        // 3. dir app.props
+        // 4. classpath app.yml
+
+        final CompositePropertySource composite = (CompositePropertySource) source;
+        assertEquals("file", composite.getProperty("test.file"));
+        assertEquals("dirCasProp", composite.getProperty("test.dir.cas"));
+        assertEquals("dirAppYml", composite.getProperty("test.dir.app"));
+        assertEquals("classpathAppYml", composite.getProperty("test.classpath"));
     }
 }

--- a/core/cas-server-core-configuration/src/test/resources/application.yml
+++ b/core/cas-server-core-configuration/src/test/resources/application.yml
@@ -11,3 +11,10 @@ cas:
   authn:
     accept:
       users: casuser::Mellon
+
+test:
+  classpath: classpathAppYml
+  dir:
+    app: classpathAppYml
+    cas: classpathAppYml
+  file: classpathAppYml

--- a/core/cas-server-core-configuration/src/test/resources/directory/application.yml
+++ b/core/cas-server-core-configuration/src/test/resources/directory/application.yml
@@ -1,0 +1,5 @@
+test:
+  dir:
+    app: dirAppYml
+    cas: dirAppYml
+  file: dirAppYml

--- a/core/cas-server-core-configuration/src/test/resources/directory/cas.properties
+++ b/core/cas-server-core-configuration/src/test/resources/directory/cas.properties
@@ -1,0 +1,2 @@
+test.dir.cas=dirCasProp
+test.file=dirCasProp

--- a/core/cas-server-core-configuration/src/test/resources/standalone.properties
+++ b/core/cas-server-core-configuration/src/test/resources/standalone.properties
@@ -1,1 +1,3 @@
 cas.server.prefix=https://cas.example.org/something
+
+test.file=file


### PR DESCRIPTION
Ensures that `cas.standalone.configurationFile` has higher priority than `cas.standalone.configurationDirectory` which in turn has higher priority than classpath `application.yml`, so that external sources can override values in the bundled file.