### PR TITLE
fix error in naming standalone.configurationSecurity properties

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/standalone/StandaloneConfigurationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/standalone/StandaloneConfigurationProperties.java
@@ -35,7 +35,7 @@ public class StandaloneConfigurationProperties implements Serializable {
      * or system/environment variables as properties are bootstrapped and fetched.
      * They are placed here to allow CAS to recognize their validity when passed.
      */
-    private StandaloneConfigurationSecurityProperties security = new StandaloneConfigurationSecurityProperties();
+    private StandaloneConfigurationSecurityProperties configurationSecurity = new StandaloneConfigurationSecurityProperties();
 
     @Getter
     @Setter


### PR DESCRIPTION
# Fix error in standalone.configurationSecurity property naming

According to the documentation at https://apereo.github.io/cas/development/installation/Configuration-Properties.html#configuration-security, properties for encrypting sensitive settings in a standalone configuration should now be named (for example) **cas.standalone.configurationSecurity.psw**

The code that actually consumes the properties (*CasConfigurationJasyptCipherExecutor.java*) agrees with the documentation, but the code that validates them (*StandaloneConfigurationProperties.java*) does not.

This fix changes the validation code to match the documentation.

## To test:

 - configure CAS to use Jasypt encryption of configuration secrets in standalone mode, using these instructions:

https://apereo.github.io/cas/development/installation/Configuration-Properties.html#configuration-security
https://apereo.github.io/cas/development/installation/Configuration-Properties-Security.html

 - Observe the following error message during startup:
```
Invalid property 'standalone.configurationSecurity[psw]' of bean class [org.apereo.cas.configuration.CasConfigurationProperties]

```

 - Apply the fix

 - Observe that CAS starts up without error
