### PR TITLE
Backporting some parts from f7ab0ca to 5.3.x

### DIFF
--- a/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/ChainingAuditPrincipalIdProvider.java
+++ b/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/ChainingAuditPrincipalIdProvider.java
@@ -1,12 +1,12 @@
 package org.apereo.cas.audit.spi;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apereo.cas.audit.AuditPrincipalIdProvider;
 import org.apereo.cas.authentication.Authentication;
-import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -17,10 +17,11 @@ import java.util.List;
  */
 @Getter
 @Slf4j
+@RequiredArgsConstructor
 public class ChainingAuditPrincipalIdProvider implements AuditPrincipalIdProvider {
     private int order = Integer.MAX_VALUE;
 
-    private List<AuditPrincipalIdProvider> providers = new ArrayList<>();
+    private final List<AuditPrincipalIdProvider> providers;
 
     /**
      * Add provider.
@@ -31,10 +32,18 @@ public class ChainingAuditPrincipalIdProvider implements AuditPrincipalIdProvide
         providers.add(provider);
     }
 
+    /**
+     * Add providers.
+     *
+     * @param provider the provider
+     */
+    public void addProviders(final List<AuditPrincipalIdProvider> provider) {
+        providers.addAll(provider);
+    }
+
     @Override
     public String getPrincipalIdFrom(final Authentication authentication, final Object resultValue, final Exception exception) {
-        AnnotationAwareOrderComparator.sort(this.providers);
-        final AuditPrincipalIdProvider result = providers.stream()
+        val result = providers.stream()
             .filter(p -> p.supports(authentication, resultValue, exception))
             .findFirst()
             .orElseGet(DefaultAuditPrincipalIdProvider::new);

--- a/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/ChainingAuditPrincipalIdProvider.java
+++ b/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/ChainingAuditPrincipalIdProvider.java
@@ -3,7 +3,6 @@ package org.apereo.cas.audit.spi;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.apereo.cas.audit.AuditPrincipalIdProvider;
 import org.apereo.cas.authentication.Authentication;
 
@@ -43,7 +42,7 @@ public class ChainingAuditPrincipalIdProvider implements AuditPrincipalIdProvide
 
     @Override
     public String getPrincipalIdFrom(final Authentication authentication, final Object resultValue, final Exception exception) {
-        val result = providers.stream()
+        final AuditPrincipalIdProvider result = providers.stream()
             .filter(p -> p.supports(authentication, resultValue, exception))
             .findFirst()
             .orElseGet(DefaultAuditPrincipalIdProvider::new);

--- a/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
+++ b/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.audit.spi.config;
 
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.audit.AuditPrincipalIdProvider;
 import org.apereo.cas.audit.AuditTrailExecutionPlan;
@@ -40,7 +41,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -217,10 +220,10 @@ public class CasCoreAuditConfiguration implements AuditTrailExecutionPlanConfigu
     @ConditionalOnMissingBean(name = "auditPrincipalIdProvider")
     @Bean
     public AuditPrincipalIdProvider auditPrincipalIdProvider() {
-        final ChainingAuditPrincipalIdProvider chain = new ChainingAuditPrincipalIdProvider();
-        final Map<String, AuditPrincipalIdProvider> resolvers = applicationContext.getBeansOfType(AuditPrincipalIdProvider.class, false, true);
-        resolvers.values().forEach(chain::addProvider);
-        return chain;
+        val resolvers = applicationContext.getBeansOfType(AuditPrincipalIdProvider.class, false, true);
+        val providers = new ArrayList<>(resolvers.values());
+        AnnotationAwareOrderComparator.sort(providers);
+        return new ChainingAuditPrincipalIdProvider(providers);
     }
 
     @Override

--- a/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
+++ b/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.audit.spi.config;
 
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.audit.AuditPrincipalIdProvider;
 import org.apereo.cas.audit.AuditTrailExecutionPlan;
@@ -220,8 +219,8 @@ public class CasCoreAuditConfiguration implements AuditTrailExecutionPlanConfigu
     @ConditionalOnMissingBean(name = "auditPrincipalIdProvider")
     @Bean
     public AuditPrincipalIdProvider auditPrincipalIdProvider() {
-        val resolvers = applicationContext.getBeansOfType(AuditPrincipalIdProvider.class, false, true);
-        val providers = new ArrayList<>(resolvers.values());
+        final Map<String, AuditPrincipalIdProvider> resolvers = applicationContext.getBeansOfType(AuditPrincipalIdProvider.class, false, true);
+        final List<AuditPrincipalIdProvider> providers = new ArrayList<>(resolvers.values());
         AnnotationAwareOrderComparator.sort(providers);
         return new ChainingAuditPrincipalIdProvider(providers);
     }


### PR DESCRIPTION
This is a backport of some parts of f7ab0ca to the 5.3.x branch. This should fix a concurrency bug in `ChainingAuditPrincipalIdProvider` when `providers` field is modified concurrently in some cases. 

I did not manage to pass `checkstyle` because it complains about lombok `val`'s that should be final. `final val` seems redundant to me and not present in master:
```
> Task :core:cas-server-core-audit:checkstyleMain FAILED
[ant:checkstyle] [ERROR] /home/gagarski/repos/other/cas/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java:223:13: Variable 'resolvers' should be declared final. [FinalLocalVariable]
[ant:checkstyle] [ERROR] /home/gagarski/repos/other/cas/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java:224:13: Variable 'providers' should be declared final. [FinalLocalVariable]

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':core:cas-server-core-audit:checkstyleMain'.
> Checkstyle rule violations were found. See the report at: file:///home/gagarski/repos/other/cas/core/cas-server-core-audit/build/reports/checkstyle/main.html
  Checkstyle files with violations: 1
  Checkstyle violations by severity: [error:2]
```

Probably checkstyle should be properly configured to know about lombok types, but i did not find how to do it yet.