### PR TITLE
Fixing support for delegated authn to azure and path based callbacks with pac4j

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jBaseClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jBaseClientProperties.java
@@ -36,5 +36,5 @@ public class Pac4jBaseClientProperties implements Serializable {
     /**
      * Create a callback url with the clientId in the path instead of in the querystring.
      */
-    private boolean usePathBasedCallbackUrl = false;
+    private boolean usePathBasedCallbackUrl;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jBaseClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jBaseClientProperties.java
@@ -32,4 +32,9 @@ public class Pac4jBaseClientProperties implements Serializable {
      * Auto-redirect to this client.
      */
     private boolean autoRedirect;
+
+    /**
+     * Create a callback url with the clientId in the path instead of in the querystring.
+     */
+    private boolean usePathBasedCallbackUrl = false;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jOidcClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jOidcClientProperties.java
@@ -63,4 +63,9 @@ public class Pac4jOidcClientProperties extends Pac4jIdentifiableClientProperties
      * Custom parameters to send along in authZ requests, etc.
      */
     private Map<String, String> customParams = new HashMap<>();
+
+    /**
+     * Tenant Id as required by Microsoft Azure integrations.
+     */
+    private String azureTenantId;
 }

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -2629,6 +2629,7 @@ Delegate authentication to an external CAS server.
 ```properties
 # cas.authn.pac4j.cas[0].loginUrl=
 # cas.authn.pac4j.cas[0].protocol=
+# cas.authn.pac4j.cas[0].usePathBasedCallbackUrl=false
 ```
 
 ### OAuth20
@@ -2643,6 +2644,7 @@ Delegate authentication to an generic OAuth2 server. Common settings for this id
 # cas.authn.pac4j.oauth2[0].profileVerb=GET|POST
 # cas.authn.pac4j.oauth2[0].profileAttrs.attr1=path-to-attr-in-profile
 # cas.authn.pac4j.oauth2[0].customParams.param1=value1
+# cas.authn.pac4j.oauth2[0].usePathBasedCallbackUrl=false
 ```
 
 ### OpenID Connect
@@ -2658,6 +2660,8 @@ Delegate authentication to an external OpenID Connect server. Common settings fo
 # cas.authn.pac4j.oidc[0].useNonce=
 # cas.authn.pac4j.oidc[0].preferredJwsAlgorithm=
 # cas.authn.pac4j.oidc[0].customParams.param1=value1
+# cas.authn.pac4j.oidc[0].azureTenantId=
+# cas.authn.pac4j.oidc[0].usePathBasedCallbackUrl=false
 ```
 
 ### SAML2

--- a/gradle.properties
+++ b/gradle.properties
@@ -146,7 +146,7 @@ reflectionsVersion=0.9.11
 guavaVersion=25.0-jre
 
 pac4jSpringWebmvcVersion=3.0.0
-pac4jVersion=3.0.1
+pac4jVersion=3.1.0-SNAPSHOT
 
 dropwizardMetricsSpringVersion=3.1.3
 statsdVersion=3.1.0

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
@@ -13,6 +13,7 @@ import org.pac4j.cas.client.CasClient;
 import org.pac4j.cas.config.CasConfiguration;
 import org.pac4j.cas.config.CasProtocol;
 import org.pac4j.core.client.BaseClient;
+import org.pac4j.core.http.callback.PathParameterCallbackUrlResolver;
 import org.pac4j.oauth.client.BitbucketClient;
 import org.pac4j.oauth.client.DropBoxClient;
 import org.pac4j.oauth.client.FacebookClient;
@@ -311,6 +312,9 @@ public class DelegatedClientFactory {
                 if (StringUtils.isBlank(cas.getClientName())) {
                     client.setName(client.getClass().getSimpleName() + count);
                 }
+                if (cas.isUsePathBasedCallbackUrl()) {
+                    client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
+                }
                 configureClient(client, cas);
 
                 index.incrementAndGet();
@@ -364,6 +368,9 @@ public class DelegatedClientFactory {
                 if (StringUtils.isBlank(saml.getClientName())) {
                     client.setName(client.getClass().getSimpleName() + count);
                 }
+                if (saml.isUsePathBasedCallbackUrl()) {
+                    client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
+                }
                 configureClient(client, saml);
 
                 index.incrementAndGet();
@@ -397,6 +404,9 @@ public class DelegatedClientFactory {
                 if (StringUtils.isBlank(oauth.getClientName())) {
                     client.setName(client.getClass().getSimpleName() + count);
                 }
+                if (oauth.isUsePathBasedCallbackUrl()) {
+                    client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
+                }
                 configureClient(client, oauth);
 
                 index.incrementAndGet();
@@ -424,7 +434,10 @@ public class DelegatedClientFactory {
                         break;
                     case "AZURE":
                         final AzureAdOidcConfiguration azure = getOidcConfigurationForClient(oidc, AzureAdOidcConfiguration.class);
-                        client = new AzureAdClient(new AzureAdOidcConfiguration(azure));
+                        final AzureAdOidcConfiguration azureAdOidcConfiguration = new AzureAdOidcConfiguration(azure);
+                        azureAdOidcConfiguration.setTenant(oidc.getAzureTenantId());
+                        client = new AzureAdClient(azureAdOidcConfiguration);
+                        client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
                         break;
                     case "KEYCLOAK":
                         final KeycloakOidcConfiguration keycfg = getOidcConfigurationForClient(oidc, KeycloakOidcConfiguration.class);
@@ -440,6 +453,9 @@ public class DelegatedClientFactory {
                 final int count = index.intValue();
                 if (StringUtils.isBlank(oidc.getClientName())) {
                     client.setName(client.getClass().getSimpleName() + count);
+                }
+                if (oidc.isUsePathBasedCallbackUrl()) {
+                    client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
                 }
                 configureClient(client, oidc);
                 index.incrementAndGet();

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
@@ -434,10 +434,8 @@ public class DelegatedClientFactory {
                         break;
                     case "AZURE":
                         final AzureAdOidcConfiguration azure = getOidcConfigurationForClient(oidc, AzureAdOidcConfiguration.class);
-                        final AzureAdOidcConfiguration azureAdOidcConfiguration = new AzureAdOidcConfiguration(azure);
-                        azureAdOidcConfiguration.setTenant(oidc.getAzureTenantId());
-                        client = new AzureAdClient(azureAdOidcConfiguration);
-                        client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());
+                        azure.setTenant(oidc.getAzureTenantId());
+                        client = new AzureAdClient(new AzureAdOidcConfiguration(azure));
                         break;
                     case "KEYCLOAK":
                         final KeycloakOidcConfiguration keycfg = getOidcConfigurationForClient(oidc, KeycloakOidcConfiguration.class);

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
@@ -103,7 +103,7 @@ public class DelegatedClientNavigationController {
      */
     @GetMapping(ENDPOINT_RESPONSE)
     public View redirectResponseToFlow(final @PathVariable("clientName") String clientName, final HttpServletRequest request, final HttpServletResponse response) {
-        final URIBuilder builder = new URIBuilder(request.getRequestURL().append("?").append(request.getQueryString()).toString());
+        final URIBuilder builder = new URIBuilder(request.getRequestURL().append('?').append(request.getQueryString()).toString());
         builder.setPath(builder.getPath().replace('/' + clientName, ""));
         builder.addParameter(Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER, clientName);
 

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
@@ -19,6 +19,7 @@ import org.pac4j.core.redirect.RedirectAction;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.view.RedirectView;
@@ -41,6 +42,8 @@ public class DelegatedClientNavigationController {
      * Endpoint path controlled by this controller to make the redirect.
      */
     public static final String ENDPOINT_REDIRECT = "clientredirect";
+    public static final String ENDPOINT_RESPONSE = "login/{clientName}";
+
 
     private final Clients clients;
     private final DelegatedClientWebflowManager delegatedClientWebflowManager;
@@ -83,5 +86,18 @@ public class DelegatedClientNavigationController {
             }
             throw new UnauthorizedServiceException(e.getMessage(), e);
         }
+    }
+
+    @GetMapping(ENDPOINT_RESPONSE)
+    public View redirectResponseToFlow(final @PathVariable("clientName") String clientName, final HttpServletRequest request, final HttpServletResponse response) {
+        final URIBuilder builder = new URIBuilder(request.getRequestURL().append("?").append(request.getQueryString()).toString());
+        builder.setPath(builder.getPath().replace('/' + clientName, ""));
+        builder.addParameter(Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER, clientName);
+
+        final String url = builder.toString();
+        LOGGER.debug("Received a response for {}, redirecting the login flow ({})", clientName, url);
+
+        final View result = new RedirectView(url);
+        return result;
     }
 }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
@@ -88,6 +88,15 @@ public class DelegatedClientNavigationController {
         }
     }
 
+    /**
+     * Redirect response to flow. Receives the CAS, OAuth, OIDC, etc. callback response, adjust it to work with
+     * the login webflow, and redirects the requests to the login webflow endpoint.
+     *
+     * @param clientName the path-based parameter that provider the pac4j client name
+     * @param request  the request
+     * @param response the response
+     * @return the view
+     */
     @GetMapping(ENDPOINT_RESPONSE)
     public View redirectResponseToFlow(final @PathVariable("clientName") String clientName, final HttpServletRequest request, final HttpServletResponse response) {
         final URIBuilder builder = new URIBuilder(request.getRequestURL().append("?").append(request.getQueryString()).toString());

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
@@ -42,6 +42,10 @@ public class DelegatedClientNavigationController {
      * Endpoint path controlled by this controller to make the redirect.
      */
     public static final String ENDPOINT_REDIRECT = "clientredirect";
+
+    /**
+     * Endpoint path controlled by this controller that receives the response to PAC4J.
+     */
     public static final String ENDPOINT_RESPONSE = "login/{clientName}";
 
 


### PR DESCRIPTION
Delegated authn to Azure is broken in two ways in 5.3.x. Pac4j's Azure impl requires a tenant value to be specified, and Azure does not return querystrings on the callback url (?client_name=AzureOidc). 

This PR adds in the azureTenantId property, adds the ability to switch from querystring based callbacks to an optional* path-based identifier, and adds an endpoint mapping to handle the callback and redirect it to the webflow.

* The Azure config forcefully sets path based callbacks.

New properties documented in the PR commit:
```
# cas.authn.pac4j.oidc[0].usePathBasedCallbackUrl=true
# cas.authn.pac4j.oidc[0].azureTenantId=common
```