### PR TITLE
Use Duration in Hz Throttle Map timeout

### DIFF
--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -1138,8 +1138,8 @@ To learn more about this topic, [please review this guide](Configuring-Authentic
 
 ```properties
 # cas.authn.throttle.usernameParameter=username
-# cas.authn.throttle.schedule.startDelay=10000
-# cas.authn.throttle.schedule.repeatInterval=20000
+# cas.authn.throttle.schedule.startDelay=PT10S
+# cas.authn.throttle.schedule.repeatInterval=PT30S
 # cas.authn.throttle.appcode=CAS
 
 # cas.authn.throttle.failure.threshold=100

--- a/support/cas-server-support-aup-webflow/src/main/java/org/apereo/cas/web/flow/AcceptableUsagePolicyWebflowConfigurer.java
+++ b/support/cas-server-support-aup-webflow/src/main/java/org/apereo/cas/web/flow/AcceptableUsagePolicyWebflowConfigurer.java
@@ -1,8 +1,9 @@
 package org.apereo.cas.web.flow;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.web.flow.configurer.AbstractCasWebflowConfigurer;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.engine.ActionState;
@@ -24,7 +25,7 @@ public class AcceptableUsagePolicyWebflowConfigurer extends AbstractCasWebflowCo
     private static final String VIEW_ID_ACCEPTABLE_USAGE_POLICY_VIEW = "acceptableUsagePolicyView";
     private static final String AUP_ACCEPTED_ACTION = "aupAcceptedAction";
     private static final String STATE_ID_AUP_CHECK = "acceptableUsagePolicyCheck";
-    
+
     public AcceptableUsagePolicyWebflowConfigurer(final FlowBuilderServices flowBuilderServices,
                                                   final FlowDefinitionRegistry loginFlowDefinitionRegistry,
                                                   final ApplicationContext applicationContext,
@@ -99,5 +100,9 @@ public class AcceptableUsagePolicyWebflowConfigurer extends AbstractCasWebflowCo
         final TransitionSet transitionSet = actionState.getTransitionSet();
         transitionSet.add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS, target));
         transitionSet.add(createTransition(AcceptableUsagePolicyVerifyAction.EVENT_ID_MUST_ACCEPT, VIEW_ID_ACCEPTABLE_USAGE_POLICY_VIEW));
+
+        final ActionState ticketCreateState = getState(flow, CasWebflowConstants.STATE_ID_CREATE_TICKET_GRANTING_TICKET, ActionState.class);
+        prependActionsToActionStateExecutionList(flow, ticketCreateState, "acceptableUsagePolicyVerifyAction");
+        createTransitionForState(ticketCreateState, AcceptableUsagePolicyVerifyAction.EVENT_ID_MUST_ACCEPT, VIEW_ID_ACCEPTABLE_USAGE_POLICY_VIEW);
     }
 }

--- a/support/cas-server-support-throttle-hazelcast/src/main/java/org/apereo/cas/web/support/config/CasHazelcastThrottlingConfiguration.java
+++ b/support/cas-server-support-throttle-hazelcast/src/main/java/org/apereo/cas/web/support/config/CasHazelcastThrottlingConfiguration.java
@@ -8,7 +8,6 @@ import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.hazelcast.HazelcastTicketRegistryProperties;
 import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.hz.HazelcastConfigurationFactory;
-import org.joda.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/support/cas-server-support-throttle-hazelcast/src/main/java/org/apereo/cas/web/support/config/CasHazelcastThrottlingConfiguration.java
+++ b/support/cas-server-support-throttle-hazelcast/src/main/java/org/apereo/cas/web/support/config/CasHazelcastThrottlingConfiguration.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.hazelcast.HazelcastTicketRegistryProperties;
 import org.apereo.cas.hz.HazelcastConfigurationFactory;
+import org.joda.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -37,7 +38,7 @@ public class CasHazelcastThrottlingConfiguration {
     @Bean
     public IMap throttleSubmissionMap() {
         final HazelcastTicketRegistryProperties hz = casProperties.getTicket().getRegistry().getHazelcast();
-        final int timeout = Integer.parseInt(casProperties.getAuthn().getThrottle().getSchedule().getRepeatInterval());
+        final int timeout = Duration.parse(casProperties.getAuthn().getThrottle().getSchedule().getRepeatInterval()).toStandardSeconds().getSeconds();
         final HazelcastConfigurationFactory factory = new HazelcastConfigurationFactory();
         LOGGER.debug("Creating [{}] to record failed logins for throttling with timeout set to [{}]", MAP_KEY, timeout);
         final MapConfig ipMapConfig = factory.buildMapConfig(hz, MAP_KEY, timeout);

--- a/support/cas-server-support-throttle-hazelcast/src/main/java/org/apereo/cas/web/support/config/CasHazelcastThrottlingConfiguration.java
+++ b/support/cas-server-support-throttle-hazelcast/src/main/java/org/apereo/cas/web/support/config/CasHazelcastThrottlingConfiguration.java
@@ -6,6 +6,7 @@ import com.hazelcast.core.IMap;
 import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.hazelcast.HazelcastTicketRegistryProperties;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.hz.HazelcastConfigurationFactory;
 import org.joda.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ public class CasHazelcastThrottlingConfiguration {
     @Bean
     public IMap throttleSubmissionMap() {
         final HazelcastTicketRegistryProperties hz = casProperties.getTicket().getRegistry().getHazelcast();
-        final int timeout = Duration.parse(casProperties.getAuthn().getThrottle().getSchedule().getRepeatInterval()).toStandardSeconds().getSeconds();
+        final long timeout = Beans.newDuration(casProperties.getAuthn().getThrottle().getSchedule().getRepeatInterval()).getSeconds();
         final HazelcastConfigurationFactory factory = new HazelcastConfigurationFactory();
         LOGGER.debug("Creating [{}] to record failed logins for throttling with timeout set to [{}]", MAP_KEY, timeout);
         final MapConfig ipMapConfig = factory.buildMapConfig(hz, MAP_KEY, timeout);


### PR DESCRIPTION
Changed Throttle documentation to show correct defaults in Duration notation that are code in ThrottleProperties.  Changed Hazelcast throttle config to use duration when setting map idle timeout.