### PR TITLE
TLS Connection Detailer

### DIFF
--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/ValidateEndpointCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/ValidateEndpointCommand.java
@@ -79,7 +79,7 @@ public class ValidateEndpointCommand implements CommandMarker {
             }
         } catch (final Exception e) {
             LOGGER.info("Could not connect to the host address [{}]", url);
-            LOGGER.info("The error is: " + e.getMessage());
+            LOGGER.info("The error is: {}", e.getMessage());
             LOGGER.info("Here are the details:");
             LOGGER.error(e.getMessage(), e);
         }

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/ValidateEndpointCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/ValidateEndpointCommand.java
@@ -14,11 +14,33 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * This is {@link ValidateEndpointCommand}.
  *
  * @author Misagh Moayyed
+ * @author John Gasper
  * @since 5.3.0
  */
 @Service
@@ -53,17 +75,9 @@ public class ValidateEndpointCommand implements CommandMarker {
             optionContext = "Timeout to use in milliseconds when testing the url") final int timeout) {
 
         try {
-            final URL constructedUrl = new URL(url);
-            final URLConnection conn;
             LOGGER.info("Trying to connect to [{}]", url);
-            if (StringUtils.isNotBlank(proxy)) {
-                final URL proxyUrl = new URL(proxy);
-                LOGGER.info("Using proxy address [{}]");
-                final InetSocketAddress proxyAddr = new InetSocketAddress(proxyUrl.getHost(), proxyUrl.getPort());
-                conn = constructedUrl.openConnection(new Proxy(Proxy.Type.HTTP, proxyAddr));
-            } else {
-                conn = constructedUrl.openConnection();
-            }
+            final URLConnection conn = createConnection(url, proxy);
+
             LOGGER.info("Setting connection timeout to [{}]", timeout);
             conn.setConnectTimeout(timeout);
 
@@ -81,7 +95,176 @@ public class ValidateEndpointCommand implements CommandMarker {
             LOGGER.info("Could not connect to the host address [{}]", url);
             LOGGER.info("The error is: {}", e.getMessage());
             LOGGER.info("Here are the details:");
+            LOGGER.error(consolidateExceptionMessages(e));
+            testBadTlsConnection(url, proxy);
+        }
+    }
+
+    private URLConnection createConnection(final String url, final String proxy) throws Exception {
+        final URL constructedUrl = new URL(url);
+        final URLConnection conn;
+
+        if (StringUtils.isNotBlank(proxy)) {
+            final URL proxyUrl = new URL(proxy);
+            LOGGER.info("Using proxy address [{}]");
+            final InetSocketAddress proxyAddr = new InetSocketAddress(proxyUrl.getHost(), proxyUrl.getPort());
+            conn = constructedUrl.openConnection(new Proxy(Proxy.Type.HTTP, proxyAddr));
+        } else {
+            conn = constructedUrl.openConnection();
+        }
+
+        return conn;
+    }
+
+    private String consolidateExceptionMessages(final Throwable throwable) {
+        final StringBuilder stringBuilder = new StringBuilder();
+
+        Throwable pointer = throwable;
+
+        while (pointer != null) {
+            stringBuilder.append("  Caused by: ")
+                    .append(pointer.toString())
+                    .append(System.getProperty("line.separator"));
+            pointer = pointer.getCause();
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private void testBadTlsConnection(final String url, final String proxy) {
+        try {
+            final URLConnection urlConnection = createConnection(url, proxy);
+
+            if (!(urlConnection instanceof HttpsURLConnection)) {
+                LOGGER.info("Not an TLS connection.");
+                return;
+            }
+
+            final HttpsURLConnection httpsConnection = (HttpsURLConnection) urlConnection;
+
+            //Setting our own Trust Manager so the connection completes and we can examine the server cert chain.
+            httpsConnection.setSSLSocketFactory(getTheAllTrustingSSLContext().getSocketFactory());
+
+            try (InputStreamReader reader = new InputStreamReader(httpsConnection.getInputStream(), "UTF-8")) {
+                tlsConnectionReport(httpsConnection);
+            }
+        } catch (final Exception e) {
+            LOGGER.error(e.getMessage());
+        }
+    }
+
+    private void tlsConnectionReport(final HttpsURLConnection httpsConnection) {
+        final X509TrustManager[] systemTrustManagers = getSystemTrustManagers();
+
+        final Certificate[] certificates;
+        try {
+            certificates = httpsConnection.getServerCertificates();
+        } catch (final SSLPeerUnverifiedException e) {
             LOGGER.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+
+        final X509Certificate[] serverCertificates =
+                Arrays.copyOf(certificates, certificates.length, X509Certificate[].class);
+
+        LOGGER.info("Server provided certs: ");
+        for (final X509Certificate certificate : serverCertificates) {
+
+            String validity;
+            try {
+                certificate.checkValidity();
+                validity = "valid";
+            } catch (final CertificateExpiredException e) {
+                validity = "invalid";
+            } catch (final CertificateNotYetValidException e) {
+                validity = "invalid";
+            }
+
+            LOGGER.info("  subject: {}", certificate.getSubjectDN().getName());
+            LOGGER.info("  issuer: {}", certificate.getIssuerDN().getName());
+            LOGGER.info("  expiration: {} - {} ({})", certificate.getNotBefore(), certificate.getNotAfter(), validity);
+            LOGGER.info("  trust anchor {}", checkTrustedCertStatus(certificate, systemTrustManagers));
+            LOGGER.info("---");
+        }
+    }
+
+    private static X509TrustManager[] getSystemTrustManagers() {
+        TrustManagerFactory trustManagerFactory = null;
+        try {
+            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+        } catch (final NoSuchAlgorithmException e) {
+
+        } catch (final KeyStoreException e) {
+
+        }
+
+        LOGGER.info("Detected Truststore: {}", trustManagerFactory.getProvider().getName());
+        final List<X509TrustManager> x509TrustManagers = new ArrayList<X509TrustManager>();
+
+        for (final TrustManager trustManager : trustManagerFactory.getTrustManagers()) {
+            if (trustManager instanceof X509TrustManager) {
+                final X509TrustManager x509TrustManager = (X509TrustManager) trustManager;
+                LOGGER.info("  Trusted issuers found: {}", x509TrustManager.getAcceptedIssuers().length);
+
+                x509TrustManagers.add(x509TrustManager);
+            }
+        }
+
+        return x509TrustManagers.toArray(new X509TrustManager[]{});
+    }
+
+    private String checkTrustedCertStatus(final X509Certificate certificate, final X509TrustManager[] trustManagers) {
+
+        for (final X509TrustManager trustManager : trustManagers) {
+            for (final X509Certificate trustedCert : trustManager.getAcceptedIssuers()) {
+                try {
+                    certificate.verify(trustedCert.getPublicKey());
+                    return "matched found: " + trustedCert.getIssuerDN().getName();
+
+                } catch (final CertificateException e) {
+                    LOGGER.trace("{}: {}", trustedCert.getIssuerDN().getName(), e.getMessage());
+                } catch (final NoSuchAlgorithmException e) {
+                    LOGGER.trace("{}: {}", trustedCert.getIssuerDN().getName(), e.getMessage());
+                } catch (final InvalidKeyException e) {
+                    LOGGER.trace("{}: {}", trustedCert.getIssuerDN().getName(), e.getMessage());
+                } catch (final NoSuchProviderException e) {
+                    LOGGER.trace("{}: {}", trustedCert.getIssuerDN().getName(), e.getMessage());
+                } catch (final SignatureException e) {
+                    LOGGER.trace("{}: {}", trustedCert.getIssuerDN().getName(), e.getMessage());
+                }
+            }
+        }
+
+        return "not matched in trust store (which is expected of the host certificate that is part of a chain)";
+    }
+
+    private SSLContext getTheAllTrustingSSLContext() {
+        try {
+            final SSLContext sslContext = SSLContext.getInstance("TLS");
+
+            sslContext.init(null, new TrustManager[] {new X509TrustManager() {
+
+                @Override
+                public void checkClientTrusted(final X509Certificate[] xcs, final String string) {
+                }
+
+                @Override
+                public void checkServerTrusted(final X509Certificate[] xcs, final String string) {
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+
+            }}, null);
+
+            return sslContext;
+
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }
+

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/ValidateLdapConnectionCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/ValidateLdapConnectionCommand.java
@@ -119,7 +119,7 @@ public class ValidateLdapConnectionCommand implements CommandMarker {
             LOGGER.info("******* Ldap Search *******");
             LOGGER.info("Ldap filter: [{}]", searchFilter);
             LOGGER.info("Ldap search base: [{}]", baseDn);
-            LOGGER.info("Returning attributes: " + Arrays.toString(attrIDs));
+            LOGGER.info("Returning attributes: {}", Arrays.toString(attrIDs));
             LOGGER.info("***************************\n");
 
             final SearchControls ctls = new SearchControls();


### PR DESCRIPTION
This update changes the validate-endpoint command-line function to include details that can be used to troubleshoot failed https client connection. An example of the output form a failed connection:

```
validate-endpoint --url https://expired.badssl.com
Trying to connect to [https://expired.badssl.com]
Setting connection timeout to [5000]
Could not connect to the host address [https://expired.badssl.com]
The error is: sun.security.validator.ValidatorException: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
Here are the details:
  Caused by: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
  Caused by: sun.security.validator.ValidatorException: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed
  Caused by: java.security.cert.CertPathValidatorException: validity check failed
  Caused by: java.security.cert.CertificateExpiredException: NotAfter: Sun Apr 12 16:59:59 PDT 2015

Server provided certs: 
  subject: CN=*.badssl.com, OU=PositiveSSL Wildcard, OU=Domain Control Validated
  issuer: CN=COMODO RSA Domain Validation Secure Server CA, O=COMODO CA Limited, L=Salford, ST=Greater Manchester, C=GB
  expiration: 2015-04-08T17:00:00.000-0700 - 2015-04-12T16:59:59.000-0700 (invalid)
  trust anchor not matched in trust store (which is expected of the host certificate that is part of a chain)
---
  subject: CN=COMODO RSA Domain Validation Secure Server CA, O=COMODO CA Limited, L=Salford, ST=Greater Manchester, C=GB
  issuer: CN=COMODO RSA Certification Authority, O=COMODO CA Limited, L=Salford, ST=Greater Manchester, C=GB
  expiration: 2014-02-11T16:00:00.000-0800 - 2029-02-11T15:59:59.000-0800 (valid)
  trust anchor matched found: CN=COMODO RSA Certification Authority, O=COMODO CA Limited, L=Salford, ST=Greater Manchester, C=GB
---
  subject: CN=COMODO RSA Certification Authority, O=COMODO CA Limited, L=Salford, ST=Greater Manchester, C=GB
  issuer: CN=AddTrust External CA Root, OU=AddTrust External TTP Network, O=AddTrust AB, C=SE
  expiration: 2000-05-30T03:48:38.000-0700 - 2020-05-30T03:48:38.000-0700 (valid)
  trust anchor matched found: CN=AddTrust External CA Root, OU=AddTrust External TTP Network, O=AddTrust AB, C=SE
```


