### PR TITLE
ScriptEnginePersonAttributeDao gets engineName based on file extension

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/ScriptedPrincipalAttributesProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/ScriptedPrincipalAttributesProperties.java
@@ -20,6 +20,15 @@ public class ScriptedPrincipalAttributesProperties extends SpringResourcePropert
     private static final long serialVersionUID = 4221139939506528713L;
 
     /**
+     * Script engine name, e.g. groovy, js, python, etc.
+     * Required if CAS can't determine based on extension.
+     * The file extension of the resource will be used to determine the engineName if not specified.
+     * Engines must be on the classpath in order for the engineName to be determined automatically.
+     * The first engine found claiming to support the extension of the file specified will be used.
+     */
+    private String engineName;
+
+    /**
      * Whether attribute repository should consider the underlying
      * attribute names in a case-insensitive manner.
      */

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -860,7 +860,7 @@ Map<String, List<Object>> run(final Object... args) {
     def uid = args[0]
     def logger = args[1]
 
-    logger.debug("Things are happening just fine")
+    logger.debug("Groovy things are happening just fine with UID: {}",uid)
     return[username:[uid], likes:["cheese", "food"], id:[1234,2,3,4,5], another:"attribute"]
 }
 ```
@@ -868,14 +868,20 @@ Map<String, List<Object>> run(final Object... args) {
 The Javascript script may be defined as:
 
 ```javascript
-function run(args) {
-    var uid = args[0]
-    var logger = args[1]
+function run(uid, logger) {
     print("Things are happening just fine")
+    logger.warn("Javascript called with UID: {}",uid);
+
+    // If you want to call back into Java, this is one way to do so
+    var javaObj = new JavaImporter(org.yourorgname.yourpackagename);
+    with (javaObj) {
+    	var objFromJava = JavaClassInPackage.someStaticMethod(uid);
+    }
 
     var map = {};
+    map["attr_from_java"] = objFromJava.getSomething();
     map["username"] = uid;
-    map["likes"] = "chees";
+    map["likes"] = "cheese";
     map["id"] = [1234,2,3,4,5];
     map["another"] = "attribute";
 

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -837,16 +837,19 @@ to be a JSON map as such:
 
 ### Ruby/Python/Javascript/Groovy
 
-Similar to the Groovy option but more versatile, this option takes advantage of Java's native scripting API to invoke Groovy, Python or Javascript scripting engines to compile a pre-defined script o resolve attributes. The following settings are relevant:
+Similar to the Groovy option but more versatile, this option takes advantage of Java's native scripting API to invoke Groovy, Python or Javascript scripting engines to compile a pre-defined script to resolve attributes. 
+The following settings are relevant:
 
 ```properties
 # cas.authn.attributeRepository.script[0].location=file:/etc/cas/script.groovy
 # cas.authn.attributeRepository.script[0].order=0
 # cas.authn.attributeRepository.script[0].caseInsensitive=false
+# cas.authn.attributeRepository.script[0].engineName=js|groovy|ruby|python
 ```
 
 While Javascript and Groovy should be natively supported by CAS, Python scripts may need
 to massage the CAS configuration to include the [Python modules](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22jython-standalone%22).
+Ruby scripts are supported via [JRuby](https://search.maven.org/search?q=g:org.jruby%20AND%20a:jruby)  
 
 The Groovy script may be defined as:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -190,7 +190,7 @@ azureKeyVaultSecretsVersion=2.0.6
 
 jsonVersion=20180813
 hjsonVersion=3.0.0
-personDirectoryVersion=1.8.7
+personDirectoryVersion=1.8.8-SNAPSHOT
 quartzVersion=2.3.0
 
 okioHttpVersion=2.7.5

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
@@ -267,8 +267,9 @@ public class CasPersonDirectoryConfiguration implements PersonDirectoryAttribute
         casProperties.getAuthn().getAttributeRepository().getScript()
             .forEach(Unchecked.consumer(script -> {
                 val scriptContents = IOUtils.toString(script.getLocation().getInputStream(), StandardCharsets.UTF_8);
-                val engineName = script.getEngineName() == null ?
-                        ScriptEnginePersonAttributeDao.getScriptEngineName(script.getLocation().getFilename()) : script.getEngineName();
+                val engineName = script.getEngineName() == null
+                    ? ScriptEnginePersonAttributeDao.getScriptEngineName(script.getLocation().getFilename())
+                    : script.getEngineName();
                 val dao = new ScriptEnginePersonAttributeDao(scriptContents, engineName);
                 dao.setCaseInsensitiveUsername(script.isCaseInsensitive());
                 dao.setOrder(script.getOrder());

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
@@ -266,9 +266,10 @@ public class CasPersonDirectoryConfiguration implements PersonDirectoryAttribute
         val list = new ArrayList<IPersonAttributeDao>();
         casProperties.getAuthn().getAttributeRepository().getScript()
             .forEach(Unchecked.consumer(script -> {
-                val dao = new ScriptEnginePersonAttributeDao();
-                val scriptFile = IOUtils.toString(script.getLocation().getInputStream(), StandardCharsets.UTF_8);
-                dao.setScriptFile(scriptFile);
+                val scriptContents = IOUtils.toString(script.getLocation().getInputStream(), StandardCharsets.UTF_8);
+                val engineName = script.getEngineName() == null ?
+                        ScriptEnginePersonAttributeDao.getScriptEngineName(script.getLocation().getFilename()) : script.getEngineName();
+                val dao = new ScriptEnginePersonAttributeDao(scriptContents, engineName);
                 dao.setCaseInsensitiveUsername(script.isCaseInsensitive());
                 dao.setOrder(script.getOrder());
                 LOGGER.debug("Configured scripted attribute sources from [{}]", script.getLocation());


### PR DESCRIPTION
This is ported from 5.3.x pull request, requires new person-directory snapshot. 

Also allows engineName to be set to something that ScriptEnginePersonAttributeDao doesn't know how to guess based on extension.

Rely on warnings in script dao if engine can't be determined or isn't on classpath.

