### PR TITLE
REST: Obtain ST with SSO bypass.

### DIFF
--- a/docs/cas-server-documentation/protocol/REST-Protocol.md
+++ b/docs/cas-server-documentation/protocol/REST-Protocol.md
@@ -97,6 +97,14 @@ POST /cas/v1/tickets/{TGT id} HTTP/1.0
 service={form encoded parameter for the service url}
 ```
 
+You may also specify a `renew` parameter to obtain a service ticket that can be accepted by a service that only wants tickets issued from the presentation of the user's primary credentials. In that case, user credentials have to be passed in the request, for example, as `username` and `password` parameters.
+
+```bash
+POST /cas/v1/tickets/{TGT id} HTTP/1.0
+
+service={form encoded parameter for the service url}&renew=true&username=battags&password=password
+```
+
 You may also submit service ticket requests using the semantics [SAML1 protocol](SAML-Protocol.html).
 
 ### Successful Response

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/config/CasRestConfiguration.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/config/CasRestConfiguration.java
@@ -85,11 +85,13 @@ public class CasRestConfiguration implements RestHttpRequestCredentialFactoryCon
     @Bean
     @Autowired
     public ServiceTicketResource serviceTicketResource(
-        @Qualifier("serviceTicketResourceEntityResponseFactory") final ServiceTicketResourceEntityResponseFactory serviceTicketResourceEntityResponseFactory) {
+        @Qualifier("serviceTicketResourceEntityResponseFactory") final ServiceTicketResourceEntityResponseFactory serviceTicketResourceEntityResponseFactory,
+        @Qualifier("restHttpRequestCredentialFactory") final RestHttpRequestCredentialFactory restHttpRequestCredentialFactory) {
         return new ServiceTicketResource(authenticationSystemSupport.getIfAvailable(),
             ticketRegistrySupport.getIfAvailable(),
             argumentExtractor.getIfAvailable(),
-            serviceTicketResourceEntityResponseFactory);
+            serviceTicketResourceEntityResponseFactory,
+            restHttpRequestCredentialFactory);
     }
 
     @Bean

--- a/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/ServiceTicketResourceTests.java
+++ b/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/ServiceTicketResourceTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.rest;
 
 import org.apereo.cas.CentralAuthenticationService;
+import org.apereo.cas.authentication.AuthenticationException;
 import org.apereo.cas.authentication.AuthenticationManager;
 import org.apereo.cas.authentication.AuthenticationResult;
 import org.apereo.cas.authentication.AuthenticationTransaction;
@@ -11,6 +12,7 @@ import org.apereo.cas.authentication.DefaultPrincipalElectionStrategy;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
 import org.apereo.cas.rest.factory.CasProtocolServiceTicketResourceEntityResponseFactory;
+import org.apereo.cas.rest.factory.UsernamePasswordRestHttpRequestCredentialFactory;
 import org.apereo.cas.support.rest.resources.ServiceTicketResource;
 import org.apereo.cas.support.rest.resources.TicketGrantingTicketResource;
 import org.apereo.cas.ticket.InvalidTicketException;
@@ -30,6 +32,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import javax.security.auth.login.LoginException;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -46,6 +52,10 @@ public class ServiceTicketResourceTests {
     private static final String TICKETS_RESOURCE_URL = "/cas/v1/tickets";
     private static final String OTHER_EXCEPTION = "Other exception";
     private static final String SERVICE = "service";
+    private static final String RENEW = "renew";
+    private static final String TEST_VALUE = "test";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
 
     @Mock
     private CentralAuthenticationService casMock;
@@ -65,11 +75,13 @@ public class ServiceTicketResourceTests {
         when(ticketSupport.getAuthenticationFrom(anyString())).thenReturn(CoreAuthenticationTestUtils.getAuthentication());
 
         val publisher = mock(ApplicationEventPublisher.class);
+
         this.serviceTicketResource = new ServiceTicketResource(
             new DefaultAuthenticationSystemSupport(new DefaultAuthenticationTransactionManager(publisher, mgmr),
                 new DefaultPrincipalElectionStrategy()),
             ticketSupport, new DefaultArgumentExtractor(new WebApplicationServiceFactory()),
-            new CasProtocolServiceTicketResourceEntityResponseFactory(casMock));
+            new CasProtocolServiceTicketResourceEntityResponseFactory(casMock),
+            new UsernamePasswordRestHttpRequestCredentialFactory());
 
         this.mockMvc = MockMvcBuilders.standaloneSetup(this.serviceTicketResource)
             .defaultRequest(get("/")
@@ -87,6 +99,22 @@ public class ServiceTicketResourceTests {
             .andExpect(status().isOk())
             .andExpect(content().contentType("text/plain;charset=ISO-8859-1"))
             .andExpect(content().string("ST-1"));
+    }
+
+    @Test
+    public void normalCreationOfSTWithRenew() throws Exception {
+        configureCasMockToCreateValidST();
+
+        val content = this.mockMvc.perform(post(TICKETS_RESOURCE_URL + "/TGT-1")
+            .param(SERVICE, CoreAuthenticationTestUtils.getService().getId())
+            .param(RENEW, "true")
+            .param(USERNAME, TEST_VALUE)
+            .param(PASSWORD, TEST_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("text/plain;charset=ISO-8859-1"))
+            .andExpect(content().string("ST-1"))
+            .andReturn().getResponse().getContentAsString();
+        assertTrue(content.contains("ST-1"));
     }
 
     @Test
@@ -108,6 +136,32 @@ public class ServiceTicketResourceTests {
             .andExpect(content().string(OTHER_EXCEPTION));
     }
 
+    @Test
+    public void creationOfSTWithBadRequestException() throws Exception {
+        configureCasMockToCreateValidST();
+
+        val content = this.mockMvc.perform(post(TICKETS_RESOURCE_URL + "/TGT-1")
+            .param(SERVICE, CoreAuthenticationTestUtils.getService().getId())
+            .param(RENEW, "true"))
+            .andExpect(status().isBadRequest())
+            .andReturn().getResponse().getContentAsString();
+        assertTrue(content.contains("No credentials"));
+    }
+
+    @Test
+    public void creationOfSTWithAuthenticationException() throws Exception {
+        configureCasMockSTCreationToThrowAuthenticationException();
+
+        val content = this.mockMvc.perform(post(TICKETS_RESOURCE_URL + "/TGT-1")
+            .param(SERVICE, CoreAuthenticationTestUtils.getService().getId())
+            .param(RENEW, "true")
+            .param(USERNAME, TEST_VALUE)
+            .param(PASSWORD, TEST_VALUE))
+            .andExpect(status().isUnauthorized())
+            .andReturn().getResponse().getContentAsString();
+        assertTrue(content.contains("LoginException"));
+    }
+
     private void configureCasMockSTCreationToThrow(final Throwable e) {
         when(this.casMock.grantServiceTicket(anyString(), any(Service.class), any(AuthenticationResult.class))).thenThrow(e);
     }
@@ -116,5 +170,12 @@ public class ServiceTicketResourceTests {
         val st = mock(ServiceTicket.class);
         when(st.getId()).thenReturn("ST-1");
         when(this.casMock.grantServiceTicket(anyString(), any(Service.class), any(AuthenticationResult.class))).thenReturn(st);
+    }
+
+    private void configureCasMockSTCreationToThrowAuthenticationException() {
+        val handlerErrors = new HashMap<String, Throwable>(1);
+        handlerErrors.put("TestCaseAuthenticationHandler", new LoginException("Login failed"));
+        when(this.casMock.grantServiceTicket(anyString(), any(Service.class), any(AuthenticationResult.class)))
+            .thenThrow(new AuthenticationException(handlerErrors));
     }
 }


### PR DESCRIPTION
Applications that use the CAS REST protocol may need to authenticate to security sensitive services that demand a service ticket that was issued from the presentation of the user’s primary credentials (those services only validate service tickets with the activation of the optional "renew" parameter of the /validate /serviceValidate CAS requests)

This proposed change to the REST API is to allow applications to add optional "username", "password", and "renew" parameters to the REST service ticket request, to be able to obtain STs that can be accepted by such security sensitive services.

This change has the same purpose as PR #3633 and is supposed to replace it. The approach seems better as it avoids the problem of potentially creating two resources in a single REST request.
