### PR TITLE
Fix Nexmo support 4.0.x

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/NexmoProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/NexmoProperties.java
@@ -29,11 +29,11 @@ public class NexmoProperties implements Serializable {
     /**
      * Nexmo API secret obtained from Nexmo.
      */
-    @RequiredProperty
     private String apiSecret;
 
     /**
-     * The nexmo application id.
+     * Nexmo Signature secret obtained from Nexmo.
      */
-    private String applicationId = "CAS";
+    private String signatureSecret;
+
 }

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -1488,11 +1488,12 @@ Send text messaging using Clickatell.
 ### Nexmo
 
 Send text messaging using Nexmo.
+Nexmo needs at least apiSecret or signatureSecret field set.
 
 ```properties
 # cas.smsProvider.nexmo.apiToken=
 # cas.smsProvider.nexmo.apiSecret=
-# cas.smsProvider.nexmo.applicationId=CAS
+# cas.smsProvider.nexmo.signatureSecret=
 ```
 
 ### Amazon SNS

--- a/support/cas-server-support-passwordless/src/main/java/org/apereo/cas/web/flow/DisplayBeforePasswordlessAuthenticationAction.java
+++ b/support/cas-server-support-passwordless/src/main/java/org/apereo/cas/web/flow/DisplayBeforePasswordlessAuthenticationAction.java
@@ -58,7 +58,7 @@ public class DisplayBeforePasswordlessAuthenticationAction extends AbstractActio
                 user.getEmail());
         }
         if (communicationsManager.isSmsSenderDefined() && StringUtils.isNotBlank(user.getPhone())) {
-            communicationsManager.sms(passwordlessProperties.getTokens().getMail().getFrom(), user.getPhone(), token);
+            communicationsManager.sms(passwordlessProperties.getTokens().getSms().getFrom(), user.getPhone(), token);
         }
 
         passwordlessTokenRepository.deleteTokens(user.getUsername());

--- a/support/cas-server-support-sms-nexmo/src/main/java/org/apereo/cas/support/sms/NexmoSmsSender.java
+++ b/support/cas-server-support-sms-nexmo/src/main/java/org/apereo/cas/support/sms/NexmoSmsSender.java
@@ -28,7 +28,7 @@ public class NexmoSmsSender implements SmsSender {
         val builder = new NexmoClient.Builder();
         this.nexmoClient = builder.apiKey(nexmo.getApiToken())
             .apiSecret(nexmo.getApiSecret())
-            .applicationId(nexmo.getApplicationId()).build();
+            .signatureSecret(nexmo.getSignatureSecret()).build();
     }
 
     @Override


### PR DESCRIPTION
Fix Nexmo SMS support

Nexmo client needs private key if applicationId is set. DisplayBeforePasswordlessAuthenticationAction uses email configuration for sms notifications.

[x] Remove applicationId default value from NexmoProperties
[x] Add privateKeyContentsPath to NexmoProperties
[x] Use SMS configuration for sms notifications (DisplayBeforePasswordlessAuthenticationAction)
[x] Use default applicationId "CAS" if a private key path is set and applicationId not
