### PR TITLE
CosmosDB DocumentDBConverter Fixed

### DIFF
--- a/support/cas-server-support-cosmosdb-core/src/main/java/org/apereo/cas/cosmosdb/CosmosDbDocument.java
+++ b/support/cas-server-support-cosmosdb-core/src/main/java/org/apereo/cas/cosmosdb/CosmosDbDocument.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.cosmosdb;
 
 import com.microsoft.azure.spring.data.documentdb.core.mapping.PartitionKey;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import lombok.Getter;
@@ -14,7 +13,6 @@ import lombok.Setter;
  * @since 5.2.0
  */
 @Document
-@Slf4j
 @Getter
 @Setter
 public class CosmosDbDocument {


### PR DESCRIPTION
Removed @Slf4j as it is adding LOGGER field which is not mapped to properties in BasicPersistentEntity.

Making available for 5.3.1