### PR TITLE
Remove Bean that might not being used

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -230,11 +230,6 @@ public class CasOAuthConfiguration implements AuditTrailRecordResolutionPlanConf
         };
     }
 
-    @Bean
-    public OAuth20CasClientRedirectActionBuilder defaultOAuthCasClientRedirectActionBuilder() {
-        return new OAuth20DefaultCasClientRedirectActionBuilder();
-    }
-
     @ConditionalOnMissingBean(name = "oAuthClientAuthenticator")
     @Bean
     public Authenticator<UsernamePasswordCredentials> oAuthClientAuthenticator() {


### PR DESCRIPTION
- Brief description of changes applied

I have seen a bean named : `OAuth20CasClientRedirectActionBuilder defaultOAuthCasClientRedirectActionBuilder`" that is created **(seemingly) without being used anywhere** (supported by github repo search "https://github.com/search?q=defaultOAuthCasClientRedirectActionBuilder+repo%3Aapereo%2Fcas&type=Code")


A bean with the same class called: "`OAuth20CasClientRedirectActionBuilder oauthCasClientRedirectActionBuilder`" **is being used instead** of the above.

If this is indeed an unused Bean, then it would be nice that it can be removed, thanks!

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
