### PR TITLE
Log to info when performing attribute sanitization [FORWARD-PORT]

### DIFF
--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/support/DefaultCasProtocolAttributeEncoder.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/support/DefaultCasProtocolAttributeEncoder.java
@@ -71,7 +71,7 @@ public class DefaultCasProtocolAttributeEncoder extends AbstractProtocolAttribut
             .collect(Collectors.toSet());
 
         if (!attrs.isEmpty()) {
-            LOGGER.warn("Found [{}] attribute(s) that need to be sanitized/encoded.", attrs);
+            LOGGER.info("Found [{}] attribute(s) that need to be sanitized/encoded.", attrs);
             attributes.keySet().removeIf(getSanitizingAttributeNamePredicate());
             attrs.forEach(p -> {
                 val key = p.getKey();


### PR DESCRIPTION
It is quite common for CAS to perform attribute sanitization, therefore it should
not be logged as a warning.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
