### PR TITLE
5.3.x: Adding the ability to change the name of samlArtifactsCache and samlAttributeQueryCache

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPProperties.java
@@ -77,4 +77,10 @@ public class SamlIdPProperties implements Serializable {
     @NestedConfigurationProperty
     private SamlIdPAlgorithmsProperties algs = new SamlIdPAlgorithmsProperties();
     
+    /**
+     * Settings related to naming saml cache storages.
+     */
+    @NestedConfigurationProperty
+    private SamlIdPTicketProperties ticket = new SamlIdPTicketProperties();
+
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPTicketProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPTicketProperties.java
@@ -1,0 +1,29 @@
+package org.apereo.cas.configuration.model.support.saml.idp;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+/**
+ * This is {@link SamlIdPTicketProperties.java}.
+ *
+ * @author Samuel Lyons
+ * @since 5.3.0
+ */
+@Getter
+@Setter
+public class SamlIdPTicketProperties implements Serializable {
+
+    private static final long serialVersionUID = 9837089259390742073L;
+
+    /**
+     * name that should be given to the saml artifact cache storage name.
+     */
+    private String samlArtifactsCacheStorageName = "samlArtifactsCache";
+
+    /**
+     * The name that should be given to the saml attribute query cache storage name.
+     */
+    private String samlAttributeQueryCacheStorageName = "samlAttributeQueryCache";
+}

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPTicketProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPTicketProperties.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 @Setter
 public class SamlIdPTicketProperties implements Serializable {
 
-    private static final long serialVersionUID = 9837089259390742073L;
+    private static final long serialVersionUID = 6837089259390742073L;
 
     /**
      * name that should be given to the saml artifact cache storage name.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPTicketProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPTicketProperties.java
@@ -1,16 +1,19 @@
 package org.apereo.cas.configuration.model.support.saml.idp;
 
+import org.apereo.cas.configuration.support.RequiresModule;
+
 import lombok.Getter;
 import lombok.Setter;
 
 import java.io.Serializable;
 
 /**
- * This is {@link SamlIdPTicketProperties.java}.
+ * This is {@link SamlIdPTicketProperties}.
  *
  * @author Samuel Lyons
  * @since 5.3.0
  */
+@RequiresModule(name = "cas-server-support-saml-idp")
 @Getter
 @Setter
 public class SamlIdPTicketProperties implements Serializable {

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -2484,6 +2484,13 @@ under the configuration key `cas.authn.samlIdp.metadata.amazonS3`.
 # cas.authn.samlIdp.response.attributeNameFormats=attributeName->basic|uri|unspecified|custom-format-etc,...
 ```
 
+### SAML Ticket
+
+```properties
+# cas.authn.samlIdp.ticket.samlArtifactsCacheStorageName=samlArtifactsCache
+# cas.authn.samlIdp.ticket.samlAttributeQueryCacheStorageName=samlAttributeQueryCache
+```
+
 ## SAML SPs
 
 Allow CAS to register and enable a number of built-in SAML service provider integrations.

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPTicketCatalogConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPTicketCatalogConfiguration.java
@@ -33,13 +33,13 @@ public class SamlIdPTicketCatalogConfiguration extends BaseTicketCatalogConfigur
     }
 
     protected void buildAndRegisterSamlArtifactDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
-        metadata.getProperties().setStorageName("samlArtifactsCache");
+        metadata.getProperties().setStorageName(casProperties.getAuthn().getSamlIdp().getTicket().getSamlArtifactsCacheStorageName());
         metadata.getProperties().setStorageTimeout(casProperties.getTicket().getSt().getTimeToKillInSeconds());
         registerTicketDefinition(plan, metadata);
     }
 
     protected void buildAndRegisterSamlAttributeQueryDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
-        metadata.getProperties().setStorageName("samlAttributeQueryCache");
+        metadata.getProperties().setStorageName(casProperties.getAuthn().getSamlIdp().getTicket().getSamlAttributeQueryCacheStorageName());
         metadata.getProperties().setStorageTimeout(casProperties.getTicket().getSt().getTimeToKillInSeconds());
         registerTicketDefinition(plan, metadata);
     }


### PR DESCRIPTION
master is done, trying 5.3.x now

Added the ability to change the name of samlArtifactsCache and samlAttributeQueryCache. I created a new file SamlIdPTicketProperties which had the Strings for naming the above variables. I modified the file SamlIdProperties to include the new file SamlIdPTicketProperties (ticket). I changed the values in SamlIdPTicketCatalogConfiguration.java to use those variables instead of hard coded Strings. This is nice for us when we're running cas both in stage and copy that they aren't looking at the same storage place. I've been struggling getting checkstyle to work properly on my computer (Windows) but I'm pretty sure this is all correct I guess we'll see. This is for the master branch and 5.3.x