### PR TITLE
NPE during startup due to missing parent of ApplicationContext used in CasCoreUtilConfiguration

### DIFF
--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
@@ -97,7 +97,7 @@ public class CasCoreUtilConfiguration {
         final DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService(true);
         conversionService.setEmbeddedValueResolver(new CasEmbeddedValueResolver(ctx));
         ctx.getEnvironment().setConversionService(conversionService);
-        if(ctx.getParent() != null) {
+        if (ctx.getParent() != null) {
             final ConfigurableEnvironment env = (ConfigurableEnvironment) ctx.getParent().getEnvironment();
             env.setConversionService(conversionService);
         }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
@@ -97,8 +97,10 @@ public class CasCoreUtilConfiguration {
         final DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService(true);
         conversionService.setEmbeddedValueResolver(new CasEmbeddedValueResolver(ctx));
         ctx.getEnvironment().setConversionService(conversionService);
-        final ConfigurableEnvironment env = (ConfigurableEnvironment) ctx.getParent().getEnvironment();
-        env.setConversionService(conversionService);
+        if(ctx.getParent() != null) {
+            final ConfigurableEnvironment env = (ConfigurableEnvironment) ctx.getParent().getEnvironment();
+            env.setConversionService(conversionService);
+        }
         final ConverterRegistry registry = (ConverterRegistry) DefaultConversionService.getSharedInstance();
         registry.addConverter(zonedDateTimeToStringConverter());
     }


### PR DESCRIPTION
In some environments spring's ApplicationContext does not have a parent set, which will cause a NPE during startup