### PR TITLE
Fix for CAS not finding built-in services due to incorrect priority

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -118,6 +118,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -745,7 +746,7 @@ public class CasOAuthConfiguration implements AuditTrailRecordResolutionPlanConf
             public void configureServiceRegistry(final ServiceRegistryExecutionPlan plan) {
                 val service = new RegexRegisteredService();
                 service.setId(RandomUtils.getNativeInstance().nextLong());
-                service.setEvaluationOrder(Integer.MAX_VALUE);
+                service.setEvaluationOrder(Ordered.HIGHEST_PRECEDENCE);
                 service.setName(service.getClass().getSimpleName());
                 service.setDescription("OAuth Authentication Callback Request URL");
                 service.setServiceId(oauthCallbackService().getId());

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcDynamicClientRegistrationEndpointController.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcDynamicClientRegistrationEndpointController.java
@@ -25,6 +25,7 @@ import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -110,7 +111,7 @@ public class OidcDynamicClientRegistrationEndpointController extends BaseOAuth20
 
             registeredService.setClientId(clientIdGenerator.getNewString());
             registeredService.setClientSecret(clientSecretGenerator.getNewString());
-            registeredService.setEvaluationOrder(Integer.MIN_VALUE);
+            registeredService.setEvaluationOrder(Ordered.HIGHEST_PRECEDENCE);
             registeredService.setLogoutUrl(org.springframework.util.StringUtils.collectionToCommaDelimitedString(registrationRequest.getPostLogoutRedirectUris()));
 
             val supportedScopes = new HashSet<String>(casProperties.getAuthn().getOidc().getScopes());

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 
 /**
  * This is {@link SamlIdPEndpointsConfiguration}.
@@ -349,7 +350,7 @@ public class SamlIdPEndpointsConfiguration {
                 LOGGER.debug("Initializing SAML IdP callback service [{}]", callbackService);
                 val service = new RegexRegisteredService();
                 service.setId(RandomUtils.getNativeInstance().nextLong());
-                service.setEvaluationOrder(Integer.MAX_VALUE);
+                service.setEvaluationOrder(Ordered.HIGHEST_PRECEDENCE);
                 service.setName(service.getClass().getSimpleName());
                 service.setDescription("SAML Authentication Request Callback");
                 service.setServiceId(callbackService);

--- a/support/cas-server-support-saml-sp-integrations/src/main/java/org/apereo/cas/util/SamlSPUtils.java
+++ b/support/cas-server-support-saml-sp-integrations/src/main/java/org/apereo/cas/util/SamlSPUtils.java
@@ -21,6 +21,7 @@ import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.filter.impl.PredicateFilter;
 import org.opensaml.saml.metadata.resolver.impl.AbstractBatchMetadataResolver;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.springframework.core.Ordered;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +57,7 @@ public class SamlSPUtils {
         val service = new SamlRegisteredService();
         service.setName(sp.getName());
         service.setDescription(sp.getDescription());
-        service.setEvaluationOrder(Integer.MIN_VALUE);
+        service.setEvaluationOrder(Ordered.HIGHEST_PRECEDENCE);
         service.setMetadataLocation(sp.getMetadata());
         val attributesToRelease = new ArrayList<String>(sp.getAttributes());
         if (StringUtils.isNotBlank(sp.getNameIdAttribute())) {

--- a/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/config/CoreWsSecurityIdentityProviderConfiguration.java
+++ b/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/config/CoreWsSecurityIdentityProviderConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.core.Ordered;
 
 import java.util.HashSet;
 
@@ -177,7 +178,7 @@ public class CoreWsSecurityIdentityProviderConfiguration implements Authenticati
                 LOGGER.debug("Initializing WS Federation callback service [{}]", callbackService);
                 val service = new RegexRegisteredService();
                 service.setId(RandomUtils.getNativeInstance().nextLong());
-                service.setEvaluationOrder(Integer.MAX_VALUE);
+                service.setEvaluationOrder(Ordered.HIGHEST_PRECEDENCE);
                 service.setName(service.getClass().getSimpleName());
                 service.setDescription("WS-Federation Authentication Request");
                 service.setServiceId(callbackService.getId().concat(".+"));


### PR DESCRIPTION
Port forward of #3768

Change some built-in services from MAX_VALUE (low priority, last) to
MIN_VALUE/HIGHEST_PRIORITY b/c CAS built-in services or internal services
will not match non-CAS services (b/c they are
^protocol://domain/casprefix/.*)

Use Ordered.HIGHEST_PRIORITY instead of Integer.MIN_VALUE which are same
but HIGHEST_PRIORITY makes intent clear.
