### PR TITLE
ScriptEnginePersonAttributeDao gets engineName based on file extension

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/ScriptedPrincipalAttributesProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/ScriptedPrincipalAttributesProperties.java
@@ -19,6 +19,15 @@ public class ScriptedPrincipalAttributesProperties extends SpringResourcePropert
     private static final long serialVersionUID = 4221139939506528713L;
 
     /**
+     * Script engine name, e.g. groovy, js, python, etc.
+     * Required if CAS can't determine based on extension.
+     * The file extension of the resource will be used to determine the engineName if not specified.
+     * Engines must be on the classpath in order for the engineName to be determined automatically.
+     * The first engine found claiming to support the extension of the file specified will be used.
+     */
+    private String engineName;
+
+    /**
      * Whether attribute repository should consider the underlying
      * attribute names in a case-insensitive manner.
      */

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -879,16 +879,19 @@ to be a JSON map as such:
 
 ### Ruby/Python/Javascript/Groovy
 
-Similar to the Groovy option but more versatile, this option takes advantage of Java's native scripting API to invoke Groovy, Python or Javascript scripting engines to compile a pre-defined script o resolve attributes. The following settings are relevant:
+Similar to the Groovy option but more versatile, this option takes advantage of Java's native scripting API to invoke Groovy, Python or Javascript scripting engines to compile a pre-defined script to resolve attributes. 
+The following settings are relevant:
 
 ```properties
 # cas.authn.attributeRepository.script[0].location=file:/etc/cas/script.groovy
 # cas.authn.attributeRepository.script[0].order=0
 # cas.authn.attributeRepository.script[0].caseInsensitive=false
+# cas.authn.attributeRepository.script[0].engineName=js|groovy|ruby|python
 ```
 
 While Javascript and Groovy should be natively supported by CAS, Python scripts may need
 to massage the CAS configuration to include the [Python modules](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22jython-standalone%22).
+Ruby scripts are supported via [JRuby](https://search.maven.org/search?q=g:org.jruby%20AND%20a:jruby)  
 
 The Groovy script may be defined as:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -159,7 +159,7 @@ azureKeyVaultSecretsVersion=2.0.2
 
 jsonVersion=20160810
 hjsonVersion=3.0.0
-personDirectoryVersion=1.8.7
+personDirectoryVersion=1.8.8-SNAPSHOT
 quartzVersion=2.3.0
 
 okioHttpVersion=2.7.5

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
@@ -267,9 +267,10 @@ public class CasPersonDirectoryConfiguration implements PersonDirectoryAttribute
         final List<IPersonAttributeDao> list = new ArrayList<>();
         casProperties.getAuthn().getAttributeRepository().getScript()
             .forEach(Unchecked.consumer(script -> {
-                final ScriptEnginePersonAttributeDao dao = new ScriptEnginePersonAttributeDao();
-                final String scriptFile = IOUtils.toString(script.getLocation().getInputStream(), StandardCharsets.UTF_8);
-                dao.setScriptFile(scriptFile);
+                final String scriptContents = IOUtils.toString(script.getLocation().getInputStream(), StandardCharsets.UTF_8);
+                final String engineName = script.getEngineName() == null ?
+                        ScriptEnginePersonAttributeDao.getScriptEngineName(script.getLocation().getFilename()) : script.getEngineName();
+                final ScriptEnginePersonAttributeDao dao = new ScriptEnginePersonAttributeDao(scriptContents, engineName);
                 dao.setCaseInsensitiveUsername(script.isCaseInsensitive());
                 dao.setOrder(script.getOrder());
                 LOGGER.debug("Configured scripted attribute sources from [{}]", script.getLocation());


### PR DESCRIPTION
Also allows engineName to be set to something that ScriptEnginePersonAttributeDao doesn't know how to guess based on extension.