### PR TITLE
Fixed ldapSpnegoClientAction parameter

### DIFF
--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -115,7 +115,7 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
         try {
             connection = createConnection();
             final Operation searchOperation = new SearchOperation(connection);
-            this.searchRequest.getSearchFilter().setParameter(0, remoteHostName);
+            this.searchRequest.getSearchFilter().setParameter("host", remoteHostName);
 
             LOGGER.debug("Using search filter [{}] on baseDn [{}]",
                     this.searchRequest.getSearchFilter().format(),

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
@@ -1,9 +1,12 @@
 package org.apereo.cas.web.flow.config;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.spnego.SpnegoProperties;
-
 import org.apereo.cas.util.LdapUtils;
 import org.apereo.cas.web.flow.SpnegoCredentialsAction;
 import org.apereo.cas.web.flow.SpnegoNegociateCredentialsAction;
@@ -23,11 +26,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.webflow.execution.Action;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This is {@link SpnegoWebflowActionsConfiguration}.
@@ -97,8 +95,7 @@ public class SpnegoWebflowActionsConfiguration {
     public Action ldapSpnegoClientAction() {
         final SpnegoProperties spnegoProperties = casProperties.getAuthn().getSpnego();
         final ConnectionFactory connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(spnegoProperties.getLdap());
-        final SearchFilter filter = LdapUtils.newLdaptiveSearchFilter(spnegoProperties.getLdap().getSearchFilter(),
-                "host", new ArrayList<>(0));
+        final SearchFilter filter = LdapUtils.newLdaptiveSearchFilter(spnegoProperties.getLdap().getSearchFilter());
 
         final SearchRequest searchRequest = LdapUtils.newLdaptiveSearchRequest(spnegoProperties.getLdap().getBaseDn(), filter);
         return new LdapSpnegoKnownClientSystemsFilterAction(spnegoProperties.getIpsToCheckPattern(), 

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
@@ -1,9 +1,5 @@
 package org.apereo.cas.web.flow.config;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.spnego.SpnegoProperties;
@@ -26,6 +22,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.webflow.execution.Action;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This is {@link SpnegoWebflowActionsConfiguration}.

--- a/support/cas-server-support-spnego-webflow/src/test/resources/spnego.properties
+++ b/support/cas-server-support-spnego-webflow/src/test/resources/spnego.properties
@@ -16,6 +16,6 @@ cas.authn.spnego.spnegoAttributeName=mail
 cas.authn.spnego.ldap.ldapUrl=ldap://localhost:1381
 cas.authn.spnego.ldap.useSsl=false
 cas.authn.spnego.ldap.baseDn=ou=people,dc=example,dc=org
-cas.authn.spnego.ldap.searchFilter=host={0}
+cas.authn.spnego.ldap.searchFilter=host={host}
 cas.authn.spnego.ldap.bindDn=${ldap.managerDn}
 cas.authn.spnego.ldap.bindCredential=${ldap.managerPassword}


### PR DESCRIPTION
Fixed ldapSpnegoClientAction to set the parameter to host as documented for the property cas.authn.spnego.ldap.searchFilter (https://apereo.github.io/cas/5.2.x/installation/Configuration-Properties.html#spnego-authentication)
instead of 0