### PR TITLE
Dependency update - exclude dom4j using new group

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -158,7 +158,7 @@ jgitVersion=5.2.1.201812262042-r
 zuulVersion=2.1.3
 
 hibernateValidatorVersion=6.0.13.Final
-dom4jVersion=1.6.1
+dom4jVersion=2.1.1
 javaParserVersion=3.10.1
 
 casClientVersion=3.5.1

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -621,19 +621,19 @@ ext.libraries = [
                     exclude(group: "org.jboss.logging", module: "jboss-logging-annotations")
                     exclude(group: "org.javassist", module: "javassist")
                     exclude(group: "xml-apis", module: "xml-apis")
-                    exclude(group: "dom4j", module: "dom4j")
+                    exclude(group: "org.dom4j", module: "dom4j")
                     exclude(group: "com.fasterxml", module: "classmate")
                     exclude(group: "org.hibernate", module: "hibernate-validator")
                     exclude(group: "org.jboss.logging", module: "jboss-logging")
                     force = true
                 },
-                dependencies.create("dom4j:dom4j:$dom4jVersion") {
+                dependencies.create("org.dom4j:dom4j:$dom4jVersion") {
                     exclude(group: "xml-apis", module: "xml-apis")
                     force = true
                 },
                 dependencies.create("org.hibernate:hibernate-hikaricp:$hibernateVersion") {
                     exclude(group: "org.javassist", module: "javassist")
-                    exclude(group: "dom4j", module: "dom4j")
+                    exclude(group: "org.dom4j", module: "dom4j")
                     exclude(group: "xml-apis", module: "xml-apis")
                     exclude(group: "org.hibernate", module: "hibernate-validator")
                     exclude(group: "org.hibernate", module: "hibernate-core")
@@ -646,7 +646,7 @@ ext.libraries = [
                 },
                 dependencies.create("org.hibernate:hibernate-entitymanager:$hibernateVersion") {
                     exclude(group: "org.javassist", module: "javassist")
-                    exclude(group: "dom4j", module: "dom4j")
+                    exclude(group: "org.dom4j", module: "dom4j")
                     exclude(group: "xml-apis", module: "xml-apis")
                     exclude(group: "org.hibernate", module: "hibernate-validator")
                     exclude(group: "org.jboss.logging", module: "jboss-logging")


### PR DESCRIPTION
Newer version of dom4j (than what is defined in gradle.properties) showing up in tomcat war.