### PR TITLE
pac4j: Consider typedIdUsed when a custom principalAttributeId is specified

### DIFF
--- a/support/cas-server-support-pac4j-authentication/src/main/java/org/apereo/cas/integration/pac4j/authentication/handler/support/AbstractPac4jAuthenticationHandler.java
+++ b/support/cas-server-support-pac4j-authentication/src/main/java/org/apereo/cas/integration/pac4j/authentication/handler/support/AbstractPac4jAuthenticationHandler.java
@@ -86,6 +86,7 @@ public abstract class AbstractPac4jAuthenticationHandler extends AbstractPreAndP
                     final Optional<Object> firstAttribute = CollectionUtils.firstElement(profile.getAttribute(principalAttribute));
                     if (firstAttribute.isPresent()) {
                         id = firstAttribute.get().toString();
+                        id = typePrincipalId(id, profile);
                     }
                     LOGGER.debug("Delegated authentication indicates usage of client principal attribute [{}] for the identifier [{}]", principalAttribute, id);
                 } else {
@@ -99,6 +100,7 @@ public abstract class AbstractPac4jAuthenticationHandler extends AbstractPreAndP
                 final Optional<Object> firstAttribute = CollectionUtils.firstElement(profile.getAttribute(principalAttributeId));
                 if (firstAttribute.isPresent()) {
                     id = firstAttribute.get().toString();
+                    id = typePrincipalId(id, profile);
                 }
             } else {
                 LOGGER.warn("CAS cannot use [{}] as the principal attribute id, since the profile attributes do not contain the attribute. "
@@ -112,5 +114,13 @@ public abstract class AbstractPac4jAuthenticationHandler extends AbstractPreAndP
         }
         LOGGER.debug("Final principal id determined based on client [{}] and user profile [{}] is [{}]", profile, client, id);
         return id;
+    }
+    
+    private String typePrincipalId(final String id, final UserProfile profile) {
+        if (isTypedIdUsed) {
+            return profile.getClass().getName() + UserProfile.SEPARATOR + id;
+        } else {
+            return id;
+        }
     }
 }


### PR DESCRIPTION
Currently, when `cas.authn.pac4j.principalAttributeId` or `cas.authn.pac4j.PROVIDER.principalAttributeId` is specified, `cas.authn.pac4j.typedIdUsed` is not considered, [cf. AbstractPac4jAuthenticationHandler](https://github.com/apereo/cas/blob/8461a5bbc0f76058cf0b6e9e173b45a12e170372/support/cas-server-support-pac4j-authentication/src/main/java/org/apereo/cas/integration/pac4j/authentication/handler/support/AbstractPac4jAuthenticationHandler.java#L105).

In case you need to know, which pac4j client did the authentication in the authn flow, it is useful to consistently return a typed principal ID irrespective of whether a custom principalAttributeId is set or not.

This patch implements exactly that behaviour.