### PR TITLE
Make it easier to disable attribute caching

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -729,6 +729,7 @@ If multiple attribute repository sources are defined, they are added into a list
 and their results are cached and merged.
 
 ```properties
+# A negative expirationTime disables attribute caching
 # cas.authn.attributeRepository.expirationTime=30
 # cas.authn.attributeRepository.expirationTimeUnit=MINUTES
 # cas.authn.attributeRepository.maximumCacheSize=10000


### PR DESCRIPTION
**Brief description of changes applied**
Modified method that creates the cachingAttributeRepository bean so that a negative cas.authn.attributeRepository.expirationTime value disables caching.  Added comment to documentation.

This is modeled after the method that creates the globalPrincipalAttributeRepository bean in CasCoreAuthenticationPrincipalConfiguration, where a negative cas.authn.attributeRepository.expirationTime value disables caching.

Without this modification, a negative expirationTime would trigger an exception when the cachingAttributeRepository bean is being created.

This is a fairly frequently asked question on the CAS group list, and there is no clear documentation on how to do this or whether this is possible.

**Any documentation on how to configure, test**
1. Configure an appropriate PersonDirectory attribute repository (say, REST), and set cas.authn.attributeRepository.expirationTime to a negative value.
2. Login and observe the REST endpoint being called to retrieve attributes.  Logout.
3. Login again immediately and observe the REST endpoint being called again to retrieve attributes.

If no cas.authn.attributeRepository.expirationTime is specified, the default 30 minutes is assumed.  If step 2 and step 3 take place within this 30 minutes the REST endpoint would not be called to retrieve attributes in step 3.

**Any possible limitations, side effects, etc**
No.

**Reference any other pull requests that might be related**
None.
