### PR TITLE
Remove creation of lambda interrupt inquirer

### DIFF
--- a/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/config/CasInterruptConfiguration.java
+++ b/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/config/CasInterruptConfiguration.java
@@ -5,7 +5,6 @@ import org.apereo.cas.interrupt.DefaultInterruptInquiryExecutionPlan;
 import org.apereo.cas.interrupt.GroovyScriptInterruptInquirer;
 import org.apereo.cas.interrupt.InterruptInquiryExecutionPlan;
 import org.apereo.cas.interrupt.InterruptInquiryExecutionPlanConfigurer;
-import org.apereo.cas.interrupt.InterruptResponse;
 import org.apereo.cas.interrupt.JsonResourceInterruptInquirer;
 import org.apereo.cas.interrupt.RegexAttributeInterruptInquirer;
 import org.apereo.cas.interrupt.RestEndpointInterruptInquirer;

--- a/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/config/CasInterruptConfiguration.java
+++ b/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/config/CasInterruptConfiguration.java
@@ -63,6 +63,5 @@ public class CasInterruptConfiguration implements InterruptInquiryExecutionPlanC
         if (StringUtils.isNotBlank(ip.getRest().getUrl())) {
             plan.registerInterruptInquirer(new RestEndpointInterruptInquirer(ip.getRest()));
         }
-        plan.registerInterruptInquirer((authentication, registeredService, service, credential, requestContext) -> new InterruptResponse());
     }
 }


### PR DESCRIPTION
This lambda inquirer causes to always interrupt the login process.
```
2019-02-11 18:52:58,269 DEBUG [org.apereo.cas.interrupt.webflow.actions.InquireInterruptAction] - <Invoking interrupt inquirer using [GroovyScriptInterruptInquirer]>
2019-02-11 18:52:58,269 DEBUG [org.apereo.cas.interrupt.BaseInterruptInquirer] - <No service was found in the request context. Proceeding as usual...>
2019-02-11 18:52:58,270 DEBUG [org.apereo.cas.interrupt.webflow.actions.InquireInterruptAction] - <Invoking interrupt inquirer using [CasInterruptConfiguration$$Lambda$863/0x0000000840dc7c40]>
2019-02-11 18:52:58,270 DEBUG [org.apereo.cas.interrupt.webflow.actions.InquireInterruptAction] - <Interrupt inquiry is required since inquirer produced a response [InterruptResponse(message=Authentication flow is interrupted, links={}, block=false, ssoEnabled=true, interrupt=true, autoRedirect=false, autoRedirectAfterSeconds=-1)]>
```