### PR TITLE
Allow missing mobile phone in surrogation for SMS notification

### DIFF
--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/SurrogateAuthenticationEventListener.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/SurrogateAuthenticationEventListener.java
@@ -48,8 +48,14 @@ public class SurrogateAuthenticationEventListener {
         final String eventDetails = event.toString();
         if (communicationsManager.isSmsSenderDefined()) {
             final SmsProperties sms = casProperties.getAuthn().getSurrogate().getSms();
-            final String text = sms.getText().concat("\n").concat(eventDetails);
-            communicationsManager.sms(sms.getFrom(), principal.getAttributes().get(sms.getAttributeName()).toString(), text);
+            final String smsAttribute = sms.getAttributeName();
+            final Object to = principal.getAttributes().get(smsAttribute);
+            if (to != null) {
+                final String text = sms.getText().concat("\n").concat(eventDetails);
+                communicationsManager.sms(sms.getFrom(), to.toString(), text);
+            } else {
+                LOGGER.trace("The principal has no {} attribute, cannot send SMS notification", smsAttribute);
+            }
         } else {
             LOGGER.trace("CAS is unable to send surrogate-authentication SMS messages given no settings are defined to account for servers, etc");
         }


### PR DESCRIPTION
Previously, if the user has no SMS attribute, an `NullPointerException` was thrown.

Fixed by this change, like for the email notification.
