### PR TITLE
Backport Fix for ClassCastException

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
@@ -1,14 +1,15 @@
 package org.apereo.cas.ticket.support;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.authentication.RememberMeCredential;
 import org.apereo.cas.ticket.ExpirationPolicy;
 import org.apereo.cas.ticket.TicketState;
 
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 /**
  * Delegates to different expiration policies depending on whether remember me
@@ -19,10 +20,27 @@ import java.util.Map;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @Slf4j
+@ToString(callSuper = true)
 public class RememberMeDelegatingExpirationPolicy extends BaseDelegatingExpirationPolicy {
 
-
     private static final long serialVersionUID = -2735975347698196127L;
+
+    @JsonCreator
+    public RememberMeDelegatingExpirationPolicy(@JsonProperty("policy") final ExpirationPolicy policy) {
+        super(policy);
+    }
+
+    @Override
+    protected String getExpirationPolicyNameFor(final TicketState ticketState) {
+        val attrs = ticketState.getAuthentication().getAttributes();
+        val b = (Boolean) attrs.get(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
+
+        if (b == null || b.equals(Boolean.FALSE)) {
+            LOGGER.debug("Ticket is not associated with a remember-me authentication.");
+            return PolicyTypes.DEFAULT.name();
+        }
+        return PolicyTypes.REMEMBER_ME.name();
+    }
 
     /**
      * Policy types.
@@ -36,27 +54,5 @@ public class RememberMeDelegatingExpirationPolicy extends BaseDelegatingExpirati
          * Default policy type.
          */
         DEFAULT
-    }
-
-    /**
-     * Instantiates a new Remember me delegating expiration policy.
-     *
-     * @param policy the policy
-     */
-    @JsonCreator
-    public RememberMeDelegatingExpirationPolicy(@JsonProperty("policy") final ExpirationPolicy policy) {
-        super(policy);
-    }
-
-    @Override
-    protected String getExpirationPolicyNameFor(final TicketState ticketState) {
-        final Map<String, Object> attrs = ticketState.getAuthentication().getAttributes();
-        final Boolean b = (Boolean) attrs.get(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
-
-        if (b == null || b.equals(Boolean.FALSE)) {
-            LOGGER.debug("Ticket is not associated with a remember-me authentication.");
-            return PolicyTypes.DEFAULT.name();
-        }
-        return PolicyTypes.REMEMBER_ME.name();
     }
 }


### PR DESCRIPTION
Would you please backport this fix, as 5.3.x is the current stable branch and "remember-me" function is not working, because of:
```
ERROR [org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner] - <java.util.LinkedList cannot be cast to java.lang.Boolean>
java.lang.ClassCastException: java.util.LinkedList cannot be cast to java.lang.Boolean
        at org.apereo.cas.ticket.support.RememberMeDelegatingExpirationPolicy.getExpirationPolicyNameFor(RememberMeDelegatingExpirationPolicy.java:54) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.support.BaseDelegatingExpirationPolicy.getExpirationPolicyFor(BaseDelegatingExpirationPolicy.java:135) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.support.BaseDelegatingExpirationPolicy.isExpired(BaseDelegatingExpirationPolicy.java:80) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.AbstractTicket.isExpired(AbstractTicket.java:120) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174) ~[?:1.8.0_181]
        at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1553) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_181]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_181]
        at java.util.stream.IntPipeline.reduce(IntPipeline.java:456) ~[?:1.8.0_181]
        at java.util.stream.IntPipeline.sum(IntPipeline.java:414) ~[?:1.8.0_181]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner.cleanInternal(DefaultTicketRegistryCleaner.java:60) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner.clean(DefaultTicketRegistryCleaner.java:43) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner$$FastClassBySpringCGLIB$$29f046b2.invoke(<generated>) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204) ~[spring-core-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:736) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99) ~[spring-tx-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:282) ~[spring-tx-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96) ~[spring-tx-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:671) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner$$EnhancerBySpringCGLIB$$356ef2da.clean(<generated>) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.config.CasCoreTicketsSchedulingConfiguration$TicketRegistryCleanerScheduler.run(CasCoreTicketsSchedulingConfiguration.java:91) ~[cas-server-core-tickets-5.3.5.jar:5.3.5]
        at sun.reflect.GeneratedMethodAccessor306.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_181]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_181]
        at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:65) ~[spring-context-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_181]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:1.8.0_181]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_181]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:1.8.0_181]
```