### PR TITLE
Minor typo fix in attributes merger configuration

### DIFF
--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
@@ -334,7 +334,7 @@ public class CasPersonDirectoryConfiguration implements PersonDirectoryAttribute
     @ConditionalOnMissingBean(name = "aggregatingAttributeRepository")
     public IPersonAttributeDao aggregatingAttributeRepository() {
         val mergingDao = new MergingPersonAttributeDaoImpl();
-        val merger = StringUtils.defaultIfBlank(casProperties.getAuthn().getAttributeRepository().getMerger(), "replace".trim());
+        val merger = StringUtils.defaultIfBlank(casProperties.getAuthn().getAttributeRepository().getMerger(), "replace").trim();
         LOGGER.trace("Configured merging strategy for attribute sources is [{}]", merger);
         mergingDao.setMerger(getAttributeMerger(merger));
 


### PR DESCRIPTION
It's actually not a big deal and probably no one would notice it but it clearly makes no sense to trim constant string without spaces. Not sure if trim is needed here at all though.