### PR TITLE
backport change from master that add some attributes from cert

### DIFF
--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolver.java
@@ -3,7 +3,10 @@ package org.apereo.cas.adaptors.x509.authentication.principal;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
+import org.apereo.cas.util.CollectionUtils;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -15,10 +18,13 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Credential to principal resolver that extracts Subject Alternative Name UPN extension
@@ -148,5 +154,26 @@ public class X509SubjectAlternativeNameUPNPrincipalResolver extends AbstractX509
             LOGGER.error("An error has occurred while reading the subject alternative name value", e);
         }
         return null;
+    }
+
+    @Override
+    protected Map<String, List<Object>> retrievePersonAttributes(final String principalId, final Credential credential) {
+        final Map<String, List<Object>> attributes = new LinkedHashMap<>(super.retrievePersonAttributes(principalId, credential));
+        final X509Certificate certificate = ((X509CertificateCredential) credential).getCertificate();
+
+        if (certificate != null) {
+            if (StringUtils.isNotBlank(certificate.getSigAlgOID())) {
+                attributes.put("sigAlgOid", CollectionUtils.wrapList(certificate.getSigAlgOID()));
+            }
+            final Principal subjectDn = certificate.getSubjectDN();
+            if (subjectDn != null) {
+                attributes.put("subjectDn", CollectionUtils.wrapList(subjectDn.getName()));
+            }
+            final Principal subjectPrincipal = certificate.getSubjectX500Principal();
+            if (subjectPrincipal != null) {
+                attributes.put("subjectX500Principal", CollectionUtils.wrapList(subjectPrincipal.getName()));
+            }
+        }
+        return attributes;
     }
 }

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolverTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.adaptors.x509.authentication.principal;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apereo.cas.authentication.principal.Principal;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,6 +13,8 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
+
+import static org.junit.Assert.*;
 
 /**
  * Unit test for {@link X509SubjectAlternativeNameUPNPrincipalResolver}.
@@ -65,7 +68,13 @@ public class X509SubjectAlternativeNameUPNPrincipalResolverTests {
 
     @Test
     public void verifyResolvePrincipalInternal() {
-        Assert.assertEquals(this.expected, this.resolver.resolvePrincipalInternal(this.certificate));
+        final String userId = this.resolver.resolvePrincipalInternal(this.certificate);
+        assertEquals(this.expected, userId);
+        final X509CertificateCredential credential = new X509CertificateCredential(new X509Certificate[]{this.certificate});
+        credential.setCertificate(this.certificate);
+        final Principal principal = this.resolver.resolve(credential);
+        assertNotNull(principal);
+        assertFalse(principal.getAttributes().isEmpty());
     }
 
 }


### PR DESCRIPTION
This is a backport of change by @mmoayyed in master. 

Attributes are added if you are using SUBJECT_ALT_NAME as the principal.

Should I document this somewhere? 

I was thinking maybe this could be pushed up to AbstractX509PrincipalResolver but maybe that can wait until somebody needs that. 
