### PR TITLE
make cas configuration standalone properties work more like spring boot

### DIFF
--- a/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
+++ b/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
@@ -6,10 +6,6 @@ import org.apereo.cas.configuration.api.CasConfigurationPropertiesSourceLocator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOCase;
-import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.jooq.lambda.Unchecked;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.Environment;
@@ -23,8 +19,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -39,27 +33,73 @@ import java.util.stream.Collectors;
 @Slf4j
 @RequiredArgsConstructor
 public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfigurationPropertiesSourceLocator {
+    // The order of the elements in these constants is important, last one overrides previous ones
+    private static final List<String> EXTENSIONS = Arrays.asList("properties", "yml", "yaml");
+    private static final List<String> PROFILE_PATTERNS = Arrays.asList("application-%s.%s", "%s.%s");
+
     private final CipherExecutor<String, String> configurationCipherExecutor;
     private final CasConfigurationPropertiesEnvironmentManager casConfigurationPropertiesEnvironmentManager;
 
-    private static Collection<File> scanForConfigurationFilesByPattern(final File config, final String regex) {
-        return FileUtils.listFiles(config, new RegexFileFilter(regex, IOCase.INSENSITIVE), TrueFileFilter.INSTANCE)
-            .stream()
-            .sorted(Comparator.comparing(File::getName))
-            .collect(Collectors.toList());
+
+    private List<String> getApplicationNames() {
+        val appNames = new ArrayList<String>();
+        val appName = casConfigurationPropertiesEnvironmentManager.getApplicationName();
+        appNames.add("application");
+        appNames.add(appName.toLowerCase());
+        if (!appName.equals(appName.toLowerCase())) {
+            appNames.add(casConfigurationPropertiesEnvironmentManager.getApplicationName());
+        }
+        return appNames;
     }
 
-    private static String buildPatternForConfigurationFileDiscovery(final File config, final List<String> profiles) {
-        val propertyNames = String.join("|", profiles);
-        val profiledProperties = profiles.stream()
-            .map(p -> String.format("application-%s", p))
-            .collect(Collectors.joining("|"));
+    /**
+     * Make a list of files that will be processed in order where the last one processed wins.
+     * Profiles are added after base property names like application.properties, cas.properties, CAS.properties so that
+     * the profiles will override the base properites.
+     * Profiles are processed in order so that the last profile list (e.g. in spring.active.profiles) will override the
+     * the first profile.
+     * Where multiple filenames with same base name and different extensions exist, the priority is yaml, yml, properties.
+     */
+    private List<File> getAllPossibleExternalConfigDirFilenames(final File configdir, final List<String> profiles) {
 
-        val regex = String.format("(%s|%s|application)\\.(yml|properties)", propertyNames, profiledProperties);
-        LOGGER.debug("Looking for configuration files at [{}] that match the pattern [{}]", config, regex);
-        return regex;
+        val fileNames = getApplicationNames()
+                .stream()
+                .flatMap(appName -> EXTENSIONS
+                        .stream()
+                        .map(ext -> new File(configdir, String.format("%s.%s", appName, ext))))
+                .collect(Collectors.toList());
+
+        fileNames.addAll(profiles
+                .stream()
+                .flatMap(profile -> EXTENSIONS
+                        .stream()
+                        .flatMap(ext -> PROFILE_PATTERNS
+                              .stream().map(pattern -> new File(configdir, String.format(pattern, profile, ext))))).collect(Collectors.toList()));
+
+        return fileNames;
     }
 
+    /**
+     * Get all possible configuration files for config directory that actually exist as files.
+     * @param config Folder in which to look for files
+     * @param profiles Profiles that are active
+     * @return List of files to be processed in order where last one processed overrides others
+     */
+    private List<File> scanForConfigurationFiles(final File config, final List<String> profiles) {
+        val possibleFiles = getAllPossibleExternalConfigDirFilenames(config, profiles);
+        return possibleFiles.stream().filter(File::exists).filter(File::isFile).collect(Collectors.toList());
+    }
+
+    /**
+     * Adding items to composite property source which contains property sources processed in order, first one wins.
+     * First Priority: Standalone configuration file
+     * Second Priority: Configuration files in config dir, profiles override non-profiles, last profile overrides first
+     * Third Priority: classpath:/application.yml
+     *
+     * @param environment    the environment
+     * @param resourceLoader the resource loader
+     * @return CompositePropertySource containing sources listed above
+     */
     @Override
     public PropertySource<?> locate(final Environment environment, final ResourceLoader resourceLoader) {
         val compositePropertySource = new CompositePropertySource("casCompositePropertySource");
@@ -101,16 +141,27 @@ public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfig
     }
 
     private PropertySource<?> loadSettingsByApplicationProfiles(final Environment environment, final File config) {
-        val props = new Properties();
-
         val profiles = getApplicationProfiles(environment);
-        val regex = buildPatternForConfigurationFileDiscovery(config, profiles);
-        val configFiles = scanForConfigurationFilesByPattern(config, regex);
+        val profileConfigFiles = scanForConfigurationFiles(config, profiles);
 
+        return new PropertiesPropertySource("applicationProfilesProperties", getProperties(environment, config, profileConfigFiles));
+    }
+
+    /**
+     * Property files processed in order of non-profiles first and then profiles, and profiles are first to last
+     * with properties in the last profile overriding properties in previous profiles or non-profiles.
+     * @param environment Spring environnment
+     * @param config Location of config files
+     * @param configFiles List of all config files to load
+     * @return Merged properties
+     */
+    private Properties getProperties(final Environment environment, final File config, final List<File> configFiles) {
         LOGGER.info("Configuration files found at [{}] are [{}] under profile(s) [{}]", config, configFiles, environment.getActiveProfiles());
+        val props = new Properties();
         configFiles.forEach(Unchecked.consumer(f -> {
             LOGGER.debug("Loading configuration file [{}]", f);
-            if (f.getName().toLowerCase().endsWith("yml")) {
+            val fileName = f.getName().toLowerCase();
+            if (fileName.endsWith("yml") || fileName.endsWith("yaml")) {
                 val pp = CasCoreConfigurationUtils.loadYamlProperties(new FileSystemResource(f));
                 LOGGER.debug("Found settings [{}] in YAML file [{}]", pp.keySet(), f);
                 props.putAll(decryptProperties(pp));
@@ -123,8 +174,7 @@ public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfig
                 props.putAll(decryptProperties(pp));
             }
         }));
-
-        return new PropertiesPropertySource("applicationProfilesProperties", props);
+        return props;
     }
 
     private PropertySource<?> loadEmbeddedYamlOverriddenProperties(final ResourceLoader resourceLoader) {
@@ -147,11 +197,6 @@ public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfig
     }
 
     private List<String> getApplicationProfiles(final Environment environment) {
-        val profiles = new ArrayList<String>();
-        profiles.add(casConfigurationPropertiesEnvironmentManager.getApplicationName());
-        profiles.addAll(Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toList()));
-        return profiles;
+        return Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toList());
     }
-
-
 }

--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/DefaultCasConfigurationPropertiesSourceLocatorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/DefaultCasConfigurationPropertiesSourceLocatorTests.java
@@ -41,7 +41,8 @@ public class DefaultCasConfigurationPropertiesSourceLocatorTests {
     public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
     static {
-        System.setProperty("spring.profiles.active", "standalone");
+        System.setProperty("spring.application.name", "cas");
+        System.setProperty("spring.profiles.active", "standalone,dev");
         System.setProperty("cas.standalone.configurationDirectory", "src/test/resources/directory");
         System.setProperty("cas.standalone.configurationFile", "src/test/resources/standalone.properties");
     }
@@ -70,8 +71,10 @@ public class DefaultCasConfigurationPropertiesSourceLocatorTests {
         assertTrue(source instanceof CompositePropertySource);
         val composite = (CompositePropertySource) source;
         assertEquals("file", composite.getProperty("test.file"));
-        assertEquals("dirCasProp", composite.getProperty("test.dir.cas"));
         assertEquals("dirAppYml", composite.getProperty("test.dir.app"));
         assertEquals("classpathAppYml", composite.getProperty("test.classpath"));
+        assertEquals("devProfileProp", composite.getProperty("test.dir.profile"));
+        assertEquals("standaloneProfileProp", composite.getProperty("profile.override.me"));
+        assertEquals("dirCasProp", composite.getProperty("test.dir.cas"));
     }
 }

--- a/core/cas-server-core-configuration/src/test/resources/directory/application-dev.properties
+++ b/core/cas-server-core-configuration/src/test/resources/directory/application-dev.properties
@@ -1,0 +1,2 @@
+
+test.dir.profile=devProfileProp

--- a/core/cas-server-core-configuration/src/test/resources/directory/application-standalone.yml
+++ b/core/cas-server-core-configuration/src/test/resources/directory/application-standalone.yml
@@ -1,0 +1,8 @@
+---
+test:
+  dir:
+    profile: standaloneProfileProp
+
+profile:
+  override:
+    me: standaloneProfileProp

--- a/core/cas-server-core-configuration/src/test/resources/directory/application.yml
+++ b/core/cas-server-core-configuration/src/test/resources/directory/application.yml
@@ -1,5 +1,7 @@
+---
 test:
   dir:
     app: dirAppYml
     cas: dirAppYml
   file: dirAppYml
+  profile: dirAppYml

--- a/core/cas-server-core-configuration/src/test/resources/directory/cas.properties
+++ b/core/cas-server-core-configuration/src/test/resources/directory/cas.properties
@@ -1,2 +1,3 @@
 test.dir.cas=dirCasProp
 test.file=dirCasProp
+profile.override.me=dirCasProp


### PR DESCRIPTION
I think the current way external cas properties are loaded is too unlike what people expect (assuming they are familiar with spring/spring boot). In the current impl profiles do not override non-profiles (e.g. cas.properties) and profiles are processed in alphabetical order. If you think this change is too much (it's not backwards compatible) then I could submit an alternate config class that could be configurable (to use it instead of the default). 

There are differences between this and spring boot but
files in the config directory are processed in the following order
with the last file to contain the property winning, similar to
spring boot (but spring boot does not look for <profile>.<ext>)

--spring.active.profiles=1stprofile,2ndprofile

application.properties
application.yml
application.yaml
cas.properties
cas.yml
cas.yaml
application-1stprofile.properties
1stprofile.properties
application-1stprofile.yml
1stprofile.yml
application-1stprofile.yaml
1stprofile.yaml
application-2ndprofile.properties
2ndprofile.properties
application-2ndprofile.yml
2ndprofile.yml
application-2ndprofile.yaml
2ndprofile.yaml

In addition to config files in the config directory (specified by
cas.standalone.configurationDirectory), files in the external
config file (specified by cas.standalone.configurationFile) override files
in the config dir. This class also loads classpath:/application.yml
but I am not sure this does anything b/c spring boot should have already
processed it. Properties read from classpath:/application.yam are
lower priority than anything in config file or config dir
