### PR TITLE
Fix mfa initialize

### DIFF
--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasMultifactorWebflowConfigurer.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasMultifactorWebflowConfigurer.java
@@ -10,15 +10,12 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.webflow.definition.FlowDefinition;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
-import org.springframework.webflow.engine.ActionState;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.SubflowAttributeMapper;
 import org.springframework.webflow.engine.SubflowState;
-import org.springframework.webflow.engine.Transition;
 import org.springframework.webflow.engine.TransitionSet;
 import org.springframework.webflow.engine.TransitionableState;
 import org.springframework.webflow.engine.builder.support.FlowBuilderServices;
-import org.springframework.webflow.engine.support.DefaultTargetStateResolver;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,8 +31,6 @@ import java.util.List;
  */
 @Slf4j
 public abstract class AbstractCasMultifactorWebflowConfigurer extends AbstractCasWebflowConfigurer {
-
-    private static final String MFA_INITIALIZE_BEAN_ID = "mfaInitializeAction";
 
     public AbstractCasMultifactorWebflowConfigurer(final FlowBuilderServices flowBuilderServices,
                                                    final FlowDefinitionRegistry loginFlowDefinitionRegistry,
@@ -103,16 +98,6 @@ public abstract class AbstractCasMultifactorWebflowConfigurer extends AbstractCa
      */
     protected void registerMultifactorProviderAuthenticationWebflow(final Flow flow, final String subflowId, final FlowDefinitionRegistry mfaProviderFlowRegistry) {
         final Flow mfaFlow = (Flow) mfaProviderFlowRegistry.getFlowDefinition(subflowId);
-
-        // Set the mfaInitialize action
-        final ActionState initLoginState = getState(mfaFlow, CasWebflowConstants.STATE_ID_INIT_LOGIN_FORM, ActionState.class);
-        final Transition transition = (Transition) initLoginState.getTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS);
-        final String targetStateId = transition.getTargetStateId();
-        transition.setTargetStateResolver(new DefaultTargetStateResolver(CasWebflowConstants.STATE_ID_MFA_INITIALIZE));
-        final ActionState initializeAction = createActionState(mfaFlow,
-                CasWebflowConstants.STATE_ID_MFA_INITIALIZE,
-                createEvaluateAction(MFA_INITIALIZE_BEAN_ID));
-        createTransitionForState(initializeAction, CasWebflowConstants.TRANSITION_ID_SUCCESS, targetStateId);
 
         LOGGER.debug("Adding end state [{}] with transition to [{}] to flow 'login' for MFA", CasWebflowConstants.STATE_ID_MFA_UNAVAILABLE, CasWebflowConstants.VIEW_ID_MFA_UNAVAILABLE);
         createEndState(flow, CasWebflowConstants.STATE_ID_MFA_UNAVAILABLE, CasWebflowConstants.VIEW_ID_MFA_UNAVAILABLE);

--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/login/mfa/MfaInitializeAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/login/mfa/MfaInitializeAction.java
@@ -22,16 +22,20 @@ public class MfaInitializeAction extends AbstractAction {
     protected Event doExecute(final RequestContext context) throws Exception {
         final ApplicationContext applicationContext = ApplicationContextProvider.getApplicationContext();
         final String activeFlow = context.getActiveFlow().getId();
+
+        // Find the provider that matches the flow id
         final Optional<MultifactorAuthenticationProvider> provider =
                 applicationContext
                         .getBeansOfType(MultifactorAuthenticationProvider.class)
-                        .entrySet().stream().filter(e -> e.getKey().startsWith(activeFlow))
+                        .entrySet().stream().filter(e -> e.getValue().getId().equals(activeFlow))
                         .map(e -> e.getValue())
                         .findFirst();
+
         if (provider.isPresent()) {
-            context.getFlowScope().put("provider", provider);
+            context.getFlowScope().put("provider", provider.get());
             return success();
         }
+
         return error();
     }
 

--- a/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/DetermineDuoUserAccountAction.java
+++ b/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/DetermineDuoUserAccountAction.java
@@ -6,11 +6,15 @@ import org.apereo.cas.adaptors.duo.DuoUserAccount;
 import org.apereo.cas.adaptors.duo.authn.DuoMultifactorAuthenticationProvider;
 import org.apereo.cas.adaptors.duo.authn.DuoSecurityAuthenticationService;
 import org.apereo.cas.authentication.Authentication;
+import org.apereo.cas.authentication.MultifactorAuthenticationUtils;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceMultifactorPolicy;
+import org.apereo.cas.util.CollectionUtils;
+import org.apereo.cas.util.spring.ApplicationContextProvider;
 import org.apereo.cas.web.flow.CasWebflowConstants;
 import org.apereo.cas.web.support.WebUtils;
+import org.springframework.context.ApplicationContext;
 import org.springframework.util.StringUtils;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.action.EventFactorySupport;
@@ -35,8 +39,11 @@ public class DetermineDuoUserAccountAction extends AbstractAction {
         final Authentication authentication = WebUtils.getAuthentication(requestContext);
         final Principal p = authentication.getPrincipal();
         final RegisteredService service = WebUtils.getRegisteredService(requestContext);
-        final DuoMultifactorAuthenticationProvider provider = requestContext.getFlowScope().get("provider",
-                DuoMultifactorAuthenticationProvider.class);
+        final String flowId = requestContext.getActiveFlow().getId();
+        final ApplicationContext applicationContext = ApplicationContextProvider.getApplicationContext();
+        final DuoMultifactorAuthenticationProvider provider = (DuoMultifactorAuthenticationProvider)
+                MultifactorAuthenticationUtils.getMultifactorAuthenticationProvidersByIds(CollectionUtils.wrap(flowId),
+                        applicationContext).iterator().next();
 
         final Event enrollEvent = new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_ENROLL);
         final Event denyEvent = new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_DENY);

--- a/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/PrepareDuoWebLoginFormAction.java
+++ b/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/PrepareDuoWebLoginFormAction.java
@@ -5,9 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.adaptors.duo.authn.DuoCredential;
 import org.apereo.cas.adaptors.duo.authn.DuoMultifactorAuthenticationProvider;
 import org.apereo.cas.adaptors.duo.authn.DuoSecurityAuthenticationService;
+import org.apereo.cas.authentication.MultifactorAuthenticationUtils;
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.util.CollectionUtils;
+import org.apereo.cas.util.spring.ApplicationContextProvider;
 import org.apereo.cas.web.flow.CasWebflowConstants;
 import org.apereo.cas.web.support.WebUtils;
+import org.springframework.context.ApplicationContext;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.execution.Event;
@@ -26,8 +30,11 @@ public class PrepareDuoWebLoginFormAction extends AbstractAction {
     @Override
     protected Event doExecute(final RequestContext requestContext) {
         final Principal p = WebUtils.getAuthentication(requestContext).getPrincipal();
-        final DuoMultifactorAuthenticationProvider duoProvider =
-                 requestContext.getFlowScope().get("provider", DuoMultifactorAuthenticationProvider.class);
+        final ApplicationContext applicationContext = ApplicationContextProvider.getApplicationContext();
+        final String flowId = requestContext.getActiveFlow().getId();
+        final DuoMultifactorAuthenticationProvider duoProvider = (DuoMultifactorAuthenticationProvider)
+                MultifactorAuthenticationUtils.getMultifactorAuthenticationProvidersByIds(CollectionUtils.wrap(flowId),
+                        applicationContext).iterator().next();
 
         final DuoCredential c = requestContext.getFlowScope().get(CasWebflowConstants.VAR_ID_CREDENTIAL, DuoCredential.class);
         c.setUsername(p.getId());


### PR DESCRIPTION
PR fixes the provider not find error by comparing the provider id to the flow id instead of the registered bean id in the application context.