### PR TITLE
fix build script when using -DskipFindbugs=true

### DIFF
--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -61,7 +61,9 @@ task cleanLogs(description: "Clean build log files") {
 }
 
 task spotbugs(type: FindBugs, description: "Set up classpath for Spotbugs") {
-    pluginClasspath = project.configurations.spotbugsPlugins
+    if (!Boolean.getBoolean("skipFindbugs")) {
+        pluginClasspath = project.configurations.spotbugsPlugins
+    }
 }
 
 task showConfiguration {


### PR DESCRIPTION
Build was failing when I ran with -DskipFindugs=true

```
* Where:
Script 'C:\Users\hdead\git\cas\gradle\tasks.gradle' line: 64

* What went wrong:
A problem occurred evaluating script.
> Could not get unknown property 'spotbugsPlugins' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer.
```