### PR TITLE
Fix to print all maps in a cache for heath endpoint

### DIFF
--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/AbstractCacheHealthIndicator.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/AbstractCacheHealthIndicator.java
@@ -51,12 +51,12 @@ public abstract class AbstractCacheHealthIndicator extends AbstractHealthIndicat
             }
 
             Arrays.stream(statistics).forEach(s -> {
-                builder.withDetail("size", s.getSize())
-                    .withDetail("capacity", s.getCapacity())
-                    .withDetail("evictions", s.getEvictions())
-                    .withDetail("percentFree", s.getPercentFree())
-                    .withDetail("percentFree", s.toString(new StringBuilder()))
-                    .withDetail("name", s.getName());
+                Map<String, Object> map = new HashMap<>();
+                map.put("size", s.getSize());
+                map.put("capacity", s.getCapacity());
+                map.put("evictions", s.getEvictions());
+                map.put("percentFree", s.getPercentFree());
+                builder.withDetail(s.getName(), map);
             });
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
Currently only the last map executed in the lambda has it's info printed out to the health endpoint.  This fix ensures all maps in the cache are printed.
