### PR TITLE
fix ConversionFailedException that is throw when saving RegisteredService to mongoDB

### DIFF
--- a/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/MongoDbConnectionFactory.java
+++ b/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/MongoDbConnectionFactory.java
@@ -83,8 +83,8 @@ public class MongoDbConnectionFactory {
         converters.add(new BaseConverters.CaffeinCacheLoaderConverter());
         converters.add(new BaseConverters.CacheConverter());
         converters.add(new BaseConverters.ZonedDateTimeToDateConverter());
-        converters.add(new BaseConverters.ZonedDateTimeToStringConverter());
-        converters.add(new BaseConverters.StringToZonedDateTimeConverter());
+//        converters.add(new BaseConverters.ZonedDateTimeToStringConverter());
+//        converters.add(new BaseConverters.StringToZonedDateTimeConverter());
         converters.add(new BaseConverters.DateToZonedDateTimeConverter());
 
         converters.addAll(JodaTimeConverters.getConvertersToRegister());


### PR DESCRIPTION
- The `StringToZonedDateTimeConverter` will converter all `String` in the `RegisteredService` to `ZonedDateTime`,and it will cause an exception as follow :
  ```
  org.springframework.core.convert.ConversionFailedException: Failed to convert from type [java.lang.String] to type [java.time.ZonedDateTime] for value '^(https|http|imaps)://.'; nested exception is java.time.format.DateTimeParseException: Text '^(https|http|imaps)://.' could not be parsed at index 0
  ```
- It likely has been fixed in the master branch, but not in this `5.3.x` branch