### PR TITLE
Lookup OAuthService by clientId, as pre 5.2.5

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
@@ -69,7 +69,7 @@ public class AccessTokenAuthorizationCodeGrantRequestExtractor extends BaseAcces
      */
     protected RegisteredService getOAuthRegisteredServiceForToken(final OAuthToken token) {
         final Service codeService = token.getService();
-        return OAuth20Utils.getRegisteredOAuthServiceByRedirectUri(this.servicesManager, codeService.getId());
+        return OAuth20Utils.getRegisteredOAuthService(this.servicesManager, codeService.getId());
     }
 
     /**


### PR DESCRIPTION
Up to 5.2.4, the OAuthService used to be looked up by client id, e.g. via `OAuth20Utils#getRegisteredOAuthService`: see https://github.com/apereo/cas/blob/v5.2.4/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java#L63

In 5.2.5, instead, `OAuth20Utils#getRegisteredOAuthServiceByRedirectUri` is used: see https://github.com/apereo/cas/blob/v5.2.5/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java#L72

I found this when upgrading some code from 5.2.4 to 5.2.5

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
