### PR TITLE
Impersonation: Add missing jackson annotations to expiration policy

### DIFF
--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/ticket/support/SurrogateSessionExpirationPolicy.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/ticket/support/SurrogateSessionExpirationPolicy.java
@@ -4,6 +4,8 @@ import org.apereo.cas.authentication.surrogate.SurrogateAuthenticationService;
 import org.apereo.cas.ticket.ExpirationPolicy;
 import org.apereo.cas.ticket.TicketState;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +29,8 @@ public class SurrogateSessionExpirationPolicy extends BaseDelegatingExpirationPo
      *
      * @param policy the policy
      */
-    public SurrogateSessionExpirationPolicy(final ExpirationPolicy policy) {
+    @JsonCreator
+    public SurrogateSessionExpirationPolicy(@JsonProperty("policy") final ExpirationPolicy policy) {
         super(policy);
     }
 


### PR DESCRIPTION
Add missing jackson annotations required for de-serialization of SurrogateSessionExpirationPolicy class without default constructor.
This mimics the annotations in the RememberMeDelegatingExpirationPolicy class which also extends the 
BaseDelegatingExpirationPolicy and has a constructor with an ExpirationPolicy parameter.