### PR TITLE
Update authentication when custom bypass used

### DIFF
--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationProviderBypass.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationProviderBypass.java
@@ -118,7 +118,7 @@ public class DefaultMultifactorAuthenticationProviderBypass implements Multifact
         return true;
     }
 
-    private static void updateAuthenticationToForgetBypass(final Authentication authentication,
+    protected static void updateAuthenticationToForgetBypass(final Authentication authentication,
                                                            final MultifactorAuthenticationProvider provider,
                                                            final Principal principal) {
         LOGGER.debug("Bypass rules for service [{}] indicate the request may be ignored", principal.getId());
@@ -126,7 +126,7 @@ public class DefaultMultifactorAuthenticationProviderBypass implements Multifact
         LOGGER.debug("Updated authentication session to remember bypass for [{}] via [{}]", provider.getId(), AUTHENTICATION_ATTRIBUTE_BYPASS_MFA);
     }
 
-    private static void updateAuthenticationToRememberBypass(final Authentication authentication, final MultifactorAuthenticationProvider provider,
+    protected static void updateAuthenticationToRememberBypass(final Authentication authentication, final MultifactorAuthenticationProvider provider,
                                                              final Principal principal) {
         LOGGER.debug("Bypass rules for service [{}] indicate the request may NOT be ignored", principal.getId());
         authentication.addAttribute(AUTHENTICATION_ATTRIBUTE_BYPASS_MFA, Boolean.TRUE);

--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationProviderBypass.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationProviderBypass.java
@@ -118,6 +118,13 @@ public class DefaultMultifactorAuthenticationProviderBypass implements Multifact
         return true;
     }
 
+    /**
+     * Method will remove any previous bypass set in the authentication.
+     *
+     * @param authentication - the authentication
+     * @param provider - the provider
+     * @param principal - the principal
+     */
     protected static void updateAuthenticationToForgetBypass(final Authentication authentication,
                                                            final MultifactorAuthenticationProvider provider,
                                                            final Principal principal) {
@@ -126,6 +133,13 @@ public class DefaultMultifactorAuthenticationProviderBypass implements Multifact
         LOGGER.debug("Updated authentication session to remember bypass for [{}] via [{}]", provider.getId(), AUTHENTICATION_ATTRIBUTE_BYPASS_MFA);
     }
 
+    /**
+     * Method will set the bypass into the authentication.
+     *
+     * @param authentication - the authentication
+     * @param provider - the provider
+     * @param principal - the principal
+     */
     protected static void updateAuthenticationToRememberBypass(final Authentication authentication, final MultifactorAuthenticationProvider provider,
                                                              final Principal principal) {
         LOGGER.debug("Bypass rules for service [{}] indicate the request may NOT be ignored", principal.getId());

--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/GroovyMultifactorAuthenticationProviderBypass.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/GroovyMultifactorAuthenticationProviderBypass.java
@@ -37,8 +37,15 @@ public class GroovyMultifactorAuthenticationProviderBypass extends DefaultMultif
             LOGGER.debug("Evaluating multifactor authentication bypass properties for principal [{}], "
                     + "service [{}] and provider [{}] via Groovy script [{}]",
                 principal.getId(), registeredService, provider, this.groovyScript);
-            return ScriptingUtils.executeGroovyScript(this.groovyScript,
+            final boolean isBypassed = ScriptingUtils.executeGroovyScript(this.groovyScript,
                 new Object[]{authentication, principal, registeredService, provider, LOGGER, request}, Boolean.class);
+            if (isBypassed) {
+                LOGGER.info("Groovy bypass script determined [{}] would be passed for [{}]", principal.getId(), provider.getId());
+                updateAuthenticationToRememberBypass(authentication, provider, principal);
+            } else {
+                updateAuthenticationToForgetBypass(authentication, provider, principal);
+            }
+            return isBypassed;
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
         }

--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/GroovyMultifactorAuthenticationProviderBypass.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/GroovyMultifactorAuthenticationProviderBypass.java
@@ -37,15 +37,15 @@ public class GroovyMultifactorAuthenticationProviderBypass extends DefaultMultif
             LOGGER.debug("Evaluating multifactor authentication bypass properties for principal [{}], "
                     + "service [{}] and provider [{}] via Groovy script [{}]",
                 principal.getId(), registeredService, provider, this.groovyScript);
-            final boolean isBypassed = ScriptingUtils.executeGroovyScript(this.groovyScript,
+            final boolean shouldExecute = ScriptingUtils.executeGroovyScript(this.groovyScript,
                 new Object[]{authentication, principal, registeredService, provider, LOGGER, request}, Boolean.class);
-            if (isBypassed) {
+            if (shouldExecute) {
+                updateAuthenticationToForgetBypass(authentication, provider, principal);
+            } else {
                 LOGGER.info("Groovy bypass script determined [{}] would be passed for [{}]", principal.getId(), provider.getId());
                 updateAuthenticationToRememberBypass(authentication, provider, principal);
-            } else {
-                updateAuthenticationToForgetBypass(authentication, provider, principal);
             }
-            return isBypassed;
+            return shouldExecute;
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
         }

--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/RestMultifactorAuthenticationProviderBypass.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/RestMultifactorAuthenticationProviderBypass.java
@@ -47,14 +47,14 @@ public class RestMultifactorAuthenticationProviderBypass extends DefaultMultifac
 
             final HttpResponse response = HttpUtils.execute(rest.getUrl(), rest.getMethod(),
                 rest.getBasicAuthUsername(), rest.getBasicAuthPassword(), parameters, new HashMap<>());
-            final boolean isBypassed = response.getStatusLine().getStatusCode() == HttpStatus.ACCEPTED.value();
-            if (isBypassed) {
+            final boolean shouldExecute = response.getStatusLine().getStatusCode() == HttpStatus.ACCEPTED.value();
+            if (shouldExecute) {
+                updateAuthenticationToForgetBypass(authentication, provider, principal);
+            } else {
                 LOGGER.info("REST bypass endpoint response determined [{}] would be passed for [{}]", principal.getId(), provider.getId());
                 updateAuthenticationToRememberBypass(authentication, provider, principal);
-            } else {
-                updateAuthenticationToForgetBypass(authentication, provider, principal);
             }
-            return isBypassed;
+            return shouldExecute;
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
         }

--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/RestMultifactorAuthenticationProviderBypass.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/RestMultifactorAuthenticationProviderBypass.java
@@ -47,7 +47,14 @@ public class RestMultifactorAuthenticationProviderBypass extends DefaultMultifac
 
             final HttpResponse response = HttpUtils.execute(rest.getUrl(), rest.getMethod(),
                 rest.getBasicAuthUsername(), rest.getBasicAuthPassword(), parameters, new HashMap<>());
-            return response.getStatusLine().getStatusCode() == HttpStatus.ACCEPTED.value();
+            final boolean isBypassed = response.getStatusLine().getStatusCode() == HttpStatus.ACCEPTED.value();
+            if (isBypassed) {
+                LOGGER.info("REST bypass endpoint response determined [{}] would be passed for [{}]", principal.getId(), provider.getId());
+                updateAuthenticationToRememberBypass(authentication, provider, principal);
+            } else {
+                updateAuthenticationToForgetBypass(authentication, provider, principal);
+            }
+            return isBypassed;
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
         }


### PR DESCRIPTION
PR fixes the issue if a custom GROOVY or REST bypass provider is configured, the authentication context is never updated to remember or forget the bypass in the authentication.  The PR addresses this by evaluating the response from the custom provider and then setting the authentication context based on the result before returning. 
