### PR TITLE
Allow surrogate authentication separator to be of multiple characters.

### DIFF
--- a/support/cas-server-support-surrogate-webflow/src/main/java/org/apereo/cas/web/flow/action/SurrogateInitialAuthenticationAction.java
+++ b/support/cas-server-support-surrogate-webflow/src/main/java/org/apereo/cas/web/flow/action/SurrogateInitialAuthenticationAction.java
@@ -50,7 +50,7 @@ public class SurrogateInitialAuthenticationAction extends InitialAuthenticationA
 
         final String tUsername = up.getUsername();
         final String surrogateUsername = tUsername.substring(0, tUsername.indexOf(this.separator));
-        final String realUsername = tUsername.substring(tUsername.indexOf(this.separator) + 1);
+        final String realUsername = tUsername.substring(tUsername.indexOf(this.separator) + this.separator.length());
         LOGGER.debug("Converting to surrogate credential for username [{}], surrogate username [{}]", realUsername, surrogateUsername);
 
         if (StringUtils.isBlank(surrogateUsername)) {


### PR DESCRIPTION
This is a very simple change to allow the separator in a surrogate authentication credentials be of multiple characters long.

By default, the separator character is "+", which can be overridden via _cas.authn.surrogate.separator_ in _cas.properties_.  Single character separator is rather unfortunate because almost all characters on the keyboard are legal characters for use in an email address, and email addresses are very frequently used as usernames.  This means when the surrogate authentication separator is a single character, email address as username can easily trigger unintended surrogate authentication.

Example:
**foo+bar@host.net**: surrogate authentication (surrogate = "foo", primary = "bar@host.net), or just an unusual email address "foo+bar@host.net"?

By allowing multiple characters as the separator, we can configure a separator that may greatly reduce the likelihood of such dubious cases.  As an example, consecutive periods are not allowed unless quoted in an email address.  So "..." as separator will almost never trigger unintended surrogate authentication.

Multiple characters also allow for more expressive separator.  I often forget whether surrogate goes first or primary goes first, but if the separator is "<--", I find it easier to remember it is "surrogate<--primary".

**Brief description of changes applied**
Modified SurrogateInitialAuthenticationAction to not assume the separator is 1 character long.

**Any documentation on how to configure, test**
Setup surrogate authentication as documented, and in cas.properties set cas.authn.surrogate.separator to be a multi-character string.

I'd love to write a test for this, but am not sure how to do so and where the test would belong (I am guessing cas-server-support-surrogate-webflow).  Help is greatly appreciated.

**Any possible limitations, side effects, etc**
No.  Completely compatible with existing use cases.

**Reference any other pull requests that might be related.**
None.
