### PR TITLE
Fixed issue with TicketRegistryCleaner schedule

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
@@ -89,7 +89,7 @@ public class CasCoreTicketsSchedulingConfiguration {
         public void run() {
             try {
                 this.ticketRegistryCleaner.clean();
-            } catch (RuntimeException e) {
+            } catch (final Exception e) {
                 LOGGER.error(e.getMessage(), e);
             }
         }

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
@@ -87,7 +87,11 @@ public class CasCoreTicketsSchedulingConfiguration {
         @Scheduled(initialDelayString = "${cas.ticket.registry.cleaner.schedule.startDelay:PT30S}",
                 fixedDelayString = "${cas.ticket.registry.cleaner.schedule.repeatInterval:PT120S}")
         public void run() {
-            this.ticketRegistryCleaner.clean();
+            try {
+                this.ticketRegistryCleaner.clean();
+            } catch (RuntimeException e) {
+                LOGGER.error(e.getMessage(), e);
+            }
         }
     }
 }


### PR DESCRIPTION
If the schedule method throws an exception, it will stop the schedule
from ever running again.  Catching this exception here fixes this issue
from ever occurring.  This case can happen if the
lockingStrategy.release() within the DefaultTicketRegistryCleaner throws
an exception which has happened for us a few times causing this problem.