### PR TITLE
Unsolicitedssorelaystate

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/IdPInitiatedProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/IdPInitiatedProfileHandlerController.java
@@ -42,6 +42,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import org.opensaml.saml.common.binding.SAMLBindingSupport;
 
 /**
  * This is {@link IdPInitiatedProfileHandlerController}.
@@ -151,7 +152,7 @@ public class IdPInitiatedProfileHandlerController extends AbstractSamlProfileHan
         }
         ctx.setMessage(authnRequest);
         ctx.getSubcontext(SAMLBindingContext.class, true).setHasBindingSignature(false);
-		ctx.getSubcontext(SAMLBindingContext.class, false).setRelayState(ctx, target);
+        SAMLBindingSupport.setRelayState(ctx, target);
 
         final Pair<SignableSAMLObject, MessageContext> pair = Pair.of(authnRequest, ctx);
         initiateAuthenticationRequest(pair, response, request);

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/IdPInitiatedProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/IdPInitiatedProfileHandlerController.java
@@ -151,6 +151,7 @@ public class IdPInitiatedProfileHandlerController extends AbstractSamlProfileHan
         }
         ctx.setMessage(authnRequest);
         ctx.getSubcontext(SAMLBindingContext.class, true).setHasBindingSignature(false);
+		ctx.getSubcontext(SAMLBindingContext.class, false).setRelayState(ctx, target);
 
         final Pair<SignableSAMLObject, MessageContext> pair = Pair.of(authnRequest, ctx);
         initiateAuthenticationRequest(pair, response, request);


### PR DESCRIPTION
During an unsolicited SAML SSO the supplied target parameter got lost, since it was only saved in the request not in the message context. With this patch it's preserved and the relay state is supplied to the service provider.

Testing just requires a targer paramter in an unsolicited SAML request, the debug output will show an empty relay state without the patch and the supplied target parameter with the patch in the SAML response enconding.
