### PR TITLE
Fix for Multivalue Authentication Attributes

### DIFF
--- a/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationContextValidator.java
+++ b/core/cas-server-core-authentication-mfa/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationContextValidator.java
@@ -79,8 +79,8 @@ public class DefaultMultifactorAuthenticationContextValidator implements Authent
         }
         if (attributes.containsKey(MultifactorAuthenticationProviderBypass.AUTHENTICATION_ATTRIBUTE_BYPASS_MFA)
             && attributes.containsKey(MultifactorAuthenticationProviderBypass.AUTHENTICATION_ATTRIBUTE_BYPASS_MFA_PROVIDER)) {
-            final boolean isBypass = Boolean.class.cast(attributes.get(MultifactorAuthenticationProviderBypass.AUTHENTICATION_ATTRIBUTE_BYPASS_MFA));
-            final String bypassedId = attributes.get(MultifactorAuthenticationProviderBypass.AUTHENTICATION_ATTRIBUTE_BYPASS_MFA_PROVIDER).toString();
+            final boolean isBypass = Boolean.class.cast(CollectionUtils.firstElement(attributes.get(MultifactorAuthenticationProviderBypass.AUTHENTICATION_ATTRIBUTE_BYPASS_MFA)).get());
+            final String bypassedId = attributes.get(CollectionUtils.firstElement(MultifactorAuthenticationProviderBypass.AUTHENTICATION_ATTRIBUTE_BYPASS_MFA_PROVIDER).get()).toString();
             LOGGER.debug("Found multifactor authentication bypass attributes for provider [{}]", bypassedId);
             if (isBypass && StringUtils.equals(bypassedId, requestedContext)) {
                 LOGGER.debug("Requested authentication context [{}] is satisfied given mfa was bypassed for the authentication attempt", requestedContext);


### PR DESCRIPTION
Bypass values coming through now wrapped in LinkedList.  This PR unwraps the attribute from the list when pulling out bypass attributes.

It is possible there are other places that have this same issue.