### PR TITLE
avoid NPE when oauth service specified by client_id is not registered

### DIFF
--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapPasswordSynchronizationAuthenticationPostProcessor.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapPasswordSynchronizationAuthenticationPostProcessor.java
@@ -13,7 +13,6 @@ import org.ldaptive.LdapAttribute;
 import org.ldaptive.ModifyOperation;
 import org.ldaptive.ModifyRequest;
 import org.ldaptive.ResultCode;
-import org.ldaptive.SearchResult;
 import org.ldaptive.ad.UnicodePwdAttribute;
 
 import java.util.Collections;

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/authorization/OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidator.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/authorization/OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidator.java
@@ -66,12 +66,7 @@ public class OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidator i
 
         val clientId = request.getParameter(OAuth20Constants.CLIENT_ID);
         val registeredService = getRegisteredServiceByClientId(clientId);
-        if (registeredService == null) {
-            LOGGER.warn("Registered service for {}=[{}] is not registered",
-                    OAuth20Constants.CLIENT_ID, clientId);
-            return false;
-        }
-        val service = webApplicationServiceServiceFactory.createService(registeredService.getServiceId());
+        val service = registeredService != null ? webApplicationServiceServiceFactory.createService(registeredService.getServiceId()) : null;
         val audit = AuditableContext.builder()
             .service(service)
             .registeredService(registeredService)

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/authorization/OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidator.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/validator/authorization/OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidator.java
@@ -66,7 +66,11 @@ public class OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidator i
 
         val clientId = request.getParameter(OAuth20Constants.CLIENT_ID);
         val registeredService = getRegisteredServiceByClientId(clientId);
-
+        if (registeredService == null) {
+            LOGGER.warn("Registered service for {}=[{}] is not registered",
+                    OAuth20Constants.CLIENT_ID, clientId);
+            return false;
+        }
         val service = webApplicationServiceServiceFactory.createService(registeredService.getServiceId());
         val audit = AuditableContext.builder()
             .service(service)


### PR DESCRIPTION
I just ran into this error on a new service I am trying to configure. Might as well log warning with some info rather than have a big NPE stack trace with no information (if service is not registered). 