### PR TITLE
Port forward of: mfa_allow_boolean_match_for_principal_attribute_valu…

### DIFF
--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
@@ -160,9 +160,9 @@ public class MultifactorAuthenticationUtils {
                                                             final Optional<RequestContext> context,
                                                             final MultifactorAuthenticationProvider provider,
                                                             final Predicate<String> predicate) {
-        if (attributeValue instanceof String) {
+        if (!(attributeValue instanceof Collection)) {
             LOGGER.debug("Attribute value [{}] is a single-valued attribute", attributeValue);
-            if (predicate.test((String) attributeValue)) {
+            if (predicate.test(attributeValue.toString())) {
                 LOGGER.debug("Attribute value predicate [{}] has matched the [{}]", predicate, attributeValue);
                 return evaluateEventForProviderInContext(principal, service, context, provider);
             }


### PR DESCRIPTION
…e_regex

Port forward of change on 5.3.9

Changed the MFA trigger to allow regex matches against boolean principal attributes.
Previously non-String values would have been silently ignored.