### PR TITLE
Fix incorrect CasProfile caching between different OAuth 2.0 services

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -24,6 +24,7 @@ import org.apereo.cas.support.oauth.authenticator.Authenticators;
 import org.apereo.cas.support.oauth.authenticator.OAuth20CasAuthenticationBuilder;
 import org.apereo.cas.support.oauth.authenticator.OAuth20ClientAuthenticator;
 import org.apereo.cas.support.oauth.authenticator.OAuth20UserAuthenticator;
+import org.apereo.cas.support.oauth.profile.ClientIdAwareProfileManager;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20ProfileScopeToAttributesFilter;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20UserProfileDataCreator;
 import org.apereo.cas.support.oauth.profile.OAuth20ProfileScopeToAttributesFilter;
@@ -201,6 +202,7 @@ public class CasOAuthConfiguration implements AuditTrailRecordResolutionPlanConf
         final Config config = new Config(OAuth20Utils.casOAuthCallbackUrl(casProperties.getServer().getPrefix()),
             oauthCasClient, basicAuthClient, directFormClient, userFormClient);
         config.setSessionStore(new J2ESessionStore());
+        config.setProfileManagerFactory(ClientIdAwareProfileManager::new);
         return config;
     }
 

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/profile/ClientIdAwareProfileManager.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/profile/ClientIdAwareProfileManager.java
@@ -1,0 +1,55 @@
+package org.apereo.cas.support.oauth.profile;
+
+import com.github.scribejava.core.model.OAuthConstants;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileManager;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This is a profile manager used during OAuth authentication.
+ *
+ * It saves returns a profile based on client_id from the request.
+ *
+ * @author Kirill Gagarski
+ * @param <U> profile type
+ * @since 5.3.8
+ */
+public class ClientIdAwareProfileManager<U extends CommonProfile> extends ProfileManager<U> {
+
+    private static final String SESSION_CLIENT_ID = "oauthClientId";
+    private static final String REQUEST_CLIENT_ID = OAuthConstants.CLIENT_ID;
+
+    public ClientIdAwareProfileManager(final WebContext context, final SessionStore sessionStore) {
+        super(context, sessionStore);
+    }
+
+    public ClientIdAwareProfileManager(final WebContext context) {
+        super(context);
+    }
+
+    @Override
+    protected LinkedHashMap<String, U> retrieveAll(final boolean readFromSession) {
+        return super.retrieveAll(readFromSession).entrySet().stream().filter(
+            it -> it.getValue()
+                .getAttribute(SESSION_CLIENT_ID)
+                .equals(context.getRequestParameter(REQUEST_CLIENT_ID)))
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                Map.Entry::getValue,
+                (v1, v2) -> {
+                    throw new IllegalStateException("Duplicate key");
+                },
+                LinkedHashMap::new));
+    }
+
+    @Override
+    public void save(final boolean saveInSession, final U profile, final boolean multiProfile) {
+        profile.addAttribute(SESSION_CLIENT_ID, context.getRequestParameter(REQUEST_CLIENT_ID));
+        super.save(saveInSession, profile, multiProfile);
+    }
+}

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/profile/ClientIdAwareProfileManager.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/profile/ClientIdAwareProfileManager.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.support.oauth.profile;
 
-import com.github.scribejava.core.model.OAuthConstants;
+import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.profile.CommonProfile;
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 public class ClientIdAwareProfileManager<U extends CommonProfile> extends ProfileManager<U> {
 
     private static final String SESSION_CLIENT_ID = "oauthClientId";
-    private static final String REQUEST_CLIENT_ID = OAuthConstants.CLIENT_ID;
+    private static final String REQUEST_CLIENT_ID = OAuth20Constants.CLIENT_ID;
 
     public ClientIdAwareProfileManager(final WebContext context, final SessionStore sessionStore) {
         super(context, sessionStore);

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/profile/ClientIdAwareProfileManager.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/support/oauth/profile/ClientIdAwareProfileManager.java
@@ -36,7 +36,7 @@ public class ClientIdAwareProfileManager<U extends CommonProfile> extends Profil
     protected LinkedHashMap<String, U> retrieveAll(final boolean readFromSession) {
         return super.retrieveAll(readFromSession).entrySet().stream().filter(
             it -> it.getValue()
-                .getAttribute(SESSION_CLIENT_ID)
+                .getAuthenticationAttribute(SESSION_CLIENT_ID)
                 .equals(context.getRequestParameter(REQUEST_CLIENT_ID)))
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
@@ -49,7 +49,7 @@ public class ClientIdAwareProfileManager<U extends CommonProfile> extends Profil
 
     @Override
     public void save(final boolean saveInSession, final U profile, final boolean multiProfile) {
-        profile.addAttribute(SESSION_CLIENT_ID, context.getRequestParameter(REQUEST_CLIENT_ID));
+        profile.addAuthenticationAttribute(SESSION_CLIENT_ID, context.getRequestParameter(REQUEST_CLIENT_ID));
         super.save(saveInSession, profile, multiProfile);
     }
 }


### PR DESCRIPTION
This PR fixes incorrect CasProfile caching when doing two subsequent authentications into different services.

Let's consider two services:

 - A that is allowed to release attributes a1, a2
 - B that is allowed to release attributes a1, a2, a3

Let's consider that user is also logged into CAS (for simplicity), i. e. he has TGT.

Now let's consider this user initiating authorization code flow by going to `/oauth2.0/authorize` endpoint with service `A` credentials. User's browser goes through the following redirects:

 - /oauth2.0/callbackAuthorize/
 - /login/
 - /oauth2.0/authorize
 - supplied callback URL

So far so good. But the bad thing is that now a pac4j profile is attached to a user session and this profile contains only a1 and a2 attributes. I believe the profile is added by this interceptor. This profile is bound to CasOAuthClient client (and it is not aware of a specific OAuth 2.0 service).

Now the bad things happen.

Let's consider the same user initialing authorization code flow by going to /oauth2.0/authorize endpoint with service B credentials. Now he already have a pac4j session, so authorize endpoint immediately produces OC ticket with only `a1` and `a2` attributes (`a3` is missing). Therefore `AT`s created from this `OC` also miss `a3`. If B relies on `a3` attribute for authentication then he can't perform it.

If you do these steps vice-versa, this also happens but now A can release more attributes than it is allowed.

This PR tries to fix it.