### PR TITLE
the mfaTrustStorageCleaner can't be lazy

### DIFF
--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
  * @since 5.0.0
  */
 @EnableTransactionManagement(proxyTargetClass = true)
-@Transactional(transactionManager = "transactionManagerU2f")
+@Transactional(transactionManager = "transactionManagerMfaAuthnTrust")
 @Slf4j
 @RequiredArgsConstructor
 @Getter

--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/config/MultifactorAuthnTrustConfiguration.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/config/MultifactorAuthnTrustConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -112,7 +111,6 @@ public class MultifactorAuthnTrustConfiguration implements AuditTrailRecordResol
 
     @ConditionalOnMissingBean(name = "mfaTrustStorageCleaner")
     @Bean
-    @Lazy
     public MultifactorAuthenticationTrustStorageCleaner mfaTrustStorageCleaner() {
         return new MultifactorAuthenticationTrustStorageCleaner(
             casProperties.getAuthn().getMfa().getTrusted(),


### PR DESCRIPTION
Because the mfaTrustStorageCleaner bean is self contained and isn't referenced elsewhere, setting it to be Lazy means it is never initialized and never actually cleans out old trust records.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
