### PR TITLE
Backport Fix for ClassCastException in remember-me functionality

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.ticket.support;
 
+import java.util.Collection;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -51,9 +53,9 @@ public class RememberMeDelegatingExpirationPolicy extends BaseDelegatingExpirati
     @Override
     protected String getExpirationPolicyNameFor(final TicketState ticketState) {
         final Map<String, Object> attrs = ticketState.getAuthentication().getAttributes();
-        final Boolean b = (Boolean) attrs.get(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
+        final Collection c = (Collection) attrs.get(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
 
-        if (b == null || b.equals(Boolean.FALSE)) {
+        if (c == null || c.contains(Boolean.FALSE)) {
             LOGGER.debug("Ticket is not associated with a remember-me authentication.");
             return PolicyTypes.DEFAULT.name();
         }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicyTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicyTests.java
@@ -56,7 +56,7 @@ public class RememberMeDelegatingExpirationPolicyTests {
         final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication(
                 this.principalFactory.createPrincipal("test"),
                 Collections.singletonMap(
-                        RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, true));
+                        RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, Collections.singletonList(true)));
         final TicketGrantingTicketImpl t = new TicketGrantingTicketImpl("111", authentication, this.p);
         assertFalse(t.isExpired());
         t.grantServiceTicket("55", RegisteredServiceTestUtils.getService(), this.p, false, true);
@@ -77,7 +77,7 @@ public class RememberMeDelegatingExpirationPolicyTests {
         final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication(
                 this.principalFactory.createPrincipal("test"),
                 Collections.singletonMap(
-                        RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, true));
+                        RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, Collections.singletonList(true)));
         final TicketGrantingTicketImpl t = new TicketGrantingTicketImpl("111", authentication, this.p);
         assertEquals(REMEMBER_ME_TTL, p.getTimeToLive(t));
     }


### PR DESCRIPTION
Would you please backport this fix, as 5.3.x is the current stable branch and "remember-me" function is not working, because of:
```
ERROR [org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner] - <java.util.LinkedList cannot be cast to java.lang.Boolean>
java.lang.ClassCastException: java.util.LinkedList cannot be cast to java.lang.Boolean
        at org.apereo.cas.ticket.support.RememberMeDelegatingExpirationPolicy.getExpirationPolicyNameFor(RememberMeDelegatingExpirationPolicy.java:54) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.support.BaseDelegatingExpirationPolicy.getExpirationPolicyFor(BaseDelegatingExpirationPolicy.java:135) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.support.BaseDelegatingExpirationPolicy.isExpired(BaseDelegatingExpirationPolicy.java:80) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.AbstractTicket.isExpired(AbstractTicket.java:120) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174) ~[?:1.8.0_181]
        at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1553) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_181]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_181]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_181]
        at java.util.stream.IntPipeline.reduce(IntPipeline.java:456) ~[?:1.8.0_181]
        at java.util.stream.IntPipeline.sum(IntPipeline.java:414) ~[?:1.8.0_181]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner.cleanInternal(DefaultTicketRegistryCleaner.java:60) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner.clean(DefaultTicketRegistryCleaner.java:43) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner$$FastClassBySpringCGLIB$$29f046b2.invoke(<generated>) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204) ~[spring-core-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:736) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:99) ~[spring-tx-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:282) ~[spring-tx-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96) ~[spring-tx-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:671) ~[spring-aop-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner$$EnhancerBySpringCGLIB$$356ef2da.clean(<generated>) ~[cas-server-core-tickets-api-5.3.5.jar:5.3.5]
        at org.apereo.cas.config.CasCoreTicketsSchedulingConfiguration$TicketRegistryCleanerScheduler.run(CasCoreTicketsSchedulingConfiguration.java:91) ~[cas-server-core-tickets-5.3.5.jar:5.3.5]
        at sun.reflect.GeneratedMethodAccessor306.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_181]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_181]
        at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:65) ~[spring-context-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-4.3.20.RELEASE.jar:4.3.20.RELEASE]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_181]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:1.8.0_181]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_181]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:1.8.0_181]
```