### PR TITLE
Fixed ldapSpnegoClientAction parameter

### DIFF
--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -117,7 +117,7 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
 
         try (val connection = createConnection()) {
             val searchOperation = new SearchOperation(connection);
-            this.searchRequest.getSearchFilter().setParameter(0, remoteHostName);
+            this.searchRequest.getSearchFilter().setParameter("host", remoteHostName);
 
             LOGGER.debug("Using search filter [{}] on baseDn [{}]",
                 this.searchRequest.getSearchFilter().format(),

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
@@ -1,8 +1,5 @@
 package org.apereo.cas.web.flow.config;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.support.Beans;
@@ -15,6 +12,8 @@ import org.apereo.cas.web.flow.client.HostNameSpnegoKnownClientSystemsFilterActi
 import org.apereo.cas.web.flow.client.LdapSpnegoKnownClientSystemsFilterAction;
 import org.apereo.cas.web.flow.resolver.CasDelegatingWebflowEventResolver;
 import org.apereo.cas.web.flow.resolver.CasWebflowEventResolver;
+
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -24,7 +23,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.webflow.execution.Action;
 
-import lombok.val;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This is {@link SpnegoWebflowActionsConfiguration}.

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
@@ -1,5 +1,8 @@
 package org.apereo.cas.web.flow.config;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.support.Beans;
@@ -12,8 +15,6 @@ import org.apereo.cas.web.flow.client.HostNameSpnegoKnownClientSystemsFilterActi
 import org.apereo.cas.web.flow.client.LdapSpnegoKnownClientSystemsFilterAction;
 import org.apereo.cas.web.flow.resolver.CasDelegatingWebflowEventResolver;
 import org.apereo.cas.web.flow.resolver.CasWebflowEventResolver;
-
-import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -23,9 +24,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.webflow.execution.Action;
 
-import java.util.ArrayList;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import lombok.val;
 
 /**
  * This is {@link SpnegoWebflowActionsConfiguration}.
@@ -96,8 +95,7 @@ public class SpnegoWebflowActionsConfiguration {
     public Action ldapSpnegoClientAction() {
         val spnegoProperties = casProperties.getAuthn().getSpnego();
         val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(spnegoProperties.getLdap());
-        val filter = LdapUtils.newLdaptiveSearchFilter(spnegoProperties.getLdap().getSearchFilter(),
-            "host", new ArrayList<>(0));
+        val filter = LdapUtils.newLdaptiveSearchFilter(spnegoProperties.getLdap().getSearchFilter());
 
         val searchRequest = LdapUtils.newLdaptiveSearchRequest(spnegoProperties.getLdap().getBaseDn(), filter);
         return new LdapSpnegoKnownClientSystemsFilterAction(RegexUtils.createPattern(spnegoProperties.getIpsToCheckPattern()),

--- a/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap-ci.properties
+++ b/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap-ci.properties
@@ -1,6 +1,6 @@
 cas.authn.spnego.ldap.ldapUrl=ldap://localhost:10389
 cas.authn.spnego.ldap.useSsl=false
 cas.authn.spnego.ldap.baseDn=ou=people,dc=example,dc=org
-cas.authn.spnego.ldap.searchFilter=host={0}
+cas.authn.spnego.ldap.searchFilter=host={host}
 cas.authn.spnego.ldap.bindDn=cn=Directory Manager
 cas.authn.spnego.ldap.bindCredential=password

--- a/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap.properties
+++ b/support/cas-server-support-spnego-webflow/src/test/resources/spnego-ldap.properties
@@ -7,6 +7,6 @@ ldap.managerPassword=Password
 cas.authn.spnego.ldap.ldapUrl=ldap://localhost:1381
 cas.authn.spnego.ldap.useSsl=false
 cas.authn.spnego.ldap.baseDn=ou=people,dc=example,dc=org
-cas.authn.spnego.ldap.searchFilter=host={0}
+cas.authn.spnego.ldap.searchFilter=host={host}
 cas.authn.spnego.ldap.bindDn=${ldap.managerDn}
 cas.authn.spnego.ldap.bindCredential=${ldap.managerPassword}


### PR DESCRIPTION
Fixed ldapSpnegoClientAction to set the parameter to host as documented for the property cas.authn.spnego.ldap.searchFilter (https://apereo.github.io/cas/development/installation/Configuration-Properties.html#spnego-authentication)
instead of 0