### PR TITLE
fix jws signature - use base64url encoding with trailing "=" characte…

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/EncodingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/EncodingUtils.java
@@ -341,9 +341,8 @@ public class EncodingUtils {
      */
     @SneakyThrows
     public static byte[] signJws(final Key key, final byte[] value, final String algHeaderValue) {
-        final String base64 = EncodingUtils.encodeBase64(value);
         final JsonWebSignature jws = new JsonWebSignature();
-        jws.setEncodedPayload(base64);
+        jws.setPayloadBytes(value);
         jws.setAlgorithmHeaderValue(algHeaderValue);
         jws.setKey(key);
         return jws.getCompactSerialization().getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
Fix JWS protocol implementation.

The payload must be base64url encoded with with trailing "=" characters omitted (actually it is base64 encoded).

see [specification](https://tools.ietf.org/html/rfc7515#section-3.1)

> BASE64URL(UTF8(JWS Protected Header)) || '.' ||
BASE64URL(JWS Payload) || '.' ||
BASE64URL(JWS Signature)
