### PR TITLE
Delete used tokens after their lifetime has expired

### DIFF
--- a/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/config/GoogleAuthenticatorJpaConfiguration.java
+++ b/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/config/GoogleAuthenticatorJpaConfiguration.java
@@ -104,7 +104,7 @@ public class GoogleAuthenticatorJpaConfiguration {
     @Bean
     public OneTimeTokenRepository oneTimeTokenAuthenticatorTokenRepository() {
         return new GoogleAuthenticatorJpaTokenRepository(
-            casProperties.getAuthn().getMfa().getGauth().getTimeStepSize()
+            casProperties.getAuthn().getMfa().getGauth().getTimeStepSize() * casProperties.getAuthn().getMfa().getGauth().getWindowSize()
         );
     }
 


### PR DESCRIPTION
IMHO, I think the token should not be deleted after "time step size" but after "time step size" multiplied by "window size", in fact the total lifetime of the token

