### PR TITLE
Reducing Redis heap memory overhead when running ticket registry cleaner

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
@@ -79,6 +79,9 @@ public interface TicketRegistry {
     /**
      * Gets tickets as a stream having applied a predicate.
      *
+     * The returning stream may be bound to an IO channel (such as database connection),
+     * so it should be properly closed after usage.
+     *
      * @param predicate the predicate
      * @return the tickets
      */
@@ -110,6 +113,9 @@ public interface TicketRegistry {
 
     /**
      * Gets tickets stream.
+     *
+     * The returning stream may be bound to an IO channel (such as database connection),
+     * so it should be properly closed after usage.
      *
      * @return the tickets stream
      */

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/UniquePrincipalAuthenticationPolicy.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/UniquePrincipalAuthenticationPolicy.java
@@ -31,7 +31,7 @@ public class UniquePrincipalAuthenticationPolicy implements AuthenticationPolicy
     public boolean isSatisfiedBy(final Authentication authentication) throws Exception {
         try {
             final Principal authPrincipal = authentication.getPrincipal();
-            try (final Stream<Ticket> ticketsStream =
+            try (Stream<Ticket> ticketsStream =
                          this.ticketRegistry.getTickets(t -> isSamePrincipalId(t, authPrincipal))) {
                 final long count = ticketsStream.count();
                 if (count == 0) {

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/UniquePrincipalAuthenticationPolicy.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/UniquePrincipalAuthenticationPolicy.java
@@ -5,10 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.AuthenticationPolicy;
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 
 import java.security.GeneralSecurityException;
+import java.util.stream.Stream;
 
 /**
  * This is {@link UniquePrincipalAuthenticationPolicy}
@@ -29,23 +31,28 @@ public class UniquePrincipalAuthenticationPolicy implements AuthenticationPolicy
     public boolean isSatisfiedBy(final Authentication authentication) throws Exception {
         try {
             final Principal authPrincipal = authentication.getPrincipal();
-            final long count = this.ticketRegistry.getTickets(t -> {
-                boolean pass = TicketGrantingTicket.class.isInstance(t) && !t.isExpired();
-                if (pass) {
-                    final Principal principal = TicketGrantingTicket.class.cast(t).getAuthentication().getPrincipal();
-                    pass = principal.getId().equalsIgnoreCase(authPrincipal.getId());
+            try (final Stream<Ticket> ticketsStream =
+                         this.ticketRegistry.getTickets(t -> isSamePrincipalId(t, authPrincipal))) {
+                final long count = ticketsStream.count();
+                if (count == 0) {
+                    LOGGER.debug("Authentication policy is satisfied with [{}]", authPrincipal.getId());
+                    return true;
                 }
-                return pass;
-            }).count();
-            if (count == 0) {
-                LOGGER.debug("Authentication policy is satisfied with [{}]", authPrincipal.getId());
-                return true;
+                LOGGER.warn("Authentication policy cannot be satisfied for principal [{}] because [{}] sessions currently exist",
+                        authPrincipal.getId(), count);
+                return false;
             }
-            LOGGER.warn("Authentication policy cannot be satisfied for principal [{}] because [{}] sessions currently exist",
-                    authPrincipal.getId(), count);
-            return false;
         } catch (final Exception e) {
             throw new GeneralSecurityException(e);
         }
+    }
+
+    private boolean isSamePrincipalId(final Ticket t, final Principal p) {
+        boolean pass = TicketGrantingTicket.class.isInstance(t) && !t.isExpired();
+        if (pass) {
+            final Principal principal = TicketGrantingTicket.class.cast(t).getAuthentication().getPrincipal();
+            pass = principal.getId().equalsIgnoreCase(p.getId());
+        }
+        return pass;
     }
 }

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -65,7 +65,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
     @Override
     public long sessionCount() {
         try {
-            return getTickets().stream().filter(TicketGrantingTicket.class::isInstance).count();
+            return getTicketsStream().filter(TicketGrantingTicket.class::isInstance).count();
         } catch (final Exception t) {
             LOGGER.trace("sessionCount() operation is not implemented by the ticket registry instance [{}]. "
                 + "Message is: [{}] Returning unknown as [{}]", this.getClass().getName(), t.getMessage(), Long.MIN_VALUE);
@@ -76,7 +76,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
     @Override
     public long serviceTicketCount() {
         try {
-            return getTickets().stream().filter(ServiceTicket.class::isInstance).count();
+            return getTicketsStream().filter(ServiceTicket.class::isInstance).count();
         } catch (final Exception t) {
             LOGGER.trace("serviceTicketCount() operation is not implemented by the ticket registry instance [{}]. "
                 + "Message is: [{}] Returning unknown as [{}]", this.getClass().getName(), t.getMessage(), Long.MIN_VALUE);
@@ -268,11 +268,21 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
      * @return the set
      */
     protected Collection<Ticket> decodeTickets(final Collection<Ticket> items) {
+        return decodeTickets(items.stream()).collect(Collectors.toSet());
+    }
+
+    /**
+     * Decode tickets.
+     *
+     * @param items the items
+     * @return the set
+     */
+    protected Stream<Ticket> decodeTickets(final Stream<Ticket> items) {
         if (!isCipherExecutorEnabled()) {
             LOGGER.trace(MESSAGE);
             return items;
         }
-        return items.stream().map(this::decodeTicket).collect(Collectors.toSet());
+        return items.map(this::decodeTicket);
     }
 
     protected boolean isCipherExecutorEnabled() {

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -64,8 +64,8 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
 
     @Override
     public long sessionCount() {
-        try {
-            return getTicketsStream().filter(TicketGrantingTicket.class::isInstance).count();
+        try (Stream<Ticket> tgtStream = getTicketsStream().filter(TicketGrantingTicket.class::isInstance)) {
+            return tgtStream.count();
         } catch (final Exception t) {
             LOGGER.trace("sessionCount() operation is not implemented by the ticket registry instance [{}]. "
                 + "Message is: [{}] Returning unknown as [{}]", this.getClass().getName(), t.getMessage(), Long.MIN_VALUE);
@@ -75,8 +75,8 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
 
     @Override
     public long serviceTicketCount() {
-        try {
-            return getTicketsStream().filter(ServiceTicket.class::isInstance).count();
+        try (Stream<Ticket> stStream = getTicketsStream().filter(ServiceTicket.class::isInstance)) {
+            return stStream.count();
         } catch (final Exception t) {
             LOGGER.trace("serviceTicketCount() operation is not implemented by the ticket registry instance [{}]. "
                 + "Message is: [{}] Returning unknown as [{}]", this.getClass().getName(), t.getMessage(), Long.MIN_VALUE);

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.stream.Stream;
+
 
 /**
  * This is {@link DefaultTicketRegistryCleaner}.
@@ -56,12 +58,14 @@ public class DefaultTicketRegistryCleaner implements TicketRegistryCleaner, Seri
      * Clean tickets.
      */
     protected void cleanInternal() {
-        final int ticketsDeleted = ticketRegistry.getTicketsStream()
-            .filter(Objects::nonNull)
-            .filter(Ticket::isExpired)
-            .mapToInt(this::cleanTicket)
-            .sum();
-        LOGGER.info("[{}] expired tickets removed.", ticketsDeleted);
+        try (final Stream<Ticket> ticketsStream = ticketRegistry.getTicketsStream()) {
+            final int ticketsDeleted = ticketsStream
+                    .filter(Objects::nonNull)
+                    .filter(Ticket::isExpired)
+                    .mapToInt(this::cleanTicket)
+                    .sum();
+            LOGGER.info("[{}] expired tickets removed.", ticketsDeleted);
+        }
     }
 
     @Override

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
@@ -58,7 +58,7 @@ public class DefaultTicketRegistryCleaner implements TicketRegistryCleaner, Seri
      * Clean tickets.
      */
     protected void cleanInternal() {
-        try (final Stream<Ticket> ticketsStream = ticketRegistry.getTicketsStream()) {
+        try (Stream<Ticket> ticketsStream = ticketRegistry.getTicketsStream()) {
             final int ticketsDeleted = ticketsStream
                     .filter(Objects::nonNull)
                     .filter(Ticket::isExpired)

--- a/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
@@ -35,6 +35,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import lombok.Setter;
 
 /**
@@ -152,7 +154,9 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
     @Counted(name = "GET_TICKETS_COUNTER", monotonic = true)
     @Override
     public Collection<Ticket> getTickets(final Predicate<Ticket> predicate) {
-        return this.ticketRegistry.getTicketsStream().filter(predicate).collect(Collectors.toSet());
+        try (Stream<Ticket> ticketsStream = this.ticketRegistry.getTicketsStream().filter(predicate)) {
+            return ticketsStream.collect(Collectors.toSet());
+        }
     }
 
     @Transactional(transactionManager = "ticketTransactionManager")

--- a/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
@@ -152,7 +152,7 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
     @Counted(name = "GET_TICKETS_COUNTER", monotonic = true)
     @Override
     public Collection<Ticket> getTickets(final Predicate<Ticket> predicate) {
-        return this.ticketRegistry.getTickets().stream().filter(predicate).collect(Collectors.toSet());
+        return this.ticketRegistry.getTicketsStream().filter(predicate).collect(Collectors.toSet());
     }
 
     @Transactional(transactionManager = "ticketTransactionManager")

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
@@ -240,6 +240,7 @@ public class DefaultCentralAuthenticationServiceMockitoTests {
         when(ticketRegMock.getTicket(eq(stMock.getId()), eq(ServiceTicket.class))).thenReturn(stMock);
         when(ticketRegMock.getTicket(eq(stMock2.getId()), eq(ServiceTicket.class))).thenReturn(stMock2);
         when(ticketRegMock.getTickets()).thenReturn(Arrays.asList(tgtMock, tgtMock2, stMock, stMock2));
+        when(ticketRegMock.getTicketsStream()).thenCallRealMethod();
     }
 
     @Test

--- a/support/cas-server-support-couchdb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchDbTicketRegistry.java
+++ b/support/cas-server-support-couchdb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchDbTicketRegistry.java
@@ -147,9 +147,4 @@ public class CouchDbTicketRegistry extends AbstractTicketRegistry {
         }
         return null;
     }
-
-    @Override
-    public Stream<Ticket> getTicketsStream() {
-        return getTickets().stream();
-    }
 }

--- a/support/cas-server-support-couchdb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchDbTicketRegistry.java
+++ b/support/cas-server-support-couchdb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CouchDbTicketRegistry.java
@@ -13,7 +13,6 @@ import org.ektorp.UpdateConflictException;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This is {@link CouchDbTicketRegistry }.

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -9,7 +9,11 @@ import org.springframework.data.redis.core.ScanOptions;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -131,10 +135,10 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
                                      .build())) {
             return StreamSupport
                     .stream(Spliterators.spliteratorUnknownSize(cursor, Spliterator.ORDERED), false)
-                    .map((key) -> (String) client.getKeySerializer().deserialize(key))
+                    .map(key -> (String) client.getKeySerializer().deserialize(key))
                     .collect(Collectors.toList())
                     .stream();
-        } catch (IOException ex) {
+        } catch (final IOException ex) {
             LOGGER.error("Could not acquire a Redis connection", ex);
             return Stream.empty();
         }

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -90,7 +90,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public Collection<Ticket> getTickets() {
-        try (final Stream<Ticket> ticketsStream = getTicketsStream()) {
+        try (Stream<Ticket> ticketsStream = getTicketsStream()) {
             return ticketsStream.collect(Collectors.toSet());
         }
     }

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -3,14 +3,17 @@ package org.apereo.cas.ticket.registry;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.ticket.Ticket;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 
 import javax.validation.constraints.NotNull;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Set;
+import java.io.IOException;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Key-value ticket registry implementation that stores tickets in redis keyed on the ticket ID.
@@ -22,6 +25,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class RedisTicketRegistry extends AbstractTicketRegistry {
     private static final String CAS_TICKET_PREFIX = "CAS_TICKET:";
+    private static final long SCAN_COUNT = 100L;
 
     @NotNull
     private final RedisTemplate<String, Ticket> client;
@@ -82,7 +86,12 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
 
     @Override
     public Collection<Ticket> getTickets() {
-        return this.client.keys(getPatternTicketRedisKey()).stream()
+        return getTicketsStream().collect(Collectors.toSet());
+    }
+
+    @Override
+    public Stream<Ticket> getTicketsStream() {
+        return getKeysStream()
                 .map(redisKey -> {
                     final Ticket ticket = this.client.boundValueOps(redisKey).get();
                     if (ticket == null) {
@@ -92,8 +101,8 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
                     return ticket;
                 })
                 .filter(Objects::nonNull)
-                .map(this::decodeTicket)
-                .collect(Collectors.toSet());
+                .map(this::decodeTicket);
+
     }
 
     @Override
@@ -108,6 +117,27 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
             LOGGER.error("Failed to update [{}]", ticket, e);
         }
         return null;
+    }
+
+    private Stream<String> getKeysStream() {
+        try (Cursor<byte[]> cursor =
+                     client
+                             .getConnectionFactory()
+                             .getConnection()
+                             .scan(ScanOptions
+                                     .scanOptions()
+                                     .match(getPatternTicketRedisKey())
+                                     .count(SCAN_COUNT)
+                                     .build())) {
+            return StreamSupport
+                    .stream(Spliterators.spliteratorUnknownSize(cursor, Spliterator.ORDERED), false)
+                    .map((key) -> (String) client.getKeySerializer().deserialize(key))
+                    .collect(Collectors.toList())
+                    .stream();
+        } catch (IOException ex) {
+            LOGGER.error("Could not acquire a Redis connection", ex);
+            return Stream.empty();
+        }
     }
 
     /**

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -131,7 +131,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
      * @return stream of all CAS-related keys from Redis DB
      */
     private Stream<String> getKeysStream() {
-        try (final Cursor<byte[]> cursor =
+        try (Cursor<byte[]> cursor =
                      client
                              .getConnectionFactory()
                              .getConnection()

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -131,29 +131,25 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
      * @return stream of all CAS-related keys from Redis DB
      */
     private Stream<String> getKeysStream() {
-        try (Cursor<byte[]> cursor =
-                     client
-                             .getConnectionFactory()
-                             .getConnection()
-                             .scan(ScanOptions
-                                     .scanOptions()
-                                     .match(getPatternTicketRedisKey())
-                                     .count(SCAN_COUNT)
-                                     .build())) {
-            return StreamSupport
-                    .stream(Spliterators.spliteratorUnknownSize(cursor, Spliterator.ORDERED), false)
-                    .map(key -> (String) client.getKeySerializer().deserialize(key))
-                    .onClose(() -> {
-                        try {
-                            cursor.close();
-                        } catch (final IOException e) {
-                            LOGGER.error("Could not close Redis connection", e);
-                        }
-                    });
-        } catch (final IOException e) {
-            LOGGER.error("Could not acquire a Redis connection", e);
-            return Stream.empty();
-        }
+        Cursor<byte[]> cursor =
+                client
+                        .getConnectionFactory()
+                        .getConnection()
+                        .scan(ScanOptions
+                                .scanOptions()
+                                .match(getPatternTicketRedisKey())
+                                .count(SCAN_COUNT)
+                                .build());
+        return StreamSupport
+                .stream(Spliterators.spliteratorUnknownSize(cursor, Spliterator.ORDERED), false)
+                .map(key -> (String) client.getKeySerializer().deserialize(key))
+                .onClose(() -> {
+                    try {
+                        cursor.close();
+                    } catch (final IOException e) {
+                        LOGGER.error("Could not close Redis connection", e);
+                    }
+                });
     }
 
     /**

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -131,7 +131,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
      * @return stream of all CAS-related keys from Redis DB
      */
     private Stream<String> getKeysStream() {
-        Cursor<byte[]> cursor =
+        final Cursor<byte[]> cursor =
                 client
                         .getConnectionFactory()
                         .getConnection()


### PR DESCRIPTION
I've noticed some bursts in memory usage when using `RedisTicketRegistry` together with `DefaultTicketRegistryCleaner`. 

![mem](https://i.imgur.com/5oKLl1D.jpg)

After some research I've found out that `DefaultTicketRegistryCleaner` loads all the tickets from Redis to Java heap memory due to default implementation of `getTicketsStream()` in `RedisTicketRegistry` (which calls `getTickets()`).

This PR does two things:
 - defines proper `getTicketsStream` in `RedisTicketRegistry`
 - fetches Redis KEYS in a proper way as Redis documentation suggests (using SCAN instead of KEYS).
