### PR TITLE
Update REST-Protocol.md

### DIFF
--- a/docs/cas-server-documentation/protocol/REST-Protocol.md
+++ b/docs/cas-server-documentation/protocol/REST-Protocol.md
@@ -31,7 +31,7 @@ Support is enabled by including the following to the overlay:
 
 ```bash
 POST /cas/v1/tickets HTTP/1.0
-
+'Content-type': 'Application/x-www-form-urlencoded'
 username=battags&password=password&additionalParam1=paramvalue
 ```
 


### PR DESCRIPTION
Add a line showing the expected content-type for the request

It's possible this content-type is obvious if you do enough REST development, but it took me some googling to figure out how to solve the 415 error and I think this would be useful to have directly in the docs.
