### PR TITLE
REST & Internationalization: Add localized msg in resp. on auth failure.

### DIFF
--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/RestResourceUtils.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/RestResourceUtils.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.support.rest.resources;
 
 import org.apereo.cas.authentication.AuthenticationException;
-import org.apereo.cas.util.spring.ApplicationContextProvider;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -12,6 +11,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -50,10 +50,12 @@ public class RestResourceUtils {
      *
      * @param e the e
      * @param request the http request
+     * @param applicationContext the application context
      * @return the response entity
      */
     public static ResponseEntity<String> createResponseEntityForAuthnFailure(final AuthenticationException e,
-                                                                             final HttpServletRequest request) {
+                                                                             final HttpServletRequest request,
+                                                                             final ApplicationContext applicationContext) {
         try {
             val authnExceptions = e.getHandlerErrors().values()
                 .stream()
@@ -61,7 +63,7 @@ public class RestResourceUtils {
                      + ": "
                      + StringUtils.defaultIfBlank(ex.getMessage(), "Authentication Failure: " + e.getMessage())
                      + ": "
-                     + getMessage(ex.getClass().getSimpleName(), request))
+                     + getMessage(ex.getClass().getSimpleName(), request, applicationContext))
                 .collect(Collectors.toList());
             val errorsMap = new HashMap<String, List<String>>();
             errorsMap.put("authentication_exceptions", authnExceptions);
@@ -74,11 +76,11 @@ public class RestResourceUtils {
         }
     }
 
-    private String getMessage(final String className, final HttpServletRequest request) {
+    private String getMessage(final String className,
+                              final HttpServletRequest request,
+                              final ApplicationContext applicationContext) {
         try {
-            return ApplicationContextProvider
-                .getApplicationContext()
-                .getMessage(DEFAULT_MESSAGE_BUNDLE_PREFIX + className, null, request.getLocale());
+            return applicationContext.getMessage(DEFAULT_MESSAGE_BUNDLE_PREFIX + className, null, request.getLocale());
         } catch (final Exception e) {
             return NO_MESSAGE;
         }

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/ServiceTicketResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/ServiceTicketResource.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.BooleanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +53,9 @@ public class ServiceTicketResource {
     private final ArgumentExtractor argumentExtractor;
     private final ServiceTicketResourceEntityResponseFactory serviceTicketResourceEntityResponseFactory;
     private final RestHttpRequestCredentialFactory credentialFactory;
+
+    @Autowired
+    private ApplicationContext applicationContext;
 
     /**
      * Create new service ticket.
@@ -93,7 +98,7 @@ public class ServiceTicketResource {
         } catch (final InvalidTicketException e) {
             return new ResponseEntity<>(tgtId + " could not be found or is considered invalid", HttpStatus.NOT_FOUND);
         } catch (final AuthenticationException e) {
-            return RestResourceUtils.createResponseEntityForAuthnFailure(e, httpServletRequest);
+            return RestResourceUtils.createResponseEntityForAuthnFailure(e, httpServletRequest, applicationContext);
         } catch (final BadRestRequestException e) {
             LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/ServiceTicketResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/ServiceTicketResource.java
@@ -93,7 +93,7 @@ public class ServiceTicketResource {
         } catch (final InvalidTicketException e) {
             return new ResponseEntity<>(tgtId + " could not be found or is considered invalid", HttpStatus.NOT_FOUND);
         } catch (final AuthenticationException e) {
-            return RestResourceUtils.createResponseEntityForAuthnFailure(e);
+            return RestResourceUtils.createResponseEntityForAuthnFailure(e, httpServletRequest);
         } catch (final BadRestRequestException e) {
             LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
@@ -64,7 +64,7 @@ public class TicketGrantingTicketResource {
             val tgtId = createTicketGrantingTicketForRequest(requestBody, request);
             return createResponseEntityForTicket(request, tgtId);
         } catch (final AuthenticationException e) {
-            return RestResourceUtils.createResponseEntityForAuthnFailure(e);
+            return RestResourceUtils.createResponseEntityForAuthnFailure(e, request);
         } catch (final BadRestRequestException e) {
             LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
@@ -12,6 +12,8 @@ import org.apereo.cas.ticket.TicketGrantingTicket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -50,6 +52,9 @@ public class TicketGrantingTicketResource {
     private final ServiceFactory serviceFactory;
     private final TicketGrantingTicketResourceEntityResponseFactory ticketGrantingTicketResourceEntityResponseFactory;
 
+    @Autowired
+    private ApplicationContext applicationContext;
+
     /**
      * Create new ticket granting ticket.
      *
@@ -64,7 +69,7 @@ public class TicketGrantingTicketResource {
             val tgtId = createTicketGrantingTicketForRequest(requestBody, request);
             return createResponseEntityForTicket(request, tgtId);
         } catch (final AuthenticationException e) {
-            return RestResourceUtils.createResponseEntityForAuthnFailure(e, request);
+            return RestResourceUtils.createResponseEntityForAuthnFailure(e, request, applicationContext);
         } catch (final BadRestRequestException e) {
             LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/UserAuthenticationResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/UserAuthenticationResource.java
@@ -10,6 +10,8 @@ import org.apereo.cas.rest.factory.UserAuthenticationResourceEntityResponseFacto
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +47,9 @@ public class UserAuthenticationResource {
     private final ServiceFactory serviceFactory;
     private final UserAuthenticationResourceEntityResponseFactory userAuthenticationResourceEntityResponseFactory;
 
+    @Autowired
+    private ApplicationContext applicationContext;
+
     /**
      * Create new ticket granting ticket.
      *
@@ -68,7 +73,7 @@ public class UserAuthenticationResource {
             }
             return this.userAuthenticationResourceEntityResponseFactory.build(authenticationResult, request);
         } catch (final AuthenticationException e) {
-            return RestResourceUtils.createResponseEntityForAuthnFailure(e, request);
+            return RestResourceUtils.createResponseEntityForAuthnFailure(e, request, applicationContext);
         } catch (final BadRestRequestException e) {
             LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/UserAuthenticationResource.java
+++ b/support/cas-server-support-rest/src/main/java/org/apereo/cas/support/rest/resources/UserAuthenticationResource.java
@@ -68,7 +68,7 @@ public class UserAuthenticationResource {
             }
             return this.userAuthenticationResourceEntityResponseFactory.build(authenticationResult, request);
         } catch (final AuthenticationException e) {
-            return RestResourceUtils.createResponseEntityForAuthnFailure(e);
+            return RestResourceUtils.createResponseEntityForAuthnFailure(e, request);
         } catch (final BadRestRequestException e) {
             LOGGER.error(e.getMessage(), e);
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
This change adds localized messages to get human readable reasons of authentication failures on a REST request.
Messages are added at the end of already existent messages in the json response.
A "Accept-Language" http header in the request allows messages language selection.
