### PR TITLE
Exclude el-api 2.2 dependency that conflicts with 3.0 from tomcat 9

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -674,6 +674,7 @@ ext.libraries = [
                 },
                 dependencies.create("org.glassfish.web:el-impl:2.2") {
                     exclude(group: "javax.el", module: "javax.el-api")
+                    exclude(group: "javax.el", module: "el-api")
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     force = true
                 }


### PR DESCRIPTION
Exclude el-api under another artifact name that is currently used. Not sure why we are including el-impl:2.2 since Tomat comes with 3.0 impl of its own (and 3.0 api). 
