### PR TITLE
Backport Fix for NullPointerException in SAML ECP Request

### DIFF
--- a/support/cas-server-support-saml/build.gradle
+++ b/support/cas-server-support-saml/build.gradle
@@ -3,6 +3,7 @@ description = "Apereo CAS SAML Server and Validation Support"
 dependencies {
     
     implementation project(":support:cas-server-support-saml-core")
+    implementation project(":support:cas-server-support-saml-idp-core")
     implementation project(":core:cas-server-core-services")
     implementation project(":core:cas-server-core-authentication-api")
     implementation project(":core:cas-server-core-tickets-api")

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/authentication/principal/SamlServiceFactory.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/authentication/principal/SamlServiceFactory.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.saml.authentication.principal;
 
 import org.apereo.cas.authentication.principal.AbstractServiceFactory;
+import org.apereo.cas.support.saml.SamlIdPConstants;
 import org.apereo.cas.support.saml.SamlProtocolConstants;
 import org.apereo.cas.support.saml.util.Saml10ObjectBuilder;
 
@@ -35,6 +36,15 @@ public class SamlServiceFactory extends AbstractServiceFactory<SamlService> {
 
     @Override
     public SamlService createService(final HttpServletRequest request) {
+        /**
+          * As per http://docs.oasis-open.org/security/saml/Post2.0/saml-ecp/v2.0/saml-ecp-v2.0.html we cannot create service from SAML ECP Request.
+          * This will result in NullPointerException, when trying to get samlp:Request from S:Body.
+          */
+        if (request.getRequestURI().contains(SamlIdPConstants.ENDPOINT_SAML2_IDP_ECP_PROFILE_SSO)) {
+            LOGGER.trace("The {} request on {} seems to be a SOAP ECP Request, skip creating service from it.", request.getMethod(), request.getRequestURI());
+            return null;
+        }
+
         final String service = request.getParameter(SamlProtocolConstants.CONST_PARAM_TARGET);
         final String requestBody = request.getMethod().equalsIgnoreCase(HttpMethod.POST.name()) ? getRequestBody(request) : null;
 


### PR DESCRIPTION
When using SAML ECP, `createService` in `SamlServiceFactory` throws a `NullPointerException`. For SAML ECP workflow, the service is extracted later from `<samlp:Request>`.

See http://docs.oasis-open.org/security/saml/Post2.0/saml-ecp/v2.0/saml-ecp-v2.0.html for more information.