### PR TITLE
Fix replacements in additional spring metadata

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -116,8 +116,7 @@
       "description": "Enable actuator endpoints.",
       "defaultValue": false,
       "deprecation": {
-        "replacement": "management.endpoints.enabled-by-default",
-        "reason": "cas.adminPagesSecurity.* moved to management.endpoints.*.",
+        "reason": "cas.adminPagesSecurity.* moved to management.endpoints.*., e.g. management.endpoints.enabled-by-default.",
         "level": "error"
       }
     },
@@ -127,8 +126,7 @@
       "description": "Enable actuator endpoints.",
       "defaultValue": "127.0.0.1",
       "deprecation": {
-        "replacement": "cas.monitor.endpoints.endpoint.defaults.access",
-        "reason": "management endpoints security under cas.monitor.endpoints.endpoint.*.",
+        "reason": "management endpoints security under cas.monitor.endpoints.endpoint.*. e.g. cas.monitor.endpoints.endpoint.defaults.access[0].",
         "level": "error"
       }
     }

--- a/api/cas-server-core-api-configuration-model/src/test/java/org/apereo/cas/configuration/AdditionalMetadataVerificationTests.java
+++ b/api/cas-server-core-api-configuration-model/src/test/java/org/apereo/cas/configuration/AdditionalMetadataVerificationTests.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.ClassRule;
@@ -13,12 +14,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyNameException;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -28,6 +29,7 @@ import static org.junit.Assert.*;
  *
  * @since 6.0
  */
+@Slf4j
 public class AdditionalMetadataVerificationTests {
 
     @ClassRule
@@ -43,32 +45,40 @@ public class AdditionalMetadataVerificationTests {
      * Make sure the property names are canonical (not camel case) otherwise app won't start.
      * Spring boot {@link org.springframework.boot.context.properties.migrator.PropertiesMigrationListener}
      * will prevent startup if property names aren't valid.
-     *
+     * It may be that some replacement properties need array syntax but none should contain [0].
      * @throws IOException if additional property file is missing
      */
     @Test
     public void verifyMetaData() throws IOException {
-        val mapper = new ObjectMapper().findAndRegisterModules();
-        val jsonFile = resourceLoader.getResource("META-INF/additional-spring-configuration-metadata.json");
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
-        mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
-        val values = new TypeReference<Map<String, Set<ConfigurationMetadataProperty>>>() {
-        };
-        val jsonMap = (Map) mapper.readValue(jsonFile.getURL(), values);
-        val props = (Set<ConfigurationMetadataProperty>) jsonMap.get("properties");
-        for (val prop : props) {
+        val additionalMetadataJsonFile = resourceLoader.getResource("META-INF/additional-spring-configuration-metadata.json");
+        val additionalProps = getProperties(additionalMetadataJsonFile);
+        for (val prop : additionalProps) {
             try {
                 ConfigurationPropertyName.of(prop.getName());
-                val deprecation = prop.getDeprecation();
-                if (deprecation != null && StringUtils.isNotBlank(deprecation.getReplacement())) {
-                    ConfigurationPropertyName.of(deprecation.getReplacement());
-                    if (deprecation.getReplacement().contains("[0]")) {
-                        fail("No array references allowed in replacement value.");
-                    }
-                }
             } catch (final InvalidConfigurationPropertyNameException e) {
                 fail(e.getMessage());
             }
+            val deprecation = prop.getDeprecation();
+            if (deprecation != null && StringUtils.isNotBlank(deprecation.getReplacement())) {
+                ConfigurationPropertyName.of(deprecation.getReplacement());
+                if (deprecation.getReplacement().endsWith("[0]")) {
+                    // array references may work, but not at the end
+                    fail("Deprecation replacement should not end in [0].");
+                }
+            }
         }
+    }
+
+    private Set<ConfigurationMetadataProperty> getProperties(final Resource jsonFile) throws IOException {
+        val mapper = new ObjectMapper().findAndRegisterModules();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+        val jsonNodeRoot = mapper.readTree(jsonFile.getURL());
+        val propertiesNode = jsonNodeRoot.get("properties");
+        val values = new TypeReference<Set<ConfigurationMetadataProperty>>() {
+        };
+        val reader = mapper.readerFor(values);
+        val jsonSet = (Set) reader.readValue(propertiesNode);
+        return jsonSet;
     }
 }


### PR DESCRIPTION
Spring boot property migrator currently fails if replacement doesn't
exist in metadata. Change the two properties that are either not in
cas metadata or are in spring metadata which we can't validate
against easily.

The reason property still points to the new values.
