### PR TITLE
Allow to set responseType and responseMode for OIDC clients

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/BasePac4jOidcClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/BasePac4jOidcClientProperties.java
@@ -60,4 +60,18 @@ public abstract class BasePac4jOidcClientProperties extends Pac4jIdentifiableCli
      * Custom parameters to send along in authZ requests, etc.
      */
     private Map<String, String> customParams = new HashMap<>();
+
+    /**
+     * The response mode specifies how the result of the authorization request is formatted.
+     * For backward compatibility the default value is empty, which means the default pac4j (empty) response mode is used. 
+     * Possible values includes "query", "fragment", "form_post", or "web_message" 
+     */
+    private String responseMode;
+
+    /**
+     * The response type tells the authorization server which grant to execute.
+     * For backward compatibility the default value is empty, which means the default pac4j ("code") response type is used.
+     * Possibles values includes "code", "token" or "id_token".     
+     */
+    private String responseType;
 }

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -1039,6 +1039,8 @@ to an external OpenID Connect provider such as Azure AD, given the provider's *c
 # ${configurationKey}.scope=
 # ${configurationKey}.useNonce=
 # ${configurationKey}.preferredJwsAlgorithm=
+# ${configurationKey}.responseMode=
+# ${configurationKey}.responseType=
 # ${configurationKey}.customParams.param1=value1
 ```
 

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
@@ -546,6 +546,13 @@ public class DelegatedClientFactory {
         cfg.setDiscoveryURI(oidc.getDiscoveryUri());
         cfg.setCustomParams(oidc.getCustomParams());
         cfg.setLogoutUrl(oidc.getLogoutUrl());
+        
+        if (StringUtils.isNotBlank(oidc.getResponseMode())) {
+            cfg.setResponseMode(oidc.getResponseMode());
+        }
+        if (StringUtils.isNotBlank(oidc.getResponseType())) {
+            cfg.setResponseType(oidc.getResponseType());
+        }
         return cfg;
     }
 


### PR DESCRIPTION
This change allows to set the response mode and response type parameters for oidc client delegation.
Priori to this change, the response mode and type could not be set and the default pac4j values where used.
The change is backward compatible and does not change the default response mode and type.