### PR TITLE
Make sure built-in CAS services are highest priority (SAML)

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -567,7 +567,7 @@ public class CasOAuthConfiguration implements AuditTrailRecordResolutionPlanConf
     public void configureServiceRegistry(final ServiceRegistryExecutionPlan plan) {
         final RegexRegisteredService service = new RegexRegisteredService();
         service.setId(Math.abs(RandomUtils.getNativeInstance().nextLong()));
-        service.setEvaluationOrder(0);
+        service.setEvaluationOrder(Integer.MIN_VALUE);
         service.setName(service.getClass().getSimpleName());
         service.setDescription("OAuth Authentication Callback Request URL");
         service.setServiceId(oauthCallbackService().getId());

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
@@ -349,7 +349,7 @@ public class SamlIdPEndpointsConfiguration implements ServiceRegistryExecutionPl
         LOGGER.debug("Initializing callback service [{}]", callbackService);
         final RegexRegisteredService service = new RegexRegisteredService();
         service.setId(Math.abs(RandomUtils.getNativeInstance().nextLong()));
-        service.setEvaluationOrder(Integer.MAX_VALUE);
+        service.setEvaluationOrder(Integer.MIN_VALUE);
         service.setName(service.getClass().getSimpleName());
         service.setDescription("SAML Authentication Request");
         service.setServiceId(callbackService);

--- a/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/config/CoreWsSecurityIdentityProviderConfiguration.java
+++ b/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/config/CoreWsSecurityIdentityProviderConfiguration.java
@@ -152,7 +152,7 @@ public class CoreWsSecurityIdentityProviderConfiguration implements Authenticati
 
         final RegexRegisteredService service = new RegexRegisteredService();
         service.setId(Math.abs(RandomUtils.getNativeInstance().nextLong()));
-        service.setEvaluationOrder(0);
+        service.setEvaluationOrder(Integer.MIN_VALUE);
         service.setName(service.getClass().getSimpleName());
         service.setDescription("WS-Federation Authentication Request");
         service.setServiceId(callbackService.getId().concat(".+"));


### PR DESCRIPTION
So other services aren't matched before they are. 
Backport of #3768