### PR TITLE
Fix failed application to start

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,7 +1,7 @@
 {
   "properties": [
     {
-      "name": "cas.authn.releaseProtocolAttributes",
+      "name": "cas.authn.release-protocol-attributes",
       "type": "java.lang.Boolean",
       "description": "Whether to release authentication attributes.",
       "defaultValue": true,
@@ -12,7 +12,7 @@
       }
     },
     {
-      "name": "cas.authn.x509.principalSNRadix",
+      "name": "cas.authn.x509.principal-sn-radix",
       "type": "java.lang.Integer",
       "description": "X509 principal extraction config.",
       "defaultValue": 10,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "name": "cas.authn.x509.principalHexSNZeroPadding",
+      "name": "cas.authn.x509.principal-hex-sn-zero-padding",
       "type": "java.lang.Boolean",
       "description": "X509 principal extraction config.",
       "defaultValue": true,
@@ -34,7 +34,7 @@
       }
     },
     {
-      "name": "cas.authn.x509.valueDelimiter",
+      "name": "cas.authn.x509.value-delimiter",
       "type": "java.lang.String",
       "description": "X509 principal extraction config.",
       "defaultValue": ",",
@@ -45,7 +45,7 @@
       }
     },
     {
-      "name": "cas.authn.x509.serialNumberPrefix",
+      "name": "cas.authn.x509.serial-number-prefix",
       "type": "java.lang.String",
       "description": "X509 principal extraction config.",
       "defaultValue": "SERIALNUMBER=",
@@ -56,7 +56,7 @@
       }
     },
     {
-      "name": "cas.server.basicAuthn.enabled",
+      "name": "cas.server.basic-authn.enabled",
       "type": "java.lang.Boolean",
       "description": "Enable basic auth on tomcat.",
       "defaultValue": false,
@@ -78,7 +78,7 @@
       }
     },
     {
-      "name": "cas.adminPagesSecurity.actuatorEndpointsEnabled",
+      "name": "cas.admin-pages-security.actuator-endpoints-enabled",
       "type": "java.lang.Boolean",
       "description": "Enable actuator endpoints.",
       "defaultValue": false,
@@ -89,7 +89,7 @@
       }
     },
     {
-      "name": "cas.adminPagesSecurity.ip",
+      "name": "cas.admin-pages-security.ip",
       "type": "java.lang.String",
       "description": "Enable actuator endpoints.",
       "defaultValue": "127.0.0.1",


### PR DESCRIPTION
<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->

# issue summary
After commiting https://github.com/apereo/cas/commit/e5f17b5a87f75049b08e81905b511a7d9267735c#diff-4d3402fa641ea36ce78b3fc0039335cd , cas-overlay-template app failed to start.

```
$ ./build.sh run
Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8

BUILD SUCCESSFUL in 5s
2 actionable tasks: 2 executed
Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.vmplugin.v7.Java7$1 (jar:file:/Users/artn/cas-overlay-template/build/libs/cas.war!/WEB-INF/lib/groovy-2.5.4.jar!/) to constructor java.lang.invoke.MethodHandles$Lookup(java.lang.Class,int)
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.vmplugin.v7.Java7$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2018-11-21 18:01:51.853  INFO 9081 --- [           main] ConditionEvaluationReportLoggingListener : 

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2018-11-21 18:01:51.911 ERROR 9081 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   : 

***************************
APPLICATION FAILED TO START
***************************

Description:

Configuration property name 'cas.server.basicAuthn.enabled' is not valid:

    Invalid characters: 'A'
    Reason: Canonical names should be kebab-case ('-' separated), lowercase alpha-numeric characters and must start with a letter

Action:

Modify 'cas.server.basicAuthn.enabled' so that it conforms to the canonical names requirements.

2018-11-21 18:01:51.913 ERROR 9081 --- [           main] o.s.b.SpringApplication                  : Application run failed

org.springframework.boot.context.properties.source.InvalidConfigurationPropertyNameException: Configuration property name 'cas.server.basicAuthn.enabled' is not valid
	at org.springframework.boot.context.properties.source.ConfigurationPropertyName.of(ConfigurationPropertyName.java:444) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.context.properties.source.ConfigurationPropertyName.of(ConfigurationPropertyName.java:411) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.lambda$null$2(PropertiesMigrationReporter.java:160) ~[spring-boot-properties-migrator-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at java.util.ArrayList.forEach(ArrayList.java:1540) ~[?:?]
	at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.lambda$getMatchingProperties$3(PropertiesMigrationReporter.java:157) ~[spring-boot-properties-migrator-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684) ~[?:?]
	at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.getMatchingProperties(PropertiesMigrationReporter.java:156) ~[spring-boot-properties-migrator-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.getReport(PropertiesMigrationReporter.java:68) ~[spring-boot-properties-migrator-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.context.properties.migrator.PropertiesMigrationListener.onApplicationPreparedEvent(PropertiesMigrationListener.java:69) ~[spring-boot-properties-migrator-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.context.properties.migrator.PropertiesMigrationListener.onApplicationEvent(PropertiesMigrationListener.java:57) ~[spring-boot-properties-migrator-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.context.properties.migrator.PropertiesMigrationListener.onApplicationEvent(PropertiesMigrationListener.java:44) ~[spring-boot-properties-migrator-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:127) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.boot.context.event.EventPublishingRunListener.contextLoaded(EventPublishingRunListener.java:93) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.SpringApplicationRunListeners.contextLoaded(SpringApplicationRunListeners.java:66) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.SpringApplication.prepareContext(SpringApplication.java:393) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:314) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:139) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.bootstrapServiceContext(BootstrapApplicationListener.java:197) ~[spring-cloud-context-2.1.0.M1.jar!/:2.1.0.M1]
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.onApplicationEvent(BootstrapApplicationListener.java:104) ~[spring-cloud-context-2.1.0.M1.jar!/:2.1.0.M1]
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.onApplicationEvent(BootstrapApplicationListener.java:70) ~[spring-cloud-context-2.1.0.M1.jar!/:2.1.0.M1]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:127) ~[spring-context-5.1.2.RELEASE.jar!/:5.1.2.RELEASE]
	at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:75) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:54) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:347) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:306) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:139) ~[spring-boot-2.1.0.RELEASE.jar!/:2.1.0.RELEASE]
	at org.apereo.cas.web.CasWebApplication.main(CasWebApplication.java:71) ~[cas-server-webapp-init-6.0.0-RC4-SNAPSHOT.jar!/:6.0.0-RC4-SNAPSHOT]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48) ~[cas.war:?]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:87) ~[cas.war:?]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:50) ~[cas.war:?]
	at org.springframework.boot.loader.WarLauncher.main(WarLauncher.java:58) ~[cas.war:?]
```

The root cause is the configuration property name does not allow CamelCase when using spring boot 2.0.
So I changed property name format to Kebab-Case.

Also there was similar issue on https://github.com/watson-developer-cloud/spring-boot-starter/issues/7 
