### PR TITLE
return issuer to oidc discovery endpoint

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
@@ -49,7 +49,7 @@ public class OidcServerDiscoverySettings {
     @JsonIgnore
     private final CasConfigurationProperties casProperties;
 
-    @JsonIgnore
+    @JsonProperty
     private final String issuer;
 
     @JsonIgnore


### PR DESCRIPTION
Regression:

[Required issuer](http://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) is missing from openid connect metadata on the discovery endpoint.

This is one of the blockers for using openid connect.

Let's fix it.
