### PR TITLE
Shibcas Decode entity from request parameter

### DIFF
--- a/support/cas-server-support-shibboleth/build.gradle
+++ b/support/cas-server-support-shibboleth/build.gradle
@@ -4,8 +4,6 @@ dependencies {
 
     implementation project(":core:cas-server-core-util-api")
     implementation project(":core:cas-server-core-configuration-api")
-    implementation project(":support:cas-server-support-saml-core")
-    implementation project(":support:cas-server-support-trusted")
     implementation project(":core:cas-server-core-web-api")
     implementation project(":core:cas-server-core-authentication-api")
     implementation project(":core:cas-server-core-services-authentication")

--- a/support/cas-server-support-shibboleth/src/main/java/org/apereo/cas/config/ExternalShibbolethIdPAuthenticationServiceSelectionStrategyConfiguration.java
+++ b/support/cas-server-support-shibboleth/src/main/java/org/apereo/cas/config/ExternalShibbolethIdPAuthenticationServiceSelectionStrategyConfiguration.java
@@ -2,6 +2,7 @@ package org.apereo.cas.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionStrategy;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionStrategyConfigurer;
@@ -38,6 +39,10 @@ public class ExternalShibbolethIdPAuthenticationServiceSelectionStrategyConfigur
     private ServiceFactory<WebApplicationService> webApplicationServiceFactory;
 
     @Autowired
+    @Qualifier("registeredServiceAccessStrategyEnforcer")
+    private AuditableExecution registeredServiceAccessStrategyEnforcer;
+
+    @Autowired
     @Qualifier("servicesManager")
     private ServicesManager servicesManager;
 
@@ -47,7 +52,8 @@ public class ExternalShibbolethIdPAuthenticationServiceSelectionStrategyConfigur
     public AuthenticationServiceSelectionStrategy shibbolethIdPEntityIdAuthenticationServiceSelectionStrategy() {
         return new ShibbolethIdPEntityIdAuthenticationServiceSelectionStrategy(webApplicationServiceFactory,
                 casProperties.getAuthn().getShibIdp().getServerUrl(),
-                servicesManager);
+                servicesManager,
+                registeredServiceAccessStrategyEnforcer);
     }
 
     @Override

--- a/support/cas-server-support-shibboleth/src/main/java/org/apereo/cas/config/ExternalShibbolethIdPAuthenticationServiceSelectionStrategyConfiguration.java
+++ b/support/cas-server-support-shibboleth/src/main/java/org/apereo/cas/config/ExternalShibbolethIdPAuthenticationServiceSelectionStrategyConfiguration.java
@@ -8,6 +8,7 @@ import org.apereo.cas.authentication.AuthenticationServiceSelectionStrategyConfi
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.saml.ShibbolethIdPEntityIdAuthenticationServiceSelectionStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -36,12 +37,17 @@ public class ExternalShibbolethIdPAuthenticationServiceSelectionStrategyConfigur
     @Qualifier("webApplicationServiceFactory")
     private ServiceFactory<WebApplicationService> webApplicationServiceFactory;
 
+    @Autowired
+    @Qualifier("servicesManager")
+    private ServicesManager servicesManager;
+
     @ConditionalOnMissingBean(name = "shibbolethIdPEntityIdAuthenticationServiceSelectionStrategy")
     @Bean
     @RefreshScope
     public AuthenticationServiceSelectionStrategy shibbolethIdPEntityIdAuthenticationServiceSelectionStrategy() {
         return new ShibbolethIdPEntityIdAuthenticationServiceSelectionStrategy(webApplicationServiceFactory,
-                casProperties.getAuthn().getShibIdp().getServerUrl());
+                casProperties.getAuthn().getShibIdp().getServerUrl(),
+                servicesManager);
     }
 
     @Override

--- a/support/cas-server-support-shibboleth/src/main/java/org/apereo/cas/support/saml/ShibbolethIdPEntityIdAuthenticationServiceSelectionStrategy.java
+++ b/support/cas-server-support-shibboleth/src/main/java/org/apereo/cas/support/saml/ShibbolethIdPEntityIdAuthenticationServiceSelectionStrategy.java
@@ -9,20 +9,16 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apereo.cas.audit.AuditableContext;
 import org.apereo.cas.audit.AuditableExecution;
-import org.apereo.cas.audit.AuditableExecutionResult;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionStrategy;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.services.RegisteredService;
-import org.apereo.cas.services.RegisteredServiceAccessStrategyAuditableEnforcer;
-import org.apereo.cas.services.RegisteredServiceAccessStrategyUtils;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.util.EncodingUtils;
 import org.apereo.cas.web.support.WebUtils;
 import org.springframework.core.Ordered;
 
 import javax.servlet.http.HttpServletRequest;
-import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -38,14 +34,13 @@ import java.util.Optional;
 public class ShibbolethIdPEntityIdAuthenticationServiceSelectionStrategy implements AuthenticationServiceSelectionStrategy {
     private static final long serialVersionUID = -2059445756475980894L;
 
+    private static final String PARAMETER_ENTITY_ID = "entityId";
+
     private final int order = Ordered.HIGHEST_PRECEDENCE;
     private final transient ServiceFactory webApplicationServiceFactory;
     private final String idpServerPrefix;
     private final ServicesManager servicesManager;
     private final AuditableExecution registeredServiceAccessStrategyEnforcer;
-
-
-    private static final String PARAMETER_ENTITY_ID = "entityId";
 
     /**
      * Method attempts to resolve the service from the entityId parameter.  If present, an attempt is made


### PR DESCRIPTION
This PR pertains to the cas-server-support-shibboleth for resolving services from an external Shibboleth IdP using the Shibcas pluglin.

- **Adds a URL decoder step when extracting the entityId parameter from the request query params.**
- **Removes cas-server-support-saml and cas-server-support-trusted as dependencies**
    The SAML module was included in the build to only provide SAML_PROTOCOL_CONSTANTS_ENTITY_ID.  Use of the shibboleth module does not require that SAML be included in the build for the CAS Server.  This protocol is stable enough that defining it locally should not be a risk, and saves compiling the saml module into the build.
- **Looks for the existence of the entityId as service registry entry**
   This may be more specific to our use of the registry than how others use it.  We don't require SPs coming from the Shibcas Plugin to be also registered in CAS, besides our IDP.  We register SP entity ids only when they need to trigger some advanced feature like MFA in CAS.  We disable the catch all wildcard and run a closed registry.  If an entity is not found in the registry, we want to use the Shib call back url in the service parameter of request.