### PR TITLE
Fixed ldapSpnegoClientAction parameter

### DIFF
--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -119,7 +119,7 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
         try {
             connection = createConnection();
             final Operation searchOperation = new SearchOperation(connection);
-            this.searchRequest.getSearchFilter().setParameter(0, remoteHostName);
+            this.searchRequest.getSearchFilter().setParameter("host", remoteHostName);
 
             LOGGER.debug("Using search filter [{}] on baseDn [{}]",
                     this.searchRequest.getSearchFilter().format(),

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
@@ -1,9 +1,6 @@
 package org.apereo.cas.web.flow.config;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.spnego.SpnegoProperties;
@@ -29,7 +26,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.webflow.execution.Action;
 
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This is {@link SpnegoWebflowActionsConfiguration}.

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
@@ -1,6 +1,9 @@
 package org.apereo.cas.web.flow.config;
 
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.spnego.SpnegoProperties;
@@ -26,10 +29,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.webflow.execution.Action;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is {@link SpnegoWebflowActionsConfiguration}.
@@ -101,8 +101,7 @@ public class SpnegoWebflowActionsConfiguration {
     public Action ldapSpnegoClientAction() {
         final SpnegoProperties spnegoProperties = casProperties.getAuthn().getSpnego();
         final ConnectionFactory connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(spnegoProperties.getLdap());
-        final SearchFilter filter = LdapUtils.newLdaptiveSearchFilter(spnegoProperties.getLdap().getSearchFilter(),
-            "host", new ArrayList<>(0));
+        final SearchFilter filter = LdapUtils.newLdaptiveSearchFilter(spnegoProperties.getLdap().getSearchFilter());
 
         final SearchRequest searchRequest = LdapUtils.newLdaptiveSearchRequest(spnegoProperties.getLdap().getBaseDn(), filter);
         return new LdapSpnegoKnownClientSystemsFilterAction(RegexUtils.createPattern(spnegoProperties.getIpsToCheckPattern()),

--- a/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap-ci.properties
+++ b/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap-ci.properties
@@ -1,6 +1,6 @@
 cas.authn.spnego.ldap.ldapUrl=ldap://localhost:10389
 cas.authn.spnego.ldap.useSsl=false
 cas.authn.spnego.ldap.baseDn=ou=people,dc=example,dc=org
-cas.authn.spnego.ldap.searchFilter=host={0}
+cas.authn.spnego.ldap.searchFilter=host={host}
 cas.authn.spnego.ldap.bindDn=cn=Directory Manager
 cas.authn.spnego.ldap.bindCredential=password

--- a/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap.properties
+++ b/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap.properties
@@ -7,6 +7,6 @@ ldap.managerPassword=Password
 cas.authn.spnego.ldap.ldapUrl=ldap://localhost:1381
 cas.authn.spnego.ldap.useSsl=false
 cas.authn.spnego.ldap.baseDn=ou=people,dc=example,dc=org
-cas.authn.spnego.ldap.searchFilter=host={0}
+cas.authn.spnego.ldap.searchFilter=host={host}
 cas.authn.spnego.ldap.bindDn=${ldap.managerDn}
 cas.authn.spnego.ldap.bindCredential=${ldap.managerPassword}


### PR DESCRIPTION
Fixed ldapSpnegoClientAction to set the parameter to host as documented for the property cas.authn.spnego.ldap.searchFilter (https://apereo.github.io/cas/5.2.x/installation/Configuration-Properties.html#spnego-authentication)
instead of 0