### PR TITLE
[For 5.3.x] OAuth Refresh Token Flow: Allow client_secret to not be checked if the client secret is an empty string

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidator.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidator.java
@@ -50,8 +50,7 @@ public class OAuth20RefreshTokenGrantTypeTokenRequestValidator extends BaseOAuth
                                        final ProfileManager manager, final UserProfile uProfile) {
         final HttpServletRequest request = context.getRequest();
         if (!HttpRequestUtils.doesParameterExist(request, OAuth20Constants.REFRESH_TOKEN)
-                || !HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_ID)
-                || !HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_SECRET)) {
+                || !HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_ID)) {
             return false;
         }
 

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/AbstractOAuth20Tests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/AbstractOAuth20Tests.java
@@ -248,14 +248,22 @@ public abstract class AbstractOAuth20Tests {
         return addRegisteredService(false, grantTypes);
     }
 
+    protected OAuthRegisteredService addRegisteredService(final Set<OAuth20GrantTypes> grantTypes, final String clientSecret) {
+        return addRegisteredService(false, grantTypes, clientSecret);
+    }
+
     protected OAuthRegisteredService addRegisteredService() {
         return addRegisteredService(false, new HashSet<>());
     }
 
-
     protected OAuthRegisteredService addRegisteredService(final boolean generateRefreshToken,
                                                           final Set<OAuth20GrantTypes> grantTypes) {
-        final OAuthRegisteredService registeredService = getRegisteredService(REDIRECT_URI, CLIENT_SECRET, grantTypes);
+        return addRegisteredService(generateRefreshToken, grantTypes, CLIENT_SECRET);
+    }
+
+    protected OAuthRegisteredService addRegisteredService(final boolean generateRefreshToken,
+                                                          final Set<OAuth20GrantTypes> grantTypes, final String clientSecret) {
+        final OAuthRegisteredService registeredService = getRegisteredService(REDIRECT_URI, clientSecret, grantTypes);
         registeredService.setGenerateRefreshToken(generateRefreshToken);
         servicesManager.save(registeredService);
         return registeredService;

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -248,6 +248,26 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
     }
 
     @Test
+    public void verifyClientEmptySecret() throws Exception {
+        final MockHttpServletRequest mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.ACCESS_TOKEN_URL);
+        mockRequest.setParameter(OAuth20Constants.CLIENT_ID, CLIENT_ID);
+        mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
+        mockRequest.setParameter(OAuth20Constants.CLIENT_SECRET, StringUtils.EMPTY);
+        mockRequest.setParameter(OAuth20Constants.GRANT_TYPE, OAuth20GrantTypes.AUTHORIZATION_CODE.name().toLowerCase());
+        final Principal principal = createPrincipal();
+        final OAuthRegisteredService service = addRegisteredService(
+                CollectionUtils.wrapSet(OAuth20GrantTypes.AUTHORIZATION_CODE), StringUtils.EMPTY);
+        final OAuthCode code = addCode(principal, service);
+        mockRequest.setParameter(OAuth20Constants.CODE, code.getId());
+
+        final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
+        assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
+        final String response = mockResponse.getContentAsString();
+        assertTrue(response.contains(OAuth20Constants.ACCESS_TOKEN));
+    }
+
+    @Test
     public void verifyClientExpiredCode() throws Exception {
         final RegisteredService registeredService = getRegisteredService(REDIRECT_URI, CLIENT_SECRET,
                 CollectionUtils.wrapSet(OAuth20GrantTypes.AUTHORIZATION_CODE));
@@ -388,7 +408,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         mockResponse = new MockHttpServletResponse();
         oAuth20AccessTokenController.handleRequest(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
-        response = mockResponse.getContentAsString();
+        String response = mockResponse.getContentAsString();
         assertTrue(response.contains(OAuth20Constants.ACCESS_TOKEN));
     }
 
@@ -567,6 +587,25 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         oAuth20AccessTokenController.handleRequest(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_UNAUTHORIZED, mockResponse.getStatus());
         assertEquals(ERROR_EQUALS + OAuth20Constants.INVALID_REQUEST, mockResponse.getContentAsString());
+    }
+
+    @Test
+    public void verifyRefreshTokenEmptySecret() throws Exception {
+        final Principal principal = createPrincipal();
+        final OAuthRegisteredService service = addRegisteredService(
+                CollectionUtils.wrapSet(OAuth20GrantTypes.REFRESH_TOKEN), StringUtils.EMPTY);
+        final RefreshToken refreshToken = addRefreshToken(principal, service);
+
+        final MockHttpServletRequest mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.ACCESS_TOKEN_URL);
+        mockRequest.setParameter(OAuth20Constants.GRANT_TYPE, OAuth20GrantTypes.REFRESH_TOKEN.name().toLowerCase());
+        mockRequest.setParameter(OAuth20Constants.CLIENT_ID, CLIENT_ID);
+        mockRequest.setParameter(OAuth20Constants.CLIENT_SECRET, StringUtils.EMPTY);
+        mockRequest.setParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
+        final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
+        assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
+        final String response = mockResponse.getContentAsString();
+        assertTrue(response.contains(OAuth20Constants.ACCESS_TOKEN));
     }
 
     @Test

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -262,6 +262,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
 
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
+        oAuth20AccessTokenController.handleRequest(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
         final String response = mockResponse.getContentAsString();
         assertTrue(response.contains(OAuth20Constants.ACCESS_TOKEN));
@@ -603,6 +604,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
         requiresAuthenticationInterceptor.preHandle(mockRequest, mockResponse, null);
+        oAuth20AccessTokenController.handleRequest(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
         final String response = mockResponse.getContentAsString();
         assertTrue(response.contains(OAuth20Constants.ACCESS_TOKEN));

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20AccessTokenControllerTests.java
@@ -408,7 +408,7 @@ public class OAuth20AccessTokenControllerTests extends AbstractOAuth20Tests {
         mockResponse = new MockHttpServletResponse();
         oAuth20AccessTokenController.handleRequest(mockRequest, mockResponse);
         assertEquals(HttpStatus.SC_OK, mockResponse.getStatus());
-        String response = mockResponse.getContentAsString();
+        response = mockResponse.getContentAsString();
         assertTrue(response.contains(OAuth20Constants.ACCESS_TOKEN));
     }
 


### PR DESCRIPTION
Same fix as #3619, applied to 5.3.x. 

I don't know if the change in this PR is still in the scope of 5.3.x, feel free to close it if it is not in the scope, thanks!

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
