### PR TITLE
Before creating mongo indexes delete any index with the same key but different options (5.3.x)

### DIFF
--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -1,7 +1,9 @@
 package org.apereo.cas.ticket.registry;
 
+import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
 import com.mongodb.WriteResult;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -33,6 +35,8 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
     private static final String FIELD_NAME_EXPIRE_AFTER_SECONDS = "expireAfterSeconds";
     private static final Query SELECT_ALL_NAMES_QUERY = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).regex(".+"));
 
+    private static final ImmutableSet<String> MONGO_INDEX_KEYS = ImmutableSet.of("v", "key", "name", "ns");
+
     private final TicketCatalog ticketCatalog;
     private final MongoOperations mongoTemplate;
     private final boolean dropCollection;
@@ -55,10 +59,36 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
 
         LOGGER.debug("Creating indices on collection [{}] to auto-expire documents...", collectionName);
         final DBCollection collection = mongoTemplate.getCollection(collectionName);
-        collection.createIndex(new BasicDBObject(TicketHolder.FIELD_NAME_EXPIRE_AT, 1),
-                new BasicDBObject(FIELD_NAME_EXPIRE_AFTER_SECONDS, ticket.getProperties().getStorageTimeout()));
+        final BasicDBObject indexKey = new BasicDBObject(TicketHolder.FIELD_NAME_EXPIRE_AT, 1);
+        final BasicDBObject indexOptions = new BasicDBObject(FIELD_NAME_EXPIRE_AFTER_SECONDS, ticket.getProperties().getStorageTimeout());
+        removeDifferingIndexIfAny(collection, indexKey, indexOptions);
+        collection.createIndex(indexKey, indexOptions);
         return collection;
     }
+
+    /**
+     * Remove any index with the same indexKey but differing indexOptions in anticipation of recreating it.
+     *
+     * @param collection   The collection to check the indexes of
+     * @param indexKey     The key of the index to find
+     * @param indexOptions The options the new index with be created with
+     */
+    private void removeDifferingIndexIfAny(final DBCollection collection, final BasicDBObject indexKey, final BasicDBObject indexOptions) {
+        final List<DBObject> indexes = collection.getIndexInfo();
+        final boolean indexExistsWithDifferentOptions = indexes.stream()
+                .anyMatch(dbObject -> {
+                    final boolean keyMatches = dbObject.get("key").equals(indexKey);
+                    final boolean optionsMatch = indexOptions.entrySet().stream().allMatch(entry -> entry.getValue().equals(dbObject.get(entry.getKey())));
+                    final boolean noExtraOptions = dbObject.keySet().stream().allMatch(key -> MONGO_INDEX_KEYS.contains(key) || indexOptions.keySet().contains(key));
+
+                    return keyMatches && !(optionsMatch && noExtraOptions);
+                });
+        if (indexExistsWithDifferentOptions) {
+            LOGGER.debug("Removing MongoDb index [{}] from [{}] because it appears to already exist in a different form", indexKey, collection.getName());
+            collection.dropIndex(indexKey);
+        }
+    }
+
 
     private void createTicketCollections() {
         final Collection<TicketDefinition> definitions = ticketCatalog.findAll();


### PR DESCRIPTION
Equivalent of #3387 for 5.3.x, without a change like this modifying a ticket timeout will cause a duplicate index exception.