### PR TITLE
Avoid ClassCastException in OneTimeTokenAccount

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/OneTimeTokenAccount.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/OneTimeTokenAccount.java
@@ -92,7 +92,7 @@ public class OneTimeTokenAccount implements Serializable, Comparable<OneTimeToke
 
     @Override
     public int compareTo(final OneTimeTokenAccount o) {
-        return new CompareToBuilder().append(this.scratchCodes, o.getScratchCodes()).append(this.validationCode, o.getValidationCode())
+        return new CompareToBuilder().append(this.scratchCodes.toArray(new Integer[this.scratchCodes.size()]), o.getScratchCodes().toArray(new Integer[o.getScratchCodes().size()])).append(this.validationCode, o.getValidationCode())
             .append(this.secretKey, o.getSecretKey()).append(this.username, o.getUsername()).build();
     }
 

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/OneTimeTokenAccount.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/OneTimeTokenAccount.java
@@ -92,8 +92,15 @@ public class OneTimeTokenAccount implements Serializable, Comparable<OneTimeToke
 
     @Override
     public int compareTo(final OneTimeTokenAccount o) {
-        return new CompareToBuilder().append(this.scratchCodes.toArray(new Integer[this.scratchCodes.size()]), o.getScratchCodes().toArray(new Integer[o.getScratchCodes().size()])).append(this.validationCode, o.getValidationCode())
-            .append(this.secretKey, o.getSecretKey()).append(this.username, o.getUsername()).build();
+        
+        
+        return new CompareToBuilder()
+            .append(this.scratchCodes.toArray(new Integer[this.scratchCodes.size()]),
+                    o.getScratchCodes().toArray(new Integer[o.getScratchCodes().size()]))
+            .append(this.validationCode, o.getValidationCode())
+            .append(this.secretKey, o.getSecretKey())
+            .append(this.username, o.getUsername())
+            .build();
     }
 
     @Override

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/OneTimeTokenAccountTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/OneTimeTokenAccountTests.java
@@ -1,0 +1,28 @@
+
+package org.apereo.cas.authentication;
+
+import org.apereo.cas.util.CollectionUtils;
+
+import lombok.val;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * This is {@link OneTimeTokenAccountTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.3.4
+ */
+public class OneTimeTokenAccountTests {
+
+    @Test
+    public void verifyComparisonWorks() {
+        val otp1 = new OneTimeTokenAccount("casuser", "secret", 123456,
+            CollectionUtils.wrapList(1, 2, 3, 4, 5, 6));
+        val otp2 = new OneTimeTokenAccount("casuser", "secret", 987063,
+            CollectionUtils.wrapList(1, 2, 1, 4, 7, 6));
+        assertEquals(1, otp1.compareTo(otp2));
+        assertEquals(0, otp1.compareTo(otp1.clone()));
+    }
+}


### PR DESCRIPTION
The CompareToBuilder cannot compare ArrayLists since they do not implement the Comparable interface. Executing this method causes an immediate ClassCastException in CompareToBuilder.append.

If you know a better way to fix this problem, you are welcome to abandon my proposal! ;)
