### PR TITLE
Fixed SpnegoWebflowConfigurer to use the evaluateClientRequest as documented

### DIFF
--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpengoWebflowConfigurer.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpengoWebflowConfigurer.java
@@ -48,7 +48,11 @@ public class SpengoWebflowConfigurer extends AbstractCasWebflowConfigurer {
 
     private void augmentWebflowToStartSpnego(final Flow flow) {
         final ActionState state = getState(flow, CasWebflowConstants.STATE_ID_INIT_LOGIN_FORM, ActionState.class);
-        createTransitionForState(state, CasWebflowConstants.TRANSITION_ID_SUCCESS, START_SPNEGO_AUTHENTICATE, true);
+        if (casProperties.getAuthn().getSpnego().isMixedModeAuthentication()) {
+            createTransitionForState(state, CasWebflowConstants.TRANSITION_ID_SUCCESS, EVALUATE_SPNEGO_CLIENT, true);
+        } else {
+            createTransitionForState(state, CasWebflowConstants.TRANSITION_ID_SUCCESS, START_SPNEGO_AUTHENTICATE, true);
+        }
     }
 
     private void createStartSpnegoAction(final Flow flow) {
@@ -71,6 +75,6 @@ public class SpengoWebflowConfigurer extends AbstractCasWebflowConfigurer {
         final ActionState evaluateClientRequest = createActionState(flow, EVALUATE_SPNEGO_CLIENT,
                 createEvaluateAction(casProperties.getAuthn().getSpnego().getHostNameClientActionStrategy()));
         evaluateClientRequest.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_YES, START_SPNEGO_AUTHENTICATE));
-        evaluateClientRequest.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_NO, getStartState(flow)));
+        evaluateClientRequest.getTransitionSet().add(createTransition(CasWebflowConstants.TRANSITION_ID_NO, CasWebflowConstants.STATE_ID_VIEW_LOGIN_FORM));
     }
 }


### PR DESCRIPTION
Changes include the following:
- Added conditional logic when mixedModeAuthentication is false to use
startSpnegoAuthenticate flow.  Otherwise it will use
evaluateClientRequest.
- Modified createEvaluateSpnegoClientAction to be equivlent to the other
Spnego actions on failure which is
CasWebflowConstants.STATE_ID_VIEW_LOGIN_FORM

Since this change fixes the documentation listed out [here](https://apereo.github.io/cas/5.2.x/installation/SPNEGO-Authentication.html#client-selection-strategy), this change re-enables the functionality which may cause unexpected results to those using the defaults.  Some of those properties are the following:
- cas.authn.spnego.hostNameClientActionStrategy
- cas.authn.spnego.hostNamePatternString
- cas.authn.spnego.mixedModeAuthentication
- cas.authn.spnego.ipsToCheckPattern

I have done my best to ensure as few changes are affected as possible.