### PR TITLE
use distinct ports

### DIFF
--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/adaptive/intel/RestfulIPAddressIntelligenceServiceTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/adaptive/intel/RestfulIPAddressIntelligenceServiceTests.java
@@ -23,12 +23,12 @@ import static org.junit.Assert.*;
 public class RestfulIPAddressIntelligenceServiceTests {
     @Test
     public void verifyAllowedOperation() {
-        try (val webServer = new MockWebServer(9293,
+        try (val webServer = new MockWebServer(9300,
             new ByteArrayResource(StringUtils.EMPTY.getBytes(StandardCharsets.UTF_8), "Output"), HttpStatus.OK)) {
             webServer.start();
 
             val props = new AdaptiveAuthenticationProperties();
-            props.getIpIntel().getRest().setUrl("http://localhost:9293");
+            props.getIpIntel().getRest().setUrl("http://localhost:9300");
             val service = new RestfulIPAddressIntelligenceService(props);
             val result = service.examine(new MockRequestContext(), "1.2.3.4");
             assertNotNull(result);
@@ -40,11 +40,11 @@ public class RestfulIPAddressIntelligenceServiceTests {
 
     @Test
     public void verifyBannedOperation() {
-        try (val webServer = new MockWebServer(9299,
+        try (val webServer = new MockWebServer(9300,
             new ByteArrayResource(StringUtils.EMPTY.getBytes(StandardCharsets.UTF_8), "Output"), HttpStatus.FORBIDDEN)) {
             webServer.start();
             val props = new AdaptiveAuthenticationProperties();
-            props.getIpIntel().getRest().setUrl("http://localhost:9299");
+            props.getIpIntel().getRest().setUrl("http://localhost:9300");
             val service = new RestfulIPAddressIntelligenceService(props);
             val result = service.examine(new MockRequestContext(), "1.2.3.4");
             assertNotNull(result);

--- a/core/cas-server-core-web-api/src/test/java/org/apereo/cas/web/view/RestfulUrlTemplateResolverTests.java
+++ b/core/cas-server-core-web-api/src/test/java/org/apereo/cas/web/view/RestfulUrlTemplateResolverTests.java
@@ -24,12 +24,12 @@ import static org.mockito.Mockito.*;
 public class RestfulUrlTemplateResolverTests {
     @Test
     public void verifyAction() {
-        try (val webServer = new MockWebServer(9294,
+        try (val webServer = new MockWebServer(9302,
             new ByteArrayResource("template".getBytes(StandardCharsets.UTF_8), "REST Output"), MediaType.APPLICATION_JSON_VALUE)) {
             webServer.start();
 
             val props = new CasConfigurationProperties();
-            props.getView().getRest().setUrl("http://localhost:9294");
+            props.getView().getRest().setUrl("http://localhost:9302");
             val r = new RestfulUrlTemplateResolver(props);
             val res = r.resolveTemplate(mock(IEngineConfiguration.class), "cas",
                 "template", new LinkedHashMap<>());

--- a/support/cas-server-support-rest-service-registry/src/test/resources/restful-svc.properties
+++ b/support/cas-server-support-rest-service-registry/src/test/resources/restful-svc.properties
@@ -1,4 +1,4 @@
-server.port=9295
+server.port=9303
 
 cas.serviceRegistry.rest.url=http://localhost:${server.port}
 cas.serviceRegistry.initFromJson=false

--- a/support/cas-server-support-surrogate-authentication-rest/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationServiceTests.java
+++ b/support/cas-server-support-surrogate-authentication-rest/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationServiceTests.java
@@ -85,7 +85,7 @@ import static org.junit.Assert.*;
     SurrogateAuthenticationMetadataConfiguration.class,
     SurrogateRestAuthenticationConfiguration.class
 })
-@TestPropertySource(properties = "cas.authn.surrogate.rest.url=http://localhost:9293")
+@TestPropertySource(properties = "cas.authn.surrogate.rest.url=http://localhost:9301")
 public class SurrogateRestAuthenticationServiceTests {
     private static final ObjectMapper MAPPER = new ObjectMapper()
         .findAndRegisterModules()
@@ -99,7 +99,7 @@ public class SurrogateRestAuthenticationServiceTests {
     @Test
     public void verifyAccountsQualifying() throws Exception {
         val data = MAPPER.writeValueAsString(CollectionUtils.wrapList("casuser", "otheruser"));
-        try (val webServer = new MockWebServer(9293,
+        try (val webServer = new MockWebServer(9301,
             new ByteArrayResource(data.getBytes(StandardCharsets.UTF_8), "REST Output"), MediaType.APPLICATION_JSON_VALUE)) {
             webServer.start();
             val results = surrogateAuthenticationService.getEligibleAccountsForSurrogateToProxy("casuser");
@@ -108,7 +108,7 @@ public class SurrogateRestAuthenticationServiceTests {
             throw new AssertionError(e.getMessage(), e);
         }
 
-        try (val webServer = new MockWebServer(9293,
+        try (val webServer = new MockWebServer(9301,
             new ByteArrayResource(data.getBytes(StandardCharsets.UTF_8), "REST Output"), MediaType.APPLICATION_JSON_VALUE)) {
             webServer.start();
             val result = surrogateAuthenticationService.canAuthenticateAs("cassurrogate",


### PR DESCRIPTION
uses distinct ports for each `MockWebServer` instance to avoid transient failures due to port collisions.