### PR TITLE
REST: Add support for direct tls client authentication

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/rest/RestProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/rest/RestProperties.java
@@ -42,4 +42,9 @@ public class RestProperties implements Serializable {
      * Flag that enables X509Certificate extraction from the request body for authentication.
      */
     private boolean bodyAuth;
+
+    /**
+     * Flag that enables TLS client X509Certificate extraction from the servlet container for authentication.
+     */
+    private boolean tlsClientAuth;
 }

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -4213,6 +4213,7 @@ To learn more about this topic, [please review this guide](../protocol/REST-Prot
 # cas.rest.attributeValue=
 # cas.rest.headerAuth=
 # cas.rest.bodyAuth=
+# cas.rest.tlsClientAuth=
 ```
 
 ## Metrics

--- a/docs/cas-server-documentation/protocol/REST-Protocol.md
+++ b/docs/cas-server-documentation/protocol/REST-Protocol.md
@@ -217,6 +217,18 @@ This pattern may be of interest in cases where the internal network architecture
 the CAS server from external users behind firewall, reverse proxy, or a messaging bus and
 allows only trusted applications to connect directly to the CAS server.
 
+<div class="alert alert-warning"><strong>Usage Warning!</strong><p>The X.509 feature over REST
+using a body parameter or a http header provides a tremendously convenient target for claiming
+user identities or obtaining TGTs without proof of private key ownership.
+To securely use this feature, network configuration <strong>MUST</strong> allow connections
+to the CAS server only from trusted hosts which in turn have strict security limitations and
+logging.
+It is also recommended to make sure that the body parameter or the http header can only come
+from trusted hosts and not from the original authenticating client.</p></div>
+
+It is also possible to let the servlet container validate the TLS client key / X.509 certificate
+during TLS handshake, and have CAS server retrieve the certificate from the container.
+
 Support is enabled by including the following in your overlay:
 
 ```xml
@@ -227,19 +239,19 @@ Support is enabled by including the following in your overlay:
 </dependency>
 ```
 
-### Request a Ticket Granting Ticket (request body method)
-
-<div class="alert alert-warning"><strong>Usage Warning!</strong><p>The X.509 feature over REST
-provides a tremendously convenient target for claiming user identities. To securely use this feature, 
-network configuration <strong>MUST</strong> allow connections to the CAS server 
-only from trusted hosts which in turn have strict security limitations and logging.</p></div>
+### Request a Ticket Granting Ticket (Proxy TLS Client Authentication using a body parameter)
 
 ```bash
 POST /cas/v1/tickets HTTP/1.0
 cert=<ascii certificate>
 ```
 
-### Request a Ticket Granting Ticket (TLS Client Authentication)
+### Request a Ticket Granting Ticket (Proxy TLS Client Authentication using a http header)
+
+The cas server should be configured for X509 authentication on the login page for
+this to function properly.
+
+### Request a Ticket Granting Ticket (TLS Client Authentication from the servlet container)
 
 The cas server should be configured for X509 authentication on the login page for
 this to function properly.

--- a/support/cas-server-support-rest-x509/src/main/java/org/apereo/cas/support/x509/rest/X509RestTlsClientCertCredentialFactory.java
+++ b/support/cas-server-support-rest-x509/src/main/java/org/apereo/cas/support/x509/rest/X509RestTlsClientCertCredentialFactory.java
@@ -1,0 +1,40 @@
+package org.apereo.cas.support.x509.rest;
+
+import org.apereo.cas.adaptors.x509.authentication.principal.X509CertificateCredential;
+import org.apereo.cas.authentication.Credential;
+import org.apereo.cas.rest.factory.RestHttpRequestCredentialFactory;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.util.MultiValueMap;
+
+import javax.servlet.http.HttpServletRequest;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is {@link X509RestTlsClientCertCredentialFactory} that attempts to
+ * fetch the TLS client certificate from the servlet container, to construct
+ * X509 credentials.
+ *
+ * @author sadt
+ * @since 6.0.0
+ */
+@Slf4j
+public class X509RestTlsClientCertCredentialFactory implements RestHttpRequestCredentialFactory {
+
+    private static final String REQUEST_ATTRIBUTE_X509_CERTIFICATE = "javax.servlet.request.X509Certificate";
+
+    @Override
+    public List<Credential> fromRequest(final HttpServletRequest request, final MultiValueMap<String, String> requestBody) {
+        val credentials = new ArrayList<Credential>();
+        val certificates = (X509Certificate[]) request.getAttribute(REQUEST_ATTRIBUTE_X509_CERTIFICATE);
+
+        if (certificates != null && certificates.length > 0) {
+            LOGGER.debug("Certificates found in request attribute: {}", REQUEST_ATTRIBUTE_X509_CERTIFICATE);
+            credentials.add(new X509CertificateCredential(certificates));
+        }
+        return credentials;
+    }
+}

--- a/support/cas-server-support-rest-x509/src/main/java/org/apereo/cas/support/x509/rest/config/X509RestConfiguration.java
+++ b/support/cas-server-support-rest-x509/src/main/java/org/apereo/cas/support/x509/rest/config/X509RestConfiguration.java
@@ -62,6 +62,13 @@ public class X509RestConfiguration implements RestHttpRequestCredentialFactoryCo
         val tlsClientAuth = restProperties.isTlsClientAuth();
         LOGGER.debug("is certificate extractor available? = {}, headerAuth = {}, bodyAuth = {}, tlsClientAuth = {}",
                      extractor, headerAuth, bodyAuth, tlsClientAuth);
+
+        if (tlsClientAuth && (headerAuth || bodyAuth)) {
+            LOGGER.warn("X509 REST configuration seems inconsistant as activating headerAuth or bodyAuth supposes "
+                        + "that the CAS server is not directly reachable by clients (see security warning in the "
+                        +"documentation) and activating tlsClientAuth suppose the opposite.");
+        }
+
         if (extractor != null && headerAuth) {
             factory.registerCredentialFactory(x509RestRequestHeader());
         }

--- a/support/cas-server-support-rest-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-rest-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -3,6 +3,7 @@ package org.apereo.cas;
 
 import org.apereo.cas.support.x509.rest.X509RestHttpRequestHeaderCredentialFactoryTests;
 import org.apereo.cas.support.x509.rest.X509RestMultipartBodyCredentialFactoryTests;
+import org.apereo.cas.support.x509.rest.X509RestTlsClientCertCredentialFactoryTests;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -16,7 +17,9 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     X509RestHttpRequestHeaderCredentialFactoryTests.class,
-    X509RestMultipartBodyCredentialFactoryTests.class
+    X509RestMultipartBodyCredentialFactoryTests.class,
+    X509RestTlsClientCertCredentialFactoryTests.class
+
 })
 public class AllTestsSuite {
 }

--- a/support/cas-server-support-rest-x509/src/test/java/org/apereo/cas/support/x509/rest/X509RestTlsClientCertCredentialFactoryTests.java
+++ b/support/cas-server-support-rest-x509/src/test/java/org/apereo/cas/support/x509/rest/X509RestTlsClientCertCredentialFactoryTests.java
@@ -7,8 +7,6 @@ import lombok.val;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.util.LinkedMultiValueMap;
@@ -25,10 +23,9 @@ import static org.junit.Assert.*;
  * Unit tests for {@link X509RestTlsClientCertCredentialFactory}.
  *
  * @author Dmytro Fedonin
- * @author sadt
+ * @author Stéphane Adenot
  * @since 6.0.0
  */
-@RunWith(MockitoJUnitRunner.Silent.class)
 public class X509RestTlsClientCertCredentialFactoryTests {
 
     private static final String REQUEST_ATTRIBUTE_X509_CERTIFICATE = "javax.servlet.request.X509Certificate";
@@ -43,7 +40,7 @@ public class X509RestTlsClientCertCredentialFactoryTests {
         val request = new MockHttpServletRequest();
 
         try (val inStream = new FileInputStream(new ClassPathResource("ldap-crl.crt").getFile())) {
-            X509Certificate[] certs = {CertUtils.readCertificate(inStream)};
+            val certs = new X509Certificate[]{CertUtils.readCertificate(inStream)};
             request.setAttribute(REQUEST_ATTRIBUTE_X509_CERTIFICATE, certs);
 
             val cred = factory.fromRequest(request, null).iterator().next();

--- a/support/cas-server-support-rest-x509/src/test/java/org/apereo/cas/support/x509/rest/X509RestTlsClientCertCredentialFactoryTests.java
+++ b/support/cas-server-support-rest-x509/src/test/java/org/apereo/cas/support/x509/rest/X509RestTlsClientCertCredentialFactoryTests.java
@@ -1,0 +1,63 @@
+package org.apereo.cas.support.x509.rest;
+
+import org.apereo.cas.adaptors.x509.authentication.principal.X509CertificateCredential;
+import org.apereo.cas.util.crypto.CertUtils;
+
+import lombok.val;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.util.LinkedMultiValueMap;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link X509RestTlsClientCertCredentialFactory}.
+ *
+ * @author Dmytro Fedonin
+ * @author sadt
+ * @since 6.0.0
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class X509RestTlsClientCertCredentialFactoryTests {
+
+    private static final String REQUEST_ATTRIBUTE_X509_CERTIFICATE = "javax.servlet.request.X509Certificate";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final X509RestTlsClientCertCredentialFactory factory = new X509RestTlsClientCertCredentialFactory();
+
+    @Test
+    public void createX509Credential() throws IOException, CertificateException {
+        val request = new MockHttpServletRequest();
+
+        try (val inStream = new FileInputStream(new ClassPathResource("ldap-crl.crt").getFile())) {
+            X509Certificate[] certs = {CertUtils.readCertificate(inStream)};
+            request.setAttribute(REQUEST_ATTRIBUTE_X509_CERTIFICATE, certs);
+
+            val cred = factory.fromRequest(request, null).iterator().next();
+            assertTrue(cred instanceof X509CertificateCredential);
+        }
+    }
+
+    @Test
+    public void createDefaultCredential() {
+        val request = new MockHttpServletRequest();
+        val requestBody = new LinkedMultiValueMap<String, String>();
+        requestBody.add("username", "name");
+        requestBody.add("password", "passwd");
+        val cred = factory.fromRequest(request, requestBody);
+        assertTrue(cred.isEmpty());
+    }
+}


### PR DESCRIPTION
This PR is about authenticating a REST client with its tls client key pair and certificate. There are already other means of doing so, using some http header or parameter, but they need the deployment of an http proxy (as far as I can understand). 

This mean simply asks the servlet container for the client certificate, much as it's done, in the non REST (browser) part of CAS.