### PR TITLE
Clean up for delegated auth redirects

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationServiceSelectionPlan.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationServiceSelectionPlan.java
@@ -49,6 +49,9 @@ public class DefaultAuthenticationServiceSelectionPlan implements Authentication
     @Override
     public <T extends Service> T resolveService(final Service service, final Class<T> clazz) {
         final Service result = resolveService(service);
+        if (result == null) {
+            return null;
+        }
         if (!clazz.isAssignableFrom(result.getClass())) {
             throw new ClassCastException("Object [" + result + " is of type " + result.getClass() + " when we were expecting " + clazz);
         }

--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractServiceFactory.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractServiceFactory.java
@@ -4,6 +4,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -66,9 +67,9 @@ public abstract class AbstractServiceFactory<T extends Service> implements Servi
      * @return the source parameter
      */
     protected static String getSourceParameter(final HttpServletRequest request, final String... paramNames) {
-        final Map<String, String[]> parameterMap = request.getParameterMap();
+        final Map<String, String[]> parameterMap = request != null ? request.getParameterMap() : Collections.emptyMap();
         final String param = Stream.of(paramNames)
-            .filter(p -> parameterMap.containsKey(p) || request.getAttribute(p) != null)
+            .filter(p -> parameterMap.containsKey(p) || (request != null && request.getAttribute(p) != null))
             .findFirst()
             .orElse(null);
         return param;

--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/WebApplicationServiceFactory.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/WebApplicationServiceFactory.java
@@ -52,7 +52,7 @@ public class WebApplicationServiceFactory extends AbstractServiceFactory<WebAppl
         final String id = cleanupUrl(serviceToUse);
         final AbstractWebApplicationService newService = new SimpleWebApplicationServiceImpl(id, serviceToUse, artifactId);
         determineWebApplicationFormat(request, newService);
-        final String source = getSourceParameter(request, CasProtocolConstants.PARAMETER_TARGET_SERVICE, CasProtocolConstants.PARAMETER_TARGET_SERVICE);
+        final String source = getSourceParameter(request, CasProtocolConstants.PARAMETER_TARGET_SERVICE, CasProtocolConstants.PARAMETER_SERVICE);
         newService.setSource(source);
         return newService;
     }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/WebApplicationServiceFactoryTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/WebApplicationServiceFactoryTests.java
@@ -34,6 +34,7 @@ public class WebApplicationServiceFactoryTests {
         final WebApplicationServiceFactory factory = new WebApplicationServiceFactory();
         final WebApplicationService service = factory.createService(request);
         assertNotNull(service);
+        assertEquals(CasProtocolConstants.PARAMETER_SERVICE, service.getSource());
     }
 
     @Test
@@ -43,6 +44,7 @@ public class WebApplicationServiceFactoryTests {
         final WebApplicationServiceFactory factory = new WebApplicationServiceFactory();
         final WebApplicationService service = factory.createService(request);
         assertNotNull(service);
+        assertEquals(CasProtocolConstants.PARAMETER_TARGET_SERVICE, service.getSource());
     }
 
     @Test
@@ -65,5 +67,13 @@ public class WebApplicationServiceFactoryTests {
 
         final WebApplicationService service = factory.createService(request);
         assertNull(service);
+    }
+
+    @Test
+    public void verifyServiceCreationNoRequest() {
+        final WebApplicationServiceFactory factory = new WebApplicationServiceFactory();
+
+        final WebApplicationService service = factory.createService("testservice");
+        assertNotNull(service);
     }
 }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
@@ -221,8 +221,13 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
             .fromUriString(DelegatedClientNavigationController.ENDPOINT_REDIRECT)
             .queryParam(Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER, name);
 
-        final String serviceParam = service.getOriginalUrl();
-        uriBuilder.queryParam(service.getSource(), serviceParam);
+        if (service != null) {
+            final String sourceParam = service.getSource();
+            final String serviceParam = service.getOriginalUrl();
+            if (StringUtils.isNotBlank(sourceParam) && StringUtils.isNotBlank(serviceParam)) {
+                uriBuilder.queryParam(sourceParam, serviceParam);
+            }
+        }
 
         final String methodParam = webContext.getRequestParameter(CasProtocolConstants.PARAMETER_METHOD);
         if (StringUtils.isNotBlank(methodParam)) {


### PR DESCRIPTION
Follows on from #3304 and fixes a few minor issues introduced

 - Fix crash when no Service is resolved
 - Fix missing auth providers on login when no Service is resolved
 - Fix crash when creating the OAuth Callback Service on startup because no HTTP request is available
 - Fix CAS `service` parameter being ignored
