### PR TITLE
Don't create sessions unnecessarily

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/view/ThemeFileTemplateResolver.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/view/ThemeFileTemplateResolver.java
@@ -11,6 +11,7 @@ import org.thymeleaf.templateresolver.FileTemplateResolver;
 import org.thymeleaf.templateresource.ITemplateResource;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.util.Map;
 
 /**
@@ -48,7 +49,10 @@ public class ThemeFileTemplateResolver extends FileTemplateResolver {
     protected String getCurrentTheme() {
         final HttpServletRequest request = WebUtils.getHttpServletRequestFromExternalWebflowContext();
         if (request != null) {
-            return (String) request.getSession().getAttribute(casProperties.getTheme().getParamName());
+            final HttpSession session = request.getSession(false);
+            if (session != null) {
+                return (String) session.getAttribute(casProperties.getTheme().getParamName());
+            }
         }
         return null;
     }

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/mfa/request/RequestSessionAttributeMultifactorAuthenticationPolicyEventResolver.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/mfa/request/RequestSessionAttributeMultifactorAuthenticationPolicyEventResolver.java
@@ -45,7 +45,7 @@ public class RequestSessionAttributeMultifactorAuthenticationPolicyEventResolver
 
     @Override
     protected List<String> resolveEventFromHttpRequest(final HttpServletRequest request) {
-        final HttpSession session = request.getSession();
+        final HttpSession session = request.getSession(false);
         Object attributeValue = session != null ? session.getAttribute(attributeName) : null;
         if (attributeValue == null) {
             LOGGER.debug("No value could be found for session attribute [{}]. Checking request attributes...", this.attributeName);


### PR DESCRIPTION
When reading a session attribute use the version of `getSession()` that doesn't create a session if none exists.