### PR TITLE
Impersonation: Add missing jackson annotations to expiration policy (port backward to 5.3.x)

### DIFF
--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/ticket/support/SurrogateSessionExpirationPolicy.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/ticket/support/SurrogateSessionExpirationPolicy.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.ticket.support;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.apereo.cas.authentication.surrogate.SurrogateAuthenticationService;
@@ -39,7 +41,8 @@ public class SurrogateSessionExpirationPolicy extends BaseDelegatingExpirationPo
      *
      * @param policy the policy
      */
-    public SurrogateSessionExpirationPolicy(final ExpirationPolicy policy) {
+    @JsonCreator
+    public SurrogateSessionExpirationPolicy(@JsonProperty("policy") final ExpirationPolicy policy) {
         super(policy);
     }
 


### PR DESCRIPTION
 Backport of https://github.com/apereo/cas/pull/3725

Add missing jackson annotations required for de-serialization of SurrogateSessionExpirationPolicy class without default constructor.
This mimics the annotations in the RememberMeDelegatingExpirationPolicy class which also extends the
BaseDelegatingExpirationPolicy and has a constructor with an ExpirationPolicy parameter.