### PR TITLE
Fixes 500 error which was being returned to client in the case where …

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcIntrospectionEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcIntrospectionEndpointController.java
@@ -53,17 +53,15 @@ public class OidcIntrospectionEndpointController extends BaseOAuth20Controller {
     private final AuditableExecution registeredServiceAccessStrategyEnforcer;
 
     public OidcIntrospectionEndpointController(final ServicesManager servicesManager,
-                                               final TicketRegistry ticketRegistry,
-                                               final AccessTokenFactory accessTokenFactory,
-                                               final PrincipalFactory principalFactory,
-                                               final ServiceFactory<WebApplicationService> webApplicationServiceServiceFactory,
-                                               final OAuth20ProfileScopeToAttributesFilter scopeToAttributesFilter,
-                                               final CasConfigurationProperties casProperties,
-                                               final CookieRetrievingCookieGenerator cookieGenerator,
-                                               final CentralAuthenticationService centralAuthenticationService,
-                                               final AuditableExecution registeredServiceAccessStrategyEnforcer) {
+            final TicketRegistry ticketRegistry, final AccessTokenFactory accessTokenFactory,
+            final PrincipalFactory principalFactory,
+            final ServiceFactory<WebApplicationService> webApplicationServiceServiceFactory,
+            final OAuth20ProfileScopeToAttributesFilter scopeToAttributesFilter,
+            final CasConfigurationProperties casProperties, final CookieRetrievingCookieGenerator cookieGenerator,
+            final CentralAuthenticationService centralAuthenticationService,
+            final AuditableExecution registeredServiceAccessStrategyEnforcer) {
         super(servicesManager, ticketRegistry, accessTokenFactory, principalFactory,
-            webApplicationServiceServiceFactory, scopeToAttributesFilter, casProperties, cookieGenerator);
+                webApplicationServiceServiceFactory, scopeToAttributesFilter, casProperties, cookieGenerator);
         this.centralAuthenticationService = centralAuthenticationService;
         this.registeredServiceAccessStrategyEnforcer = registeredServiceAccessStrategyEnforcer;
     }
@@ -71,44 +69,56 @@ public class OidcIntrospectionEndpointController extends BaseOAuth20Controller {
     /**
      * Handle request.
      *
-     * @param request  the request
-     * @param response the response
+     * @param request
+     *            the request
+     * @param response
+     *            the response
      * @return the response entity
      */
-    @GetMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-        produces = MediaType.APPLICATION_JSON_VALUE,
-        value = {'/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.INTROSPECTION_URL})
+    @GetMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, value = {
+            '/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.INTROSPECTION_URL })
     public ResponseEntity<OidcIntrospectionAccessTokenResponse> handleRequest(final HttpServletRequest request,
-                                                                              final HttpServletResponse response) {
+            final HttpServletResponse response) {
         return handlePostRequest(request, response);
     }
 
     /**
      * Handle post request.
      *
-     * @param request  the request
-     * @param response the response
+     * @param request
+     *            the request
+     * @param response
+     *            the response
      * @return the response entity
      */
-    @PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-        produces = MediaType.APPLICATION_JSON_VALUE,
-        value = {'/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.INTROSPECTION_URL})
+    @PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, value = {
+            '/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.INTROSPECTION_URL })
     public ResponseEntity<OidcIntrospectionAccessTokenResponse> handlePostRequest(final HttpServletRequest request,
-                                                                                  final HttpServletResponse response) {
+            final HttpServletResponse response) {
         try {
             final CredentialsExtractor<UsernamePasswordCredentials> authExtractor = new BasicAuthExtractor();
-            final UsernamePasswordCredentials credentials = authExtractor.extract(Pac4jUtils.getPac4jJ2EContext(request, response));
+            final UsernamePasswordCredentials credentials = authExtractor
+                    .extract(Pac4jUtils.getPac4jJ2EContext(request, response));
             if (credentials == null) {
-                throw new IllegalArgumentException("No credentials are provided to verify introspection on the access token");
+                throw new IllegalArgumentException(
+                        "No credentials are provided to verify introspection on the access token");
             }
 
-            final OAuthRegisteredService service = OAuth20Utils.getRegisteredOAuthServiceByClientId(this.servicesManager, credentials.getUsername());
+            final OAuthRegisteredService service = OAuth20Utils
+                    .getRegisteredOAuthServiceByClientId(this.servicesManager, credentials.getUsername());
             if (validateIntrospectionRequest(service, credentials, request)) {
-                final String accessToken = StringUtils.defaultIfBlank(request.getParameter(OAuth20Constants.ACCESS_TOKEN),
-                    request.getParameter(OAuth20Constants.TOKEN));
+                final String accessToken = StringUtils.defaultIfBlank(
+                        request.getParameter(OAuth20Constants.ACCESS_TOKEN),
+                        request.getParameter(OAuth20Constants.TOKEN));
 
                 LOGGER.debug("Located access token [{}] in the request", accessToken);
-                final AccessToken ticket = this.centralAuthenticationService.getTicket(accessToken, AccessToken.class);
+                final AccessToken ticket = null;
+                try {
+                    this.centralAuthenticationService.getTicket(accessToken, AccessToken.class);
+                } catch (final org.apereo.cas.ticket.InvalidTicketException ite) {
+                    LOGGER.info("No ticket for supplied access token");
+                }
+
                 if (ticket != null) {
                     return createIntrospectionResponse(service, ticket);
                 }
@@ -121,50 +131,54 @@ public class OidcIntrospectionEndpointController extends BaseOAuth20Controller {
     }
 
     private boolean validateIntrospectionRequest(final OAuthRegisteredService registeredService,
-                                                 final UsernamePasswordCredentials credentials,
-                                                 final HttpServletRequest request) {
+            final UsernamePasswordCredentials credentials, final HttpServletRequest request) {
         final boolean tokenExists = HttpRequestUtils.doesParameterExist(request, OAuth20Constants.ACCESS_TOKEN)
-            || HttpRequestUtils.doesParameterExist(request, OAuth20Constants.TOKEN);
-
+                || HttpRequestUtils.doesParameterExist(request, OAuth20Constants.TOKEN);
 
         if (tokenExists && OAuth20Utils.checkClientSecret(registeredService, credentials.getPassword())) {
-            final WebApplicationService service = webApplicationServiceServiceFactory.createService(registeredService.getServiceId());
-            final AuditableContext audit = AuditableContext.builder()
-                .service(service)
-                .registeredService(registeredService)
-                .build();
+            final WebApplicationService service = webApplicationServiceServiceFactory
+                    .createService(registeredService.getServiceId());
+            final AuditableContext audit = AuditableContext.builder().service(service)
+                    .registeredService(registeredService).build();
             final AuditableExecutionResult accessResult = this.registeredServiceAccessStrategyEnforcer.execute(audit);
             return !accessResult.isExecutionFailure();
         }
         return false;
     }
 
-    private ResponseEntity<OidcIntrospectionAccessTokenResponse> createIntrospectionResponse(final OAuthRegisteredService service, final AccessToken ticket) {
+    private ResponseEntity<OidcIntrospectionAccessTokenResponse> createIntrospectionResponse(
+            final OAuthRegisteredService service, final AccessToken ticket) {
+
         final OidcIntrospectionAccessTokenResponse introspect = new OidcIntrospectionAccessTokenResponse();
-        introspect.setActive(true);
-        introspect.setClientId(service.getClientId());
-        final Authentication authentication = ticket.getAuthentication();
-        final String subject = authentication.getPrincipal().getId();
-        introspect.setSub(subject);
-        introspect.setUniqueSecurityName(subject);
-        introspect.setExp(ticket.getExpirationPolicy().getTimeToLive());
-        introspect.setIat(ticket.getCreationTime().toInstant().getEpochSecond());
 
-        final Object methods = authentication.getAttributes().get(AuthenticationManager.AUTHENTICATION_METHOD_ATTRIBUTE);
-        final String realmNames = CollectionUtils.toCollection(methods)
-            .stream()
-            .map(Object::toString)
-            .collect(Collectors.joining(","));
+        if (ticket != null) {
+            introspect.setActive(true);
+            introspect.setClientId(service.getClientId());
+            final Authentication authentication = ticket.getAuthentication();
+            final String subject = authentication.getPrincipal().getId();
+            introspect.setSub(subject);
+            introspect.setUniqueSecurityName(subject);
+            introspect.setExp(ticket.getExpirationPolicy().getTimeToLive());
+            introspect.setIat(ticket.getCreationTime().toInstant().getEpochSecond());
 
-        introspect.setRealmName(realmNames);
-        introspect.setTokenType(OAuth20Constants.TOKEN_TYPE_BEARER);
+            final Object methods = authentication.getAttributes()
+                    .get(AuthenticationManager.AUTHENTICATION_METHOD_ATTRIBUTE);
+            final String realmNames = CollectionUtils.toCollection(methods).stream().map(Object::toString)
+                    .collect(Collectors.joining(","));
 
-        final String grant = authentication.getAttributes()
-            .getOrDefault(OAuth20Constants.GRANT_TYPE, StringUtils.EMPTY).toString().toLowerCase();
-        introspect.setGrantType(grant);
-        introspect.setScope(OidcConstants.StandardScopes.OPENID.getScope());
-        introspect.setAud(service.getServiceId());
-        introspect.setIss(casProperties.getAuthn().getOidc().getIssuer());
+            introspect.setRealmName(realmNames);
+            introspect.setTokenType(OAuth20Constants.TOKEN_TYPE_BEARER);
+
+            final String grant = authentication.getAttributes()
+                    .getOrDefault(OAuth20Constants.GRANT_TYPE, StringUtils.EMPTY).toString().toLowerCase();
+            introspect.setGrantType(grant);
+            introspect.setScope(OidcConstants.StandardScopes.OPENID.getScope());
+            introspect.setAud(service.getServiceId());
+            introspect.setIss(casProperties.getAuthn().getOidc().getIssuer());
+        } else {
+            introspect.setActive(false);
+        }
+
         return new ResponseEntity<>(introspect, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
Fixes 500 error which was being returned to client in the case where an invalid access token was supplied for introspect. With this fix, the client now receives a valid response with the 'active' flag set to 'false'.