### PR TITLE
fixes identifier for oracle databases

### DIFF
--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/authentication/api/MultifactorAuthenticationTrustRecord.java
@@ -30,7 +30,7 @@ import java.time.temporal.ChronoUnit;
  * @since 5.0.0
  */
 @Entity
-@Table(name = "MultifactorAuthenticationTrustRecord")
+@Table(name = "MultifactorAuthnTrustRecord")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ToString
 @Getter


### PR DESCRIPTION
fixes identifier for oracle databases with a maximum length of 30 characters