### PR TITLE
doc typo fix: 5.2.x ssEnabled to sslEnabled

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3045,7 +3045,7 @@ To learn more about this topic, [please review this guide](FIDO-U2F-Authenticati
 # cas.authn.mfa.u2f.mongo.writeConcern=NORMAL
 # cas.authn.mfa.u2f.mongo.authenticationDatabaseName=
 # cas.authn.mfa.u2f.mongo.replicaSet=
-# cas.authn.mfa.u2f.mongo.ssEnabled=false
+# cas.authn.mfa.u2f.mongo.sslEnabled=false
 # cas.authn.mfa.u2f.mongo.conns.lifetime=60000
 # cas.authn.mfa.u2f.mongo.conns.perHost=10
 ```
@@ -4085,7 +4085,7 @@ Store audit logs inside a MongoDb database.
 # cas.audit.mongo.writeConcern=NORMAL
 # cas.audit.mongo.authenticationDatabaseName=
 # cas.audit.mongo.replicaSet=
-# cas.audit.mongo.ssEnabled=false
+# cas.audit.mongo.sslEnabled=false
 # cas.audit.mongo.conns.lifetime=60000
 # cas.audit.mongo.conns.perHost=10
 ```
@@ -4210,7 +4210,7 @@ Decide how CAS should monitor the internal state of a MongoDb instance.
 # cas.monitor.mongo.writeConcern=NORMAL
 # cas.monitor.mongo.authenticationDatabaseName=
 # cas.monitor.mongo.replicaSet=
-# cas.monitor.mongo.ssEnabled=false
+# cas.monitor.mongo.sslEnabled=false
 # cas.monitor.mongo.conns.lifetime=60000
 # cas.monitor.mongo.conns.perHost=10
 ```
@@ -4607,7 +4607,7 @@ To learn more about this topic, [please review this guide](Mongo-Service-Managem
 # cas.serviceRegistry.mongo.writeConcern=NORMAL
 # cas.serviceRegistry.mongo.authenticationDatabaseName=
 # cas.serviceRegistry.mongo.replicaSet=
-# cas.serviceRegistry.mongo.ssEnabled=false
+# cas.serviceRegistry.mongo.sslEnabled=false
 # cas.serviceRegistry.mongo.conns.lifetime=60000
 # cas.serviceRegistry.mongo.conns.perHost=10
 ```
@@ -5085,7 +5085,7 @@ To learn more about this topic, [please review this guide](MongoDb-Ticket-Regist
 # cas.ticket.registry.mongo.clientUri=
 # cas.ticket.registry.mongo.authenticationDatabaseName=
 # cas.ticket.registry.mongo.replicaSet=
-# cas.ticket.registry.mongo.ssEnabled=false
+# cas.ticket.registry.mongo.sslEnabled=false
 
 # cas.ticket.registry.mongo.conns.lifetime=60000
 # cas.ticket.registry.mongo.conns.perHost=10
@@ -5538,7 +5538,7 @@ If AUP is controlled via JDBC, decide how choices should be remembered back insi
 # cas.acceptableUsagePolicy.mongo.writeConcern=NORMAL
 # cas.acceptableUsagePolicy.mongo.authenticationDatabaseName=
 # cas.acceptableUsagePolicy.mongo.replicaSet=
-# cas.acceptableUsagePolicy.mongo.ssEnabled=false
+# cas.acceptableUsagePolicy.mongo.sslEnabled=false
 # cas.acceptableUsagePolicy.mongo.conns.lifetime=60000
 # cas.acceptableUsagePolicy.mongo.conns.perHost=10
 ```
@@ -5660,7 +5660,7 @@ To learn more about this topic, [please review this guide](Monitoring-Statistics
 # cas.metrics.mongo.writeConcern=NORMAL
 # cas.metrics.mongo.authenticationDatabaseName=
 # cas.metrics.mongo.replicaSet=
-# cas.metrics.mongo.ssEnabled=false
+# cas.metrics.mongo.sslEnabled=false
 # cas.metrics.mongo.conns.lifetime=60000
 # cas.metrics.mongo.conns.perHost=10
 ```
@@ -5874,7 +5874,7 @@ To learn more about this topic, [please review this guide](../integration/Attrib
 # cas.consent.mongo.writeConcern=NORMAL
 # cas.consent.mongo.authenticationDatabaseName=
 # cas.consent.mongo.replicaSet=
-# cas.consent.mongo.ssEnabled=false
+# cas.consent.mongo.sslEnabled=false
 # cas.consent.mongo.conns.lifetime=60000
 # cas.consent.mongo.conns.perHost=10
 ```


### PR DESCRIPTION
- Reference any other pull requests that might be related.

Ref: #3413 

- Brief description of changes applied

 
The PR will change all all ssEnabled to **ssl**Enabled for all MongoDB setting for **5.2.x  CAS doc**.

**5.1.x** and version before **do not have** this properties **sslEnabled** for MongoDB, 
so after this PR, this typo should be fixed in all version of CAS doc.

Thanks!
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
