### PR TITLE
point upgrader at new property names for properties that have been renamed

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jpa/AbstractJpaProperties.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -100,6 +101,7 @@ public abstract class AbstractJpaProperties implements Serializable {
     /**
      * Database connection pooling settings.
      */
+    @NestedConfigurationProperty
     private ConnectionPoolingProperties pool = new ConnectionPoolingProperties();
 
     /**

--- a/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,103 @@
+{
+  "properties": [
+    {
+      "name": "cas.authn.releaseProtocolAttributes",
+      "type": "java.lang.Boolean",
+      "description": "Whether to release authentication attributes.",
+      "defaultValue": true,
+      "deprecation": {
+        "replacement": "cas.authn.authenticationAttributeRelease.enabled",
+        "reason": "Property renamed due to new cas.authn.authenticationAttributeRelease.* settings.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.authn.x509.principalSNRadix",
+      "type": "java.lang.Integer",
+      "description": "X509 principal extraction config.",
+      "defaultValue": 10,
+      "deprecation": {
+        "replacement": "cas.authn.x509.serialNo.principalSNRadix",
+        "reason": "Property renamed due to x509 settings reorganization.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.authn.x509.principalHexSNZeroPadding",
+      "type": "java.lang.Boolean",
+      "description": "X509 principal extraction config.",
+      "defaultValue": true,
+      "deprecation": {
+        "replacement": "cas.authn.x509.serialNo.principalHexSNZeroPadding",
+        "reason": "Property renamed due to x509 settings reorganization.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.authn.x509.valueDelimiter",
+      "type": "java.lang.String",
+      "description": "X509 principal extraction config.",
+      "defaultValue": ",",
+      "deprecation": {
+        "replacement": "cas.authn.x509.serialNoDn.valueDelimiter",
+        "reason": "Property renamed due to x509 settings reorganization.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.authn.x509.serialNumberPrefix",
+      "type": "java.lang.String",
+      "description": "X509 principal extraction config.",
+      "defaultValue": "SERIALNUMBER=",
+      "deprecation": {
+        "replacement": "cas.authn.x509.serialNoDn.serialNumberPrefix",
+        "reason": "Property renamed due to x509 settings reorganization.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.server.basicAuthn.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable basic auth on tomcat.",
+      "defaultValue": false,
+      "deprecation": {
+        "replacement": "cas.server.tomcat.basicAuthn.enabled",
+        "reason": "cas.server.* moved to cas.server.tomcat.*.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.tomcat.clustering.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable tomcat clustering.",
+      "defaultValue": false,
+      "deprecation": {
+        "replacement": "cas.server.tomcat.clustering.enabled",
+        "reason": "cas.server.* moved to cas.server.tomcat.*.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.adminPagesSecurity.actuatorEndpointsEnabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable actuator endpoints.",
+      "defaultValue": false,
+      "deprecation": {
+        "replacement": "management.endpoints.enabled-by-default",
+        "reason": "cas.adminPagesSecurity.* moved to management.endpoints.*.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.adminPagesSecurity.ip",
+      "type": "java.lang.String",
+      "description": "Enable actuator endpoints.",
+      "defaultValue": "127.0.0.1",
+      "deprecation": {
+        "replacement": "cas.monitor.endpoints.endpoint.defaults.access[0]",
+        "reason": "management endpoints security under cas.monitor.endpoints.endpoint.*.",
+        "level": "error"
+      }
+    }
+  ]
+}

--- a/gradle/webapp.gradle
+++ b/gradle/webapp.gradle
@@ -63,7 +63,8 @@ dependencies {
     implementation libraries.metrics
     implementation libraries.bouncycastle
     implementation libraries.springcloudconfigclient
-    
+
+
     developmentOnly libraries.springbootdevtools
     runtimeOnly libraries.webjars
 }


### PR DESCRIPTION
I think this file should be picked up and processed by the spring boot property migration stuff but I haven't tested it yet.

The spring-boot PropertiesMigrationReporter picks up any properties that have a deprecation section with level=error. There is a @DeprecatedConfigurationProperty annotation for deprecating properties that you still support but that you want users to migrate away from but once the property is gone, this "additional-spring-configuration-metadata.json" file is where you put properties that no longer exist. 

The "replacement" and "reason" attributes aren't both required. Spring-boot seems to leave off reason when there is a replacement and specify reason when there is no replacement but I think the code allows for both to be there. 

[Example from spring-boot #1](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json)

We need a little program that parses spring-configuration-metadata.json from the last few releases and collects properties that don't exist in 6.0. Otherwise, we can just add to this file as we find changed properties. I have some more at work I can add. 
