### PR TITLE
Use ReturnAttributes.ALL_USER instead of ReturnAttributes.NONE.

### DIFF
--- a/support/cas-server-support-gua/src/main/java/org/apereo/cas/gua/impl/LdapUserGraphicalAuthenticationRepository.java
+++ b/support/cas-server-support-gua/src/main/java/org/apereo/cas/gua/impl/LdapUserGraphicalAuthenticationRepository.java
@@ -58,7 +58,7 @@ public class LdapUserGraphicalAuthenticationRepository implements UserGraphicalA
                 LdapUtils.newLdaptiveConnectionFactory(gua.getLdap()),
                 gua.getLdap().getBaseDn(), filter,
                 new String[]{gua.getLdap().getImageAttribute()},
-                ReturnAttributes.NONE.value());
+                ReturnAttributes.ALL_USER.value());
     }
 
 }


### PR DESCRIPTION
Use ReturnAttributes.ALL_USER instead of ReturnAttributes.NONE in order to
retrieve imageAttribute from user's object.