### PR TITLE
This fixes and issue with Duo bypass resulting in an authentication error

### DIFF
--- a/support/cas-server-support-duo-core-mfa/src/main/java/org/apereo/cas/adaptors/duo/authn/DefaultDuoMultifactorAuthenticationProvider.java
+++ b/support/cas-server-support-duo-core-mfa/src/main/java/org/apereo/cas/adaptors/duo/authn/DefaultDuoMultifactorAuthenticationProvider.java
@@ -58,7 +58,7 @@ public class DefaultDuoMultifactorAuthenticationProvider extends AbstractMultifa
         LOGGER.debug("Found duo user account status [{}] for [{}]", acct, principal);
         if (acct.getStatus() == DuoUserAccountAuthStatus.ALLOW) {
             LOGGER.debug("Account status is set for allow/bypass for [{}]", principal);
-            return false;
+            return true;
         }
         if (acct.getStatus() == DuoUserAccountAuthStatus.DENY) {
             LOGGER.warn("Account status is set to deny access to [{}]", principal);


### PR DESCRIPTION
This change fixes and issue that occurs if a user is set to bypass on the Duo Administrator Console.
It would result in an "INVALID_AUTHENTICATION_CONTEXT" failure.

```
 <cas:authenticationFailure code="INVALID_AUTHENTICATION_CONTEXT">
```

I was seeing the error in  CAS 5.2.4 and above, I did not test lower versions.

This is a result of the DefaultDuoMultifactorAuthenticationProvider returning that it is not supported.
I have change it to return true if the account is set to bypass.

I have tested this change with my setup and and has fixed the issue.