### PR TITLE
Improve debuging of SAML requests

### DIFF
--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/authentication/principal/SamlServiceFactory.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/authentication/principal/SamlServiceFactory.java
@@ -48,6 +48,8 @@ public class SamlServiceFactory extends AbstractServiceFactory<SamlService> {
         final String id = cleanupUrl(service);
 
         if (StringUtils.hasText(requestBody)) {
+            LOGGER.debug("Request Body: [{}]", requestBody);
+
             request.setAttribute(SamlProtocolConstants.PARAMETER_SAML_REQUEST, requestBody);
 
             final Document document = saml10ObjectBuilder.constructDocumentFromXml(requestBody);
@@ -71,7 +73,7 @@ public class SamlServiceFactory extends AbstractServiceFactory<SamlService> {
             }
         }
 
-        LOGGER.debug("Request Body: [{}]\n\"Extracted ArtifactId: [{}]. Extracted Request Id: [{}]", requestBody, artifactId, requestId);
+        LOGGER.debug("Extracted ArtifactId: [{}]. Extracted Request Id: [{}]", artifactId, requestId);
         final SamlService samlService = new SamlService(id, service, artifactId, requestId);
         samlService.setSource(SamlProtocolConstants.CONST_PARAM_TARGET);
         return samlService;


### PR DESCRIPTION
Split the debug log of Saml request to allow dumping the Request before parsing-exception are triggered

The new Saml/XML parsing tool is subject to throwing exception when the Saml request has issue, however the current debug LOG is made too late to get the usefull information in the log so this patch split back the LOGGER.debug in two line and dump the RequestBody before attempting to parse it.

Regards