### PR TITLE
dependency update to fix test on 5.3 branch 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -68,8 +68,8 @@ sentryRavenVersion=8.0.3
 springIntegrationVersion=4.3.16.RELEASE
 springWebflowClientVersion=1.0.3
 springWebflowVersion=2.5.0.RELEASE
-springDataCommonsVersion=1.13.15.RELEASE
-springDataMongoDbVersion=1.10.15.RELEASE
+springDataCommonsVersion=1.13.7.RELEASE
+springDataMongoDbVersion=1.10.7.RELEASE
 springSecurityVersion=4.2.8.RELEASE
 springShellVersion=1.2.0.RELEASE
 


### PR DESCRIPTION
Backing off on spring-data dependency upgrades b/c they break mongodb test
MongoDbAuditTrailManagerTests broke due to code trying to convert all strings to dates
The fixes appear to be on master but they are fairly extensive and probably not worth merging to 5.3

I tried not upgrading spring data mongo but still got error so spring data commons may be where breaking change exists. 