### PR TITLE
Adds OIDC Introspection error responses

### DIFF
--- a/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/support/oauth/OAuth20Constants.java
+++ b/support/cas-server-support-oauth-core/src/main/java/org/apereo/cas/support/oauth/OAuth20Constants.java
@@ -79,6 +79,9 @@ public interface OAuth20Constants {
     /** The error view. */
     String ERROR_VIEW = "casServiceErrorView";
 
+    /** The invalid client. */
+    String INVALID_CLIENT = "invalid_client";
+
     /** The invalid request. */
     String INVALID_REQUEST = "invalid_request";
 
@@ -114,4 +117,7 @@ public interface OAuth20Constants {
 
     /** The bearer type. */
     String TOKEN_TYPE_BEARER = "bearer";
+
+    /** The unauthorized client. */
+    String UNAUTHORIZED_CLIENT = "unauthorized_client";
 }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcIntrospectionEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/OidcIntrospectionEndpointController.java
@@ -30,14 +30,18 @@ import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.extractor.BasicAuthExtractor;
 import org.pac4j.core.credentials.extractor.CredentialsExtractor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -96,51 +100,64 @@ public class OidcIntrospectionEndpointController extends BaseOAuth20Controller {
     public ResponseEntity<OidcIntrospectionAccessTokenResponse> handlePostRequest(final HttpServletRequest request,
             final HttpServletResponse response) {
         try {
+            final ResponseEntity<OidcIntrospectionAccessTokenResponse> result;
             final CredentialsExtractor<UsernamePasswordCredentials> authExtractor = new BasicAuthExtractor();
             final UsernamePasswordCredentials credentials = authExtractor
                     .extract(Pac4jUtils.getPac4jJ2EContext(request, response));
             if (credentials == null) {
-                throw new IllegalArgumentException(
-                        "No credentials are provided to verify introspection on the access token");
-            }
+                result = buildUnauthorizedResponseEntity(OAuth20Constants.INVALID_CLIENT, true);
+            } else {
+                final OAuthRegisteredService service = OAuth20Utils
+                        .getRegisteredOAuthServiceByClientId(this.servicesManager, credentials.getUsername());
 
-            final OAuthRegisteredService service = OAuth20Utils
-                    .getRegisteredOAuthServiceByClientId(this.servicesManager, credentials.getUsername());
-            if (validateIntrospectionRequest(service, credentials, request)) {
-                final String accessToken = StringUtils.defaultIfBlank(
-                        request.getParameter(OAuth20Constants.ACCESS_TOKEN),
-                        request.getParameter(OAuth20Constants.TOKEN));
+                final Optional<ResponseEntity<OidcIntrospectionAccessTokenResponse>> validationError =
+                        validateIntrospectionRequest(service, credentials, request);
 
-                LOGGER.debug("Located access token [{}] in the request", accessToken);
-                AccessToken ticket = null;
-                try {
-                    ticket = this.centralAuthenticationService.getTicket(accessToken, AccessToken.class);
-                } catch (final org.apereo.cas.ticket.InvalidTicketException ite) {
-                    LOGGER.info("No ticket for supplied access token");
+                if (validationError.isPresent()) {
+                    result = validationError.get();
+                } else {
+                    final String accessToken = StringUtils.defaultIfBlank(
+                            request.getParameter(OAuth20Constants.TOKEN),
+                            request.getParameter(OAuth20Constants.ACCESS_TOKEN));
+
+                    LOGGER.debug("Located access token [{}] in the request", accessToken);
+                    AccessToken ticket = null;
+                    try {
+                        ticket = this.centralAuthenticationService.getTicket(accessToken, AccessToken.class);
+                    } catch (final org.apereo.cas.ticket.InvalidTicketException ite) {
+                        LOGGER.info("No ticket for supplied access token");
+                    }
+
+                    result = createIntrospectionResponse(service, ticket);
                 }
-                return createIntrospectionResponse(service, ticket);
             }
+            return result;
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    private boolean validateIntrospectionRequest(final OAuthRegisteredService registeredService,
-            final UsernamePasswordCredentials credentials, final HttpServletRequest request) {
-        final boolean tokenExists = HttpRequestUtils.doesParameterExist(request, OAuth20Constants.ACCESS_TOKEN)
-                || HttpRequestUtils.doesParameterExist(request, OAuth20Constants.TOKEN);
+    private Optional<ResponseEntity<OidcIntrospectionAccessTokenResponse>> validateIntrospectionRequest(
+            final OAuthRegisteredService registeredService,
+            final UsernamePasswordCredentials credentials,
+            final HttpServletRequest request) {
+        final boolean tokenExists = HttpRequestUtils.doesParameterExist(request, OAuth20Constants.TOKEN)
+                || HttpRequestUtils.doesParameterExist(request, OAuth20Constants.ACCESS_TOKEN);
 
-        if (tokenExists && OAuth20Utils.checkClientSecret(registeredService, credentials.getPassword())) {
+        if (!tokenExists) {
+            return Optional.of(buildBadRequestResponseEntity(OAuth20Constants.MISSING_ACCESS_TOKEN));
+        }
+
+        if (OAuth20Utils.checkClientSecret(registeredService, credentials.getPassword())) {
             final WebApplicationService service = webApplicationServiceServiceFactory
                     .createService(registeredService.getServiceId());
             final AuditableContext audit = AuditableContext.builder().service(service)
                     .registeredService(registeredService).build();
             final AuditableExecutionResult accessResult = this.registeredServiceAccessStrategyEnforcer.execute(audit);
-            return !accessResult.isExecutionFailure();
+            return accessResult.isExecutionFailure() ? Optional.of(buildUnauthorizedResponseEntity(OAuth20Constants.UNAUTHORIZED_CLIENT, false)) : Optional.empty();
         }
-        return false;
+        return Optional.of(buildUnauthorizedResponseEntity(OAuth20Constants.INVALID_CLIENT, true));
     }
 
     private ResponseEntity<OidcIntrospectionAccessTokenResponse> createIntrospectionResponse(
@@ -177,5 +194,39 @@ public class OidcIntrospectionEndpointController extends BaseOAuth20Controller {
         }
 
         return new ResponseEntity<>(introspect, HttpStatus.OK);
+    }
+
+    /**
+     * Build unauthorized response entity.
+     *
+     * @param code the code
+     * @return the response entity
+     */
+    private static ResponseEntity<OidcIntrospectionAccessTokenResponse> buildUnauthorizedResponseEntity(final String code, final boolean isAuthenticationFailure) {
+        final LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>(1);
+        map.add(OAuth20Constants.ERROR, code);
+        final String value = OAuth20Utils.jsonify(map);
+        final MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        if (isAuthenticationFailure) {
+            headers.add(HttpHeaders.WWW_AUTHENTICATE, "Basic");
+        }
+        @SuppressWarnings("unchecked")
+        final ResponseEntity<OidcIntrospectionAccessTokenResponse> result = new ResponseEntity(value, headers, HttpStatus.UNAUTHORIZED);
+        return result;
+    }
+
+    /**
+     * Build bad request entity.
+     *
+     * @param code the code
+     * @return the response entity
+     */
+    private static ResponseEntity<OidcIntrospectionAccessTokenResponse> buildBadRequestResponseEntity(final String code) {
+        final LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>(1);
+        map.add(OAuth20Constants.ERROR, code);
+        final String value = OAuth20Utils.jsonify(map);
+        @SuppressWarnings("unchecked")
+        final ResponseEntity<OidcIntrospectionAccessTokenResponse> result = new ResponseEntity(value, HttpStatus.BAD_REQUEST);
+        return result;
     }
 }


### PR DESCRIPTION
 - Provide a 401 response instead of 200 in case of invalid or unauthorized client credentials
 - Provide a 401 response instead of 500 in case of missing client credentials
 - Check token parameter first (as per RFC) to prevent log message on access_token parameter check