### PR TITLE
make sure replacement property doesn't have array syntax in it

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -127,7 +127,7 @@
       "description": "Enable actuator endpoints.",
       "defaultValue": "127.0.0.1",
       "deprecation": {
-        "replacement": "cas.monitor.endpoints.endpoint.defaults.access[0]",
+        "replacement": "cas.monitor.endpoints.endpoint.defaults.access",
         "reason": "management endpoints security under cas.monitor.endpoints.endpoint.*.",
         "level": "error"
       }

--- a/api/cas-server-core-api-configuration-model/src/test/java/org/apereo/cas/configuration/AdditionalMetadataVerificationTests.java
+++ b/api/cas-server-core-api-configuration-model/src/test/java/org/apereo/cas/configuration/AdditionalMetadataVerificationTests.java
@@ -62,6 +62,9 @@ public class AdditionalMetadataVerificationTests {
                 val deprecation = prop.getDeprecation();
                 if (deprecation != null && StringUtils.isNotBlank(deprecation.getReplacement())) {
                     ConfigurationPropertyName.of(deprecation.getReplacement());
+                    if (deprecation.getReplacement().contains("[0]")) {
+                        fail("No array references allowed in replacement value.");
+                    }
                 }
             } catch (final InvalidConfigurationPropertyNameException e) {
                 fail(e.getMessage());


### PR DESCRIPTION
spring boot currently gets NPE when processing the replacement for cas.admin-pages-security.ip
```
2018-12-02 21:40:32,131 ERROR [org.springframework.boot.SpringApplication] - <Application run failed>
java.lang.NullPointerException: null
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.detectMapValueReplacementType(PropertiesMigrationReporter.java:140) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.isRenamed(PropertiesMigrationReporter.java:115) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.lambda$mapPropertiesWithReplacement$1(PropertiesMigrationReporter.java:88) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.mapPropertiesWithReplacement(PropertiesMigrationReporter.java:88) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.lambda$getReport$0(PropertiesMigrationReporter.java:74) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at java.util.Map.forEach(Map.java:661) ~[?:?]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationReporter.getReport(PropertiesMigrationReporter.java:73) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationListener.onApplicationPreparedEvent(PropertiesMigrationListener.java:69) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationListener.onApplicationEvent(PropertiesMigrationListener.java:57) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
        at org.springframework.boot.context.properties.migrator.PropertiesMigrationListener.onApplicationEvent(PropertiesMigrationListener.java:44) ~[spring-boot-properties-migrator-2.1.1.RELEASE.jar!/:2.1.1.RELEASE]
```