### PR TITLE
quickfix for .well-known endpoint

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcWellKnownEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcWellKnownEndpointController.java
@@ -7,6 +7,7 @@ import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettings;
+import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettingsFactory;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.oauth.profile.OAuth20ProfileScopeToAttributesFilter;
 import org.apereo.cas.support.oauth.web.endpoints.BaseOAuth20Controller;
@@ -51,7 +52,10 @@ public class OidcWellKnownEndpointController extends BaseOAuth20Controller {
      */
     @GetMapping(value = '/' + OidcConstants.BASE_OIDC_URL + "/.well-known", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<OidcServerDiscoverySettings> getWellKnownDiscoveryConfiguration() {
-        return new ResponseEntity(this.discovery, HttpStatus.OK);
+    	//This is a quick hack. Jackson cannot serialize this.discovery (a cglib proxy that forgot about annotations) because 
+    	//it has CGLIB fields which pull in the whole beanFactory.
+    	//FIXME by, e.g., implementing #clone() in OidcServerDiscoverySettings and using it here.
+        return new ResponseEntity(new OidcServerDiscoverySettingsFactory(this.discovery.getCasProperties()).getObject(), HttpStatus.OK);
     }
 
     /**


### PR DESCRIPTION
This is a quick hack to fix a regression: 

In OidcWellKnownEndpointController, Jackson cannot serialize this.discovery (a cglib proxy that forgot about annotations) because it has CGLIB fields which pull in the whole beanFactory. 

One quick way to solve it is using the factory to create a new metadata object on every request.
Maybe there are better ways?

This is one of the blockers for using openid Connect (see also https://github.com/apereo/cas/pull/3335).
