### PR TITLE
CAS configuration: Switch default LDAP provider class to UnboundIDProvider

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -140,7 +140,7 @@ public abstract class AbstractLdapProperties implements Serializable {
      * that provides the LDAP implementation without modifying any code. By default the JNDI provider is used, though
      * it may be swapped out for {@code org.ldaptive.provider.unboundid.UnboundIDProvider}.
      */
-    private String providerClass;
+    private String providerClass = "org.ldaptive.provider.unboundid.UnboundIDProvider";
     /**
      * Whether search/query results are allowed to match on multiple DNs,
      * or whether a single unique DN is expected for the result.


### PR DESCRIPTION
## Problem

```
java.lang.NullPointerException: Thread local SslConfig has not been set 
     at 
org.ldaptive.ssl.ThreadLocalTLSSocketFactory.getDefault(ThreadLocalTLSSocketFactory.java:53) 
~[ldaptive-1.2.4.jar!/:?] 
```

Reference: https://groups.google.com/a/apereo.org/forum/#!topic/cas-user/tC6qQO9zGRk

From @dfish3r:

> This appears to be a bug in JNDI code that manifests with an NPE in the ldaptive thread local code.
I've filed an issue, but there isn't a resolution yet.

> Work arounds include:
> * Use startTLS
> * Use the UnboundID provider
> * Use Java 8 (versions 9-12 are all affected)

## Solution

This pull request switches the default provider to use the UnboundID provider component instead, per Daniel's suggestion.

## Note

The `unboundid-ldapsdk` module is auto-included for deployments that pull in the `cas-server-support-ldap` module.