### PR TITLE
[5.3.x] Bump ldaptive version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -176,7 +176,7 @@ maxmindVersion=2.12.0
 googleMapsGeoCodingVersion=0.2.7
 userInfoVersion=1.1.0
 
-ldaptiveVersion=1.2.3
+ldaptiveVersion=1.2.4
 unboundidVersion=4.0.5
 
 jcifsVersion=1.3.17


### PR DESCRIPTION
The bug bothering me in CAS was https://github.com/vt-middleware/ldaptive/issues/144 and now it's fixed. Can we have the properly working version in 5.3.x?
