### PR TITLE
Fix logo header overlap in IE 11

### DIFF
--- a/webapp/resources/static/sass/cas.scss
+++ b/webapp/resources/static/sass/cas.scss
@@ -31,6 +31,7 @@ a {
   color: $link-color;
 }
 .logo {
+  height: 40px;
   width: 80px;
   display: block;
 }


### PR DESCRIPTION
Added height property to logo class so that header containing CAS logo displays properly in IE 11 (in particular it was overlapping other sections on the login page).