### PR TITLE
Fix the Mongo expireAt field for RememberMe TGTs (5.3.x)

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/ExpirationPolicy.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/ExpirationPolicy.java
@@ -25,6 +25,16 @@ public interface ExpirationPolicy extends Serializable {
     boolean isExpired(TicketState ticketState);
 
     /**
+     * Method to determine the actual TTL of a ticket, based on the policy.
+     *
+     * @param ticketState The snapshot of the current ticket state
+     * @return The time to live in seconds. A zero value indicates the time duration is not supported or is inactive.
+     */
+    default Long getTimeToLive(final TicketState ticketState) {
+        return getTimeToLive();
+    }
+
+    /**
      * Describes the time duration where this policy should consider the item alive.
      * Once this time passes, the item is considered expired and dead.
      *

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/BaseDelegatingExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/BaseDelegatingExpirationPolicy.java
@@ -88,6 +88,25 @@ public abstract class BaseDelegatingExpirationPolicy extends AbstractCasExpirati
         return policy.isExpired(ticketState);
     }
 
+    /**
+     * Checks the given ticketState and gets the timeToLive for the relevant expiration policy.
+     *
+     * @param ticketState The ticketState to get the delegated expiration policy for
+     * @return The TTL for the relevant expiration policy
+     */
+    @Override
+    public Long getTimeToLive(final TicketState ticketState) {
+        final Optional<ExpirationPolicy> match = getExpirationPolicyFor(ticketState);
+        if (!match.isPresent()) {
+            LOGGER.warn("No expiration policy was found for ticket state [{}]. "
+                    + "Consider configuring a predicate that delegates to an expiration policy.", ticketState);
+            return super.getTimeToLive(ticketState);
+        }
+        final ExpirationPolicy policy = match.get();
+        LOGGER.debug("Getting TTL from policy [{}] for ticket [{}]", policy, ticketState);
+        return policy.getTimeToLive(ticketState);
+    }
+
     @JsonIgnore
     @Override
     public Long getTimeToLive() {

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicyTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicyTests.java
@@ -32,6 +32,9 @@ public class RememberMeDelegatingExpirationPolicyTests {
     private static final File JSON_FILE = new File(FileUtils.getTempDirectoryPath(), "rememberMeDelegatingExpirationPolicy.json");
     private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
 
+    private static final Long REMEMBER_ME_TTL = 20000L;
+    private static final Long DEFAULT_TTL = 10000L;
+
     /**
      * Factory to create the principal type.
      **/
@@ -41,11 +44,11 @@ public class RememberMeDelegatingExpirationPolicyTests {
 
     @Before
     public void setUp() {
-        final MultiTimeUseOrTimeoutExpirationPolicy rememberMe = new MultiTimeUseOrTimeoutExpirationPolicy(1, 20000);
+        final MultiTimeUseOrTimeoutExpirationPolicy rememberMe = new MultiTimeUseOrTimeoutExpirationPolicy(1, REMEMBER_ME_TTL);
         p = new RememberMeDelegatingExpirationPolicy(rememberMe);
         p.addPolicy(RememberMeDelegatingExpirationPolicy.PolicyTypes.REMEMBER_ME, rememberMe);
         p.addPolicy(RememberMeDelegatingExpirationPolicy.PolicyTypes.DEFAULT,
-                new MultiTimeUseOrTimeoutExpirationPolicy(5, 20000));
+                new MultiTimeUseOrTimeoutExpirationPolicy(5, DEFAULT_TTL));
     }
 
     @Test
@@ -67,6 +70,23 @@ public class RememberMeDelegatingExpirationPolicyTests {
         assertFalse(t.isExpired());
         t.grantServiceTicket("55", RegisteredServiceTestUtils.getService(), this.p, false, true);
         assertFalse(t.isExpired());
+    }
+
+    @Test
+    public void verifyTicketTTLWithRememberMe() {
+        final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication(
+                this.principalFactory.createPrincipal("test"),
+                Collections.singletonMap(
+                        RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, true));
+        final TicketGrantingTicketImpl t = new TicketGrantingTicketImpl("111", authentication, this.p);
+        assertEquals(REMEMBER_ME_TTL, p.getTimeToLive(t));
+    }
+
+    @Test
+    public void verifyTicketTTLWithoutRememberMe() {
+        final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication();
+        final TicketGrantingTicketImpl t = new TicketGrantingTicketImpl("111", authentication, this.p);
+        assertEquals(DEFAULT_TTL, p.getTimeToLive(t));
     }
 
     @Test

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -10,6 +10,7 @@ import org.apereo.cas.ticket.BaseTicketSerializers;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketCatalog;
 import org.apereo.cas.ticket.TicketDefinition;
+import org.apereo.cas.ticket.TicketState;
 import org.hjson.JsonValue;
 import org.hjson.Stringify;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -198,7 +199,12 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
      * Makes the assumption that the CAS server date and the Mongo server date are in sync.
      */
     private static Date getExpireAt(final Ticket ticket) {
-        final long ttl = ticket.getExpirationPolicy().getTimeToLive();
+        final long ttl;
+        if (ticket instanceof TicketState) {
+            ttl = ticket.getExpirationPolicy().getTimeToLive((TicketState) ticket);
+        } else {
+            ttl = ticket.getExpirationPolicy().getTimeToLive();
+        }
 
         // expiration policy can specify not to delete automatically
         if (ttl < 1) {


### PR DESCRIPTION
The Mongo Ticket Registry applies a Mongo expire index on the expireAt field.  Currently the expireAt field is based on the expiration policy's TTL.  In the case of a Remember Me policy TTL the active TTL depends on the TicketState whereas the existing code will only ever retrieve the default TTL.  Consequently, mongo will now delete Remember Me tickets based on this default TTL expireAt index before the Remember Me time period has expired.  This change allows the Mongo Registry to query the Ticket TTL based on the ticket attributes and therefore set the correct expireAt value.