### PR TITLE
Mark variegated provider as deprecated

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/VariegatedMultifactorAuthenticationProvider.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/VariegatedMultifactorAuthenticationProvider.java
@@ -8,7 +8,11 @@ import java.util.Collection;
  *
  * @author Misagh Moayyed
  * @since 5.1.0
+ *
+ * @deprecated as of 5.3.4, use {@link MultifactorAuthenticationProviderFactory} to provide multiple instances
+ * of multifactor authentication providers.  This interface will be removed in the next 6.0 major release
  */
+@Deprecated
 public interface VariegatedMultifactorAuthenticationProvider extends MultifactorAuthenticationProvider {
 
     /**

--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultVariegatedMultifactorAuthenticationProvider.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultVariegatedMultifactorAuthenticationProvider.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.services.MultifactorAuthenticationProvider;
+import org.apereo.cas.services.MultifactorAuthenticationProviderFactory;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.VariegatedMultifactorAuthenticationProvider;
 
@@ -17,10 +18,14 @@ import java.util.stream.Collectors;
  *
  * @author Misagh Moayyed
  * @since 5.1.0
+ *
+ * @deprecated as of 5.3.4, provide an instance of {@link MultifactorAuthenticationProviderFactory} to provide multiple instances
+ * of multifactor authentication providers.  This interface will be removed in the next 6.0 major release
  */
 @Slf4j
 @NoArgsConstructor
 @Getter
+@Deprecated
 public class DefaultVariegatedMultifactorAuthenticationProvider extends AbstractMultifactorAuthenticationProvider implements VariegatedMultifactorAuthenticationProvider {
 
     private static final long serialVersionUID = 4789727148134156909L;


### PR DESCRIPTION
Marking variegated provider interface and default implementation as deprecated starting in v5.3.4 