### PR TITLE
allow ldap connectOnCreate property to be set, make default false

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ConnectionPoolingProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ConnectionPoolingProperties.java
@@ -18,7 +18,7 @@ public class ConnectionPoolingProperties implements Serializable {
     private static final long serialVersionUID = -5307463292890944799L;
 
     /**
-     * Controls the maximum size that the pool is allowed to reach, including both idle and in-use connections.
+     * Controls the minimum size that the pool is allowed to reach, including both idle and in-use connections.
      */
     private int minSize = 6;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -83,6 +83,11 @@ public abstract class AbstractLdapProperties implements Serializable {
      */
     private boolean failFast = true;
     /**
+     * Whether to connect to the ldap on connection creation.
+     * Setting this to true may cause on an ldap monitor may cause server not to start up if connection fails.
+     */
+    private boolean connectOnCreate;
+    /**
      * Removes connections from the pool based on how long they have been idle in the available queue.
      * Prunes connections that have been idle for more than the indicated amount.
      */

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -1042,6 +1042,7 @@ The following  options apply  to features that integrate with an LDAP server (i.
 #${configurationKey}.validatePeriod=PT5M
 #${configurationKey}.validateTimeout=PT5S
 #${configurationKey}.failFast=true
+#${configurationKey}.connectOnCreate=false
 #${configurationKey}.idleTime=PT10M
 #${configurationKey}.prunePeriod=PT2H
 #${configurationKey}.blockWaitTime=PT3S

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -921,6 +921,7 @@ public class LdapUtils {
         }
 
         cp.setFailFastInitialize(l.isFailFast());
+        cp.setConnectOnCreate(l.isConnectOnCreate());
 
         if (StringUtils.isNotBlank(l.getPoolPassivator())) {
             val pass =


### PR DESCRIPTION
This changes the connectOnCreate property from true to false by default and allows it to be configured.
Having connections with connectOnCreate as false means that bad connections won't happen during startup, but rather when the connection is first used or tested.

This allows for the CAS server to startup cleanly when the the ldap monitor module is used while still initializing the pool with the min number of connections (albeit lazily connected connections).

Configuring the min size of the pool to zero would also work but users may want min to be greater than zero.

With connectOnCreate set to false, connections will not actually be connected until first use but then they should remain in the pool connected. 
