### PR TITLE
Propagate "Accept-Language" to interrupt REST endpoint

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpRequestUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpRequestUtils.java
@@ -32,6 +32,12 @@ public class HttpRequestUtils {
     public static final String USER_AGENT_HEADER = "user-agent";
 
     /**
+     * Constant representing the request header for accept language.
+     */
+    public static final String ACCEPT_LANGUAGE_HEADER = "accept-language";
+
+
+    /**
      * Gets http servlet request from request attributes.
      *
      * @return the http servlet request from request attributes
@@ -110,6 +116,20 @@ public class HttpRequestUtils {
         }
         return null;
     }
+
+    /**
+     * Gets http servlet request accept language.
+     *
+     * @param request the request
+     * @return the http servlet request accept language
+     */
+    public static String getHttpServletRequestAcceptLanguage(final HttpServletRequest request) {
+        if (request != null) {
+            return request.getHeader(ACCEPT_LANGUAGE_HEADER);
+        }
+        return null;
+    }
+
 
     /**
      * Gets the service from the request based on given extractors.

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
@@ -542,6 +542,28 @@ public class WebUtils {
     }
 
     /**
+     * Gets http servlet request accept language.
+     *
+     * @return the http servlet request accept language
+     */
+    public static String getHttpServletRequestAcceptLanguageFromRequestContext() {
+        final HttpServletRequest request = getHttpServletRequestFromExternalWebflowContext();
+        return HttpRequestUtils.getHttpServletRequestAcceptLanguage(request);
+    }
+
+    /**
+     * Gets http servlet request accept language from request context.
+     *
+     * @param context the context
+     * @return the http servlet request accept language from request context
+     */
+    public static String getHttpServletRequestAcceptLanguageFromRequestContext(final RequestContext context) {
+        final HttpServletRequest request = getHttpServletRequestFromExternalWebflowContext(context);
+        return HttpRequestUtils.getHttpServletRequestAcceptLanguage(request);
+    }
+
+
+    /**
      * Gets http servlet request geo location.
      *
      * @return the http servlet request geo location

--- a/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/RestEndpointInterruptInquirer.java
+++ b/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/RestEndpointInterruptInquirer.java
@@ -12,6 +12,7 @@ import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.configuration.model.support.interrupt.InterruptProperties;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.util.HttpUtils;
+import org.apereo.cas.web.support.WebUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,9 +48,14 @@ public class RestEndpointInterruptInquirer extends BaseInterruptInquirer {
             if (registeredService != null) {
                 parameters.put("registeredService", registeredService.getServiceId());
             }
+            final String language = WebUtils.getHttpServletRequestAcceptLanguageFromRequestContext();
+            final Map<String, Object> headers = new HashMap<>();
+            if (language != null) {
+                headers.put("Accept-Language", language);
+            }
             response = HttpUtils.execute(restProperties.getUrl(), restProperties.getMethod(),
                 restProperties.getBasicAuthUsername(), restProperties.getBasicAuthPassword(),
-                parameters, new HashMap<>());
+                parameters, headers);
             if (response != null && response.getEntity() != null) {
                 return MAPPER.readValue(response.getEntity().getContent(), InterruptResponse.class);
             }


### PR DESCRIPTION
In a multi-language setup it may be valuable for the REST interrupt endpoint to have
knowledge about the browser language settings of the user. With this commit, we now
propagate that information to the REST interrupt endpoint.

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
