### PR TITLE
@ReadingConverter to avoid String -> ZonedDateTime conversion error

### DIFF
--- a/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/BaseConverters.java
+++ b/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/BaseConverters.java
@@ -10,6 +10,8 @@ import org.apache.commons.logging.Log;
 import org.apereo.services.persondir.IPersonAttributes;
 import org.slf4j.Logger;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter; 
+import org.springframework.data.convert.WritingConverter; 
 
 import java.lang.ref.ReferenceQueue;
 import java.security.cert.CertPath;
@@ -153,6 +155,7 @@ public abstract class BaseConverters {
     /**
      * The type String to zoned date time converter.
      */
+    @ReadingConverter
     public static class StringToZonedDateTimeConverter implements Converter<String, ZonedDateTime> {
         @Override
         public ZonedDateTime convert(final String source) {
@@ -173,6 +176,7 @@ public abstract class BaseConverters {
     /**
      * The type Zoned date time to string converter.
      */
+    @WritingConverter
     public static class ZonedDateTimeToStringConverter implements Converter<ZonedDateTime, String> {
         @Override
         public String convert(final ZonedDateTime source) {


### PR DESCRIPTION
Add @ReadingConverter annotation to StringToZonedDateTimeConverter to prevent spurious String->ZonedDateTime conversion error when saving to MongoDbServiceRegistry.

References:
https://stackoverflow.com/questions/50286790/spring-data-mongodb-failed-to-convert-from-type-after-upgrade-to-2-0-7-with-cus

https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#mongo.converter-disambiguation

Stack trace excerpt:
```
org.springframework.core.convert.ConversionFailedException: Failed to convert from type [java.lang.String] to type [java.time.ZonedDateTime] for value 'http://www.testshib.org/metadata/testshib-providers.xml'; nested exception is java.time.format.DateTimeParseException: Text 'http://www.testshib.org/metadata/testshib-providers.xml' could not be parsed at index 0
	at org.springframework.core.convert.support.ConversionUtils.invokeConverter(ConversionUtils.java:43) ~[spring-core-4.3.17.RELEASE.jar!/:4.3.17.RELEASE]
....
	at org.springframework.data.mongodb.core.MongoTemplate.save(MongoTemplate.java:961) ~[spring-data-mongodb-1.10.13.RELEASE.jar!/:?]
	at org.apereo.cas.services.MongoDbServiceRegistry.save(MongoDbServiceRegistry.java:65) ~[cas-server-support-mongo-service-registry-5.3.1.jar!/:5.3.1]
 	at org.apereo.cas.services.ChainingServiceRegistry.lambda$save$0(ChainingServiceRegistry.java:28) ~[cas-server-core-services-registry-5.3.1.jar!/:5.3.1]
	at java.util.ArrayList.forEach(ArrayList.java:1249) ~[?:1.8.0_111]
	at org.apereo.cas.services.ChainingServiceRegistry.save(ChainingServiceRegistry.java:28) ~[cas-server-core-services-registry-5.3.1.jar!/:5.3.1]
...
 	at org.apereo.cas.services.AbstractServicesManager.save(AbstractServicesManager.java:180) ~[cas-server-core-services-registry-5.3.1.jar!/:5.3.1]
 	at org.apereo.cas.services.AbstractServicesManager.save(AbstractServicesManager.java:171) ~[cas-server-core-services-registry-5.3.1.jar!/:5.3.1]
....
 	at org.apereo.cas.mgmt.services.ManagementServicesManager.save(ManagementServicesManager.java:121) ~[cas-management-webapp-support-5.3.1.jar!/:5.3.1]
 	at org.apereo.cas.mgmt.services.web.RegisteredServiceSimpleFormController.saveService(RegisteredServiceSimpleFormController.java:87) ~[cas-management-webapp-support-5.3.1.jar!/:5.3.1]
```


<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->