### PR TITLE
Update SpnegoNegotiateCredentialsAction.java

### DIFF
--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpnegoNegotiateCredentialsAction.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpnegoNegotiateCredentialsAction.java
@@ -83,10 +83,6 @@ public class SpnegoNegotiateCredentialsAction extends AbstractAction {
         this.mixedModeAuthentication = mixedModeAuthenticationEnabled;
 
         this.supportedBrowser = supportedBrowser;
-        this.supportedBrowser.add("MSIE");
-        this.supportedBrowser.add("Trident");
-        this.supportedBrowser.add("Firefox");
-        this.supportedBrowser.add("AppleWebKit");
     }
 
     @Override


### PR DESCRIPTION
Removed the hard-coded list of supported browsers to make the "cas.authn.spnego.supportedBrowsers" (cas.properties) directive usable.
Before this change, the "cas.authn.spnego.supportedBrowsers" allowed only to add more extra supported browser to original list (MSIE,Trident,Firefox,AppleWebKit). 
But, for example, if you didn't want to activate spnego with Chrome using "cas.authn.spnego.supportedBrowsers=MSIE,Trident,Firefox", it didn't work.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
