### PR TITLE
Added ability to set ldaptive's allowMultipleEntries via cas.properties

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -230,6 +230,11 @@ public abstract class AbstractLdapProperties implements Serializable {
      */
     private boolean allowMultipleDns;
 
+    /** 
+     * Set if multiple Entries are allowed.
+     */
+    private boolean allowMultipleEntries;
+    
     /**
      * The bind DN to use when connecting to LDAP.
      * LDAP connection configuration injected into the LDAP connection pool can be initialized with the following parameters:

--- a/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
@@ -963,6 +963,7 @@ The following  options apply  to features that integrate with an LDAP server (i.
 #${configurationKey}.useStartTls=false
 #${configurationKey}.responseTimeout=PT5S
 #${configurationKey}.allowMultipleDns=false
+#${configurationKey}.allowMultipleEntries=false
 #${configurationKey}.name=
 ```
 

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -983,6 +983,7 @@ public class LdapUtils {
         entryResolver.setUserFilter(l.getSearchFilter());
         entryResolver.setSubtreeSearch(l.isSubtreeSearch());
         entryResolver.setConnectionFactory(factory);
+        entryResolver.setAllowMultipleEntries(l.isAllowMultipleEntries());
         if (StringUtils.isNotBlank(l.getDerefAliases())) {
             entryResolver.setDerefAliases(DerefAliases.valueOf(l.getDerefAliases()));
         }


### PR DESCRIPTION
and added an appropriate line to the documentation

Not issued yet, no side-effects on tests so far
