### PR TITLE
Fix mfa u2f : Templates of view and duplicated attributes

### DIFF
--- a/support/cas-server-support-u2f/src/main/java/org/apereo/cas/adaptors/u2f/U2FAuthenticationHandler.java
+++ b/support/cas-server-support-u2f/src/main/java/org/apereo/cas/adaptors/u2f/U2FAuthenticationHandler.java
@@ -53,7 +53,7 @@ public class U2FAuthenticationHandler extends AbstractPreAndPostProcessingAuthen
         DeviceRegistration registration = null;
         try {
             registration = u2f.finishSignature(authenticateRequest, authenticateResponse, u2FDeviceRepository.getRegisteredDevices(p.getId()));
-            return createHandlerResult(tokenCredential, p);
+            return createHandlerResult(tokenCredential, this.principalFactory.createPrincipal(p.getId()));
         } catch (final DeviceCompromisedException e) {
             registration = e.getDeviceRegistration();
             throw new PreventedException("Device possibly compromised and therefore blocked: " + e.getMessage(), e);

--- a/webapp/resources/templates/casU2fLoginView.html
+++ b/webapp/resources/templates/casU2fLoginView.html
@@ -42,8 +42,8 @@
 <main role="main" class="container mt-3 mb-3">
     <div layout:fragment="content" id="login">
         <div class="alert alert-info">
-            <h3 th:text="cas.mfa.u2f.authentication.device">Authenticate Device</h3>
-            <div th:utext="cas.mfa.u2f.authentication.device.message" th:replace="tag">
+            <h3 th:text="#{cas.mfa.u2f.authentication.device}">Authenticate Device</h3>
+            <div th:utext="#{cas.mfa.u2f.authentication.message}">
                 <p><strong>Please touch the flashing U2F device now.</strong></p>
                 <p> You may be prompted to allow the site permission to access your security keys. After granting
                     permission, the device will start to blink.</p>

--- a/webapp/resources/templates/casU2fRegistrationView.html
+++ b/webapp/resources/templates/casU2fRegistrationView.html
@@ -42,8 +42,8 @@
 <main role="main" class="container mt-3 mb-3">
     <div layout:fragment="content" id="login">
         <div class="alert alert-info">
-            <h3 th:text="cas.mfa.u2f.register.device">Register Device</h3>
-            <div th:utext="cas.mfa.u2f.authentication.device.message" th:replace="tag">
+            <h3 th:text="#{cas.mfa.u2f.register.device}">Register Device</h3>
+            <div th:utext="#{cas.mfa.u2f.authentication.message}">
                 <p><strong>Please touch the flashing U2F device now.</strong></p>
                 <p> You may be prompted to allow the site permission to access your security keys. After granting
                     permission, the device will start to blink.</p>


### PR DESCRIPTION
Fix broken mfa-u2f in CAS 5.3
1. Fix non existant keys of messages on registration and authentication views :
- before patch : ![image](https://user-images.githubusercontent.com/1167372/49213758-46660c80-f3c5-11e8-961a-1c0008b3957b.png)
- after patch : ![image](https://user-images.githubusercontent.com/1167372/49217677-81b90900-f3ce-11e8-8653-742bf94b1e2b.png)


2. Fix thymeleaf exception where CAS displays registration and authentication views (mfa-u2f can't be used) :
ERROR [org.thymeleaf.TemplateEngine] - <[THYMELEAF][ajp-nio-8109-exec-9] Exception processing template "error": Error resolving template "tag", template might not exist or might not be accessible by any of the configured Template Resolvers (template: "casU2fRegistrationView" - line 46, col 71)>
org.thymeleaf.exceptions.TemplateInputException: Error resolving template "tag", template might not exist or might not be accessible by any of the configured Template Resolvers (template: "casU2fRegistrationView" - line 46, col 71)

3. Fix duplicated attributes transmitted by CAS with mfa-u2f :
- for example before patch with consent attributes : 
![image](https://user-images.githubusercontent.com/1167372/49226563-4aa32180-f3e7-11e8-8b1c-155417cf12ff.png)