### PR TITLE
thymeleaf javascript variable setting for loginwip needs fix

### DIFF
--- a/webapp/resources/templates/fragments/loginform.html
+++ b/webapp/resources/templates/fragments/loginform.html
@@ -163,7 +163,9 @@
                     </div>
 
                     <script type="text/javascript" th:inline="javascript">
-                        var i = [[#{screen.welcome.button.loginwip}]]
+                        /*<![CDATA[*/
+                        var i = /*[[@{#{screen.welcome.button.loginwip}}]]*/
+                        /*]]>*/
                         $( document ).ready(function() {
                             $("#fm1").submit(function () {
                                 $(":submit").attr("disabled", true);


### PR DESCRIPTION
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
Issue: 

in cas:webapp/resources/templates/fragments/loginform.html - in line 166, the javascript variable (var i) declaration is wrong because it didnt follow the thymeleaf javascript variable declaration aka dialect. This causes javascript error in old IE browser based engine embedded applications.
```
var i = [[#{screen.welcome.button.loginwip}]]
```

Solution: 
 We should be following correct parameter declaration as thymeleaf suggested. 

```
/*<![CDATA[*/
var i = /*[[@{#{screen.welcome.button.loginwip}}]]*/
/*]]>*/
```

Bug effects:
Mostly this issue wont show up in login forms in advance browsers; only error showed in console window. This caused Javascript error in old IE browser engine based applications.

But this issue restricted showed 'loginwip' message when user clicks login button. So this bug disabled/restricted the loginwip process.

Solution effects:
After this issue, the Javascript error is no longer happening. And, loginwip message ("One moment please..") showed in login button which stops user from clicking multiple time when browser is waiting for server response.


As it is a bug, no other pull request affected by this. It should be added in next release.

