### PR TITLE
Handle HEAD /idp/profile/SAML2/Redirect/SSO [Forward-Port]

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlPostProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlPostProfileHandlerController.java
@@ -23,6 +23,8 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -63,7 +65,7 @@ public class SSOSamlPostProfileHandlerController extends AbstractSamlProfileHand
 
 
     /**
-     * Handle SSO POST profile request.
+     * Handle SSO GET profile redirect request.
      *
      * @param response the response
      * @param request  the request
@@ -73,6 +75,20 @@ public class SSOSamlPostProfileHandlerController extends AbstractSamlProfileHand
     public void handleSaml2ProfileSsoRedirectRequest(final HttpServletResponse response,
                                                      final HttpServletRequest request) throws Exception {
         handleSsoPostProfileRequest(response, request, new HTTPRedirectDeflateDecoder());
+    }
+
+    /**
+     * Handle SSO HEAD profile redirect request (not allowed).
+     *
+     * @param response the response
+     * @param request  the request
+     * @throws Exception the exception
+     */
+    @RequestMapping(path = SamlIdPConstants.ENDPOINT_SAML2_SSO_PROFILE_REDIRECT, method = { RequestMethod.HEAD })
+    public void handleSaml2ProfileSsoRedirectHeadRequest(final HttpServletResponse response,
+                                                         final HttpServletRequest request) throws Exception {
+        LOGGER.info("Endpoint [{}] called with HTTP HEAD returning 400 Bad Request", SamlIdPConstants.ENDPOINT_SAML2_SSO_PROFILE_REDIRECT);
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
     }
 
     /**


### PR DESCRIPTION
Some systems may do a health check on SSO enabled sites. Combined with e.g. ADFS a site
redirects to ADFS and then redirecting to CAS. This is in general fine, however some
systems may issue a HEAD request instead of a GET request, leading to an unhandled
error in CAS, which is fixed by this commit.

Forward-Port: 8ef3def

<!--

# Contributing

First off, thank you for considering to contribute to CAS. 

# Details

Closes #IssueNumber

Ensure that you include the following:

- [] Brief description of changes applied
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related.

-->
