### PR TITLE
 Allows spring config to be used to customize ehcache replication config.

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ehcache/EhcacheProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ehcache/EhcacheProperties.java
@@ -1,14 +1,17 @@
 package org.apereo.cas.configuration.model.support.ehcache;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apereo.cas.configuration.model.core.util.EncryptionRandomizedSigningJwtCryptographyProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 import org.apereo.cas.configuration.support.RequiredProperty;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+
 import java.io.Serializable;
-import lombok.Getter;
-import lombok.Setter;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This is {@link EhcacheProperties}.
@@ -17,7 +20,6 @@ import lombok.Setter;
  * @since 5.0.0
  */
 @RequiresModule(name = "cas-server-support-ehcache-ticket-registry")
-
 @Getter
 @Setter
 public class EhcacheProperties implements Serializable {
@@ -155,6 +157,12 @@ public class EhcacheProperties implements Serializable {
      * </ul>
      */
     private String persistence = "NONE";
+
+    /**
+     * Allows system properties to be set prior to ehcache.xml parsing.
+     * EhCache will interpolate system properties in the ehcache xml config file e.g. ${ehCacheMulticastAddress}.
+     */
+    private final Map<String, String> systemProps = new HashMap<>();
 
     /**
      * Crypto settings for the registry.

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3433,8 +3433,8 @@ To learn more about this topic, [please review this guide](Ehcache-Ticket-Regist
 
 # The systemprops allows a map of properties to be set as system properties before configLocation config is processed.
 # These properties may be referenced in the ehcache XML config via ${key}
-# cas.ticket.registry.ehcache.systemprops.key1=value1
-# cas.ticket.registry.ehcache.systemprops.key2=value2
+# cas.ticket.registry.ehcache.systemProps.key1=value1
+# cas.ticket.registry.ehcache.systemProps.key2=value2
 ```
 
 Signing & encryption settings for this registry are available [here](Configuration-Properties-Common.html#signing--encryption) under the configuration key `cas.ticket.registry.ehcache`.

--- a/docs/cas-server-documentation/installation/Configuration-Properties.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties.md
@@ -3430,6 +3430,11 @@ To learn more about this topic, [please review this guide](Ehcache-Ticket-Regist
 # cas.ticket.registry.ehcache.cacheTimeToIdle=0
 # cas.ticket.registry.ehcache.persistence=LOCALTEMPSWAP|NONE|LOCALRESTARTABLE|DISTRIBUTED
 # cas.ticket.registry.ehcache.synchronousWrites=
+
+# The systemprops allows a map of properties to be set as system properties before configLocation config is processed.
+# These properties may be referenced in the ehcache XML config via ${key}
+# cas.ticket.registry.ehcache.systemprops.key1=value1
+# cas.ticket.registry.ehcache.systemprops.key2=value2
 ```
 
 Signing & encryption settings for this registry are available [here](Configuration-Properties-Common.html#signing--encryption) under the configuration key `cas.ticket.registry.ehcache`.

--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -60,7 +60,9 @@ task cleanLogs(description: "Clean build log files") {
 }
 
 task findbugs(type: FindBugs, description: "Set up classpath for Findbugs") {
-    pluginClasspath = project.configurations.findbugsPlugins
+    if (!Boolean.getBoolean("skipFindbugs")) {
+        pluginClasspath = project.configurations.findbugsPlugins
+    }
 }
 
 task showConfiguration {

--- a/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/config/EhcacheTicketRegistryConfiguration.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/config/EhcacheTicketRegistryConfiguration.java
@@ -54,11 +54,11 @@ public class EhcacheTicketRegistryConfiguration {
     public CacheReplicator ticketRMISynchronousCacheReplicator() {
         final EhcacheProperties cache = casProperties.getTicket().getRegistry().getEhcache();
         return new RMISynchronousCacheReplicator(
-            cache.isReplicatePuts(),
-            cache.isReplicatePutsViaCopy(),
-            cache.isReplicateUpdates(),
-            cache.isReplicateUpdatesViaCopy(),
-            cache.isReplicateRemovals());
+                cache.isReplicatePuts(),
+                cache.isReplicatePutsViaCopy(),
+                cache.isReplicateUpdates(),
+                cache.isReplicateUpdatesViaCopy(),
+                cache.isReplicateRemovals());
     }
 
     @RefreshScope
@@ -67,13 +67,13 @@ public class EhcacheTicketRegistryConfiguration {
     public CacheReplicator ticketRMIAsynchronousCacheReplicator() {
         final EhcacheProperties cache = casProperties.getTicket().getRegistry().getEhcache();
         return new RMIAsynchronousCacheReplicator(
-            cache.isReplicatePuts(),
-            cache.isReplicatePutsViaCopy(),
-            cache.isReplicateUpdates(),
-            cache.isReplicateUpdatesViaCopy(),
-            cache.isReplicateRemovals(),
-            (int) Beans.newDuration(cache.getReplicationInterval()).toMillis(),
-            cache.getMaximumBatchSize());
+                cache.isReplicatePuts(),
+                cache.isReplicatePutsViaCopy(),
+                cache.isReplicateUpdates(),
+                cache.isReplicateUpdatesViaCopy(),
+                cache.isReplicateRemovals(),
+                (int) Beans.newDuration(cache.getReplicationInterval()).toMillis(),
+                cache.getMaximumBatchSize());
     }
 
     @RefreshScope
@@ -88,6 +88,8 @@ public class EhcacheTicketRegistryConfiguration {
     public EhCacheManagerFactoryBean ehcacheTicketCacheManager() {
         final EhcacheProperties cache = casProperties.getTicket().getRegistry().getEhcache();
         final EhCacheManagerFactoryBean bean = new EhCacheManagerFactoryBean();
+
+        cache.getSystemProps().forEach((key, value) -> System.setProperty(key, value));
 
         final boolean configExists = ResourceUtils.doesResourceExist(cache.getConfigLocation());
         if (configExists) {
@@ -116,10 +118,10 @@ public class EhcacheTicketRegistryConfiguration {
             bean.setBootstrapCacheLoader(ticketCacheBootstrapCacheLoader());
         } else {
             LOGGER.warn("In registering ticket definition [{}], Ehcache configuration file [{}] cannot be found "
-                + "so no cache event listeners will be configured to bootstrap. "
-                + "The ticket registry will operate in standalone mode", ticketDefinition.getPrefix(), cache.getConfigLocation());
+                    + "so no cache event listeners will be configured to bootstrap. "
+                    + "The ticket registry will operate in standalone mode", ticketDefinition.getPrefix(), cache.getConfigLocation());
         }
-                              
+
         bean.setTimeToIdle((int) ticketDefinition.getProperties().getStorageTimeout());
         bean.setTimeToLive((int) ticketDefinition.getProperties().getStorageTimeout());
         bean.setDiskExpiryThreadIntervalSeconds(ehcacheProperties.getDiskExpiryThreadIntervalSeconds());

--- a/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/config/EhcacheTicketRegistryConfiguration.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/main/java/org/apereo/cas/config/EhcacheTicketRegistryConfiguration.java
@@ -54,11 +54,11 @@ public class EhcacheTicketRegistryConfiguration {
     public CacheReplicator ticketRMISynchronousCacheReplicator() {
         final EhcacheProperties cache = casProperties.getTicket().getRegistry().getEhcache();
         return new RMISynchronousCacheReplicator(
-                cache.isReplicatePuts(),
-                cache.isReplicatePutsViaCopy(),
-                cache.isReplicateUpdates(),
-                cache.isReplicateUpdatesViaCopy(),
-                cache.isReplicateRemovals());
+            cache.isReplicatePuts(),
+            cache.isReplicatePutsViaCopy(),
+            cache.isReplicateUpdates(),
+            cache.isReplicateUpdatesViaCopy(),
+            cache.isReplicateRemovals());
     }
 
     @RefreshScope
@@ -67,13 +67,13 @@ public class EhcacheTicketRegistryConfiguration {
     public CacheReplicator ticketRMIAsynchronousCacheReplicator() {
         final EhcacheProperties cache = casProperties.getTicket().getRegistry().getEhcache();
         return new RMIAsynchronousCacheReplicator(
-                cache.isReplicatePuts(),
-                cache.isReplicatePutsViaCopy(),
-                cache.isReplicateUpdates(),
-                cache.isReplicateUpdatesViaCopy(),
-                cache.isReplicateRemovals(),
-                (int) Beans.newDuration(cache.getReplicationInterval()).toMillis(),
-                cache.getMaximumBatchSize());
+            cache.isReplicatePuts(),
+            cache.isReplicatePutsViaCopy(),
+            cache.isReplicateUpdates(),
+            cache.isReplicateUpdatesViaCopy(),
+            cache.isReplicateRemovals(),
+            (int) Beans.newDuration(cache.getReplicationInterval()).toMillis(),
+            cache.getMaximumBatchSize());
     }
 
     @RefreshScope
@@ -118,8 +118,8 @@ public class EhcacheTicketRegistryConfiguration {
             bean.setBootstrapCacheLoader(ticketCacheBootstrapCacheLoader());
         } else {
             LOGGER.warn("In registering ticket definition [{}], Ehcache configuration file [{}] cannot be found "
-                    + "so no cache event listeners will be configured to bootstrap. "
-                    + "The ticket registry will operate in standalone mode", ticketDefinition.getPrefix(), cache.getConfigLocation());
+                + "so no cache event listeners will be configured to bootstrap. "
+                + "The ticket registry will operate in standalone mode", ticketDefinition.getPrefix(), cache.getConfigLocation());
         }
 
         bean.setTimeToIdle((int) ticketDefinition.getProperties().getStorageTimeout());


### PR DESCRIPTION
This backports pull request for master branch. In CAS 5.3 the property has to be systemProps vs systemprops, presumably due to the different spring boot versions. I think either will work in 6.0. 

There is also a minor build script change which I think is already on master branch. 