### PR TITLE
Add possibility of overriding value of x-frame-options using service files

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
@@ -98,6 +98,10 @@ public interface RegisteredServiceProperty extends Serializable {
          */
         HTTP_HEADER_ENABLE_XFRAME_OPTIONS("httpHeaderEnableXFrameOptions", "true"),
         /**
+         * Whether CAS should override xframe options headers into the response when this service is in process.
+         */
+        HTTP_HEADER_XFRAME_OPTIONS("httpHeaderXFrameOptions", "DENY"),
+        /**
          * Whether CAS should inject content security policy headers into the response when this service is in process.
          */
         HTTP_HEADER_ENABLE_CONTENT_SECURITY_POLICY("httpHeaderEnableContentSecurityPolicy", "true"),
@@ -105,7 +109,6 @@ public interface RegisteredServiceProperty extends Serializable {
          * Whether CAS should inject xss protection headers into the response when this service is in process.
          */
         HTTP_HEADER_ENABLE_XSS_PROTECTION("httpHeaderEnableXSSProtection", "true");
-
 
         private final String propertyName;
         private final String defaultValue;

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
@@ -51,6 +51,10 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
 
     @Override
     protected void decideInsertXFrameOptionsHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
+        final String xFrameOptions = getStringProperty(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_XFRAME_OPTIONS);
+        if (xFrameOptions != null) {
+            super.setXFrameOptions(xFrameOptions);
+        }
         if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
             RegisteredServiceProperties.HTTP_HEADER_ENABLE_XFRAME_OPTIONS)) {
             super.insertXFrameOptionsHeader(httpServletResponse, httpServletRequest);
@@ -87,6 +91,19 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
         } else {
             super.decideInsertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
         }
+    }
+
+    private String getStringProperty(final HttpServletRequest request,
+                                     final RegisteredServiceProperties property) {
+        final Optional<RegisteredService> result = getRegisteredServiceFromRequest(request);
+        if (result.isPresent()) {
+            final Map<String, RegisteredServiceProperty> properties = result.get().getProperties();
+            if (properties.containsKey(property.getPropertyName())) {
+                final RegisteredServiceProperty prop = properties.get(property.getPropertyName());
+                return prop.getValue();
+            }
+        }
+        return null;
     }
 
     private boolean shouldHttpHeaderBeInjectedIntoResponse(final HttpServletRequest request,

--- a/docs/cas-server-documentation/installation/Configuring-Service-Http-Security-Headers.md
+++ b/docs/cas-server-documentation/installation/Configuring-Service-Http-Security-Headers.md
@@ -35,3 +35,5 @@ Supported HTTP headers in form of service properties are:
 | `httpHeaderEnableXFrameOptions`      | Insert `X-Frame-Options` headers into the response for this service.
 | `httpHeaderEnableContentSecurityPolicy`      | Insert `Content-Security-Policy` headers into the response for this service.
 | `httpHeaderEnableXSSProtection`      | Insert `X-XSS-Protection` headers into the response for this service.
+| `httpHeaderXFrameOptions`      | Override the `X-Frame-Options` header of the response for this service.
+


### PR DESCRIPTION
The service property "httpHeaderEnableXFrameOptions" can control if the
x-frame-options header should be inserted in the HTTP response. However it
make sense to control the value of the x-frame-options using service files.
This commit implements that feature by introducing the property
"httpHeaderXFrameOptions".

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
