### PR TITLE
Fix Duo iFrame on mobile devices

### DIFF
--- a/webapp/resources/templates/casDuoLoginView.html
+++ b/webapp/resources/templates/casDuoLoginView.html
@@ -4,8 +4,6 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
     <title th:text="#{cas.mfa.duologin.pagetitle}">Duo Login View</title>
     <script th:src="@{/js/duo/Duo-Web-v2.min.js}"></script>
     <link href="../../static/css/cas.css" rel="stylesheet" th:href="@{${#themes.code('cas.standard.css.file')}}"/>

--- a/webapp/resources/templates/casDuoLoginView.html
+++ b/webapp/resources/templates/casDuoLoginView.html
@@ -4,6 +4,7 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title th:text="#{cas.mfa.duologin.pagetitle}">Duo Login View</title>
     <script th:src="@{/js/duo/Duo-Web-v2.min.js}"></script>
@@ -24,12 +25,19 @@
 
             <div id="login">
                 <iframe id="duo_iframe"
-                        width="620"
-                        height="330"
                         frameborder="0"
                         th:attr="data-host=${apiHost},data-sig-request=${sigRequest}"
                         data-post-argument="signedDuoResponse">
                 </iframe>
+                <style>
+                      #duo_iframe {
+			width: 100%;
+			min-width: 304px;
+			max-width: 620px;
+			height: 330px;
+			border: none;
+		      }
+                </style>
             </div>
         </form>
     </div>


### PR DESCRIPTION
This implements the iFrame as documented on https://duo.com/docs/duoweb.  This fixes issue with iFrame not displaying properly on mobile devices.  This also adds a tag for IE Edge that Duo recommends.

To configure/test, set up CAS with Duo enabled.  Use a mobile phone to authenticate, and confirm the Duo iFrame doesn't look really messed up.

Don't believe there are any limitations or side effects.

Not aware of any other merge requests that are related.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
