### PR TITLE
add checkstyle suppression for lombok.val

### DIFF
--- a/style/checkstyle-rules.xml
+++ b/style/checkstyle-rules.xml
@@ -9,6 +9,9 @@
     <module name="TreeWalker">
         <property name="tabWidth" value="4"/>
         <module name="SuppressionCommentFilter"/>
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${checkstyle.suppressions.file}"/>
+        </module>
         <module name="NonEmptyAtclauseDescription">
             <property name="severity" value="error"/>
         </module>

--- a/style/checkstyle-suppressions.xml
+++ b/style/checkstyle-suppressions.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<!DOCTYPE suppressions PUBLIC
+"-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
+"https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
 
 <suppressions>
     <suppress id="javadocForPropertyFields" files=".*(?&lt;!Properties\.java)$" />
@@ -22,4 +24,5 @@
     <suppress checks="\w+" files="(\.(crt|crl|class|keystore))|rebel.xml"/>
     <suppress id="finalNonUtilClass" files="(.*(Utils|Constants|Facade|Support|Beans|Tickets))\.java" />
     <suppress checks="." files="com[\\/]duosecurity[\\/]duoweb[\\/]"/>
+    <suppress-xpath checks="FinalLocalVariableCheck" query="//VARIABLE_DEF/TYPE[@text='val']/../IDENT"/>
 </suppressions>

--- a/support/cas-server-support-couchdb-service-registry/src/main/java/org/apereo/cas/services/CouchDbServiceRegistry.java
+++ b/support/cas-server-support-couchdb-service-registry/src/main/java/org/apereo/cas/services/CouchDbServiceRegistry.java
@@ -1,9 +1,11 @@
 package org.apereo.cas.services;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.couchdb.services.RegisteredServiceDocument;
 import org.apereo.cas.couchdb.services.RegisteredServiceRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.ektorp.UpdateConflictException;
 
 import java.util.List;
@@ -74,7 +76,7 @@ public class CouchDbServiceRegistry extends AbstractServiceRegistry {
 
     @Override
     public RegisteredService findServiceByExactServiceId(final String id) {
-        final var doc = dbClient.findByServiceId(id);
+        val doc = dbClient.findByServiceId(id);
         if (doc == null) {
             return null;
         }
@@ -83,7 +85,7 @@ public class CouchDbServiceRegistry extends AbstractServiceRegistry {
 
     @Override
     public RegisteredService findServiceByExactServiceName(final String name) {
-        final var doc = dbClient.findByServiceName(name);
+        val doc = dbClient.findByServiceName(name);
         if (doc == null) {
             return null;
         }


### PR DESCRIPTION
Includes `val` usage in couchdb service registry for validation.