### PR TITLE
Use backchannel cas client for OAuth

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/client/CasBackchannelConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/client/CasBackchannelConfiguration.java
@@ -1,0 +1,27 @@
+package org.apereo.cas.client;
+
+import org.apereo.cas.CentralAuthenticationService;
+import org.jasig.cas.client.validation.TicketValidator;
+import org.pac4j.cas.config.CasConfiguration;
+import org.pac4j.core.context.WebContext;
+
+/**
+ * This is a configuration for pac4j CAS client that uses {@link CasBackchannelTicketValidator}.
+ *
+ * @author Kirill Gagarski
+ * @since 5.3.8
+ */
+public class CasBackchannelConfiguration extends CasConfiguration {
+
+    private final CentralAuthenticationService cas;
+
+    public CasBackchannelConfiguration(final String loginUrl, final CentralAuthenticationService cas) {
+        super(loginUrl);
+        this.cas = cas;
+    }
+
+    @Override
+    public TicketValidator retrieveTicketValidator(final WebContext context) {
+        return super.retrieveTicketValidator(context);
+    }
+}

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/client/CasBackchannelConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/client/CasBackchannelConfiguration.java
@@ -22,6 +22,6 @@ public class CasBackchannelConfiguration extends CasConfiguration {
 
     @Override
     public TicketValidator retrieveTicketValidator(final WebContext context) {
-        return super.retrieveTicketValidator(context);
+        return new CasBackchannelTicketValidator(cas);
     }
 }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/client/CasBackchannelTicketValidator.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/client/CasBackchannelTicketValidator.java
@@ -1,0 +1,30 @@
+package org.apereo.cas.client;
+
+import org.apereo.cas.CentralAuthenticationService;
+import org.jasig.cas.client.authentication.AttributePrincipalImpl;
+import org.jasig.cas.client.validation.Assertion;
+import org.jasig.cas.client.validation.AssertionImpl;
+import org.jasig.cas.client.validation.TicketValidator;
+
+/**
+ * This is a ticket validator for pac4j client that uses CAS back channels to validate ST.
+ *
+ * @author Kirill Gagarski
+ * @since 5.3.8
+ */
+public class CasBackchannelTicketValidator implements TicketValidator {
+    private final CentralAuthenticationService cas;
+
+    public CasBackchannelTicketValidator(final CentralAuthenticationService cas) {
+        this.cas = cas;
+    }
+
+    @Override
+    public Assertion validate(final String ticketId, final String service) {
+        final org.apereo.cas.validation.Assertion ass = cas.validateServiceTicket(ticketId, () -> service);
+
+        return new AssertionImpl(new AttributePrincipalImpl(
+            ass.getPrimaryAuthentication().getPrincipal().getId(),
+            ass.getPrimaryAuthentication().getPrincipal().getAttributes()));
+    }
+}

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -10,6 +10,7 @@ import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.principal.ServiceFactory;
+import org.apereo.cas.client.CasBackchannelConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.oauth.OAuthAccessTokenProperties;
 import org.apereo.cas.configuration.model.support.oauth.OAuthProperties;
@@ -180,7 +181,9 @@ public class CasOAuthConfiguration implements AuditTrailRecordResolutionPlanConf
 
     @Bean
     public Config oauthSecConfig() {
-        final CasConfiguration cfg = new CasConfiguration(casProperties.getServer().getLoginUrl());
+        final CasConfiguration cfg = new CasBackchannelConfiguration(
+            casProperties.getServer().getLoginUrl(),
+            centralAuthenticationService);
         final CasClient oauthCasClient = new CasClient(cfg);
         oauthCasClient.setRedirectActionBuilder(webContext -> oauthCasClientRedirectActionBuilder().build(oauthCasClient, webContext));
         oauthCasClient.setName(Authenticators.CAS_OAUTH_CLIENT);


### PR DESCRIPTION
This PR may be controversial but I think it still worth discussing.

The idea is to use `centralAuthenticationService` Java bean to validate service ticket during OAuth authentication delegated to CAS instead of using CAS with HTTP.

Motivation is the following. CAS internally allows values of any type in attribute map. But when attributes are passed through `/serviceValidate` HTTP endpoint, attributes are serialized into XML and deserialized back. This cause attribute distortion because complex types are put into XML tags using `toString` method (I guess). The result is often non-machine-readable. When we get attributes directly from Java code the type information is fully preserved and then `/profile` endpoint can use full power of Jackson to serialize it to JSON.

So, this `/profile`

```json
{
    "credentialType": "UsernamePasswordCredential",
    "email_verified": "false",
    "employeeID": "12345",
    "givenName": "John",
    "oauthClientId": "whatever",
    "objectSid": "S-1-5-12-1234567890-1234567890-1234567890-1234",
    "objectSidBase64": "deadbeef",
    "permissions": [
        "Permission(type=LOGIN, serviceGroup=*, targetUser=null)",
        "Permission(type=IMPERSONATE, serviceGroup=*, targetUser=.*)",
        "Permission(type=ADMIN, serviceGroup=null, targetUser=null)"
    ],
    "sAMAccountName": "john_doe",
    "samlAuthenticationStatementAuthMethod": "urn:oasis:names:tc:SAML:1.0:am:password",
    "sn": "Doe",
    "studentID": "",
    "userPrincipalName": "john_doe@test.dc",
    "wsAsu": [
        "(email,john_doe@example.com)",
        "(structure,[{type=Worker, number=12345, dep=Dept, sub_dep=Subdep, email=null, person_id=12345, profile_id=1234567890}])",
        "(FirstName,John)",
        "(user_id,12345)",
        "(icon_profile,null)",
        "(middle_name,null)",
        "(MiddleName,null)",
        "(UserID,12345)",
        "(meta,{post_address=null, phone=null, date_of_birth=null})",
        "(LastName,Doe)",
        "(main_email,john_doe@example.com)",
        "(educational_id,)",
        "(Username,)",
        "(permissions,null)",
        "(pass_number,null)",
        "(first_name,John)",
        "(last_name,Doe)",
        "(username,john_doe)"
    ],
    "wsAsuPublic": [
        "(structure,[{type=Worker, number=12345, dep=Dept, sub_dep=Subdep, email=null, person_id=12345, profile_id=1234567890}])",
        "(user_id,12345)",
        "(icon_profile,null)",
        "(first_name,John)",
        "(middle_name,null)",
        "(last_name,Doe)"
    ],
    "service": "http://192.168.1.71/whatever/callback",
    "id": "S-1-5-12-1234567890-1234567890-1234567890-1234",
    "client_id": "whatever"
}
```

becomes this:

```
{
    "credentialType": "UsernamePasswordCredential",
    "email_verified": false,                      // Also note correct boolean value here
    "employeeID": "12345",
    "givenName": "John",
    "oauthClientId": "whatever",
    "objectSid": "S-1-5-12-1234567890-1234567890-1234567890-1234",
    "objectSidBase64": "deadbeef",
    "permissions": [
        {
            "type": "LOGIN",
            "serviceGroup": "*",
            "targetUser": null
        },
        {
            "type": "IMPERSONATE",
            "serviceGroup": "*",
            "targetUser": ".*"
        },
        {
            "type": "ADMIN",
            "serviceGroup": null,
            "targetUser": null
        }
    ],
    "sAMAccountName": "john_doe",
    "sn": "Doe",
    "studentID": "",
    "userPrincipalName": "john_doe@test.dc",
    "wsAsu": {
        "username": "john_doe",
        "user_id": "12345",
        "educational_id": "",
        "pass_number": null,
        "first_name": "John",
        "last_name": "Doe",
        "middle_name": null,
        "main_email": "john_doe@example.com",
        "icon_profile": null,
        "structure": [
            {
                "type": "Worker",
                "number": "12345",
                "dep": "Dept",
                "sub_dep": "Subdep",
                "email": null,
                "person_id": "12345",
                "profile_id": "1234567890"
            }
        ],
        "meta": {
            "post_address": null,
            "phone": null,
            "date_of_birth": null
        },
        "permissions": null,
        "UserID": "12345",
        "FirstName": "John",
        "LastName": "Doe",
        "MiddleName": null,
        "email": "john_doe@example.com",
        "Username": ""
    },
    "wsAsuPublic": {
        "user_id": "12345",
        "first_name": "John",
        "last_name": "Doe",
        "middle_name": null,
        "icon_profile": null,
        "structure": [
            {
                "type": "Worker",
                "dep": "Dept",
                "sub_dep": "Subdep"
            }
        ],
    },
    "service": "http://192.168.1.71/whatever/callback",
    "id": "S-1-5-12-1234567890-1234567890-1234567890-1234",
    "client_id": "whatever"
}
```

Second one is ofc much better.


The upside is obvious: OAuth profiles are now fully machine-readable.
The downsides:
 - This way we cannot delegate OAuth 2.0 to another CAS instance (could we do this before?)
 - This is inconsistent with `/serviceValidate` CAS Protocol endoint. I guess here we need another solution to serialize complex types. I am not sure how to do it though, maybe the way complex types are serialized should be properly specified for CAS protocol.

I am not sure that his can be useful for anyone besides me (and I really rely on complex attribute types), or should in be in 5.3 branch at all (maybe it should be scheduled to a major release).