### PR TITLE
Use `getId` as key

### DIFF
--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/RegisteredServicesReportController.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/web/report/RegisteredServicesReportController.java
@@ -50,11 +50,11 @@ public class RegisteredServicesReportController extends BaseCasMvcEndpoint {
      */
     @GetMapping
     @ResponseBody
-    public WebAsyncTask<Map<String, Object>> handle(final HttpServletRequest request, final HttpServletResponse response) {
+    public WebAsyncTask<Map<Long, Object>> handle(final HttpServletRequest request, final HttpServletResponse response) {
         ensureEndpointAccessIsAuthorized(request, response);
-        final Callable<Map<String, Object>> asyncTask = () -> this.servicesManager.getAllServices()
+        final Callable<Map<Long, Object>> asyncTask = () -> this.servicesManager.getAllServices()
                 .stream()
-                .collect(Collectors.toMap(RegisteredService::getName, Function.identity()));
+                .collect(Collectors.toMap(RegisteredService::getId, Function.identity()));
         final long timeout = Beans.newDuration(casProperties.getHttpClient().getAsyncTimeout()).toMillis();
         return new WebAsyncTask<>(timeout, asyncTask);
     }


### PR DESCRIPTION
As `configureServiceRegistry` from `SamlIdPEndpointsConfiguration.class` and `CasOAuthConfiguration.class` use the same name (RegexRegistredService), which leads to duplicate key error.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
