### PR TITLE
avoid clearing credentials on success so AUP has access to credential

### DIFF
--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/ClearWebflowCredentialAction.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/ClearWebflowCredentialAction.java
@@ -12,18 +12,18 @@ import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
 /**
- * This is {@link ClearWebflowCredentialAction} invoked ONLY as an exit-action for non-interactive authn flows.
- * Don't clear credentials when "success" occurs which leads to STATE_ID_CREATE_TICKET_GRANTING_TICKET but
- * map be overridden by the AUP flow. AUP flow needs credentials in some cases.
- * Credentials mainly need to be cleared if flow is to login page where credentials that may not have username
- * property will interfere with the login form.
+ * This action {@link ClearWebflowCredentialAction} is invoked ONLY as an exit-action for non-interactive authn flows.
+ * Don't clear credentials when {@value CasWebflowConstants#TRANSITION_ID_SUCCESS} occurs which leads the webflow to
+ * {@value CasWebflowConstants#STATE_ID_CREATE_TICKET_GRANTING_TICKET} but may be overridden by the AUP flow
+ * which needs credentials in some cases.
+ * Credentials need to be cleared if webflow is returning to login page where credentials without
+ * a username property will not bind correctly to the login form in the thymeleaf template.
  * @author Misagh Moayyed
  * @since 5.0.0
  */
 
 @Slf4j
 public class ClearWebflowCredentialAction extends AbstractAction {
-
 
     @Override
     @SneakyThrows

--- a/support/cas-server-support-aup-core/src/main/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-core/src/main/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepository.java
@@ -7,6 +7,7 @@ import org.apereo.cas.configuration.model.support.aup.AcceptableUsagePolicyPrope
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.web.support.WebUtils;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.webflow.execution.RequestContext;
@@ -20,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Misagh Moayyed
  * @since 4.2
  */
+@Slf4j
 public class DefaultAcceptableUsagePolicyRepository extends AbstractPrincipalAttributeAcceptableUsagePolicyRepository {
 
     private static final long serialVersionUID = -3059445754626980894L;
@@ -64,6 +66,10 @@ public class DefaultAcceptableUsagePolicyRepository extends AbstractPrincipalAtt
     private Pair<String, Map> getKeyAndMap(final RequestContext requestContext, final Credential credential) {
         switch (scope) {
             case GLOBAL:
+                if (credential == null) {
+                    LOGGER.debug("Falling back to AUP scope AUTHENTICATION because credential is null");
+                    return Pair.of(AUP_ACCEPTED, requestContext.getFlowScope().asMap());
+                }
                 return Pair.of(credential.getId(), policyMap);
             case AUTHENTICATION:
                 return Pair.of(AUP_ACCEPTED, requestContext.getFlowScope().asMap());


### PR DESCRIPTION
I tested this with X509 and fallback to regular login but this has potential to impact any of the other webflows that use the credential clearing action in their webflow. Assuming they all clear the credential when there is an error that results in the flow going back to login, then this should be OK but I am not very familiar with the other flows and I don't know what other reasons there might be for clearing the credentials. 

I also made a change to the default aup repository so that if the credential is null it will fall back to storing the aup acceptance in the flow along with a debug message that someone could use to figure out why they were prompting users more often than they were expecting. I figure the extra prompts are better then a server error that prevents login. The fix to not clear the credentials should fix the issue of the credentials being null in AUP but I think some defensive programming might be warranted in case of a future regression.