### PR TITLE
Avoid forced session creation in TerminateSessionAction

### DIFF
--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/logout/TerminateSessionAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/logout/TerminateSessionAction.java
@@ -98,11 +98,13 @@ public class TerminateSessionAction extends AbstractAction {
         final ProfileManager manager = Pac4jUtils.getPac4jProfileManager(request, response);
         manager.logout();
 
-        final HttpSession session = request.getSession();
+        final HttpSession session = request.getSession(false);
         if (session != null) {
-            final Object requestedUrl = request.getSession().getAttribute(Pac4jConstants.REQUESTED_URL);
+            final Object requestedUrl = session.getAttribute(Pac4jConstants.REQUESTED_URL);
             session.invalidate();
-            request.getSession(true).setAttribute(Pac4jConstants.REQUESTED_URL, requestedUrl);
+            if (requestedUrl != null && !requestedUrl.equals("")) {
+                request.getSession(true).setAttribute(Pac4jConstants.REQUESTED_URL, requestedUrl);
+            }
         }
     }
 


### PR DESCRIPTION
Note that if pac4j is using the default `SessionStore` then the `ProfileManager.logout()` call will still force creation of a session if one didn't exist already.  This patch just prevents forcing the creation of a new session after invalidation even if the pac4j `REQUESTED_URL` was not set.