### PR TITLE
update some dependencies, spring & ldaptive

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -92,10 +92,10 @@ sentryRavenVersion=8.0.3
 # Spring versions
 ###############################
 
-springBootVersion=2.1.1.RELEASE
-springBootAdminVersion=2.1.1
+springBootVersion=2.1.2.RELEASE
+springBootAdminVersion=2.1.2
 
-springIntegrationVersion=5.1.1.RELEASE
+springIntegrationVersion=5.1.2.RELEASE
 
 springWebflowClientVersion=1.0.3
 springWebflowVersion=2.5.1.RELEASE
@@ -107,18 +107,18 @@ springSecurityVersion=5.1.2.RELEASE
 springSecurityRsaVersion=1.0.8.RELEASE
 springShellVersion=2.0.1.RELEASE
 
-springCloudConfigVersion=2.1.0.RC3
-springCloudContextVersion=2.1.0.RC2
-springCloudCommonsVersion=2.1.0.RC2
-springCloudBusVersion=2.1.0.RC3
+springCloudConfigVersion=2.1.0.RELEASE
+springCloudContextVersion=2.1.0.RELEASE
+springCloudCommonsVersion=2.1.0.RELEASE
+springCloudBusVersion=2.1.0.RELEASE
 
-springCloudVaultVersion=2.1.0.RC1
-springCloudZookeeperVersion=2.1.0.RC2
-springCloudSleuthVersion=2.1.0.RC3
-springCloudEurekaVersion=2.1.0.RC3
-springCloudConsulVersion=2.1.0.RC3
+springCloudVaultVersion=2.1.0.RELEASE
+springCloudZookeeperVersion=2.1.0.RELEASE
+springCloudSleuthVersion=2.1.0.RELEASE
+springCloudEurekaVersion=2.1.0.RELEASE
+springCloudConsulVersion=2.1.0.RELEASE
 
-springWsVersion=3.0.4.RELEASE
+springWsVersion=3.0.6.RELEASE
 ########################################
 
 kafkaSpringVersion=2.2.2.RELEASE
@@ -222,7 +222,7 @@ maxmindVersion=2.12.0
 googleMapsGeoCodingVersion=0.9.1
 userInfoVersion=1.1.0
 
-ldaptiveVersion=1.2.3
+ldaptiveVersion=1.2.4
 unboundidVersion=4.0.9
 
 jcifsVersion=1.3.17


### PR DESCRIPTION
Update spring boot to latest to get transitive dependency updates (no particular reason other than avoiding possible complaints from security scanners). Update spring cloud from RC to release. Update ldaptive because release notes mention possible orphaned connections. 
