### PR TITLE
Gradle: exclude xerces dependency from default includes

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3047,6 +3047,7 @@ ext.libraries = [
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-databind")
                     exclude(group: "junit", module: "junit")
                     exclude(group: "org.mockito", module: "mockito-core")
+                    exclude(group: "xerces", module: "xercesImpl")
                     force = true
                 }
         ],


### PR DESCRIPTION
if openid needs xerces, it will get it when someone includes openid cas
module

The version of xerces referenced here has CVE associated with it and it is lower than the version cas uses. 