### PR TITLE
Add possibility of overriding the value of the "x-frame-options" header using service files [FORWARD PORT]

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
@@ -112,6 +112,10 @@ public interface RegisteredServiceProperty extends Serializable {
          */
         HTTP_HEADER_ENABLE_XFRAME_OPTIONS("httpHeaderEnableXFrameOptions", "true"),
         /**
+         * Whether CAS should override xframe options headers into the response when this service is in process.
+         */
+        HTTP_HEADER_XFRAME_OPTIONS("httpHeaderXFrameOptions", "DENY"),
+        /**
          * Whether CAS should inject content security policy headers into the response when this service is in process.
          */
         HTTP_HEADER_ENABLE_CONTENT_SECURITY_POLICY("httpHeaderEnableContentSecurityPolicy", "true"),
@@ -119,7 +123,6 @@ public interface RegisteredServiceProperty extends Serializable {
          * Whether CAS should inject xss protection headers into the response when this service is in process.
          */
         HTTP_HEADER_ENABLE_XSS_PROTECTION("httpHeaderEnableXSSProtection", "true");
-
 
         private final String propertyName;
         private final String defaultValue;

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
@@ -50,6 +50,10 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
 
     @Override
     protected void decideInsertXFrameOptionsHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
+        val xFrameOptions = getStringProperty(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_XFRAME_OPTIONS);
+        if (xFrameOptions != null) {
+            super.setXFrameOptions(xFrameOptions);
+        }
         if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
             RegisteredServiceProperties.HTTP_HEADER_ENABLE_XFRAME_OPTIONS)) {
             super.insertXFrameOptionsHeader(httpServletResponse, httpServletRequest);
@@ -86,6 +90,19 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
         } else {
             super.decideInsertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
         }
+    }
+
+    private String getStringProperty(final HttpServletRequest request,
+                                     final RegisteredServiceProperties property) {
+        val result = getRegisteredServiceFromRequest(request);
+        if (result.isPresent()) {
+            val properties = result.get().getProperties();
+            if (properties.containsKey(property.getPropertyName())) {
+                val prop = properties.get(property.getPropertyName());
+                return prop.getValue();
+            }
+        }
+        return null;
     }
 
     private boolean shouldHttpHeaderBeInjectedIntoResponse(final HttpServletRequest request,

--- a/docs/cas-server-documentation/services/Configuring-Service-Http-Security-Headers.md
+++ b/docs/cas-server-documentation/services/Configuring-Service-Http-Security-Headers.md
@@ -36,5 +36,7 @@ Supported HTTP headers in form of service properties are:
 | `httpHeaderEnableXFrameOptions`      | Insert `X-Frame-Options` headers into the response for this service.
 | `httpHeaderEnableContentSecurityPolicy`      | Insert `Content-Security-Policy` headers into the response for this service.
 | `httpHeaderEnableXSSProtection`      | Insert `X-XSS-Protection` headers into the response for this service.
+| `httpHeaderXFrameOptions`      | Override the `X-Frame-Options` header of the response for this service.
 
 The headers values are picked up from CAS properties. See [this guide](../configuration/Configuration-Properties.html#http-web-requests) for relevant settings.
+


### PR DESCRIPTION
The service property "httpHeaderEnableXFrameOptions" can control if the
x-frame-options header should be inserted in the HTTP response. However it
make sense to control the value of the x-frame-options using service files.
This commit implements that feature by introducing the property
"httpHeaderXFrameOptions".
    
Forward-Port: 95dad85
