### PR TITLE
truncate trusted device record dates to seconds

### DIFF
--- a/support/cas-server-support-trusted-mfa-jdbc/src/test/java/org/apereo/cas/trusted/authentication/storage/JpaMultifactorAuthenticationTrustStorageTests.java
+++ b/support/cas-server-support-trusted-mfa-jdbc/src/test/java/org/apereo/cas/trusted/authentication/storage/JpaMultifactorAuthenticationTrustStorageTests.java
@@ -7,6 +7,7 @@ import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustS
 import org.apereo.cas.trusted.config.JdbcMultifactorAuthnTrustConfiguration;
 import org.apereo.cas.trusted.config.MultifactorAuthnTrustConfiguration;
 import org.apereo.cas.trusted.config.MultifactorAuthnTrustedDeviceFingerprintConfiguration;
+import org.apereo.cas.trusted.util.MultifactorAuthenticationTrustUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -89,6 +90,21 @@ public class JpaMultifactorAuthenticationTrustStorageTests {
         mfaTrustEngine.expire(LocalDateTime.now().minusDays(1));
         assertThat(mfaTrustEngine.get(LocalDateTime.now().minusDays(30)), hasSize(2));
         assertThat(mfaTrustEngine.get(LocalDateTime.now().minusSeconds(1)), hasSize(2));
+
+        emptyTrustEngine();
+    }
+
+    @Test
+    public void verifyStoreAndRetrieve() {
+        // create record
+        final MultifactorAuthenticationTrustRecord original =
+                MultifactorAuthenticationTrustRecord.newInstance(PRINCIPAL, GEOGRAPHY, DEVICE_FINGERPRINT);
+        mfaTrustEngine.set(original);
+        final Set<MultifactorAuthenticationTrustRecord> records = mfaTrustEngine.get(PRINCIPAL);
+        assertEquals(1, records.size());
+        final MultifactorAuthenticationTrustRecord record = records.stream().findFirst().get();
+
+        assertEquals(MultifactorAuthenticationTrustUtils.generateKey(original), MultifactorAuthenticationTrustUtils.generateKey(record));
 
         emptyTrustEngine();
     }

--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
@@ -18,6 +18,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 /**
  * This is {@link MultifactorAuthenticationTrustRecord}.
@@ -71,7 +72,7 @@ public class MultifactorAuthenticationTrustRecord implements Comparable<Multifac
      */
     public static MultifactorAuthenticationTrustRecord newInstance(final String principal, final String geography, final String fingerprint) {
         final MultifactorAuthenticationTrustRecord r = new MultifactorAuthenticationTrustRecord();
-        r.setRecordDate(LocalDateTime.now());
+        r.setRecordDate(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
         r.setPrincipal(principal);
         r.setDeviceFingerprint(fingerprint);
         r.setName(principal.concat("-").concat(LocalDate.now().toString()).concat("-").concat(geography));


### PR DESCRIPTION
not all JPA providers support storing milliseconds for recordDate

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
