### PR TITLE
Remove error messages handled by the @Size annotation on the fields.

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/UsernamePasswordCredential.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/UsernamePasswordCredential.java
@@ -64,20 +64,6 @@ public class UsernamePasswordCredential implements Credential {
         }
 
         val messages = context.getMessageContext();
-        if (StringUtils.isBlank(username)) {
-            messages.addMessage(new MessageBuilder()
-                .error()
-                .source("username")
-                .code("username.required")
-                .build());
-        }
-        if (StringUtils.isBlank(password)) {
-            messages.addMessage(new MessageBuilder()
-                .error()
-                .source("password")
-                .code("password.required")
-                .build());
-        }
         ApplicationContextProvider.getCasProperties().ifPresent(props -> {
             if (StringUtils.isBlank(source) && props.getAuthn().getPolicy().isSourceSelectionEnabled()) {
                 messages.addMessage(new MessageBuilder()

--- a/webapp/resources/templates/casAuthyLoginView.html
+++ b/webapp/resources/templates/casAuthyLoginView.html
@@ -17,7 +17,7 @@
             <form method="post" id="fm1" class="fm-v clearfix" th:object="${credential}" th:action="@{/login}">
 
                 <div id="msg" class="alert alert-danger" role="alert" th:if="${#fields.hasErrors('*')}">
-                    <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">this error block and text is only shown if there are errors</span>
+                    <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">this error block and text is only shown if there are errors</span>
                 </div>
 
                 <div class="form-group">

--- a/webapp/resources/templates/casAzureAuthenticatorLoginView.html
+++ b/webapp/resources/templates/casAzureAuthenticatorLoginView.html
@@ -24,7 +24,7 @@
     <div layout:fragment="content" id="login" class="box">
         <form method="post" id="fm1" class="fm-v clearfix" th:object="${credential}" th:action="@{/login}">
             <div id="msg" class="alert alert-danger" role="alert" th:if="${#fields.hasErrors('*')}">
-                <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">this error block and text is only shown if there are errors</span>
+                <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">this error block and text is only shown if there are errors</span>
             </div>
 
             <div class="form-group">

--- a/webapp/resources/templates/casDuoLoginView.html
+++ b/webapp/resources/templates/casDuoLoginView.html
@@ -14,7 +14,7 @@
     <div layout:fragment="content">
         <form method="post" id="duo_form" class="fm-v clearfix" th:object="${credential}" th:action="@{/login}">
             <div id="msg" class="alert alert-danger" role="alert" th:if="${#fields.hasErrors('*')}">
-                <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">this error block and text is only shown if there are errors</span>
+                <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">this error block and text is only shown if there are errors</span>
             </div>
 
             <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>

--- a/webapp/resources/templates/casGoogleAuthenticatorLoginView.html
+++ b/webapp/resources/templates/casGoogleAuthenticatorLoginView.html
@@ -14,7 +14,7 @@
     <div layout:fragment="content" id="login">
         <form method="post" id="fm1" class="fm-v clearfix" th:object="${credential}" th:action="@{/login}">
             <div id="msg" class="errors" th:if="${#fields.hasErrors('*')}">
-                <span th:each="err : ${#fields.errors('*')}" th:utext="${err}"/>
+                <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}"/>
             </div>
 
             <div class="form-group">

--- a/webapp/resources/templates/casRadiusLoginView.html
+++ b/webapp/resources/templates/casRadiusLoginView.html
@@ -14,7 +14,7 @@
     <div layout:fragment="content" id="login">
         <form method="post" id="fm1" class="fm-v clearfix" th:object="${credential}" th:action="@{/login}">
             <div class="alert alert-danger" th:if="${#fields.hasErrors('*')}">
-                <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">error message</span>
+                <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">error message</span>
             </div>
 
             <div class="form-group">

--- a/webapp/resources/templates/casSwivelLoginView.html
+++ b/webapp/resources/templates/casSwivelLoginView.html
@@ -16,7 +16,7 @@
 
         <form method="post" id="fm1" class="fm-v clearfix" th:object="${credential}" th:action="@{/login}">
             <div id="msg" class="alert alert-danger errors" th:if="${#fields.hasErrors('*')}">
-                <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">Error message</span>
+                <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">Error message</span>
             </div>
 
             <div class="form-group">

--- a/webapp/resources/templates/casYubiKeyLoginView.html
+++ b/webapp/resources/templates/casYubiKeyLoginView.html
@@ -18,7 +18,7 @@
             </div>
 
             <div class="alert alert-danger" th:if="${#fields.hasErrors('*')}">
-                <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">Error message</span>
+                <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">Error message</span>
             </div>
 
             <div class="form-group">

--- a/webapp/resources/templates/fragments/loginform.html
+++ b/webapp/resources/templates/fragments/loginform.html
@@ -24,7 +24,7 @@
                 <div class="card-body">
                     <form method="post" id="fm1" th:object="${credential}" action="login">
                         <div class="alert alert-danger" th:if="${#fields.hasErrors('*')}">
-                            <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">Example error</span>
+                            <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">Example error</span>
                         </div>
 
                         <h3 th:utext="#{screen.welcome.instructions}">Enter your Username and Password</h3>


### PR DESCRIPTION
The errors were showing up twice.
Either this code needs to be removed or the @​Size validation constraint needs to go.  

There is still an issue where there is no space between the messages but that seems to be a problem anywhere something like this is  used:
```
                        <div class="alert alert-danger" th:if="${#fields.hasErrors('*')}">
                            <span th:each="err : ${#fields.errors('*')}" th:utext="${err}">Example error</span>
                        </div>
```
Should the space just be added after ${err}?