### PR TITLE
Fix http client host name verifier

### DIFF
--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/config/CasCoreHttpConfiguration.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/config/CasCoreHttpConfiguration.java
@@ -45,7 +45,7 @@ public class CasCoreHttpConfiguration {
     @ConditionalOnMissingBean(name = "trustStoreSslSocketFactory")
     @Bean
     public SSLConnectionSocketFactory trustStoreSslSocketFactory() {
-        return new SSLConnectionSocketFactory(sslContext());
+        return new SSLConnectionSocketFactory(sslContext(), hostnameVerifier());
     }
 
     @ConditionalOnMissingBean(name = "sslContext")

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3093,7 +3093,7 @@ a local truststore is provided by CAS to improve portability of configuration ac
 # cas.httpClient.connectionTimeout=5000
 # cas.httpClient.asyncTimeout=5000
 # cas.httpClient.readTimeout=5000
-# cas.httpClient.hostnameVerifier=NONE|DEFAULT
+# cas.httpClient.hostNameVerifier=NONE|DEFAULT
 # cas.httpClient.allowLocalLogoutUrls=false
 # cas.httpClient.authorityValidationRegEx=
 # cas.httpClient.authorityValidationRegExCaseSensitive=true


### PR DESCRIPTION

# There are 2 new issues:

- Using the property **cas.httpClient.hostnameVerifier**=NONE|DEFAULT doesn't work as results  of an upper case issue

- Creation of **SSLConnectionSocketFactory** doesn't take into consideration CAS **HostnameVerifier** . Adding the function call in the constructor helps the issue

Hope this help
_Guy_

