### PR TITLE
classloaders cause error in wsfed STS service call

### DIFF
--- a/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/authentication/SecurityTokenServiceAuthenticationMetaDataPopulator.java
+++ b/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/authentication/SecurityTokenServiceAuthenticationMetaDataPopulator.java
@@ -48,6 +48,11 @@ public class SecurityTokenServiceAuthenticationMetaDataPopulator extends BaseAut
                 properties.put(SecurityConstants.USERNAME, up.getUsername());
                 final String uid = credentialCipherExecutor.encode(up.getUsername());
                 properties.put(SecurityConstants.PASSWORD, uid);
+
+		assert Class.forName("javax.xml.transform.Source").getClassLoader() == Class.forName("org.apache.cxf.staxutils.StaxSource").getClassLoader() : "I believe" +
+                        " the class loader difference will cause a classcastexception in org.apache.cxf.service.invoker.AbstractInvoker.performInvocation " +
+                         "on line 179 (cxf-core-3.2.4): m.invoke(serviceObject, paramArray); I need help to understand this error and fix it."; 
+
                 final SecurityToken token = sts.requestSecurityToken(rp.getAppliesTo());
                 final String tokenStr = EncodingUtils.encodeBase64(SerializationUtils.serialize(token));
                 builder.addAttribute(WSFederationConstants.SECURITY_TOKEN_ATTRIBUTE, tokenStr);


### PR DESCRIPTION
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->

- The change include a comparison between the classloaders of two classes javax.xml.transform.Source and org.apache.cxf.staxutils.StaxSource; the classloaders are not the same and this causes an exception further down.
- specifically, at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation,  line 179 (cxf-core-3.2.4): m.invoke(serviceObject, paramArray); 
* m is SecurityTokenServiceProvider.invoke(javax.xml.transform.Source) 
* serviceObject is SecurityTokenServiceProvider 
* paramArray contains org.apache.cxf.staxutils.StaxSource 
causes a ClassCastException although StaxSource implements Source
-please help me fix why the classloaders are different.



