### PR TITLE
default ldap monitor to a min pool size of zero

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
@@ -124,10 +124,19 @@ public class MonitorProperties implements Serializable {
         private String maxWait = "PT5S";
 
         /**
-         * Options that define the LDAP connection pool to monitor.
+         * Options that define the thread pool that will ping on the ldap pool.
          */
         @NestedConfigurationProperty
         private ConnectionPoolingProperties pool = new ConnectionPoolingProperties();
+
+        /**
+         * Initialize minPoolSize for the monitor to zero.
+         * This prevents a bad ldap connection from causing server to fail startup.
+         * User can override this default via configuration.
+         */
+        public Ldap() {
+            setMinPoolSize(0);
+        }
     }
 
     @RequiresModule(name = "cas-server-support-memcached-monitor")

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ConnectionPoolingProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ConnectionPoolingProperties.java
@@ -18,7 +18,7 @@ public class ConnectionPoolingProperties implements Serializable {
     private static final long serialVersionUID = -5307463292890944799L;
 
     /**
-     * Controls the maximum size that the pool is allowed to reach, including both idle and in-use connections.
+     * Controls the minimum size that the pool is allowed to reach, including both idle and in-use connections.
      */
     private int minSize = 6;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.configuration.model.support.ldap;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.configuration.model.support.ldap;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -17,6 +18,7 @@ import java.io.Serializable;
 public abstract class AbstractLdapProperties implements Serializable {
 
     private static final long serialVersionUID = 2682743362616979324L;
+
     /**
      * Path of the trust certificates to use for the SSL connection.
      * Ignores keystore-related settings when activated and used.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/Beans.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/Beans.java
@@ -36,7 +36,8 @@ public class Beans {
      * @return the thread pool executor factory bean
      */
     public static ThreadPoolExecutorFactoryBean newThreadPoolExecutorFactoryBean(final ConnectionPoolingProperties config) {
-        val bean = newThreadPoolExecutorFactoryBean(config.getMaxSize(), config.getMaxSize());
+        val bean = new ThreadPoolExecutorFactoryBean();
+        bean.setMaxPoolSize(config.getMaxSize());
         bean.setCorePoolSize(config.getMinSize());
         return bean;
     }

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3336,6 +3336,7 @@ available [here](Configuration-Properties-Common.html#database-settings) under t
 Decide how CAS should monitor the LDAP server it uses for authentication, etc.  
 LDAP settings for this feature are 
 available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.monitor.ldap`.
+The default for ```cas.monitor.ldap.minPoolSize``` is zero to prevent failed ldap pool initialization to impact server startup.
 
 ```properties
 # cas.monitor.ldap.maxWait=5000
@@ -3346,7 +3347,6 @@ that will ping on the LDAP monitor connection pool.
 ```properties
 # cas.monitor.ldap.pool.minSize=6
 # cas.monitor.ldap.pool.maxSize=18
-# cas.monitor.ldap.pool.maxWait=2000
 ```
 
 ### Memory

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3338,13 +3338,11 @@ LDAP settings for this feature are
 available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.monitor.ldap`.
 The default for ```cas.monitor.ldap.minPoolSize``` is zero to prevent failed ldap pool initialization to impact server startup.
 
-```properties
-# cas.monitor.ldap.maxWait=5000
-```
-
 The following properties are specific to the ldap monitor and configure the thread pool 
 that will ping on the LDAP monitor connection pool.
+
 ```properties
+# cas.monitor.ldap.maxWait=5000
 # cas.monitor.ldap.pool.minSize=6
 # cas.monitor.ldap.pool.maxSize=18
 ```

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3331,14 +3331,22 @@ available [here](Configuration-Properties-Common.html#database-settings) under t
 # cas.monitor.jdbc.maxWait=5000
 ```
 
-### LDAP Connection Pool
+### LDAP Server Monitoring
 
-Decide how CAS should monitor the internal state of LDAP connections
-used for authentication, etc.  LDAP settings for this feature are 
+Decide how CAS should monitor the LDAP server it uses for authentication, etc.  
+LDAP settings for this feature are 
 available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.monitor.ldap`.
 
 ```properties
 # cas.monitor.ldap.maxWait=5000
+```
+
+The following properties are specific to the ldap monitor and configure the thread pool 
+that will ping on the LDAP monitor connection pool.
+```properties
+# cas.monitor.ldap.pool.minSize=6
+# cas.monitor.ldap.pool.maxSize=18
+# cas.monitor.ldap.pool.maxWait=2000
 ```
 
 ### Memory


### PR DESCRIPTION
This allows the ldap monitor module to be used and not interfere with server startup when ldap is unavailable or incorrectly configured. 
