### PR TITLE
OAuth Refresh Token Flow: Allow client_secret to not be checked if the client secret is an empty string

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidator.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidator.java
@@ -46,8 +46,7 @@ public class OAuth20RefreshTokenGrantTypeTokenRequestValidator extends BaseOAuth
                                        final ProfileManager manager, final UserProfile uProfile) {
         val request = context.getRequest();
         if (!HttpRequestUtils.doesParameterExist(request, OAuth20Constants.REFRESH_TOKEN)
-            || !HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_ID)
-            || !HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_SECRET)) {
+            || !HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_ID)) {
             return false;
         }
 


### PR DESCRIPTION
- Brief description of changes applied

According to PR #3256 , OAuth **client_secret** parameter can be omitted if the client secret in service registry is an empty string.

However, in refresh token flow currently there is **a condition to validate if client_secret is empty or not** 
`!HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_SECRET)`, 
so an empty client_secret will be rejected in Refresh Token Flow. 

This PR will remove the validation on client_secret in Refresh Flow, and allow empty client_secret to be passed in if service allows it to be empty.

- Any possible limitations, side effects, etc

As for whether removing this check will affect validation:
In Refresh Flow, there is **already check against** client_id and **client_secret** before this line of code, so from what I can tell this check is redundant. 
The validation on client_id and client_secret is in [CASOAuthConfiguration.oauthSecConfig](https://github.com/apereo/cas/blob/v6.0.0-RC2/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java#L190) 

- Any documentation on how to configure, test

I was thinking of adding the following lines to this file [OAuth20RefreshTokenGrantTypeTokenRequestValidatorTests.java](https://github.com/apereo/cas/blob/master/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidatorTests.java)  as testing:

    @Test
    public void verifyOperation() {
        //...At the end
        request.setParameter(OAuth20Constants.CLIENT_SECRET, StringUtils.EMPTY);
        assertTrue(this.validator.validate(new J2EContext(request, response)));
    }

I didn't add this test case now, because I am still figuring out how best to write testing code.
Is the above a good enough test for this scenario? :)


- Reference any other pull requests that might be related.

_OAuth 2.0: Enable client_secret parameter to be omitted if the client secret is an empty string #3256_

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
