### PR TITLE
core/cas-server-core junit migration

### DIFF
--- a/core/cas-server-core-webflow-mfa-api/build.gradle
+++ b/core/cas-server-core-webflow-mfa-api/build.gradle
@@ -1,4 +1,7 @@
 description = "Apereo CAS Core Webflow MFA API"
+ext {
+    useJunit5 = true
+}
 dependencies {
     api project(":api:cas-server-core-api-authentication")
     api project(":api:cas-server-core-api-ticket")

--- a/core/cas-server-core/build.gradle
+++ b/core/cas-server-core/build.gradle
@@ -1,5 +1,7 @@
 description = "Apereo CAS Core"
-
+ext {
+    useJunit5 = true
+}
 dependencies {
     api project(":api:cas-server-core-api-logout")
     api project(":api:cas-server-core-api")

--- a/core/cas-server-core/src/test/java/org/apereo/cas/AbstractCentralAuthenticationServiceTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/AbstractCentralAuthenticationServiceTests.java
@@ -23,7 +23,11 @@ import org.springframework.test.context.TestPropertySource;
  * @author Scott Battaglia
  * @since 3.0.0
  */
-@TestPropertySource(locations = {"classpath:/core.properties"})
+@TestPropertySource(properties = {
+    "cas.authn.policy.any.tryAll=true",
+    "spring.aop.proxy-target-class=true",
+    "cas.ticket.st.timeToKillInSeconds=30"
+    })
 @Setter
 @Getter
 public abstract class AbstractCentralAuthenticationServiceTests extends BaseCasCoreTests {

--- a/core/cas-server-core/src/test/java/org/apereo/cas/AllCoreTestsSuite.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/AllCoreTestsSuite.java
@@ -1,7 +1,6 @@
 package org.apereo.cas;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * The {@link AllCoreTestsSuite} is responsible for
@@ -10,8 +9,7 @@ import org.junit.runners.Suite;
  * @author Misagh Moayyed
  * @since 4.2.0
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@SelectClasses({
     DefaultCentralAuthenticationServiceTests.class,
     DefaultCentralAuthenticationServiceMockitoTests.class,
     DefaultCasAttributeEncoderTests.class,

--- a/core/cas-server-core/src/test/java/org/apereo/cas/BaseCasCoreTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/BaseCasCoreTests.java
@@ -27,8 +27,6 @@ import org.apereo.cas.validation.config.CasCoreValidationConfiguration;
 import org.apereo.cas.web.config.CasCookieConfiguration;
 import org.apereo.cas.web.flow.config.CasCoreWebflowConfiguration;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -38,8 +36,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
 
 /**
  * This is {@link BaseCasCoreTests}.
@@ -84,11 +80,6 @@ import org.springframework.test.context.junit4.rules.SpringMethodRule;
 @EnableScheduling
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public abstract class BaseCasCoreTests {
-    @ClassRule
-    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
-
-    @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
     @Autowired
     protected CasConfigurationProperties casProperties;

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCasAttributeEncoderTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCasAttributeEncoderTests.java
@@ -5,9 +5,9 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
 
 import lombok.val;
-import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
@@ -40,7 +40,7 @@ public class DefaultCasAttributeEncoderTests extends BaseCasCoreTests {
         return Collections.singleton(attr);
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         this.attributes = new HashMap<>();
         IntStream.range(0, 3).forEach(i -> this.attributes.put("attr" + i, newSingleAttribute("value" + i)));

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCasAttributeEncoderTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCasAttributeEncoderTests.java
@@ -5,12 +5,10 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
 
 import lombok.val;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -27,9 +25,6 @@ import static org.junit.Assert.*;
  * @since 4.1
  */
 public class DefaultCasAttributeEncoderTests extends BaseCasCoreTests {
-    @ClassRule
-    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
-
     private Map<String, Object> attributes;
 
     @Autowired

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCasAttributeEncoderTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCasAttributeEncoderTests.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This is test cases for {@link DefaultCasProtocolAttributeEncoder}.

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
@@ -62,7 +62,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
@@ -44,9 +44,9 @@ import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 
 import lombok.val;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatcher;
 import org.springframework.context.ApplicationEventPublisher;
@@ -137,7 +137,7 @@ public class DefaultCentralAuthenticationServiceMockitoTests extends BaseCasCore
         return new WebApplicationServiceFactory().createService(request);
     }
 
-    @Before
+    @BeforeEach
     public void prepareNewCAS() {
         this.authentication = mock(Authentication.class);
         when(this.authentication.getAuthenticationDate()).thenReturn(ZonedDateTime.now(ZoneOffset.UTC));

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
@@ -44,10 +44,8 @@ import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 
 import lombok.val;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatcher;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -82,9 +80,6 @@ public class DefaultCentralAuthenticationServiceMockitoTests extends BaseCasCore
     private static final String SVC2_ID = "test2";
 
     private static final String PRINCIPAL = "principal";
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private DefaultCentralAuthenticationService cas;
     private Authentication authentication;
@@ -225,32 +220,28 @@ public class DefaultCentralAuthenticationServiceMockitoTests extends BaseCasCore
 
     @Test
     public void verifyNonExistentServiceWhenDelegatingTicketGrantingTicket() {
-        this.thrown.expect(InvalidTicketException.class);
-        this.cas.createProxyGrantingTicket("bad-st", getAuthenticationContext());
+        assertThrows(InvalidTicketException.class, () -> cas.createProxyGrantingTicket("bad-st", getAuthenticationContext()));
     }
 
     @Test
     public void verifyInvalidServiceWhenDelegatingTicketGrantingTicket() {
-        this.thrown.expect(UnauthorizedServiceException.class);
-        this.cas.createProxyGrantingTicket(ST_ID, getAuthenticationContext());
+        assertThrows(UnauthorizedServiceException.class, () -> this.cas.createProxyGrantingTicket(ST_ID, getAuthenticationContext()));
     }
 
     @Test
     public void disallowVendingServiceTicketsWhenServiceIsNotAllowedToProxyCAS1019() {
-        this.thrown.expect(UnauthorizedProxyingException.class);
-        this.cas.grantServiceTicket(TGT_ID, RegisteredServiceTestUtils.getService(SVC1_ID), getAuthenticationContext());
+        assertThrows(UnauthorizedProxyingException.class,
+            () -> this.cas.grantServiceTicket(TGT_ID, RegisteredServiceTestUtils.getService(SVC1_ID), getAuthenticationContext()));
     }
 
     @Test
-    public void getTicketGrantingTicketIfTicketIdIsNull() throws InvalidTicketException {
-        this.thrown.expect(NullPointerException.class);
-        this.cas.getTicket(null, TicketGrantingTicket.class);
+    public void getTicketGrantingTicketIfTicketIdIsNull() {
+        assertThrows(NullPointerException.class, () -> this.cas.getTicket(null, TicketGrantingTicket.class));
     }
 
     @Test
-    public void getTicketGrantingTicketIfTicketIdIsMissing() throws InvalidTicketException {
-        this.thrown.expect(InvalidTicketException.class);
-        this.cas.getTicket("TGT-9000", TicketGrantingTicket.class);
+    public void getTicketGrantingTicketIfTicketIdIsMissing() {
+        assertThrows(InvalidTicketException.class, () -> this.cas.getTicket("TGT-9000", TicketGrantingTicket.class));
     }
 
     @Test

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
@@ -32,7 +32,7 @@ import org.junit.rules.ExpectedException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
@@ -27,7 +27,7 @@ import org.apereo.cas.validation.Cas20WithoutProxyingValidationSpecification;
 
 import lombok.val;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockHttpServletRequest;

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
@@ -51,9 +51,8 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
 
     @Test
     public void verifyBadCredentialsOnTicketGrantingTicketCreation() {
-        val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(),
-            CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword());
-        assertThrows(AuthenticationException.class, () -> getCentralAuthenticationService().createTicketGrantingTicket(ctx));
+        assertThrows(AuthenticationException.class, () -> CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(),
+                CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword()));
     }
 
     @Test
@@ -116,9 +115,7 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(),
             getService("TestServiceAttributeForAuthzFails"));
 
-        val ticketId = getCentralAuthenticationService().createTicketGrantingTicket(ctx);
-        assertThrows(PrincipalException.class,
-            () -> getCentralAuthenticationService().grantServiceTicket(ticketId.getId(), getService("TestServiceAttributeForAuthzFails"), ctx));
+        assertThrows(PrincipalException.class, () -> getCentralAuthenticationService().createTicketGrantingTicket(ctx));
     }
 
     @Test
@@ -222,13 +219,7 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
     @Test
     public void verifyValidateServiceTicketWithInvalidService() {
         val service = getService("badtestservice");
-        val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(), service);
-
-        val ticketGrantingTicket = getCentralAuthenticationService().createTicketGrantingTicket(ctx);
-
-        val serviceTicket = getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), service, ctx);
-
-        assertThrows(UnauthorizedServiceException.class, () -> getCentralAuthenticationService().validateServiceTicket(serviceTicket.getId(), service));
+        assertThrows(UnauthorizedServiceException.class, () -> CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(), service));
     }
 
     @Test

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
@@ -26,9 +26,7 @@ import org.apereo.cas.util.MockOnlyOneTicketRegistry;
 import org.apereo.cas.validation.Cas20WithoutProxyingValidationSpecification;
 
 import lombok.val;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -40,9 +38,6 @@ import static org.mockito.Mockito.*;
  * @since 3.0.0
  */
 public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAuthenticationServiceTests {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private static Service getService(final String name) {
         val request = new MockHttpServletRequest();
@@ -56,20 +51,15 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
 
     @Test
     public void verifyBadCredentialsOnTicketGrantingTicketCreation() {
-        this.thrown.expect(AuthenticationException.class);
         val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(),
             CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword());
-        getCentralAuthenticationService().createTicketGrantingTicket(ctx);
+        assertThrows(AuthenticationException.class, () -> getCentralAuthenticationService().createTicketGrantingTicket(ctx));
     }
 
     @Test
     public void verifyGoodCredentialsOnTicketGrantingTicketCreation() {
-        try {
-            val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport());
-            assertNotNull(getCentralAuthenticationService().createTicketGrantingTicket(ctx));
-        } catch (final AbstractTicketException e) {
-            throw new AssertionError("Exception expected", e);
-        }
+        val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport());
+        assertNotNull(getCentralAuthenticationService().createTicketGrantingTicket(ctx));
     }
 
     @Test
@@ -87,15 +77,13 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
     @Test
     public void verifyDisallowNullCredentialsWhenCreatingTicketGrantingTicket() {
         val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(), new Credential[]{null});
-        this.thrown.expect(RuntimeException.class);
-        getCentralAuthenticationService().createTicketGrantingTicket(ctx);
+        assertThrows(RuntimeException.class, () -> getCentralAuthenticationService().createTicketGrantingTicket(ctx));
     }
 
     @Test
     public void verifyDisallowNullCredentialsArrayWhenCreatingTicketGrantingTicket() {
         val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(), new Credential[]{null, null});
-        this.thrown.expect(RuntimeException.class);
-        getCentralAuthenticationService().createTicketGrantingTicket(ctx);
+        assertThrows(RuntimeException.class, () -> getCentralAuthenticationService().createTicketGrantingTicket(ctx));
     }
 
     @Test
@@ -104,8 +92,7 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val ticketId = getCentralAuthenticationService().createTicketGrantingTicket(ctx);
         val serviceTicketId = getCentralAuthenticationService().grantServiceTicket(ticketId.getId(), getService(), ctx);
 
-        this.thrown.expect(ClassCastException.class);
-        getCentralAuthenticationService().destroyTicketGrantingTicket(serviceTicketId.getId());
+        assertThrows(ClassCastException.class, () -> getCentralAuthenticationService().destroyTicketGrantingTicket(serviceTicketId.getId()));
     }
 
     @Test
@@ -129,11 +116,9 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(),
             getService("TestServiceAttributeForAuthzFails"));
 
-        this.thrown.expect(PrincipalException.class);
-
-
         val ticketId = getCentralAuthenticationService().createTicketGrantingTicket(ctx);
-        getCentralAuthenticationService().grantServiceTicket(ticketId.getId(), getService("TestServiceAttributeForAuthzFails"), ctx);
+        assertThrows(PrincipalException.class,
+            () -> getCentralAuthenticationService().grantServiceTicket(ticketId.getId(), getService("TestServiceAttributeForAuthzFails"), ctx));
     }
 
     @Test
@@ -166,9 +151,7 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val ticketId = getCentralAuthenticationService().createTicketGrantingTicket(ctx);
         getCentralAuthenticationService().destroyTicketGrantingTicket(ticketId.getId());
 
-        this.thrown.expect(AbstractTicketException.class);
-
-        getCentralAuthenticationService().grantServiceTicket(ticketId.getId(), getService(), ctx);
+        assertThrows(AbstractTicketException.class, () -> getCentralAuthenticationService().grantServiceTicket(ticketId.getId(), getService(), ctx));
     }
 
     @Test
@@ -203,9 +186,7 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val ctx2 = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(),
             RegisteredServiceTestUtils.getHttpBasedServiceCredentials());
 
-        this.thrown.expect(AbstractTicketException.class);
-
-        getCentralAuthenticationService().createProxyGrantingTicket(serviceTicketId.getId(), ctx2);
+        assertThrows(AbstractTicketException.class, () -> getCentralAuthenticationService().createProxyGrantingTicket(serviceTicketId.getId(), ctx2));
     }
 
     @Test
@@ -225,8 +206,8 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val ctx2 = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(),
             CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword("testB"));
 
-        this.thrown.expect(MixedPrincipalException.class);
-        getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), getService(), ctx2);
+        assertThrows(MixedPrincipalException.class,
+            () -> getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), getService(), ctx2));
     }
 
     @Test
@@ -240,14 +221,14 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
 
     @Test
     public void verifyValidateServiceTicketWithInvalidService() {
-        this.thrown.expect(UnauthorizedServiceException.class);
         val service = getService("badtestservice");
         val ctx = CoreAuthenticationTestUtils.getAuthenticationResult(getAuthenticationSystemSupport(), service);
 
         val ticketGrantingTicket = getCentralAuthenticationService().createTicketGrantingTicket(ctx);
 
         val serviceTicket = getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), service, ctx);
-        getCentralAuthenticationService().validateServiceTicket(serviceTicket.getId(), service);
+
+        assertThrows(UnauthorizedServiceException.class, () -> getCentralAuthenticationService().validateServiceTicket(serviceTicket.getId(), service));
     }
 
     @Test
@@ -258,15 +239,12 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val serviceTicket = getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), getService(), ctx);
         getCentralAuthenticationService().destroyTicketGrantingTicket(ticketGrantingTicket.getId());
 
-        this.thrown.expect(AbstractTicketException.class);
-
-        getCentralAuthenticationService().validateServiceTicket(serviceTicket.getId(), getService());
+        assertThrows(AbstractTicketException.class, () -> getCentralAuthenticationService().validateServiceTicket(serviceTicket.getId(), getService()));
     }
 
     @Test
     public void verifyValidateServiceTicketNonExistantTicket() {
-        this.thrown.expect(AbstractTicketException.class);
-        getCentralAuthenticationService().validateServiceTicket("google", getService());
+        assertThrows(AbstractTicketException.class, () -> getCentralAuthenticationService().validateServiceTicket("google", getService()));
     }
 
     @Test
@@ -335,10 +313,9 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         val ticketGrantingTicket = getCentralAuthenticationService().createTicketGrantingTicket(ctx);
         val service = getService("eduPersonTest");
         getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), service, ctx);
-
-        this.thrown.expect(UnauthorizedSsoServiceException.class);
         when(ctx.isCredentialProvided()).thenReturn(false);
-        getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), svc, ctx);
+
+        assertThrows(UnauthorizedSsoServiceException.class, () -> getCentralAuthenticationService().grantServiceTicket(ticketGrantingTicket.getId(), svc, ctx));
     }
 
     @Test

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultPrincipalAttributesRepositoryTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultPrincipalAttributesRepositoryTests.java
@@ -6,7 +6,7 @@ import org.apereo.cas.authentication.principal.PrincipalFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultPrincipalAttributesRepositoryTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultPrincipalAttributesRepositoryTests.java
@@ -15,7 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Handles tests for {@link DefaultPrincipalAttributesRepository}.

--- a/core/cas-server-core/src/test/resources/core.properties
+++ b/core/cas-server-core/src/test/resources/core.properties
@@ -1,3 +1,0 @@
-cas.authn.policy.any.tryAll=true
-spring.aop.proxy-target-class=true
-cas.ticket.st.timeToKillInSeconds=30

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionSsoTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionSsoTests.java
@@ -78,7 +78,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreUtilConfiguration.class,
     CasCookieConfiguration.class,
     RefreshAutoConfiguration.class,
-    CasCoreServicesConfiguration.class})
+    CasCoreServicesConfiguration.class
+})
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
 @TestPropertySource(properties = "cas.sso.allowMissingServiceParameter=false")
 public class InitialFlowSetupActionSsoTests {

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionTests.java
@@ -1,11 +1,26 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
+import org.apereo.cas.config.CasCoreConfiguration;
+import org.apereo.cas.config.CasCoreServicesConfiguration;
+import org.apereo.cas.config.CasCoreTicketsConfiguration;
+import org.apereo.cas.config.CasCoreWebConfiguration;
+import org.apereo.cas.config.CasRegisteredServicesTestConfiguration;
+import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
+import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
+import org.apereo.cas.web.config.CasCookieConfiguration;
+import org.apereo.cas.web.config.CasSupportActionsConfiguration;
 import org.apereo.cas.web.support.WebUtils;
 
+import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
@@ -20,14 +35,34 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Scott Battaglia
  * @since 3.0.0
  */
-@TestPropertySource(locations = {"classpath:/core.properties"})
+@TestPropertySource(properties = {
+    "cas.authn.policy.any.tryAll=true",
+    "spring.aop.proxy-target-class=true",
+    "cas.ticket.st.timeToKillInSeconds=30"
+})
+@SpringBootTest(classes = {
+    CasRegisteredServicesTestConfiguration.class,
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+    CasCoreConfiguration.class,
+    CasCoreAuthenticationConfiguration.class,
+    CasCoreAuthenticationSupportConfiguration.class,
+    CasCoreServicesConfiguration.class,
+    CasSupportActionsConfiguration.class,
+    CasCookieConfiguration.class,
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasCoreTicketsConfiguration.class,
+    CasCoreLogoutConfiguration.class,
+    CasCoreWebConfiguration.class,
+    RefreshAutoConfiguration.class
+})
 public class InitialFlowSetupActionTests extends AbstractWebflowActionsTests {
     @Autowired
     @Qualifier("initialFlowSetupAction")
     private Action action;
 
     @Test
-    public void verifyNoServiceFound() throws Exception {
+    @SneakyThrows
+    public void verifyNoServiceFound() {
         val context = new MockRequestContext();
         context.setExternalContext(new ServletExternalContext(new MockServletContext(), new MockHttpServletRequest(), new MockHttpServletResponse()));
         val event = this.action.execute(context);
@@ -36,7 +71,8 @@ public class InitialFlowSetupActionTests extends AbstractWebflowActionsTests {
     }
 
     @Test
-    public void verifyServiceFound() throws Exception {
+    @SneakyThrows
+    public void verifyServiceFound() {
         val context = new MockRequestContext();
         val request = new MockHttpServletRequest();
         request.setParameter("service", "test");

--- a/support/cas-server-support-validation/build.gradle
+++ b/support/cas-server-support-validation/build.gradle
@@ -1,4 +1,7 @@
 description = "Apereo CAS Web Application Protocol Validation"
+ext {
+    useJunit5 = true
+}
 dependencies {
     implementation libraries.thymeleaf
 

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -9,8 +9,7 @@ import org.apereo.cas.web.view.attributes.AttributeValuesPerLineProtocolAttribut
 import org.apereo.cas.web.view.attributes.DefaultCas30ProtocolAttributesRendererTests;
 import org.apereo.cas.web.view.attributes.InlinedCas30ProtocolAttributesRendererTests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
 
 /**
  * The {@link AllTestsSuite} is responsible for
@@ -19,8 +18,7 @@ import org.junit.runners.Suite;
  * @author Misagh Moayyed
  * @since 4.2.0
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@SelectClasses({
     Cas10ResponseViewTests.class,
     Cas20ResponseViewTests.class,
     Cas30ResponseViewTests.class,

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/AbstractServiceValidateControllerTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/AbstractServiceValidateControllerTests.java
@@ -18,8 +18,8 @@ import org.apereo.cas.web.config.CasProtocolViewsConfiguration;
 import org.apereo.cas.web.config.CasValidationConfiguration;
 
 import lombok.val;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.support.StaticApplicationContext;
@@ -29,7 +29,9 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static org.junit.Assert.*;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Scott Battaglia
@@ -44,8 +46,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
 
     protected AbstractServiceValidateController serviceValidateController;
 
-    @Before
-    public void onSetUp() throws Exception {
+    @BeforeEach
+    public void onSetUp() {
         val context = new StaticApplicationContext();
         context.refresh();
         this.serviceValidateController = getServiceValidateControllerInstance();
@@ -87,7 +89,7 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
 
         this.serviceValidateController.setProxyHandler((credential, proxyGrantingTicketId) -> null);
         val modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
-        assertFalse(modelAndView.getView().toString().contains(SUCCESS));
+        assertFalse(Objects.requireNonNull(modelAndView.getView()).toString().contains(SUCCESS));
         assertNull(modelAndView.getModel().get(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_IOU));
     }
 
@@ -103,20 +105,20 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_TICKET, sId.getId());
 
         val mv = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
-        assertTrue(mv.getView().toString().contains(SUCCESS));
+        assertTrue(Objects.requireNonNull(mv.getView()).toString().contains(SUCCESS));
     }
 
     @Test
     public void verifyValidServiceTicketInvalidSpec() throws Exception {
-        assertFalse(this.serviceValidateController.handleRequestInternal(getHttpServletRequest(),
-            new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
+        assertFalse(Objects.requireNonNull(this.serviceValidateController.handleRequestInternal(getHttpServletRequest(),
+            new MockHttpServletResponse()).getView()).toString().contains(SUCCESS));
     }
 
 
     @Test
     public void verifyRenewSpecFailsCorrectly() throws Exception {
-        assertFalse(this.serviceValidateController.handleRequestInternal(getHttpServletRequest(),
-            new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
+        assertFalse(Objects.requireNonNull(this.serviceValidateController.handleRequestInternal(getHttpServletRequest(),
+            new MockHttpServletResponse()).getView()).toString().contains(SUCCESS));
     }
 
     @Test
@@ -133,8 +135,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, SERVICE.getId());
         request.addParameter(CasProtocolConstants.PARAMETER_TICKET, sId.getId());
 
-        assertFalse(this.serviceValidateController.handleRequestInternal(request,
-            new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
+        assertFalse(Objects.requireNonNull(this.serviceValidateController.handleRequestInternal(request,
+            new MockHttpServletResponse()).getView()).toString().contains(SUCCESS));
     }
 
 
@@ -151,7 +153,7 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_URL, SERVICE.getId());
 
         val modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
-        assertTrue(modelAndView.getView().toString().contains(SUCCESS));
+        assertTrue(Objects.requireNonNull(modelAndView.getView()).toString().contains(SUCCESS));
         assertNotNull(modelAndView.getModel().get(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_IOU));
     }
 
@@ -170,7 +172,7 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_URL, "http://www.github.com");
 
         val modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
-        assertFalse(modelAndView.getView().toString().contains(SUCCESS));
+        assertFalse(Objects.requireNonNull(modelAndView.getView()).toString().contains(SUCCESS));
         assertNull(modelAndView.getModel().get(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_IOU));
     }
 
@@ -188,7 +190,7 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_FORMAT, ValidationResponseType.JSON.name());
 
         val modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
-        assertTrue(modelAndView.getView().toString().contains("Json"));
+        assertTrue(Objects.requireNonNull(modelAndView.getView()).toString().contains("Json"));
     }
 
     @Test
@@ -206,15 +208,15 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_FORMAT, "NOTHING");
 
         val modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
-        assertTrue(modelAndView.getView().toString().contains("Success"));
+        assertTrue(Objects.requireNonNull(modelAndView.getView()).toString().contains("Success"));
     }
 
 
     @Test
     public void verifyValidServiceTicketRuntimeExceptionWithSpec() throws Exception {
         this.serviceValidateController.addValidationSpecification(new MockValidationSpecification(false));
-        assertFalse(this.serviceValidateController.handleRequestInternal(getHttpServletRequest(),
-            new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
+        assertFalse(Objects.requireNonNull(this.serviceValidateController.handleRequestInternal(getHttpServletRequest(),
+            new MockHttpServletResponse()).getView()).toString().contains(SUCCESS));
     }
 
     /*
@@ -234,15 +236,15 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_TICKET, sId.getId());
 
         this.serviceValidateController.setProxyHandler(new Cas10ProxyHandler());
-        assertTrue(this.serviceValidateController.handleRequestInternal(request,
-            new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
+        assertTrue(Objects.requireNonNull(this.serviceValidateController.handleRequestInternal(request,
+            new MockHttpServletResponse()).getView()).toString().contains(SUCCESS));
     }
 
     @Test
     public void verifyValidServiceTicketWithSecurePgtUrl() throws Exception {
         this.serviceValidateController.setProxyHandler(new Cas10ProxyHandler());
         val modelAndView = getModelAndViewUponServiceValidationWithSecurePgtUrl();
-        assertTrue(modelAndView.getView().toString().contains(SUCCESS));
+        assertTrue(Objects.requireNonNull(modelAndView.getView()).toString().contains(SUCCESS));
     }
 
     @Test
@@ -258,8 +260,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_URL, SERVICE.getId());
 
         this.serviceValidateController.setProxyHandler(new Cas10ProxyHandler());
-        assertTrue(this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse())
-            .getView().toString().contains(SUCCESS));
+        assertTrue(Objects.requireNonNull(this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse())
+            .getView()).toString().contains(SUCCESS));
     }
 
     @Test
@@ -278,7 +280,8 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, RegisteredServiceTestUtils.getService(reqSvc).getId());
         request.addParameter(CasProtocolConstants.PARAMETER_TICKET, sId.getId());
         this.serviceValidateController.setProxyHandler(new Cas10ProxyHandler());
-        assertTrue(this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse()).getView().toString().contains(SUCCESS));
+        assertTrue(Objects.requireNonNull(this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse()).getView())
+            .toString().contains(SUCCESS));
     }
 
     @Test
@@ -294,7 +297,7 @@ public abstract class AbstractServiceValidateControllerTests extends AbstractCen
         request.addParameter(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_URL, "duh");
         this.serviceValidateController.setProxyHandler(new Cas10ProxyHandler());
         val modelAndView = this.serviceValidateController.handleRequestInternal(request, new MockHttpServletResponse());
-        assertTrue(modelAndView.getView().toString().contains(SUCCESS));
+        assertTrue(Objects.requireNonNull(modelAndView.getView()).toString().contains(SUCCESS));
         assertNull(modelAndView.getModel().get(CasProtocolConstants.PARAMETER_PROXY_GRANTING_TICKET_IOU));
     }
 

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/ProxyControllerTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/ProxyControllerTests.java
@@ -3,6 +3,18 @@ package org.apereo.cas.web;
 import org.apereo.cas.AbstractCentralAuthenticationServiceTests;
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
+import org.apereo.cas.config.CasCoreConfiguration;
+import org.apereo.cas.config.CasCoreServicesAuthenticationConfiguration;
+import org.apereo.cas.config.CasCoreServicesConfiguration;
+import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
+import org.apereo.cas.config.CasCoreTicketIdGeneratorsConfiguration;
+import org.apereo.cas.config.CasCoreTicketsConfiguration;
+import org.apereo.cas.config.CasCoreWebConfiguration;
+import org.apereo.cas.config.CasRegisteredServicesTestConfiguration;
+import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
 import org.apereo.cas.ticket.ProxyGrantingTicketImpl;
 import org.apereo.cas.ticket.support.NeverExpiresExpirationPolicy;
 import org.apereo.cas.web.config.CasProtocolViewsConfiguration;
@@ -10,26 +22,44 @@ import org.apereo.cas.web.config.CasValidationConfiguration;
 import org.apereo.cas.web.support.WebUtils;
 
 import lombok.val;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafProperties;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Scott Battaglia
  * @since 3.0.0
  */
-@Import({ProxyControllerTests.ProxyTestConfiguration.class,
+@SpringBootTest(classes = {
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasCoreServicesConfiguration.class,
+    CasCoreAuthenticationSupportConfiguration.class,
+    CasCoreTicketIdGeneratorsConfiguration.class,
+    CasCoreConfiguration.class,
+    CasCoreTicketsConfiguration.class,
+    CasCoreWebConfiguration.class,
+    CasRegisteredServicesTestConfiguration.class,
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+    CasCoreTicketCatalogConfiguration.class,
+    RefreshAutoConfiguration.class,
+    CasCoreAuthenticationConfiguration.class,
+    CasCoreServicesAuthenticationConfiguration.class,
+    AopAutoConfiguration.class,
+    ProxyControllerTests.ProxyTestConfiguration.class,
     CasProtocolViewsConfiguration.class,
-    CasValidationConfiguration.class})
+    CasValidationConfiguration.class
+})
 public class ProxyControllerTests extends AbstractCentralAuthenticationServiceTests {
 
     @Autowired

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas10ResponseViewTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas10ResponseViewTests.java
@@ -10,8 +10,8 @@ import org.apereo.cas.validation.DefaultAssertionBuilder;
 import org.apereo.cas.web.view.attributes.NoOpProtocolAttributesRenderer;
 
 import lombok.val;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -33,7 +33,7 @@ public class Cas10ResponseViewTests {
 
     private Map<String, Object> model;
 
-    @Before
+    @BeforeEach
     public void initialize() {
         this.model = new HashMap<>();
         val list = new ArrayList<Authentication>();

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas20ResponseViewTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas20ResponseViewTests.java
@@ -12,7 +12,7 @@ import org.apereo.cas.web.view.attributes.NoOpProtocolAttributesRenderer;
 
 import lombok.val;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link Cas20ResponseView}.

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas30ResponseViewTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/Cas30ResponseViewTests.java
@@ -26,7 +26,7 @@ import lombok.val;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.support.StubPersonAttributeDao;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -50,7 +50,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link Cas30ResponseView}.

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/attributes/AttributeValuesPerLineProtocolAttributesRendererTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/attributes/AttributeValuesPerLineProtocolAttributesRendererTests.java
@@ -3,11 +3,11 @@ package org.apereo.cas.web.view.attributes;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 
 import lombok.val;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This is {@link AttributeValuesPerLineProtocolAttributesRendererTests}.

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/attributes/DefaultCas30ProtocolAttributesRendererTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/attributes/DefaultCas30ProtocolAttributesRendererTests.java
@@ -3,11 +3,11 @@ package org.apereo.cas.web.view.attributes;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 
 import lombok.val;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This is {@link DefaultCas30ProtocolAttributesRendererTests}.

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/attributes/InlinedCas30ProtocolAttributesRendererTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/view/attributes/InlinedCas30ProtocolAttributesRendererTests.java
@@ -3,11 +3,11 @@ package org.apereo.cas.web.view.attributes;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 
 import lombok.val;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This is {@link InlinedCas30ProtocolAttributesRendererTests}.


### PR DESCRIPTION
migrates `core/cas-server-core` to junit5. see also #3684 