### PR TITLE
Fixing broken page links in the documentation

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Management.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Management.md
@@ -39,7 +39,7 @@ are considered in the following order:
 
 <div class="alert alert-info"><strong>Managing Configuration</strong><p>In order to manage
 the CAS configuration, you should configure access
-to <a href="Monitoring-Statistics.html">CAS administration panels.</a></p></div>
+to <a href="../installation/Monitoring-Statistics.html">CAS administration panels.</a></p></div>
 
 ## Configuration Server
 
@@ -49,11 +49,11 @@ place to manage external properties for CAS nodes across all environments. To le
 
 ## Extending CAS Configuration
 
-To learn more about how to extend and customize the CAS configuration, please [review this guide](../configuration/Configuration-Management-Extensions.html).
+To learn more about how to extend and customize the CAS configuration, please [review this guide](Configuration-Management-Extensions.html).
 
 ## Auto Configuration Strategy
 
-To see a complete list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#configuration-storage).
+To see a complete list of CAS properties, please [review this guide](Configuration-Properties.html#configuration-storage).
 
 Note that CAS in most if not all cases will attempt to auto-configure the context based on the declaration
 and presence of feature-specific dedicated modules. This generally SHOULD relieve the deployer

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -379,7 +379,7 @@ The following crypto options apply equally to relevant CAS components (ticket re
 
 ### RSA Keys
 
-Certain features such as the ability to produce [JWTs as CAS tickets](Configure-ServiceTicket-JWT.html) may allow you to use the `RSA` algorithm with public/private keypairs for signing and encryption. This behavior may prove useful generally in cases where the consumer of the CAS-encoded payload is an outsider and a client application that need not have access to the signing secrets directly and visibly and may only be given a half truth vis-a-vis a public key to verify the payload authenticity and decode it. This particular option makes little sense in situations where CAS itself is both a producer and a consumer of the payload.
+Certain features such as the ability to produce [JWTs as CAS tickets](../installation/Configure-ServiceTicket-JWT.html) may allow you to use the `RSA` algorithm with public/private keypairs for signing and encryption. This behavior may prove useful generally in cases where the consumer of the CAS-encoded payload is an outsider and a client application that need not have access to the signing secrets directly and visibly and may only be given a half truth vis-a-vis a public key to verify the payload authenticity and decode it. This particular option makes little sense in situations where CAS itself is both a producer and a consumer of the payload.
 
 <div class="alert alert-info"><strong>Remember</strong><p>Signing and encryption options are not mutually exclusive. While it would be rather nonsensical, it is entirely possible for CAS to use <code>AES</code> keys for signing and <code>RSA</code> keys for encryption, or vice versa.</p></div>
 
@@ -940,7 +940,7 @@ The parameters passed are as follows:
 
 ## Email Notifications
 
-To learn more about this topic, [please review this guide](SMS-Email-Configuration.html).
+To learn more about this topic, [please review this guide](../installation/SMS-Email-Configuration.html).
 
 The following options are shared and apply when CAS is configured to send email notifications, given the provider's *configuration key*:
 
@@ -976,7 +976,7 @@ The following options are shared and apply when CAS is configured to send SMS no
 ```
 
 You will also need to ensure a provider is defined that is able to send SMS messages. To learn more about this 
-topic, [please review this guide](SMS-Messaging-Configuration.html).
+topic, [please review this guide](../installation/SMS-Messaging-Configuration.html).
  
 ## Delegated Authentication Settings
 

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -93,7 +93,7 @@ The above configuration also applies to online git-based repositories such as Gi
 
 ### Consul
 
-Allow the CAS Spring Cloud configuration server to load settings from [HashiCorp's Consul](Service-Discovery-Guide-Consul.html).
+Allow the CAS Spring Cloud configuration server to load settings from [HashiCorp's Consul](../installation/Service-Discovery-Guide-Consul.html).
 
 ```properties
 # spring.cloud.consul.config.enabled=true
@@ -477,7 +477,7 @@ This check is off by default and may be enabled with a system property of `-DCAS
 The following properties describe access controls and settings for the `/actuator`
 endpoint of CAS which provides administrative functionality and oversight into the CAS software.
 
-To learn more about this topic, [please review this guide](Monitoring-Statistics.html).
+To learn more about this topic, [please review this guide](../installation/Monitoring-Statistics.html).
 
 ```properties
 # management.endpoints.enabled-by-default=true
@@ -559,7 +559,7 @@ To determine whether an endpoint is available, the calculation order for all end
 2. If undefined, the global setting noted above is consulted from CAS settings.
 3. If undefined, the default built-in setting for the endpoint in CAS is consulted, which is typically `false` by default.
 
-All available endpoint ids [should be listed here](Monitoring-Statistics.html).
+All available endpoint ids [should be listed here](../installation/Monitoring-Statistics.html).
 
 Endpoints may also be mapped to custom arbitrary endpoints. For example, to remap the `health` endpoint to `healthcheck`, 
 specify the following settings:
@@ -582,7 +582,7 @@ The `health` endpoint may also be configured to show details using `management.e
 
 ### Spring Boot Admin Server
 
-To learn more about this topic, [please review this guide](Configuring-Monitoring-Administration.html).
+To learn more about this topic, [please review this guide](../installation/Configuring-Monitoring-Administration.html).
 
 ```properties
 # spring.boot.admin.url=https://bootadmin.example.org:8444
@@ -607,7 +607,7 @@ as it's treated by the underlying servlet container engine.
 
 Control how CAS should treat views and other UI elements.
 
-To learn more about this topic, [please review this guide](User-Interface-Customization-Views.html).
+To learn more about this topic, [please review this guide](../ux/User-Interface-Customization-Views.html).
 
 ```properties
 # spring.thymeleaf.encoding=UTF-8
@@ -658,7 +658,7 @@ available [here](Configuration-Properties-Common.html#restful-integrations) unde
 ## Logging
 
 Control the location and other settings of the CAS logging configuration.
-To learn more about this topic, [please review this guide](Logging.html).
+To learn more about this topic, [please review this guide](../installation/Logging.html).
 
 ```properties
 # logging.config=file:/etc/cas/log4j2.xml
@@ -680,7 +680,7 @@ To disable log sanitization, start the container with the system property `CAS_T
 ## Authentication Attributes
 
 Set of authentication attributes that are retrieved by the principal resolution process,
-typically via some component of [Person Directory](..\integration\Attribute-Resolution.html)
+typically via some component of [Person Directory](../integration/Attribute-Resolution.html)
 from a number of attribute sources unless noted otherwise by the specific authentication scheme.
 
 If multiple attribute repository sources are defined, they are added into a list
@@ -698,7 +698,7 @@ CAS authentication is able to retrieve and resolve attributes from the authentic
 eliminate the need for configuring a separate attribute repository specially if both the authentication and the attribute source are the same.
 Using separate repositories should be required when sources are different, or when there is a need to tackle more advanced attribute
 resolution use cases such as cascading, merging, etc.
-<a href="Configuring-Principal-Resolution.html">See this guide</a> for more info.</p></div>
+<a href="../installation/Configuring-Principal-Resolution.html">See this guide</a> for more info.</p></div>
 
 Attributes for all sources are defined in their own individual block.
 CAS does not care about the source owner of attributes. It finds them where they can be found and otherwise, it moves on.
@@ -908,7 +908,7 @@ Retrieve attributes from a JDBC source. Database settings for this feature are a
 
 ### Grouper
 
-This option reads all the groups from [a Grouper instance](www.internet2.edu/grouper/software.html) for the given CAS principal and adopts them
+This option reads all the groups from [a Grouper instance](http://www.internet2.edu/grouper/software.html) for the given CAS principal and adopts them
 as CAS attributes under a `grouperGroups` multi-valued attribute.
 To learn more about this topic, [please review this guide](../integration/Attribute-Resolution.html).
 
@@ -927,7 +927,7 @@ with the following configured properties:
 
 ### Couchbase
 
-This option will fetch attributes from a Couchbase database for a given CAS principal. To learn more about this topic, [please review this guide](Couchbase-Authentication.html). Database settings for this feature are available [here](Configuration-Properties-Common.html#couchbase-integration-settings) under the configuration key `cas.authn.attributeRepository.couchbase`.
+This option will fetch attributes from a Couchbase database for a given CAS principal. To learn more about this topic, [please review this guide](../installation/Couchbase-Authentication.html). Database settings for this feature are available [here](Configuration-Properties-Common.html#couchbase-integration-settings) under the configuration key `cas.authn.attributeRepository.couchbase`.
 
 ```properties
 # cas.authn.attributeRepository.couchbase.usernameAttribute=username
@@ -974,7 +974,7 @@ In the event that a separate resolver is put into place, control how the final p
 
 ## Authentication Policy
 
-To learn more about this topic, [please review this guide](Configuring-Authentication-Components.html#authentication-policy).
+To learn more about this topic, [please review this guide](../installation/Configuring-Authentication-Components.html#authentication-policy).
 
 Global authentication policy that is applied when
 CAS attempts to vend and validate tickets.
@@ -1081,7 +1081,7 @@ to examine account status and policy.
 ## Authentication Throttling
 
 CAS provides a facility for limiting failed login attempts to support password guessing and related abuse scenarios.
-To learn more about this topic, [please review this guide](Configuring-Authentication-Throttling.html).
+To learn more about this topic, [please review this guide](../installation/Configuring-Authentication-Throttling.html).
 
 
 ```properties
@@ -1108,7 +1108,7 @@ same IP address. Database settings for this feature are available [here](Configu
 ## Adaptive Authentication
 
 Control how CAS authentication should adapt itself to incoming client requests.
-To learn more about this topic, [please review this guide](Configuring-Adaptive-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/Configuring-Adaptive-Authentication.html).
 
 ```properties
 # cas.authn.adaptive.rejectCountries=United.+
@@ -1153,7 +1153,7 @@ under the configuration key `cas.authn.adaptive.ipIntel.rest`.
 ## Surrogate Authentication
 
 Authenticate on behalf of another user.
-To learn more about this topic, [please review this guide](Surrogate-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Surrogate-Authentication.html).
 
 ```properties
 # cas.authn.surrogate.separator=+
@@ -1208,7 +1208,7 @@ available [here](Configuration-Properties-Common.html#sms-notifications) under t
 
 ## Risk-based Authentication
 
-Evaluate suspicious authentication requests and take action. To learn more about this topic, [please review this guide](Configuring-RiskBased-Authentication.html).
+Evaluate suspicious authentication requests and take action. To learn more about this topic, [please review this guide](../installation/Configuring-RiskBased-Authentication.html).
 
 ```properties
 # cas.authn.adaptive.risk.threshold=0.6
@@ -1235,7 +1235,7 @@ available [here](Configuration-Properties-Common.html#sms-notifications) under t
 
 ## Passwordless Authentication
 
-To learn more about this topic, [please review this guide](Passwordless-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Passwordless-Authentication.html).
 
 ### Account Stores
 
@@ -1269,7 +1269,7 @@ Email notifications settings are available [here](Configuration-Properties-Commo
 
 ## SMS Messaging
 
-To learn more about this topic, [please review this guide](SMS-Messaging-Configuration.html).
+To learn more about this topic, [please review this guide](../installation/SMS-Messaging-Configuration.html).
 
 ### Twilio
 
@@ -1323,7 +1323,7 @@ under the configuration key `cas.smsProvider.sns`.
 
 ## GeoTracking
 
-To learn more about this topic, [please review this guide](GeoTracking-Authentication-Requests.html).
+To learn more about this topic, [please review this guide](../installation/GeoTracking-Authentication-Requests.html).
 
 ### GoogleMaps GeoTracking
 
@@ -1348,7 +1348,7 @@ Used to geo-profile authentication events.
 
 ## Cassandra Authentication
 
-To learn more about this topic, [please review this guide](Cassandra-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Cassandra-Authentication.html).
 
 ```properties
 # cas.authn.cassandra.usernameAttribute=
@@ -1378,7 +1378,7 @@ cas.authn.cassandra.readTimeoutMillis=5000
 
 ## Digest Authentication
 
-To learn more about this topic, [please review this guide](Digest-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Digest-Authentication.html).
 
 ```properties
 # cas.authn.digest.users.casuser=3530292c24102bac7ced2022e5f1036a
@@ -1390,7 +1390,7 @@ To learn more about this topic, [please review this guide](Digest-Authentication
 
 ## Radius Authentication
 
-To learn more about this topic, [please review this guide](RADIUS-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/RADIUS-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.radius`.
 
@@ -1404,7 +1404,7 @@ Radius  settings for this feature are available [here](Configuration-Properties-
 
 ## File (Whitelist) Authentication
 
-To learn more about this topic, [please review this guide](Whitelist-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Whitelist-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.file`.
 
@@ -1418,7 +1418,7 @@ Password encoding  settings for this feature are available [here](Configuration-
 
 ## JSON (Whitelist) Authentication
 
-To learn more about this topic, [please review this guide](Whitelist-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Whitelist-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.json`.
 
@@ -1433,7 +1433,7 @@ Password policy settings for this feature are available [here](Configuration-Pro
 
 ## Reject Users (Blacklist) Authentication
 
-To learn more about this topic, [please review this guide](Blacklist-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Blacklist-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.reject`.
 
@@ -1446,7 +1446,7 @@ Password encoding  settings for this feature are available [here](Configuration-
 
 ## Database Authentication
 
-To learn more about this topic, [please review this guide](Database-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Database-Authentication.html).
 
 ### Query Database Authentication
 
@@ -1540,7 +1540,7 @@ Password encoding  settings for this feature are available [here](Configuration-
 
 ## MongoDb Authentication
 
-To learn more about this topic, [please review this guide](MongoDb-Authentication.html). 
+To learn more about this topic, [please review this guide](../installation/MongoDb-Authentication.html). 
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.mongo`. 
 Password encoding  settings for this feature are available [here](Configuration-Properties-Common.html#password-encoding) under the configuration key `cas.authn.mongo`.
@@ -1568,7 +1568,7 @@ server, simply increment the index and specify the settings for the next LDAP se
 retrieved from [other attribute repository sources](#authentication-attributes), if any.
 Attributes retrieved directly as part of LDAP authentication trump all other attributes.
 
-To learn more about this topic, [please review this guide](LDAP-Authentication.html). 
+To learn more about this topic, [please review this guide](../installation/LDAP-Authentication.html). 
 LDAP settings for this feature are available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.authn.ldap[0]`.
 
 ```properties
@@ -1600,7 +1600,7 @@ Password encoding  settings for this feature are available [here](Configuration-
 ## REST Authentication
 
 This allows the CAS server to reach to a remote REST endpoint via a `POST`.
-To learn more about this topic, [please review this guide](Rest-Authentication.html). Password encoding  settings for this feature are available [here](Configuration-Properties-Common.html#password-encoding) under the configuration key `cas.authn.rest`.
+To learn more about this topic, [please review this guide](../installation/Rest-Authentication.html). Password encoding  settings for this feature are available [here](Configuration-Properties-Common.html#password-encoding) under the configuration key `cas.authn.rest`.
 
 ```properties
 # cas.authn.rest.uri=https://...
@@ -1632,7 +1632,7 @@ are available [here](Configuration-Properties-Common.html#person-directory-princ
 
 ## SPNEGO Authentication
 
-To learn more about this topic, [please review this guide](SPNEGO-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/SPNEGO-Authentication.html).
 
 Principal resolution and Person Directory settings for this feature are available [here](Configuration-Properties-Common.html#person-directory-principal-resolution) under the configuration key `cas.authn.spnego.principal`.
 
@@ -1705,7 +1705,7 @@ LDAP settings for this feature are available [here](Configuration-Properties-Com
 
 ## JAAS Authentication
 
-To learn more about this topic, [please review this guide](JAAS-Authentication.html). Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.jaas[0]`. Password encoding  settings for this feature are available [here](Configuration-Properties-Common.html#password-encoding) under the configuration key `cas.authn.jaas[0]`.
+To learn more about this topic, [please review this guide](../installation/JAAS-Authentication.html). Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.jaas[0]`. Password encoding  settings for this feature are available [here](Configuration-Properties-Common.html#password-encoding) under the configuration key `cas.authn.jaas[0]`.
 
 ```properties
 # cas.authn.jaas[0].realm=CAS
@@ -1728,7 +1728,7 @@ under the configuration key `cas.authn.jaas[0].passwordPolicy`.
 
 ## GUA Authentication
 
-To learn more about this topic, [please review this guide](GUA-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/GUA-Authentication.html).
 
 ### LDAP Repository
 
@@ -1746,7 +1746,7 @@ LDAP settings for this feature are available [here](Configuration-Properties-Com
 
 ## JWT/Token Authentication
 
-To learn more about this topic, [please review this guide](JWT-Authentication.html). Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.token`.
+To learn more about this topic, [please review this guide](../installation/JWT-Authentication.html). Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.token`.
 
 ```properties
 # cas.authn.token.name=
@@ -1754,7 +1754,7 @@ To learn more about this topic, [please review this guide](JWT-Authentication.ht
 
 ### JWT Tickets
 
-Allow CAS tickets through various protocol channels to be created as JWTs. See [this guide](Configure-ServiceTicket-JWT.html) 
+Allow CAS tickets through various protocol channels to be created as JWTs. See [this guide](../installation/Configure-ServiceTicket-JWT.html) 
 or [this guide](../protocol/REST-Protocol.html) for more info.
 
 ```properties
@@ -1766,7 +1766,7 @@ The signing key and the encryption key [are both JWKs](Configuration-Properties-
 
 ## Couchbase Authentication
 
-To learn more about this topic, [please review this guide](Couchbase-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Couchbase-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.couchbase`.
 
@@ -1784,7 +1784,7 @@ Database settings for this feature are available [here](Configuration-Properties
 
 ## Amazon Cloud Directory Authentication
 
-To learn more about this topic, [please review this guide](AWS-CloudDirectory-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/AWS-CloudDirectory-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.cloudDirectory`.
 Password encoding  settings for this feature are available [here](Configuration-Properties-Common.html#password-encoding) under the configuration key `cas.authn.cloudDirectory`.
@@ -1807,7 +1807,7 @@ under the configuration key `cas.authn.cloudDirectory`.
 
 ## Remote Address Authentication
 
-To learn more about this topic, [please review this guide](Remote-Address-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Remote-Address-Authentication.html).
 
 ```properties
 # cas.authn.remoteAddress.ipAddressRange=
@@ -1834,7 +1834,7 @@ Password encoding settings for this feature are available [here](Configuration-P
 
 ## X509 Authentication
 
-To learn more about this topic, [please review this guide](X509-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/X509-Authentication.html).
 
 ### Principal Resolution
 
@@ -1953,7 +1953,7 @@ LDAP settings for this feature are available [here](Configuration-Properties-Com
 
 ## Syncope Authentication
 
-To learn more about this topic, [please review this guide](Syncope-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Syncope-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.syncope`.
 
@@ -1967,7 +1967,7 @@ Password encoding  settings for this feature are available [here](Configuration-
 
 ## Shiro Authentication
 
-To learn more about this topic, [please review this guide](Shiro-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Shiro-Authentication.html).
 
 Principal transformation settings for this feature are available [here](Configuration-Properties-Common.html#authentication-principal-transformation) under the configuration key `cas.authn.shiro`.
 
@@ -1982,7 +1982,7 @@ Password encoding  settings for this feature are available [here](Configuration-
 
 ## Trusted Authentication
 
-To learn more about this topic, [please review this guide](Trusted-Authentication.html). Principal resolution and Person Directory settings for this feature are available [here](Configuration-Properties-Common.html#person-directory-principal-resolution) under the configuration key `cas.authn.trusted`.
+To learn more about this topic, [please review this guide](../installation/Trusted-Authentication.html). Principal resolution and Person Directory settings for this feature are available [here](Configuration-Properties-Common.html#person-directory-principal-resolution) under the configuration key `cas.authn.trusted`.
 
 ```properties
 # cas.authn.trusted.name=
@@ -2088,7 +2088,7 @@ To learn more about this topic, [please review this guide](Configuring-Multifact
 
 ### Multifactor Trusted Device/Browser
 
-To learn more about this topic, [please review this guide](Multifactor-TrustedDevice-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/Multifactor-TrustedDevice-Authentication.html).
 
 ```properties
 # cas.authn.mfa.trusted.authenticationContextAttribute=isFromTrustedMultifactorAuthentication
@@ -2153,7 +2153,7 @@ This section controls how that process should behave.
 
 ### Simple Multifactor Authentication
 
-To learn more about this topic, [please review this guide](Simple-Multifactor-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/Simple-Multifactor-Authentication.html).
 
 ```properties
 # cas.authn.mfa.simple.name=
@@ -2169,7 +2169,7 @@ under the configuration key `cas.authn.mfa.simple`.
 
 ### Google Authenticator
 
-To learn more about this topic, [please review this guide](GoogleAuthenticator-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/GoogleAuthenticator-Authentication.html).
 
 ```properties
 # cas.authn.mfa.gauth.issuer=
@@ -2222,7 +2222,7 @@ Database settings for this feature are available [here](Configuration-Properties
 
 ### YubiKey
 
-To learn more about this topic, [please review this guide](YubiKey-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/YubiKey-Authentication.html).
 
 ```properties
 # cas.authn.mfa.yubikey.clientId=
@@ -2266,7 +2266,7 @@ Database settings for this feature are available [here](Configuration-Properties
 
 ### Radius OTP
 
-To learn more about this topic, [please review this guide](RADIUS-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/RADIUS-Authentication.html).
 
 ```properties
 # cas.authn.mfa.radius.rank=0
@@ -2280,7 +2280,7 @@ Multifactor authentication bypass settings for this provider are available [here
 
 ### DuoSecurity
 
-To learn more about this topic, [please review this guide](DuoSecurity-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/DuoSecurity-Authentication.html).
 
 ```properties
 # cas.authn.mfa.duo[0].duoSecretKey=
@@ -2306,7 +2306,7 @@ Multifactor authentication bypass settings for this provider are available [here
 
 ### FIDO U2F
 
-To learn more about this topic, [please review this guide](FIDO-U2F-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/FIDO-U2F-Authentication.html).
 
 ```properties
 # cas.authn.mfa.u2f.rank=0
@@ -2358,7 +2358,7 @@ RESTful settings for this feature are available [here](Configuration-Properties-
 
 ### Swivel Secure
 
-To learn more about this topic, [please review this guide](SwivelSecure-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/SwivelSecure-Authentication.html).
 
 ```properties
 # cas.authn.mfa.swivel.swivelTuringImageUrl=https://turing.example.edu/TURingImage
@@ -2374,7 +2374,7 @@ Multifactor authentication bypass settings for this provider are available [here
 
 ### Authy
 
-To learn more about this topic, [please review this guide](AuthyAuthenticator-Authentication.html).
+To learn more about this topic, [please review this guide](../mfa/AuthyAuthenticator-Authentication.html).
 
 ```properties
 # cas.authn.mfa.authy.apiKey=
@@ -2406,7 +2406,7 @@ Control core SAML functionality within CAS.
 
 Allow CAS to become a SAML2 identity provider.
 
-To learn more about this topic, [please review this guide](Configuring-SAML2-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/Configuring-SAML2-Authentication.html).
 
 ```properties
 # cas.authn.samlIdp.entityId=https://cas.example.org/idp
@@ -2583,7 +2583,7 @@ Configuration settings for all SAML2 service providers are [available here](Conf
 
 ## OpenID Connect
 
-Allow CAS to become an OpenID Connect provider (OP). To learn more about this topic, [please review this guide](OIDC-Authentication.html).
+Allow CAS to become an OpenID Connect provider (OP). To learn more about this topic, [please review this guide](../installation/OIDC-Authentication.html).
 
 ```properties
 # cas.authn.oidc.issuer=http://localhost:8080/cas/oidc
@@ -2788,7 +2788,7 @@ Delegate authentication to Twitter.  Common settings for this identity provider 
 Allow CAS to act as an identity provider and security token service
 to support the WS-Federation protocol.
 
-To learn more about this topic, [please review this guide](WS-Federation-Protocol.html)
+To learn more about this topic, [please review this guide](../protocol/WS-Federation-Protocol.html)
 
 ```properties
 # cas.authn.wsfedIdp.idp.realm=urn:org:apereo:cas:ws:idp:realm-CAS
@@ -2817,7 +2817,7 @@ The signing and encryption keys [are both JWKs](Configuration-Properties-Common.
 
 Allows CAS to act as an OAuth2 provider. Here you can control how long various tokens issued by CAS should last, etc.
 
-To learn more about this topic, [please review this guide](OAuth-OpenId-Authentication.html).
+To learn more about this topic, [please review this guide](../installation/OAuth-OpenId-Authentication.html).
 
 ```properties
 # cas.authn.oauth.refreshToken.timeToKillInSeconds=2592000
@@ -2856,7 +2856,7 @@ Database settings for this feature are available [here](Configuration-Properties
 
 ## Localization
 
-To learn more about this topic, [please review this guide](User-Interface-Customization-Localization.html).
+To learn more about this topic, [please review this guide](../ux/User-Interface-Customization-Localization.html).
 
 ```properties
 # cas.locale.paramName=locale
@@ -2906,7 +2906,7 @@ Signing & encryption settings for this feature are available [here](Configuratio
 
 ## Logout
 
-Control various settings related to CAS logout functionality. To learn more about this topic, [please review this guide](Logout-Single-Signout.html).
+Control various settings related to CAS logout functionality. To learn more about this topic, [please review this guide](../installation/Logout-Single-Signout.html).
 
 ```properties
 # cas.logout.followServiceRedirects=false
@@ -2918,7 +2918,7 @@ Control various settings related to CAS logout functionality. To learn more abou
 
 ## Single Logout
 
-To learn more about this topic, [please review this guide](Logout-Single-Signout.html).
+To learn more about this topic, [please review this guide](../installation/Logout-Single-Signout.html).
 
 ```properties
 # cas.slo.disabled=false
@@ -2942,7 +2942,7 @@ The signing and encryption keys [are both JWKs](Configuration-Properties-Common.
 
 ## Message Bundles
 
-To learn more about this topic, [please review this guide](User-Interface-Customization-Localization.html).
+To learn more about this topic, [please review this guide](../ux/User-Interface-Customization-Localization.html).
 The baseNames are message bundle base names representing files that either end in .properties or _xx.properties where xx is a country locale code. The commonNames are not actually message bundles but they are properties files that are merged together and contain keys that are only used if they are not found in the message bundles. Keys from the later files in the list will be preferred over keys from the earlier files.
 
 ```properties
@@ -2957,7 +2957,7 @@ The baseNames are message bundle base names representing files that either end i
 ## Audits
 
 Control how audit messages are formatted.
-To learn more about this topic, [please review this guide](Audits.html).
+To learn more about this topic, [please review this guide](../installation/Audits.html).
 
 ```properties
 # cas.audit.ignoreAuditFailures=false
@@ -3026,7 +3026,7 @@ available [here](Configuration-Properties-Common.html#restful-integrations) unde
 
 ## Sleuth Distributed Tracing
 
-To learn more about this topic, [please review this guide](Monitoring-Statistics.html#distributed-tracing).
+To learn more about this topic, [please review this guide](../installation/Monitoring-Statistics.html#distributed-tracing).
 
 ```properties
 # spring.sleuth.sampler.percentage = 0.5
@@ -3038,7 +3038,7 @@ To learn more about this topic, [please review this guide](Monitoring-Statistics
 
 ## Monitoring
 
-To learn more about this topic, [please review this guide](Monitoring-Statistics.html).
+To learn more about this topic, [please review this guide](../installation/Monitoring-Statistics.html).
 
 ### Ticket Granting Tickets
 
@@ -3110,7 +3110,7 @@ Decide how CAS should monitor the internal state of JVM memory available at runt
 
 ## Themes
 
-To learn more about this topic, [please review this guide](User-Interface-Customization-Themes.html).
+To learn more about this topic, [please review this guide](../ux/User-Interface-Customization-Themes.html).
 
 ```properties
 # cas.theme.paramName=theme
@@ -3120,7 +3120,7 @@ To learn more about this topic, [please review this guide](User-Interface-Custom
 ## Events
 
 Decide how CAS should track authentication events.
-To learn more about this topic, [please review this guide](Configuring-Authentication-Events.html).
+To learn more about this topic, [please review this guide](../installation/Configuring-Authentication-Events.html).
 
 
 ```properties
@@ -3218,7 +3218,7 @@ The default options are available for hostname verification:
 
 ## Service Registry
 
-See [this guide](Service-Management.html) to learn more.
+See [this guide](../installation/Service-Management.html) to learn more.
 
 ```properties
 # cas.serviceRegistry.watcherEnabled=true
@@ -3247,7 +3247,7 @@ to locate JSON service definitions, decide how those resources should be found.
 # cas.serviceRegistry.json.location=classpath:/services
 ```
 
-To learn more about this topic, [please review this guide](JSON-Service-Management.html).
+To learn more about this topic, [please review this guide](../installation/JSON-Service-Management.html).
 
 ### YAML Service Registry
 
@@ -3258,11 +3258,11 @@ to locate YAML service definitions, decide how those resources should be found.
 # cas.serviceRegistry.yaml.location=classpath:/services
 ```
 
-To learn more about this topic, [please review this guide](YAML-Service-Management.html).
+To learn more about this topic, [please review this guide](../installation/YAML-Service-Management.html).
 
 ### RESTful Service Registry
 
-To learn more about this topic, [please review this guide](REST-Service-Management.html).
+To learn more about this topic, [please review this guide](../installation/REST-Service-Management.html).
 
 ```properties
 # cas.serviceRegistry.rest.url=https://example.api.org
@@ -3272,15 +3272,15 @@ To learn more about this topic, [please review this guide](REST-Service-Manageme
 
 ### CouchDb Service Registry
 
-To learn more about this topic, [please review this guide](CouchDb-Service-Management.html). Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#couchdb-configuration) under the configuration key `cas.serviceRegistry`.
+To learn more about this topic, [please review this guide](../installation/CouchDb-Service-Management.html). Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#couchdb-configuration) under the configuration key `cas.serviceRegistry`.
 
 ### Redis Service Registry
 
-To learn more about this topic, [please review this guide](Redis-Service-Management.html). Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#redis-configuration) under the configuration key `cas.serviceRegistry`.
+To learn more about this topic, [please review this guide](../installation/Redis-Service-Management.html). Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#redis-configuration) under the configuration key `cas.serviceRegistry`.
 
 ### CosmosDb Service Registry
 
-To learn more about this topic, [please review this guide](CosmosDb-Service-Management.html).
+To learn more about this topic, [please review this guide](../installation/CosmosDb-Service-Management.html).
 
 ```properties
 # cas.serviceRegistry.cosmosDb.uri=
@@ -3294,7 +3294,7 @@ To learn more about this topic, [please review this guide](CosmosDb-Service-Mana
 
 ### DynamoDb Service Registry
 
-To learn more about this topic, [please review this guide](DynamoDb-Service-Management.html).
+To learn more about this topic, [please review this guide](../installation/DynamoDb-Service-Management.html).
 Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#dynamodb-configuration)
 under the configuration key `cas.serviceRegistry`.
 AWS settings for this feature are available [here](Configuration-Properties-Common.html#amazon-integration-settings) 
@@ -3306,13 +3306,13 @@ under the configuration key `cas.serviceRegistry.dynamoDb`.
 
 ### MongoDb Service Registry
 
-Store CAS service definitions inside a MongoDb instance. To learn more about this topic, [please review this guide](Mongo-Service-Management.html).
+Store CAS service definitions inside a MongoDb instance. To learn more about this topic, [please review this guide](../installation/Mongo-Service-Management.html).
  Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#mongodb-configuration) under the configuration key `cas.serviceRegistry`.
 
 ### LDAP Service Registry
 
 Control how CAS services should be found inside an LDAP instance.
-To learn more about this topic, [please review this guide](LDAP-Service-Management.html).  LDAP settings for this feature are available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.serviceRegistry.ldap`.
+To learn more about this topic, [please review this guide](../installation/LDAP-Service-Management.html).  LDAP settings for this feature are available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.serviceRegistry.ldap`.
 
 ```properties
 # cas.serviceRegistry.ldap.serviceDefinitionAttribute=description
@@ -3325,21 +3325,21 @@ To learn more about this topic, [please review this guide](LDAP-Service-Manageme
 ### Couchbase Service Registry
 
 Control how CAS services should be found inside a Couchbase instance.
-To learn more about this topic, [please review this guide](Couchbase-Service-Management.html). 
+To learn more about this topic, [please review this guide](../installation/Couchbase-Service-Management.html). 
 Database settings for this feature are available [here](Configuration-Properties-Common.html#couchbase-integration-settings) 
 under the configuration key `cas.serviceRegistry.couchbase`.
 
 ### Database Service Registry
 
 Control how CAS services should be found inside a database instance.
-To learn more about this topic, [please review this guide](JPA-Service-Management.html). 
+To learn more about this topic, [please review this guide](../installation/JPA-Service-Management.html). 
 Database settings for this feature are available [here](Configuration-Properties-Common.html#database-settings) 
 under the configuration key `cas.serviceRegistry.jpa`.
 
 ## Service Registry Replication
 
 Control how CAS services definition files should be replicated across a CAS cluster.
-To learn more about this topic, [please review this guide](Configuring-Service-Replication.html)
+To learn more about this topic, [please review this guide](../installation/Configuring-Service-Replication.html)
 
 Replication modes may be configured per the following options:
 
@@ -3356,7 +3356,7 @@ Replication modes may be configured per the following options:
 ## Service Registry Replication Hazelcast
 
 Control how CAS services definition files should be replicated across a CAS cluster backed by a distributed Hazelcast cache.
-To learn more about this topic, [please review this guide](Configuring-Service-Replication.html).
+To learn more about this topic, [please review this guide](../installation/Configuring-Service-Replication.html).
 
 Hazelcast settings for this feature are available [here](Configuration-Properties-Common.html#hazelcast-configuration) under the configuration key `cas.serviceRegistry.stream.hazelcast.config`.
 
@@ -3366,7 +3366,7 @@ Hazelcast settings for this feature are available [here](Configuration-Propertie
 
 ## Ticket Registry
 
-To learn more about this topic, [please review this guide](Configuring-Ticketing-Components.html).
+To learn more about this topic, [please review this guide](../installation/Configuring-Ticketing-Components.html).
 
 ### Signing & Encryption
 
@@ -3385,7 +3385,7 @@ This section controls how that process should behave.
 
 ### JPA Ticket Registry
 
-To learn more about this topic, [please review this guide](JPA-Ticket-Registry.html). Database settings for this feature are available [here](Configuration-Properties-Common.html#database-settings) under the configuration key `cas.ticket.registry.jpa`.
+To learn more about this topic, [please review this guide](../installation/JPA-Ticket-Registry.html). Database settings for this feature are available [here](Configuration-Properties-Common.html#database-settings) under the configuration key `cas.ticket.registry.jpa`.
 
 ```properties
 # cas.ticket.registry.jpa.ticketLockType=NONE
@@ -3396,13 +3396,13 @@ Signing & encryption settings for this registry are available [here](Configurati
 
 ### Couchbase Ticket Registry
 
-To learn more about this topic, [please review this guide](Couchbase-Ticket-Registry.html). Database settings for this feature are available [here](Configuration-Properties-Common.html#couchbase-integration-settings) under the configuration key `cas.ticket.registry.couchbase`.
+To learn more about this topic, [please review this guide](../installation/Couchbase-Ticket-Registry.html). Database settings for this feature are available [here](Configuration-Properties-Common.html#couchbase-integration-settings) under the configuration key `cas.ticket.registry.couchbase`.
 
 Signing & encryption settings for this registry are available [here](Configuration-Properties-Common.html#signing--encryption) under the configuration key `cas.ticket.registry.couchbase`.
 
 ### Hazelcast Ticket Registry
 
-To learn more about this topic, [please review this guide](Hazelcast-Ticket-Registry.html).
+To learn more about this topic, [please review this guide](../installation/Hazelcast-Ticket-Registry.html).
 
 Hazelcast settings for this feature are available [here](Configuration-Properties-Common.html#hazelcast-configuration) under the configuration key `cas.ticket.registry.hazelcast`.
 
@@ -3410,7 +3410,7 @@ Signing & encryption settings for this registry are available [here](Configurati
 
 ### Infinispan Ticket Registry
 
-To learn more about this topic, [please review this guide](Infinispan-Ticket-Registry.html).
+To learn more about this topic, [please review this guide](../installation/Infinispan-Ticket-Registry.html).
 
 ```properties
 # cas.ticket.registry.infinispan.cacheName=
@@ -3437,7 +3437,7 @@ Signing & encryption settings for this registry are available [here](Configurati
 
 ### JMS Ticket Registry
 
-To learn more about this topic, [please review this guide](Messaging-JMS-Ticket-Registry.html).
+To learn more about this topic, [please review this guide](../installation/Messaging-JMS-Ticket-Registry.html).
 
 Signing & encryption settings for this registry are available [here](Configuration-Properties-Common.html#signing--encryption) under the configuration key `cas.ticket.registry.jms`.
 
@@ -3471,7 +3471,7 @@ Signing & encryption settings for this registry are available [here](Configurati
 
 ### Ehcache Ticket Registry
 
-To learn more about this topic, [please review this guide](Ehcache-Ticket-Registry.html).
+To learn more about this topic, [please review this guide](../installation/Ehcache-Ticket-Registry.html).
 
 ```properties
 # cas.ticket.registry.ehcache.replicateUpdatesViaCopy=true
@@ -3502,7 +3502,7 @@ Signing & encryption settings for this registry are available [here](Configurati
 
 ### Ignite Ticket Registry
 
-To learn more about this topic, [please review this guide](Ignite-Ticket-Registry.html).
+To learn more about this topic, [please review this guide](../installation/Ignite-Ticket-Registry.html).
 
 ```properties
 # cas.ticket.registry.ignite.keyAlgorithm=
@@ -3534,13 +3534,13 @@ Signing & encryption settings for this registry are available [here](Configurati
 
 ### Memcached Ticket Registry
 
-To learn more about this topic, [please review this guide](Memcached-Ticket-Registry.html).Integration settings for this registry are available [here](Configuration-Properties-Common.html#memcached-integration-settings) under the configuration key `cas.ticket.registry.memcached`.
+To learn more about this topic, [please review this guide](../installation/Memcached-Ticket-Registry.html).Integration settings for this registry are available [here](Configuration-Properties-Common.html#memcached-integration-settings) under the configuration key `cas.ticket.registry.memcached`.
 
 Signing & encryption settings for this registry are available [here](Configuration-Properties-Common.html#signing--encryption) under the configuration key `cas.ticket.registry.memcached`.
 
 ### DynamoDb Ticket Registry
 
-To learn more about this topic, [please review this guide](DynamoDb-Ticket-Registry.html). 
+To learn more about this topic, [please review this guide](../installation/DynamoDb-Ticket-Registry.html). 
 
 Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#dynamodb-configuration) 
 under the configuration key `cas.ticket.registry`. 
@@ -3561,13 +3561,13 @@ under the configuration key `cas.ticket.registry.dynamoDb`.
 
 ### MongoDb Ticket Registry
 
-To learn more about this topic, [please review this guide](MongoDb-Ticket-Registry.html). 
+To learn more about this topic, [please review this guide](../installation/MongoDb-Ticket-Registry.html). 
 Signing & encryption settings for this registry are available [here](Configuration-Properties-Common.html#signing--encryption) 
 under the configuration key `cas.ticket.registry.mongo`.  Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#mongodb-configuration) under the configuration key `cas.ticket.registry`.
 
 ### Redis Ticket Registry
 
-To learn more about this topic, [please review this guide](Redis-Ticket-Registry.html). 
+To learn more about this topic, [please review this guide](../installation/Redis-Ticket-Registry.html). 
 Common configuration settings for this feature are available [here](Configuration-Properties-Common.html#redis-configuration) 
 under the configuration key `cas.ticket.registry`. Signing & encryption settings for this registry are 
 available [here](Configuration-Properties-Common.html#signing--encryption) under the configuration key `cas.ticket.registry.redis`.
@@ -3708,7 +3708,7 @@ To learn more about this topic, [please review this guide](../integration/Config
 Control how Spring Webflow's conversational session state should be managed by CAS,
 and all other webflow related settings.
 
-To learn more about this topic, [please review this guide](Webflow-Customization.html).
+To learn more about this topic, [please review this guide](../installation/Webflow-Customization.html).
 
 ```properties
 # cas.webflow.alwaysPauseRedirect=false
@@ -3730,7 +3730,7 @@ RESTful settings for this feature are available [here](Configuration-Properties-
 
 ### Spring Webflow Auto Configuration
 
-Options that control how the Spring Webflow context is dynamically altered and configured by CAS. To learn more about this topic, [please review this guide](Webflow-Customization-Extensions.html).
+Options that control how the Spring Webflow context is dynamically altered and configured by CAS. To learn more about this topic, [please review this guide](../installation/Webflow-Customization-Extensions.html).
 
 ```properties
 # cas.webflow.autoconfigure=true
@@ -3746,7 +3746,7 @@ Control the Spring Webflow context via a custom Groovy script.
 
 ### Spring Webflow Session Management
 
-To learn more about this topic, [see this guide](Webflow-Customization-Sessions.html).
+To learn more about this topic, [see this guide](../installation/Webflow-Customization-Sessions.html).
 
 ```properties
 # cas.webflow.session.lockTimeout=30
@@ -3805,7 +3805,7 @@ Signing & encryption settings for this feature are available [here](Configuratio
 
 Map custom authentication exceptions in the CAS webflow and link them to custom messages defined in message bundles.
 
-To learn more about this topic, [please review this guide](Webflow-Customization-Exceptions.html).
+To learn more about this topic, [please review this guide](../installation/Webflow-Customization-Exceptions.html).
 
 ```properties
 # cas.authn.exceptions.exceptions=value1,value2,...
@@ -3813,7 +3813,7 @@ To learn more about this topic, [please review this guide](Webflow-Customization
 
 ### Authentication Interrupt
 
-Interrupt the authentication flow to reach out to external services. To learn more about this topic, [please review this guide](Webflow-Customization-Interrupt.html).
+Interrupt the authentication flow to reach out to external services. To learn more about this topic, [please review this guide](../installation/Webflow-Customization-Interrupt.html).
 
 #### Authentication Interrupt JSON
 
@@ -3842,7 +3842,7 @@ RESTful settings for this feature are available [here](Configuration-Properties-
 ### Acceptable Usage Policy
 
 Decide how CAS should attempt to determine whether AUP is accepted.
-To learn more about this topic, [please review this guide](Webflow-Customization-AUP.html).
+To learn more about this topic, [please review this guide](../installation/Webflow-Customization-AUP.html).
 
 ```properties
 # cas.acceptableUsagePolicy.aupAttributeName=aupAccepted
@@ -3887,7 +3887,7 @@ To learn more about this topic, [please review this guide](../protocol/REST-Prot
 
 ## Metrics
 
-To learn more about this topic, [please review this guide](Monitoring-Statistics.html).
+To learn more about this topic, [please review this guide](../installation/Monitoring-Statistics.html).
 
 ### Atlas
 
@@ -4050,7 +4050,7 @@ To learn more about this topic, [please review this guide](../integration/Shibbo
 
 ## Eureka Service Discovery
 
-To learn more about this topic, [please review this guide](Service-Discovery-Guide-Eureka.html).
+To learn more about this topic, [please review this guide](../installation/Service-Discovery-Guide-Eureka.html).
 
 ```properties
 # eureka.client.serviceUrl.defaultZone=${EUREKA_SERVER_HOST:http://localhost:8761}/eureka/
@@ -4065,7 +4065,7 @@ To learn more about this topic, [please review this guide](Service-Discovery-Gui
 
 ## Consul Service Discovery
 
-To learn more about this topic, [please review this guide](Service-Discovery-Guide-Consul.html).
+To learn more about this topic, [please review this guide](../installation/Service-Discovery-Guide-Consul.html).
 
 ```properties
 # spring.cloud.consul.port=8500
@@ -4162,7 +4162,7 @@ Configure settings relevant to the Java CAS client configured to handle inbound 
 ## Password Management
 
 Allow the user to update their account password, etc in-place.
-To learn more about this topic, [please review this guide](Password-Policy-Enforcement.html).
+To learn more about this topic, [please review this guide](../installation/Password-Policy-Enforcement.html).
 
 ```properties
 # cas.authn.pm.enabled=true

--- a/docs/cas-server-documentation/configuration/Configuration-Server-Management.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Server-Management.md
@@ -229,7 +229,7 @@ Support is provided via the following dependency in the WAR overlay:
 ```
 
 Note that to access and review the collection of CAS properties,
-you will need to use [the CAS administrative interfaces](Monitoring-Statistics.html), or you may
+you will need to use [the CAS administrative interfaces](../installation/Monitoring-Statistics.html), or you may
 also use your own native tooling for MongoDB to configure and inject settings.
 
 MongoDb documents are required to be found in the collection `MongoDbProperty`, as the following document:
@@ -252,7 +252,7 @@ locate properties and settings. [Please review this guide](Configuration-Propert
 ##### HashiCorp Consul
 
 CAS is also able to use [Consul](https://www.consul.io/) to
-locate properties and settings. [Please review this guide](Service-Discovery-Guide-Consul.html).
+locate properties and settings. [Please review this guide](../installation/Service-Discovery-Guide-Consul.html).
 
 ##### Apache ZooKeeper
 

--- a/docs/cas-server-documentation/index.md
+++ b/docs/cas-server-documentation/index.md
@@ -51,7 +51,7 @@ The following demos are provided by the Apereo CAS project:
 | [CAS Boot Administration Server](installation/Configuring-Monitoring-Administration.html) | `heroku-bootadminserver` | [Link](https://casbootadminserver.herokuapp.com/) | ![](https://heroku-badge.herokuapp.com/?app=casbootadminserver)
 | [CAS Zipkin Server](installation/Monitoring-Statistics.html#distributed-tracing)          | `heroku-zipkinserver`    | [Link](https://caszipkinserver.herokuapp.com/) | ![](https://heroku-badge.herokuapp.com/?app=caszipkinserver)
 | [CAS Service Discovery Server](installation/Service-Discovery-Guide.html)                 | `heroku-discoveryserver` | [Link](https://caseureka.herokuapp.com/) | ![](https://heroku-badge.herokuapp.com/?app=caseureka)
-| [CAS Configuration Server](installation/Configuration-Server-Management.html)             | `heroku-casconfigserver` | [Link](https://casconfigserver.herokuapp.com/casconfigserver/env) | ![](https://heroku-badge.herokuapp.com/?app=casconfigserver&root=casconfigserver)
+| [CAS Configuration Server](configuration/Configuration-Server-Management.html)             | `heroku-casconfigserver` | [Link](https://casconfigserver.herokuapp.com/casconfigserver/env) | ![](https://heroku-badge.herokuapp.com/?app=casconfigserver&root=casconfigserver)
 
 Credentials used for the above demos, where needed, are: `casuser` / `Mellon`.
 

--- a/docs/cas-server-documentation/installation/Configuring-Proxy-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-Proxy-Authentication.md
@@ -53,7 +53,7 @@ See the [CAS Protocol](../protocol/CAS-Protocol.html) for more info.
 
 By default, CAS ships with a bundled HTTP client that is partly responsible to callback the URL
 for proxy authentication. Note that this URL need also be authorized by the CAS service registry
-before the callback can be made. [See this guide](Service-Management.md) for more info.
+before the callback can be made. [See this guide](Service-Management.html) for more info.
 
 If the callback URL is authorized by the service registry, and if the endpoint is under HTTPS
 and protected by an SSL certificate, CAS will also attempt to verify the validity of the endpoint's

--- a/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
@@ -8,7 +8,7 @@ category: Protocols
 
 CAS can act as a SAML2 identity provider accepting authentication requests and producing SAML assertions.
 
-If you intend to allow CAS to delegate authentication to an external SAML2 identity provider, you need to [review this guide](../integration/Delegate-Authentication.md).
+If you intend to allow CAS to delegate authentication to an external SAML2 identity provider, you need to [review this guide](../integration/Delegate-Authentication.html).
 
 <div class="alert alert-info"><strong>SAML Specification</strong><p>This document solely focuses on what one might do to turn on SAML2 support inside CAS. It is not to describe/explain the numerous characteristics of the SAML2 protocol itself. If you are unsure about the concepts referred to on this page, please start with reviewing the <a href="http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html">SAML2 Specification</a>.</p></div>
 
@@ -53,7 +53,7 @@ will always use its own signing certificate for signing of the responses generat
 Also note that support for attribute queries need to be explicitly enabled and the behavior is off by default, given it imposes a burden on 
 CAS and the underlying ticket registry to keep track of attributes and responses as tickets and have them be later used and looked up.
 
-To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.md#saml-idp).
+To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#saml-idp).
 
 ## IdP Metadata
 
@@ -149,7 +149,7 @@ your CAS overlay to be able to resolve dependencies:
 </repositories>
 ```
 
-To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.md#saml-idp).
+To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#saml-idp).
 
 ### SAML Services
 
@@ -235,7 +235,7 @@ metadata resolution to override the default global value.
 
 In addition to the more traditional means of managing service provider metadata such as direct XML files or URLs, CAS 
 provides support for a number of other strategies to fetch metadata more dynamically with the likes of MDQ and more.
-To learn more, please [review this guide](Configuring-SAML2-DynamicMetadata.md).
+To learn more, please [review this guide](Configuring-SAML2-DynamicMetadata.html).
 
 ### Attribute Name Formats
 
@@ -256,7 +256,7 @@ Attribute name formats can be specified per relying party in the service registr
 ```
 
 You may also have the option to define attributes and their relevant name format globally
-via CAS properties. To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.md#saml-idp).
+via CAS properties. To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.#saml-idp).
 
 ### Attribute Friendly Names
 
@@ -280,21 +280,21 @@ specially if the original attribute is *mapped* to a different name.
 
 ### Attribute Release
 
-Attribute filtering and release policies are defined per SAML service. See [this guide](Configuring-SAML2-Attribute-Release.md) for more info.
+Attribute filtering and release policies are defined per SAML service. See [this guide](Configuring-SAML2-Attribute-Release.html) for more info.
 
 ### Name ID Selection
 
 Each service may specify a required Name ID format. If left undefined, the metadata will be consulted to find the right format.
 The Name ID value is always simply the authenticated user that is designed to be returned to this service. In other words, if you
 decide to configure CAS to return a particular attribute as
-[the authenticated user name for this service](../integration/Attribute-Release-PrincipalId.md),
+[the authenticated user name for this service](../integration/Attribute-Release-PrincipalId.html),
 that value will then be used to construct the Name ID along with the right format.
 
 
 ## SP Integrations
 
 A number of SAML2 service provider integrations are provided natively by CAS. To learn more,
-please [review this guide](../integration/Configuring-SAML-SP-Integrations.md).
+please [review this guide](../integration/Configuring-SAML-SP-Integrations.html).
 
 ## Client Libraries
 

--- a/docs/cas-server-documentation/integration/Attribute-Release-Consent.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Consent.md
@@ -59,7 +59,7 @@ A sample definition follows:
 A page for users to review their consent decisions will be exposed at the `/consentReview` endpoint. 
 A link is included automatically on the login page. Users may view and delete the consent decisions they have made in the past. 
 The CAS service for the consent endpoint will be auto-registered during startup. 
-Regular [service access strategies](Configuring-Service-Access-Strategy.html) may be used to control access to the endpoint.
+Regular [service access strategies](../installation/Configuring-Service-Access-Strategy.html) may be used to control access to the endpoint.
 
 ## Storage
 

--- a/docs/cas-server-documentation/mfa/DuoSecurity-Authentication.md
+++ b/docs/cas-server-documentation/mfa/DuoSecurity-Authentication.md
@@ -61,7 +61,7 @@ Duo Security altogether and shall not challenge the user and will also **NOT** r
 ## Health Status
 
 CAS is able to contact Duo Security, on demand, in order to inquire the health status of the service using Duo Security's `ping` API. 
-The results of the operations are recorded and reported using `health` endpoint provided by [CAS Monitoring endpoints](Monitoring-Statistics.html).
+The results of the operations are recorded and reported using `health` endpoint provided by [CAS Monitoring endpoints](../installation/Monitoring-Statistics.html).
 Of course, the same result throughout the Duo authentication flow is also used to determine failure modes.
  
 ## Non-Browser MFA

--- a/docs/cas-server-documentation/mfa/GoogleAuthenticator-Authentication.md
+++ b/docs/cas-server-documentation/mfa/GoogleAuthenticator-Authentication.md
@@ -49,7 +49,7 @@ Registration records and tokens may be kept inside a database instance via the f
 </dependency>
 ```
 
-To learn how to configure database drivers, [please see this guide](JDBC-Drivers.html).
+To learn how to configure database drivers, [please see this guide](../installation/JDBC-Drivers.html).
 To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#google-authenticator-jpa).
 
 #### MySQL / Galera Limitations

--- a/docs/cas-server-documentation/mfa/Multifactor-TrustedDevice-Authentication.md
+++ b/docs/cas-server-documentation/mfa/Multifactor-TrustedDevice-Authentication.md
@@ -88,7 +88,7 @@ Support is provided via the following module:
 </dependency>
 ```
 
-To learn how to configure database drivers, [please see this guide](JDBC-Drivers.html).
+To learn how to configure database drivers, [please see this guide](../installation/JDBC-Drivers.html).
 To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#jdbc-storage).
 
 ### MongoDb

--- a/docs/cas-server-documentation/mfa/Simple-Multifactor-Authentication.md
+++ b/docs/cas-server-documentation/mfa/Simple-Multifactor-Authentication.md
@@ -7,7 +7,7 @@ category: Multifactor Authentication
 # Simple Multifactor Authentication
 
 Allow CAS to act as a multifactor authentication provider on its own, issuing tokens and sending them to end-users via pre-defined communication
-channels such as email or text messages. Tokens issued by CAS are tracked using the [ticket registry](Configuring-Ticketing-Components.html)
+channels such as email or text messages. Tokens issued by CAS are tracked using the [ticket registry](../installation/Configuring-Ticketing-Components.html)
 and are assigned a configurable expiration policy controlled via CAS settings.
 
 ## Configuration
@@ -36,4 +36,4 @@ examine those attributes to share generated tokens.
 Users may be notified of CAS-issued tokens via text messages and/or email. The authenticated CAS principal is expected to carry enough attributes, 
 configurable via CAS settings, in order for CAS to properly send text messages and/or email to the end-user.
 
-To learn more about available options, please [see this guide](SMS-Messaging-Configuration.html) or [this guide](Sending-Email-Configuration.html).
+To learn more about available options, please [see this guide](../installation/SMS-Messaging-Configuration.html) or [this guide](../installation/Sending-Email-Configuration.html).

--- a/docs/cas-server-documentation/mfa/SwivelSecure-Authentication.md
+++ b/docs/cas-server-documentation/mfa/SwivelSecure-Authentication.md
@@ -41,7 +41,7 @@ To enable additional logging, configure the log4j configuration file to add the 
 
 ## Swivel SDK
 
-Note that Swivel SDK artifacts are not published to a Maven repository. This means that you will need to download the necessary JAR files and include the in your build configuration. The SDK may be downloaded from [the CAS codebase](https://github.com/apereo/cas/blob/master/support/cas-server-support-swivel/lib/pinsafe.client.jar). Then, assuming the SDK is placed inside a `lib` directory of the [WAR overlay](WAR-Overlay-Installation.html) directory, it can be referenced in the build configuration as such:
+Note that Swivel SDK artifacts are not published to a Maven repository. This means that you will need to download the necessary JAR files and include the in your build configuration. The SDK may be downloaded from [the CAS codebase](https://github.com/apereo/cas/blob/master/support/cas-server-support-swivel/lib/pinsafe.client.jar). Then, assuming the SDK is placed inside a `lib` directory of the [WAR overlay](../installation/WAR-Overlay-Installation.html) directory, it can be referenced in the build configuration as such:
 
 ```gradle
 compile files("${projectDir}/lib/pinsafe.client.jar")

--- a/docs/cas-server-documentation/password_management/Password-Management.md
+++ b/docs/cas-server-documentation/password_management/Password-Management.md
@@ -18,7 +18,7 @@ By default, after a user has successfully changed their password they will be re
 to enter their new password and log in. CAS can also be configured to automatically log the user in after
 a successful change. This behavior can be altered via CAS settings. 
 
-To learn more about available notification options, please [see this guide](SMS-Messaging-Configuration.html) or [this guide](Sending-Email-Configuration.html). To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#password-management).
+To learn more about available notification options, please [see this guide](../installation/SMS-Messaging-Configuration.html) or [this guide](../installation/Sending-Email-Configuration.html). To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#password-management).
 
 ## JSON
 

--- a/docs/cas-server-documentation/protocol/Protocol-Overview.md
+++ b/docs/cas-server-documentation/protocol/Protocol-Overview.md
@@ -15,7 +15,7 @@ The following protocols are supported and provided by CAS:
 *   [WS Federation](WS-Federation-Protocol.html)
 *   [SAML1](SAML-Protocol.html)
 *   [SAML2](../installation/Configuring-SAML2-Authentication.html)
-*   [REST Protocol](protocol/REST-Protocol.html)
+*   [REST Protocol](REST-Protocol.html)
 
 ## Design
 

--- a/docs/cas-server-documentation/protocol/REST-Protocol.md
+++ b/docs/cas-server-documentation/protocol/REST-Protocol.md
@@ -97,7 +97,7 @@ POST /cas/v1/tickets/{TGT id} HTTP/1.0
 service={form encoded parameter for the service url}
 ```
 
-You may also submit service ticket requests using the semantics [SAML1 protocol](protocol/SAML-Protocol.html).
+You may also submit service ticket requests using the semantics [SAML1 protocol](SAML-Protocol.html).
 
 ### Successful Response
 

--- a/docs/cas-server-documentation/protocol/WS-Federation-Protocol.md
+++ b/docs/cas-server-documentation/protocol/WS-Federation-Protocol.md
@@ -100,7 +100,7 @@ Clients and relying parties can be registered with CAS as such:
 | `realm`                       | The realm identifier of the application, identified via the `wtrealm` parameter. This needs to match the realm defined for the identity provider. By default it's set to the realm defined for the CAS identity provider.
 | `appliesTo`                   | Controls to whom security tokens apply. Defaults to the `realm`.
 
-Service definitions may be managed by the [service management](Service-Management.html) facility.
+Service definitions may be managed by the [service management](../installation/Service-Management.html) facility.
 
 ### Claims
 

--- a/docs/cas-server-documentation/ux/User-Interface-Customization-Themes.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization-Themes.md
@@ -6,7 +6,7 @@ category: User Interface
 
 # Dynamic Themes
 
-With the introduction of [Service Management application](Service-Management.html), deployers are now able to switch the themes based on different services. For example, you may want to have different login screens (different styles) for staff applications and student applications. Or, you want to show two layouts for day time and night time. This document could help you go through the basic settings to achieve this.
+With the introduction of [Service Management application](../installation/Service-Management.html), deployers are now able to switch the themes based on different services. For example, you may want to have different login screens (different styles) for staff applications and student applications. Or, you want to show two layouts for day time and night time. This document could help you go through the basic settings to achieve this.
 
 ## Static Themes
 


### PR DESCRIPTION
Fixing broken page links found by running HTMLProofer locally