### PR TITLE
Allow Oidc services to bypass consent even if they generate refresh tokens

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/OidcConsentApprovalViewResolver.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/OidcConsentApprovalViewResolver.java
@@ -31,7 +31,7 @@ public class OidcConsentApprovalViewResolver extends OAuth20ConsentApprovalViewR
     protected boolean isConsentApprovalBypassed(final J2EContext context, final OAuthRegisteredService service) {
         final String url = context.getFullRequestURL();
         final Set<String> prompts = OidcAuthorizationRequestSupport.getOidcPromptFromAuthorizationRequest(url);
-        if (prompts.contains(OidcConstants.PROMPT_CONSENT) || service.isGenerateRefreshToken()) {
+        if (prompts.contains(OidcConstants.PROMPT_CONSENT)) {
             return false;
         }
         return super.isConsentApprovalBypassed(context, service);


### PR DESCRIPTION
Without this change an OIDC service is unable to bypass the consent screen when it can also generate refresh tokens.
