### PR TITLE
update dependencies on 5.3.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -68,9 +68,9 @@ sentryRavenVersion=8.0.3
 springIntegrationVersion=4.3.16.RELEASE
 springWebflowClientVersion=1.0.3
 springWebflowVersion=2.5.0.RELEASE
-springDataCommonsVersion=1.13.7.RELEASE
-springDataMongoDbVersion=1.10.7.RELEASE
-springSecurityVersion=4.2.6.RELEASE
+springDataCommonsVersion=1.13.15.RELEASE
+springDataMongoDbVersion=1.10.15.RELEASE
+springSecurityVersion=4.2.8.RELEASE
 springShellVersion=1.2.0.RELEASE
 
 springCloudConfigVersion=1.4.0.RELEASE
@@ -109,7 +109,7 @@ apacheFortressVersion=2.0.0
 apacheVelocityVersion=2.0
 apacheSyncopeVersion=2.0.8
 
-springBootVersion=1.5.14.RELEASE
+springBootVersion=1.5.16.RELEASE
 springBootAdminVersion=1.5.7
 
 hibernateValidatorVersion=5.4.1.Final
@@ -213,7 +213,7 @@ opensamlVersion=3.3.1
 idpVersion=3.3.3
 idpLibertyIdwsConsumerVersion=1.0.0
 xmlapisVersion=1.4.01
-bouncyCastleVersion=1.59
+bouncyCastleVersion=1.60
 shibbolethUtilJavaSupport=7.3.0
 jdomVersion=1.0
 


### PR DESCRIPTION
Upgrading bouncycastle to 1.60 resolves CVE-2018-1000613
Upgrading spring boot gets slightly newer tomcat,
I have built with these locally and my local installation still works.