### PR TITLE
Fix OIDC token revocation to better respect RFC 7009

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcRevocationEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcRevocationEndpointController.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.oidc.web.controllers;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.audit.AuditableContext;
 import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.audit.AuditableExecutionResult;
@@ -11,7 +10,6 @@ import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.services.ServicesManager;
-import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.profile.OAuth20ProfileScopeToAttributesFilter;
 import org.apereo.cas.support.oauth.services.OAuthRegisteredService;
 import org.apereo.cas.support.oauth.util.OAuth20Utils;
@@ -26,7 +24,7 @@ import org.pac4j.core.credentials.extractor.BasicAuthExtractor;
 import org.pac4j.core.credentials.extractor.CredentialsExtractor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -63,14 +61,14 @@ public class OidcRevocationEndpointController extends BaseOAuth20Controller {
      * @param response the response
      * @return the jwk set
      */
-    @GetMapping(value = '/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.REVOCATION_URL)
+    @PostMapping(value = '/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.REVOCATION_URL)
     public ResponseEntity<String> handleRequestInternal(final HttpServletRequest request,
                                                         final HttpServletResponse response) {
         try {
             final CredentialsExtractor<UsernamePasswordCredentials> authExtractor = new BasicAuthExtractor();
             final UsernamePasswordCredentials credentials = authExtractor.extract(Pac4jUtils.getPac4jJ2EContext(request, response));
             if (credentials == null) {
-                throw new IllegalArgumentException("No credentials are provided to verify introspection on the access token");
+                throw new IllegalArgumentException("No credentials are provided to verify revocation of the token");
             }
 
             final OAuthRegisteredService registeredService = OAuth20Utils.getRegisteredOAuthServiceByClientId(this.servicesManager, credentials.getUsername());
@@ -83,12 +81,11 @@ public class OidcRevocationEndpointController extends BaseOAuth20Controller {
             final AuditableExecutionResult accessResult = this.registeredServiceAccessStrategyEnforcer.execute(audit);
 
             if (!accessResult.isExecutionFailure()
-                && HttpRequestUtils.doesParameterExist(request, OAuth20Constants.ACCESS_TOKEN)
+                && HttpRequestUtils.doesParameterExist(request, OidcConstants.TOKEN)
                 && OAuth20Utils.checkClientSecret(registeredService, credentials.getPassword())) {
                 final String token = request.getParameter(OidcConstants.TOKEN);
-                if (StringUtils.isNotBlank(token)) {
-                    this.ticketRegistry.deleteTicket(token);
-                }
+                LOGGER.debug("Located token [{}] in the revocation request", token);
+                this.ticketRegistry.deleteTicket(token);
             }
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
This PR fixes the RFC 7009 (token revocation) implementation in CAS by using:
- HTTP method POST (instead of GET previously)
- a request parameter named "token" (instead of a weird mix of "access_token" and "token" previously)

Note that this does not make CAS fully compliant: as per the RFC, _"The authorization server [...] verifies whether the token was issued to the client making the revocation request"_, but I couldn't find how to trace the token back to its issuer. Did I miss the obvious or isn't it possible currently?

Also note that this should probably be added to the OAuth 2.0 endpoints as well, since the RFC isn't OIDC-specific?