### PR TITLE
update REST doc sample code to work with recent pac4j

### DIFF
--- a/docs/cas-server-documentation/protocol/REST-Protocol.md
+++ b/docs/cas-server-documentation/protocol/REST-Protocol.md
@@ -248,16 +248,56 @@ receive tickets and validate them. The following Java REST client is available
 by [pac4j](https://github.com/pac4j/pac4j):
 
 ```java
-final String casUrlPrefix = "http://localhost:8080/cas";
-final CasRestAuthenticator authenticator = new CasRestAuthenticator(casUrlPrefix);
-final CasRestFormClient client = new CasRestFormClient(authenticator);
+import org.pac4j.cas.profile.CasRestProfile;
+import org.pac4j.cas.client.rest.CasRestFormClient;
+import org.pac4j.cas.config.CasConfiguration;
+import org.pac4j.cas.credentials.authenticator.CasRestAuthenticator;
+import org.pac4j.cas.profile.CasProfile;
+import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.TokenCredentials;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.exception.HttpAction;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
-// The request object must contain credentials used for CAS authentication
-final WebContext webContext = new J2EContext(request, response);
-final HttpTGTProfile profile = client.requestTicketGrantingTicket(context);
-final CasCredentials casCreds = client.requestServiceTicket("<SERVICE_URL>", profile);
-final CasProfile casProfile = client.validateServiceTicket("<SERVICE_URL>", casCreds);
-client.destroyTicketGrantingTicket(context, profile);
+import java.util.Map;
+import java.util.Set;
+
+public class RestTestClient {
+
+    public static void main(String[] args ) throws HttpAction {
+        final String casUrlPrefix = "http://localhost:8080/cas";
+        String username = args[0];
+        String password = args[1];
+        String serviceUrl = args[2];
+        CasConfiguration casConfiguration = new CasConfiguration(casUrlPrefix);
+        final CasRestAuthenticator authenticator = new CasRestAuthenticator(casConfiguration);
+        final CasRestFormClient client = new CasRestFormClient(casConfiguration,"username","password");
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+
+        final WebContext webContext = new J2EContext(request, response);
+        casConfiguration.init(webContext);
+        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username,password,"testclient");
+        CasRestAuthenticator restAuthenticator = new CasRestAuthenticator(casConfiguration);
+        // authenticate with credentials (validate credentials)
+        restAuthenticator.validate(credentials, webContext);
+        final CasRestProfile profile = (CasRestProfile) credentials.getUserProfile();
+        // get service ticket
+        final TokenCredentials casCredentials = client.requestServiceTicket(serviceUrl, profile, webContext);
+        // validate service ticket
+        final CasProfile casProfile = client.validateServiceTicket(serviceUrl, casCredentials, webContext);
+        Map<String,Object> attributes = casProfile.getAttributes();
+        Set<Map.Entry<String,Object>> mapEntries = attributes.entrySet();
+        for (Map.Entry entry : mapEntries) {
+            System.out.println(entry.getKey() + ":" + entry.getValue());
+        }
+        client.destroyTicketGrantingTicket(profile,webContext);
+    }
+}
+
+
 ```
 
 ## Throttling


### PR DESCRIPTION
When I started to use the previous sample code, it seemed out of date or wrong relative to the current pac4j library. This replaces the sample code with a full main method that worked to log in against a local cas server (deployed with rest support).