### PR TITLE
I18n support for Password Reset view

### DIFF
--- a/webapp/resources/messages.properties
+++ b/webapp/resources/messages.properties
@@ -36,6 +36,14 @@ screen.pm.reset.sent=Password Reset Instructions Sent Successfully.
 screen.pm.reset.title=Reset your password
 screen.pm.reset.instructions=Please provide your username. You will receive an email with follow-up instructions on how to reset \
   your password.
+screen.pm.password.policyViolation=Password does not match the password policy requirement.
+screen.pm.password.confirmMismatch=Passwords do not match.
+screen.pm.password.strength=Strength:
+screen.pm.password.strength.0=Worst
+screen.pm.password.strength.1=Bad
+screen.pm.password.strength.2=Weak
+screen.pm.password.strength.3=Good
+screen.pm.password.strength.4=Strong
 
 screen.aup.heading=Acceptable Usage Policy
 screen.aup.button.accept=ACCEPT

--- a/webapp/resources/messages_de.properties
+++ b/webapp/resources/messages_de.properties
@@ -35,6 +35,14 @@ screen.pm.reset.sentInstructions=Sie werden in Kürze eine E-Mail mit Anweisunge
 screen.pm.reset.sent=Anweisungen zum Zurücksetzen des Passworts erfolgreich versandt.
 screen.pm.reset.title=Passwort zurücksetzen
 screen.pm.reset.instructions=Bitte geben Sie Ihren Benutzernamen ein. Sie werden eine E-Mail mit Anweisungen zum weiteren Vorgehen erhalten.
+screen.pm.password.policyViolation=Das Passwort entspricht nicht der Passwortrichtlinie.
+screen.pm.password.confirmMismatch=Die Passwörter stimmen nicht überein.
+screen.pm.password.strength=Passwort-Stärke:
+screen.pm.password.strength.0=Grauenhaft
+screen.pm.password.strength.1=Schlecht
+screen.pm.password.strength.2=Schwach
+screen.pm.password.strength.3=Gut
+screen.pm.password.strength.4=Stark
 
 screen.aup.heading=Nutzungsbedingungen
 screen.aup.button.accept=AKZEPTIEREN

--- a/webapp/resources/static/js/passwordMeter.js
+++ b/webapp/resources/static/js/passwordMeter.js
@@ -76,12 +76,12 @@ function jqueryReady() {
     confirmed.addEventListener('input', validate);
     
     var alertSettings = {
-            allAlertClasses: 'alert-danger alert-warning alert-info alert-success',
-            alertClassDanger: 'alert-danger',
-            alertClassWarning: 'alert-warning',
-            alertClassInfo: 'alert-info',
-            alertClassSuccess: 'alert-success'
-        };
+        allAlertClasses: 'alert-danger alert-warning alert-info alert-success',
+        alertClassDanger: 'alert-danger',
+        alertClassWarning: 'alert-warning',
+        alertClassInfo: 'alert-info',
+        alertClassSuccess: 'alert-success'
+    };
 
     function validate() {
         var val = password.value;
@@ -117,7 +117,7 @@ function jqueryReady() {
             switch (result.score) {
             case 0:
             case 1:
-                clz = alertSettings.alertClassDanger;;
+                clz = alertSettings.alertClassDanger;
                 break;
             case 2:
                 clz = alertSettings.alertClassWarning;

--- a/webapp/resources/static/js/passwordMeter.js
+++ b/webapp/resources/static/js/passwordMeter.js
@@ -76,11 +76,11 @@ function jqueryReady() {
     confirmed.addEventListener('input', validate);
     
     var alertSettings = {
-        allAlertClasses: 'alert-danger alert-warning alert-info alert-success',
-        alertClassDanger: 'alert-danger',
-        alertClassWarning: 'alert-warning',
-        alertClassInfo: 'alert-info',
-        alertClassSuccess: 'alert-success'
+        allAlertClasses: 'fa-times-circle fa-exclamation-circle fa-info-circle fa-check-circle',
+        alertClassDanger: 'fa-times-circle',
+        alertClassWarning: 'fa-exclamation-circle',
+        alertClassInfo: 'fa-info-circle',
+        alertClassSuccess: 'fa-check-circle'
     };
 
     function validate() {
@@ -89,7 +89,6 @@ function jqueryReady() {
         
         $('#password-policy-violation-msg').hide();
         $('#password-confirm-mismatch-msg').hide();
-        $('#password-strength-msg').hide();
 
         var passwordPolicyViolated = val === '' || !policyPatternRegex.test(val); 
         var passwordMismatch = val !== '' && val !== cnf;
@@ -97,19 +96,10 @@ function jqueryReady() {
         $('#submit').prop('disabled', disableSubmit);
 
         var result = zxcvbn(val);
-        $('#strengthProgressBar').zxcvbnProgressBar({ passwordInput: '#password' });
-        
-        // Check password policy
-        if (passwordPolicyViolated) {
-            $('#password-policy-violation-msg').show();
-            return;
-        }
+        $('#strengthProgressBar').zxcvbnProgressBar({ passwordInput: '#password' });       
         
         // Check strength, update the text indicator
         if (val !== '') {
-            $('#password-strength-msg').show();
-            
-            $('#password-strength-score').text(strength[result.score]);
             $('#password-strength-warning').text(result.feedback.warning);
             $('#password-strength-suggestions').text(result.feedback.suggestions);
             
@@ -131,12 +121,22 @@ function jqueryReady() {
                 clz = alertSettings.alertClassSuccess;
                 break;
             }
-            $('#password-strength-msg').removeClass(alertSettings.allAlertClasses).addClass(clz);
+            $('#password-strength-icon').removeClass(alertSettings.allAlertClasses).addClass(clz);
+        } else {
+            $('#password-strength-icon').removeClass(alertSettings.allAlertClasses);
+            $('#password-strength-warning').text('');
+            $('#password-strength-suggestions').text('');
         }
         
         // Check for mismatch
-        if (passwordMismatch) {
+        if (passwordMismatch && cnf !== '') {
             $('#password-confirm-mismatch-msg').show();
+        }
+        
+        // Check password policy
+        if (passwordPolicyViolated) {
+            $('#password-policy-violation-msg').show();
+            return;
         }
     }
 }

--- a/webapp/resources/templates/fragments/pwdupdateform.html
+++ b/webapp/resources/templates/fragments/pwdupdateform.html
@@ -12,6 +12,13 @@
       /*<![CDATA[*/
 
       var policyPattern = /*[[${policyPattern}]]*/;
+      var passwordStrengthI18n = {
+          0: /*[[#{screen.pm.password.strength.0}]]*/,
+          1: /*[[#{screen.pm.password.strength.1}]]*/,
+          2: /*[[#{screen.pm.password.strength.2}]]*/,
+          3: /*[[#{screen.pm.password.strength.3}]]*/,
+          4: /*[[#{screen.pm.password.strength.4}]]*/
+      };
 
       /*]]>*/
     </script>
@@ -38,9 +45,23 @@
 
             <div class="form-group">
                 <div class="progress">
-                    <div id="strengthProgressBar" class="progress-bar">progress bar</div>
+                    <div id="strengthProgressBar" class="progress-bar"></div>
                 </div>
-                <p id="password-strength-text"/>
+            </div>
+            <div class="form-group" id="password-strength-notes">
+                <div id="password-policy-violation-msg" class="alert alert-danger" role="alert" style="display: none;">
+                    <span class="fas fa-exclamation-circle" aria-hidden="true"></span>&nbsp;
+                    <strong th:text="#{screen.pm.password.policyViolation}">Password does not match the password policy requirement.</strong>
+                </div>
+                <div id="password-confirm-mismatch-msg" class="alert alert-danger" role="alert" style="display: none;">
+                    <span class="fas fa-exclamation-circle" aria-hidden="true"></span>&nbsp;
+                    <strong th:text="#{screen.pm.password.confirmMismatch}">Passwords do not match.</strong>
+                </div>
+                <div id="password-strength-msg" class="alert" style="display: none;">
+                    <p><span th:text="#{screen.pm.password.strength}">Strength:</span>&nbsp;<strong id="password-strength-score">&nbsp;</strong></p>
+                    <p id="password-strength-warning"></p>
+                    <p id="password-strength-suggestions"></p>
+                </div>
             </div>
 
 

--- a/webapp/resources/templates/fragments/pwdupdateform.html
+++ b/webapp/resources/templates/fragments/pwdupdateform.html
@@ -44,8 +44,15 @@
             </div>
 
             <div class="form-group">
+                <div>
+                    <span th:text="#{screen.pm.password.strength}">Strength:</span>&nbsp;
+                    <span id="password-strength-icon" class="fas" aria-hidden="true"></span>
+                </div>
                 <div class="progress">
                     <div id="strengthProgressBar" class="progress-bar"></div>
+                </div>
+                <div>
+                    <span id="password-strength-warning"></span>&nbsp;<span id="password-strength-suggestions"></span>
                 </div>
             </div>
             <div class="form-group" id="password-strength-notes">
@@ -56,11 +63,6 @@
                 <div id="password-confirm-mismatch-msg" class="alert alert-danger" role="alert" style="display: none;">
                     <span class="fas fa-exclamation-circle" aria-hidden="true"></span>&nbsp;
                     <strong th:text="#{screen.pm.password.confirmMismatch}">Passwords do not match.</strong>
-                </div>
-                <div id="password-strength-msg" class="alert" style="display: none;">
-                    <p><span th:text="#{screen.pm.password.strength}">Strength:</span>&nbsp;<strong id="password-strength-score">&nbsp;</strong></p>
-                    <p id="password-strength-warning"></p>
-                    <p id="password-strength-suggestions"></p>
                 </div>
             </div>
 
@@ -77,14 +79,7 @@
                        type="submit"
                        disabled="true"/>
                 &nbsp;
-                <input
-                        class="btn btn-danger"
-                        name="cancel"
-                        accesskey="c"
-                        th:value="#{screen.pm.button.cancel}"
-                        value="CANCEL"
-                        type="button"
-                        onclick="location.href = location.href;"/>
+                <a class="btn btn-danger" th:href="@{/login}" th:text="#{screen.pm.button.cancel}">CANCEL</a>
             </div>
         </form>
         <p th:unless="${passwordManagementEnabled}"


### PR DESCRIPTION
Added i18n support for Password Reset ([as far as currently possible with zxcvbn](https://github.com/dropbox/zxcvbn/pull/124)). This mainly involved moving the HTML elements generated inside the JavaScript code to the corresponding view fragment.
Revised passwordMeter.js and view fragment for better UX, i.e. logic of alerts and appearance.
Added German translation of new message properties.

A port forward will be provided upon (positive) feedback on these changes. What do you think?