### PR TITLE
fix val rule for null initialized variables

### DIFF
--- a/style/checkstyle-rules.xml
+++ b/style/checkstyle-rules.xml
@@ -507,7 +507,7 @@
             <property name="id" value="useLombokVar"/>
             <metadata name="net.sf.eclipsecs.core.comment" value="Using val for variable definitions"/>
             <property name="severity" value="error"/>
-            <property name="format" value="^\s*(?!return|throw|private|public|protected|val)(final\s+)*\b(?!var)\w+\b\s*(\b[a-z]\w*\b)(\s*=.+)*;"/>
+            <property name="format" value="^\s*(?!return|throw|private|public|protected|val)(final\s+)*\b(?!var)\w+\b\s*(\b[a-z]\w*\b)(\s*=\s+(?!null).+)*;"/>
             <property name="message" value="Use lombok.val or JDK var keyword when declaring variable definitions."/>
         </module>
 


### PR DESCRIPTION
fixes checkstyle rule for var case where type inference will fail.  (initialized with null)