### PR TITLE
Refactor on "Inform user to use `/status/health` instead of `/status`"

### DIFF
--- a/docs/cas-server-documentation/installation/Monitoring-Statistics.md
+++ b/docs/cas-server-documentation/installation/Monitoring-Statistics.md
@@ -43,7 +43,7 @@ by [Spring Boot actuators](http://docs.spring.io/spring-boot/docs/current/refere
 
 Actuator endpoints provided by Spring Boot can also be visually managed and monitored via the [Spring Boot Administration Server](Configuring-Monitoring-Administration.html).
 
-<div class="alert alert-info"><strong>Use `/status/health` instead of `/status` </strong><p>Note that `/status` endpoint is kept for legacy reason. It is advised to use `/status/health` instead of `/status` for the purpose of general health status monitoring</p></div>
+<div class="alert alert-info"><strong>Use <code>/status/health</code> instead of <code>/status</code> </strong><p>Note that <code>/status</code> endpoint is kept for legacy reason. It is advised to use <code>/status/health</code> instead of <code>/status</code> for the purpose of general health status monitoring</p></div>
 
 ## Security
 


### PR DESCRIPTION


After looking at #3361  again, there is some syntax problem. My previous PR is using:
```
<div class="alert"> .....   `/status`
```
instead of
```
<div class="alert"> .....    <code>/status</code>
```
So it is not highlighting properly (see blue box in https://apereo.github.io/cas/development/installation/Monitoring-Statistics.html)

This PR will solve this. Thanks!

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
