### PR TITLE
fix missing jar from (class not found on startup but shell still worked)

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/SamlIdPObjectSigner.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/SamlIdPObjectSigner.java
@@ -209,8 +209,7 @@ public class SamlIdPObjectSigner {
                     params.getSignatureReferenceDigestMethod());
         } else {
             LOGGER.warn("Unable to resolve SignatureSigningParameters, response signing will fail."
-                    + " Make sure domain names in IDP metadata URLs and certificates match CAS domain name",
-                    criteria);
+                    + " Make sure domain names in IDP metadata URLs and certificates match CAS domain name");
         }
         return params;
     }

--- a/support/cas-server-support-shell/build.gradle
+++ b/support/cas-server-support-shell/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation libraries.jasypt
     implementation libraries.bouncycastle
     implementation libraries.opensaml
+    implementation libraries.javaparser
 
     runtimeOnly project(":support:cas-server-support-jdbc-drivers")
 }


### PR DESCRIPTION
Adding javaparser to avoid this exception on shell startup. 

```
No active profile set, falling back to default profiles: default
could not get type for name com.github.javaparser.ast.visitor.VoidVisitorAdapter from any class loader
org.reflections.ReflectionsException: could not get type for name com.github.javaparser.ast.visitor.VoidVisitorAdapter
        at org.reflections.ReflectionUtils.forName(ReflectionUtils.java:390) [reflections-0.9.11.jar!/:?]
        at org.reflections.Reflections.expandSuperTypes(Reflections.java:381) [reflections-0.9.11.jar!/:?]
        at org.reflections.Reflections.<init>(Reflections.java:126) [reflections-0.9.11.jar!/:?]
        at org.reflections.Reflections.<init>(Reflections.java:168) [reflections-0.9.11.jar!/:?]
        at org.reflections.Reflections.<init>(Reflections.java:141) [reflections-0.9.11.jar!/:?]
        at org.apereo.cas.shell.commands.db.GenerateDdlCommand.<clinit>(GenerateDdlCommand.java:51) [classes!/:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[?:?]
        at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:172) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:87) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1262) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1164) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:538) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:498) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:320) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:318) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:846) [spring-beans-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:863) [spring-context-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:546) [spring-context-5.1.4.RELEASE.jar!/:5.1.4.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:775) [spring-boot-2.1.2.RELEASE.jar!/:2.1.2.RELEASE]
        at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397) [spring-boot-2.1.2.RELEASE.jar!/:2.1.2.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:316) [spring-boot-2.1.2.RELEASE.jar!/:2.1.2.RELEASE]
        at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:139) [spring-boot-2.1.2.RELEASE.jar!/:2.1.2.RELEASE]
        at org.apereo.cas.CasCommandLineShellApplication.main(CasCommandLineShellApplication.java:63) [classes!/:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48) [cas-server-support-shell-6.1.0-RC1-SNAPSHOT.jar:?]
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:87) [cas-server-support-shell-6.1.0-RC1-SNAPSHOT.jar:?]
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:50) [cas-server-support-shell-6.1.0-RC1-SNAPSHOT.jar:?]
        at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:51) [cas-server-support-shell-6.1.0-RC1-SNAPSHOT.jar:?]
Caused by: java.lang.ClassNotFoundException: com.github.javaparser.ast.visitor.VoidVisitorAdapter
        at java.net.URLClassLoader.findClass(URLClassLoader.java:471) ~[?:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:588) ~[?:?]
        at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:93) ~[cas-server-support-shell-6.1.0-RC1-SNAPSHOT.jar:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:521) ~[?:?]
        at org.reflections.ReflectionUtils.forName(ReflectionUtils.java:388) ~[reflections-0.9.11.jar!/:?]
```