### PR TITLE
Fix GoogleAuthenticatorTokenCredential package name

### DIFF
--- a/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
+++ b/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://www.springframework.org/schema/webflow
                           http://www.springframework.org/schema/webflow/spring-webflow.xsd">
 
-    <var name="credential" class="org.apereo.cas.adaptors.gauth.GoogleAuthenticatorTokenCredential" />
+    <var name="credential" class="org.apereo.cas.gauth.credential.GoogleAuthenticatorTokenCredential" />
     <on-start>
         <evaluate expression="initialFlowSetupAction" />
     </on-start>


### PR DESCRIPTION
GoogleAuthenticatorTokenCredential class wa moved from org.apereo.cas.adaptors.gauth to org.apereo.cas.gauth.credential. Webflow configuration file `mfa-gauth-webflow.xml` adjusted to reflect this.