### PR TITLE
Update Doc: Add needed parameter for building CAS

### DIFF
--- a/developer/Build-Process-5X.md
+++ b/developer/Build-Process-5X.md
@@ -63,6 +63,7 @@ The following commandline boolean flags are supported by the build:
 - If you have no need to let Gradle resolve/update dependencies and new module versions for you, you can take advantage of the `--offline` flag when you build which tends to make the build go a lot faster.
 - Using the Gradle daemon also is a big help. [It should be enabled by default](https://docs.gradle.org/current/userguide/gradle_daemon.html).
 - Enabling [Gradle's build cache](https://docs.gradle.org/current/userguide/build_cache.html) via `--build-cache` can also significantly improve build times.
+- If you are using Windows, you may find `-DskipNpmLint=true` needed for the build due to line ending difference between OS
 
 ## Tasks
 


### PR DESCRIPTION

- Brief description of changes applied

I found the following param is needed when building CAS on Windows:
-DskipNpmLint=true

when building CAS on Windows:
gradlew build install --parallel -x test -x javadoc -x check

due to line ending difference in npmLint

Would like to add that in to the doc for reference, thanks

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
