### PR TITLE
Delete passwordless token after authentication

### DIFF
--- a/support/cas-server-support-passwordless/src/main/java/org/apereo/cas/web/flow/AcceptPasswordlessAuthenticationAction.java
+++ b/support/cas-server-support-passwordless/src/main/java/org/apereo/cas/web/flow/AcceptPasswordlessAuthenticationAction.java
@@ -59,7 +59,7 @@ public class AcceptPasswordlessAuthenticationAction extends AbstractAuthenticati
                 WebUtils.putCredential(requestContext, credential);
 
                 val token = currentToken.get();
-                val finalEvent =  super.doExecute(requestContext);
+                val finalEvent = super.doExecute(requestContext);
                 passwordlessTokenRepository.deleteToken(username, token);
 
                 return finalEvent;

--- a/support/cas-server-support-passwordless/src/main/java/org/apereo/cas/web/flow/AcceptPasswordlessAuthenticationAction.java
+++ b/support/cas-server-support-passwordless/src/main/java/org/apereo/cas/web/flow/AcceptPasswordlessAuthenticationAction.java
@@ -59,9 +59,10 @@ public class AcceptPasswordlessAuthenticationAction extends AbstractAuthenticati
                 WebUtils.putCredential(requestContext, credential);
 
                 val token = currentToken.get();
+                val finalEvent =  super.doExecute(requestContext);
                 passwordlessTokenRepository.deleteToken(username, token);
 
-                return super.doExecute(requestContext);
+                return finalEvent;
             }
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
Passwordless authentication fails on token verification. Token is removed before all verifications.

This PR moves token deletion at the end of the doExecute method.

Tested with passwordless auth and in-memory tokens