### PR TITLE
Add Spring CacheManager to wrap EhCache CacheManager for springboot admin

### DIFF
--- a/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/config/EhcacheTicketRegistryConfiguration.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/config/EhcacheTicketRegistryConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
 import org.springframework.cache.ehcache.EhCacheFactoryBean;
 import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -162,5 +163,16 @@ public class EhcacheTicketRegistryConfiguration {
             LOGGER.debug("The following caches are available: [{}]", (Object[]) manager.getCacheNames());
         }
         return new EhCacheTicketRegistry(ticketCatalog, manager, CoreTicketUtils.newTicketRegistryCipherExecutor(crypto, "ehcache"));
+    }
+
+    /**
+     * This bean is used by the spring boot cache actuator which spring boot admin can use to clear caches.
+     * Actuator needs to be exposed in order for this bean to be used.
+     * @param ehcacheTicketCacheManager EhCache cache manager to be wrapped by spring cache manager.
+     * @return Spring EhCacheCacheManager that wraps EhCache CacheManager
+     */
+    @Bean
+    public EhCacheCacheManager ehCacheCacheManager(@Autowired final CacheManager ehcacheTicketCacheManager) {
+        return new EhCacheCacheManager(ehcacheTicketCacheManager);
     }
 }


### PR DESCRIPTION
This allows spring boot admin to manage cache if cache actuator is exposed.

With this bean you get this in spring boot admin:

![image](https://user-images.githubusercontent.com/1556777/47623997-a11df700-daed-11e8-952e-e9ad8ce017f3.png)

It currently only allows you to clear the caches, I was hoping for some stats (at least size of cache) but maybe they will add some more features to the cache actuator and/or to spring boot admin. 