### PR TITLE
Doc fix typo: (MongoDB service registry) ssEnabled => sslEnabled

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
@@ -573,7 +573,7 @@ The following options related to MongoDb support in CAS apply equally to a numbe
 # ${configurationKey}.mongo.writeConcern=NORMAL
 # ${configurationKey}.mongo.authenticationDatabaseName=
 # ${configurationKey}.mongo.replicaSet=
-# ${configurationKey}.mongo.ssEnabled=false
+# ${configurationKey}.mongo.sslEnabled=false
 # ${configurationKey}.mongo.conns.lifetime=60000
 # ${configurationKey}.mongo.conns.perHost=10
 ```


### PR DESCRIPTION
- Brief description of changes applied

For Mongo service registry, there might be a doc typo:
should be: **sslEnabled** 
instead of: **ssEnable** 
as seen on [ https://github.com/apereo/cas/blob/v5.3.1/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mongo/BaseMongoDbProperties.java#L106  ]

FYI, this potential typo is also seen on master branch, maybe I submit 1 more PR after this?

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
