### PR TITLE
Update deleteTicket of AbstractTicketRegistry

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractMapBasedTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractMapBasedTicketRegistry.java
@@ -60,6 +60,21 @@ public abstract class AbstractMapBasedTicketRegistry extends AbstractTicketRegis
     }
 
     @Override
+    public Ticket getTicketForDeletion(final String ticketId) {
+        val encTicketId = encodeTicketId(ticketId);
+        if (StringUtils.isBlank(ticketId)) {
+            return null;
+        }
+        val found = getMapInstance().get(encTicketId);
+        if (found == null) {
+            LOGGER.debug("Ticket  [{}] could not be found", encTicketId);
+            return null;
+        }
+
+        return decodeTicket(found);
+    }
+
+    @Override
     public boolean deleteSingleTicket(final String ticketId) {
         val encTicketId = encodeTicketId(ticketId);
         if (StringUtils.isBlank(encTicketId)) {

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -83,13 +83,21 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
         }
     }
 
+    /**
+     * Retrieve a ticket from the registry for deletion.
+     *
+     * @param ticketId the id of the ticket we wish to retrieve
+     * @return the requested ticket.
+     */
+    public abstract Ticket getTicketForDeletion(String ticketId);
+
     @Override
     public int deleteTicket(final String ticketId) {
         val count = new AtomicInteger(0);
         if (StringUtils.isBlank(ticketId)) {
             return count.intValue();
         }
-        val ticket = getTicket(ticketId);
+        val ticket = getTicketForDeletion(ticketId);
         if (ticket == null) {
             return count.intValue();
         }

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
@@ -99,6 +99,22 @@ public class JpaTicketRegistry extends AbstractTicketRegistry {
     }
 
     @Override
+    public Ticket getTicketForDeletion(final String ticketId) {
+        try {
+            val tkt = ticketCatalog.find(ticketId);
+            val sql = String.format("select t from %s t where t.id = :id", getTicketEntityName(tkt));
+            val query = entityManager.createQuery(sql, tkt.getImplementationClass());
+            query.setParameter("id", ticketId);
+            query.setLockMode(this.lockType);
+            val result = query.getSingleResult();
+            return result;
+        } catch (final Exception e) {
+            LOGGER.error("Error getting ticket [{}] from registry.", ticketId, e);
+        }
+        return null;
+    }
+
+    @Override
     public Collection<Ticket> getTickets() {
         return this.ticketCatalog.findAll()
             .stream()


### PR DESCRIPTION
Added getTicketForDeletion to AbstractTicketRegistry because some implementations of getTicket (JPA, DynamoDb, Ignite, maybe others that I missed out) return null when the ticket has already expired and do not delete them unlike other implementations. This causes the deleteTicket to not be able to delete the tickets in certain configuration(s) of CAS. This causes an issue when running a CRON job (DefaultTicketRegistryCleaner) that expired tickets are not getting deleted.

I only modify 2 implementations since I am not familiar with other implementations.


<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
