### PR TITLE
add cors for oidc endpoints

### DIFF
--- a/support/cas-server-support-oidc-core/build.gradle
+++ b/support/cas-server-support-oidc-core/build.gradle
@@ -1,13 +1,14 @@
 description = "Apereo CAS Server OpenID Connect Core"
 dependencies {
     api project(":api:cas-server-core-api-throttle")
+    api project(":support:cas-server-support-oauth-core")
     
     implementation project(":core:cas-server-core-services")
     implementation project(":core:cas-server-core-services-registry")
     implementation project(":core:cas-server-core-configuration-api")
     implementation project(":core:cas-server-core-authentication-attributes")
     implementation project(":core:cas-server-core-util-api")
-    
+	    
     testImplementation project(":core:cas-server-core-util")
     testImplementation project(path: ":support:cas-server-support-json-service-registry")
 }

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/OidcConstants.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/OidcConstants.java
@@ -1,7 +1,9 @@
 package org.apereo.cas.oidc;
 
-import lombok.Getter;
 import org.apache.commons.text.WordUtils;
+import org.apereo.cas.support.oauth.OAuth20Constants;
+
+import lombok.Getter;
 
 /**
  * This is {@link OidcConstants}.
@@ -170,4 +172,21 @@ public interface OidcConstants {
      * The confirm/consent view.
      */
     String CONFIRM_VIEW = "oidcConfirmView";
+    
+    
+    /**
+     * The .well-known url including base oidc prefix.
+     */
+    String FULL_WELL_KNOWN_URL = '/' + OidcConstants.BASE_OIDC_URL + "/.well-known";
+    
+    /**
+     * The profile url including base oidc prefix.
+     */
+    String FULL_PROFILE_URL = '/' + OidcConstants.BASE_OIDC_URL + '/' + OAuth20Constants.PROFILE_URL;
+    
+    /**
+     * JWKS Endpoint url including base oidc prefix.
+     */
+    String FULL_JWKS_URL = '/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.JWKS_URL;
+
 }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -1,9 +1,13 @@
 package org.apereo.cas.oidc.config;
 
-import com.github.benmanes.caffeine.cache.CacheLoader;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.audit.AuditableExecution;
@@ -100,6 +104,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -108,13 +113,11 @@ import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
 import org.springframework.webflow.execution.Action;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is {@link OidcConfiguration}.
@@ -563,5 +566,12 @@ public class OidcConfiguration extends WebMvcConfigurerAdapter implements CasWeb
     @Override
     public void configureWebflowExecutionPlan(final CasWebflowExecutionPlan plan) {
         plan.registerWebflowConfigurer(oidcWebflowConfigurer());
+    }
+    
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping(OidcConstants.FULL_WELL_KNOWN_URL + "/**");
+        registry.addMapping(OidcConstants.FULL_JWKS_URL);
+        registry.addMapping(OidcConstants.FULL_PROFILE_URL);
     }
 }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
@@ -73,12 +73,12 @@ public class OidcServerDiscoverySettings {
 
     @JsonProperty("userinfo_endpoint")
     public String getUserinfoEndpoint() {
-        return this.serverPrefix.concat('/' + OidcConstants.BASE_OIDC_URL + '/' + OAuth20Constants.PROFILE_URL);
+        return this.serverPrefix.concat(OidcConstants.FULL_PROFILE_URL);
     }
 
     @JsonProperty("jwks_uri")
     public String getJwksUri() {
-        return this.serverPrefix.concat('/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.JWKS_URL);
+        return this.serverPrefix.concat(OidcConstants.FULL_JWKS_URL);
     }
 
     @JsonProperty("registration_endpoint")

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcWellKnownEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcWellKnownEndpointController.java
@@ -49,7 +49,7 @@ public class OidcWellKnownEndpointController extends BaseOAuth20Controller {
      *
      * @return the well known discovery configuration
      */
-    @GetMapping(value = '/' + OidcConstants.BASE_OIDC_URL + "/.well-known", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = OidcConstants.FULL_WELL_KNOWN_URL, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<OidcServerDiscoverySettings> getWellKnownDiscoveryConfiguration() {
         return new ResponseEntity(this.discovery, HttpStatus.OK);
     }
@@ -59,7 +59,7 @@ public class OidcWellKnownEndpointController extends BaseOAuth20Controller {
      *
      * @return the well known discovery configuration
      */
-    @GetMapping(value = '/' + OidcConstants.BASE_OIDC_URL + "/.well-known/openid-configuration", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = OidcConstants.FULL_WELL_KNOWN_URL + "/openid-configuration", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<OidcServerDiscoverySettings> getWellKnownOpenIdDiscoveryConfiguration() {
         return getWellKnownDiscoveryConfiguration();
     }


### PR DESCRIPTION
CAS currently provides properties to enable CORS for all endpoints via properties.
OIDC (implicit flow) requires only three particular endpoints to have CORS.
It is reasonable to provide CORS for these endpoints by default, instead of relying on properties to enable CORS for all CAS.

The main point in this PR is the addition to Cors registry in OidcConfiguration. 

The rest of the code just provides reusable constants for these endpoints, so that their construction is not copypasted. This is opinionated. 