### PR TITLE
Keep logback off of test classpath

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1561,6 +1561,7 @@ ext.libraries = [
                     exclude(group: "junit", module: "junit")
                     exclude(group: "org.mockito", module: "mockito-all")
                     exclude(group: "org.mockito", module: "mockito-core")
+                    exclude(group: "org.springframework.boot", module: "spring-boot-starter-logging")
                     force = true
                 },
                 dependencies.create("org.hsqldb:hsqldb:$hsqlVersion"),


### PR DESCRIPTION
Logback was showing up when running tests, although slf4j 1.8 wasn't using it. Not sure why log4j is not on test classpaths despite library.tests being defined globally...