### PR TITLE
Only create a single CRLFetcher bean (depending on property)

### DIFF
--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -122,9 +122,6 @@ public class X509AuthenticationConfiguration {
         return new NoOpRevocationChecker();
     }
 
-    @Bean
-    @RefreshScope
-    @ConditionalOnMissingBean(name = "resourceCrlFetcher")
     public CRLFetcher resourceCrlFetcher() {
         return new ResourceCRLFetcher();
     }
@@ -189,9 +186,6 @@ public class X509AuthenticationConfiguration {
             x509.getOrder());
     }
 
-    @Bean
-    @RefreshScope
-    @ConditionalOnMissingBean(name = "ldaptiveResourceCRLFetcher")
     public CRLFetcher ldaptiveResourceCRLFetcher() {
         val x509 = casProperties.getAuthn().getX509();
         return new LdaptiveResourceCRLFetcher(LdapUtils.newLdaptiveConnectionConfig(x509.getLdap()),

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -122,10 +122,6 @@ public class X509AuthenticationConfiguration {
         return new NoOpRevocationChecker();
     }
 
-    public CRLFetcher resourceCrlFetcher() {
-        return new ResourceCRLFetcher();
-    }
-
     @Bean
     @RefreshScope
     @ConditionalOnMissingBean(name = "resourceCrlRevocationChecker")
@@ -152,10 +148,12 @@ public class X509AuthenticationConfiguration {
         val x509 = casProperties.getAuthn().getX509();
         switch (x509.getCrlFetcher().toLowerCase()) {
             case "ldap":
-                return ldaptiveResourceCRLFetcher();
+                return new LdaptiveResourceCRLFetcher(LdapUtils.newLdaptiveConnectionConfig(x509.getLdap()),
+                    LdapUtils.newLdaptiveSearchExecutor(x509.getLdap().getBaseDn(),
+                    x509.getLdap().getSearchFilter()), x509.getLdap().getCertificateAttribute());
             case "resource":
             default:
-                return resourceCrlFetcher();
+                return new ResourceCRLFetcher();
         }
     }
 
@@ -184,13 +182,6 @@ public class X509AuthenticationConfiguration {
             subjectDnPattern,
             revChecker,
             x509.getOrder());
-    }
-
-    public CRLFetcher ldaptiveResourceCRLFetcher() {
-        val x509 = casProperties.getAuthn().getX509();
-        return new LdaptiveResourceCRLFetcher(LdapUtils.newLdaptiveConnectionConfig(x509.getLdap()),
-            LdapUtils.newLdaptiveSearchExecutor(x509.getLdap().getBaseDn(), x509.getLdap().getSearchFilter()),
-            x509.getLdap().getCertificateAttribute());
     }
 
     @Bean

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -1,0 +1,17 @@
+package org.apereo.cas;
+
+import org.apereo.cas.adaptors.x509.authentication.ldap.LdaptiveResourceCRLFetcherTests;
+import org.apereo.cas.adaptors.x509.config.DefaultX509ConfigTests;
+import org.junit.platform.suite.api.SelectClasses;
+
+/**
+ * This is {@link AllTestsSuite}.
+ *
+ * @since 6.1.0
+ */
+@SelectClasses({
+    LdaptiveResourceCRLFetcherTests.class,
+    DefaultX509ConfigTests.class,
+})
+public class AllTestsSuite {
+}

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -11,7 +11,7 @@ import org.junit.platform.suite.api.SelectClasses;
  */
 @SelectClasses({
     LdaptiveResourceCRLFetcherTests.class,
-    DefaultX509ConfigTests.class,
+    DefaultX509ConfigTests.class
 })
 public class AllTestsSuite {
 }

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/DefaultX509ConfigTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/DefaultX509ConfigTests.java
@@ -17,6 +17,7 @@ import org.apereo.cas.config.CasCoreUtilConfiguration;
 import org.apereo.cas.config.CasCoreWebConfiguration;
 import org.apereo.cas.config.CasPersonDirectoryConfiguration;
 import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /** 
  * This test makes sure the default X509 config loads without errors.
  * It purposely has minimal configuration and the defined crlFetcher is the default.
+ * @since 6.1
 */
 @SpringBootTest(classes = {X509AuthenticationConfiguration.class,
     RefreshAutoConfiguration.class,
@@ -60,7 +62,7 @@ public class DefaultX509ConfigTests {
      * Confirm that config was loaded by ensuring bean was autowired.
      */
     @Test
-    public void testContextLoaded() {
+    public void verifyContextLoaded() {
         assertNotNull(fetcher);
     }
 }

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/DefaultX509ConfigTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/DefaultX509ConfigTests.java
@@ -1,0 +1,66 @@
+package org.apereo.cas.adaptors.x509.config;
+
+
+import org.apereo.cas.adaptors.x509.authentication.CRLFetcher;
+import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationPolicyConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
+import org.apereo.cas.config.CasCoreHttpConfiguration;
+import org.apereo.cas.config.CasCoreServicesAuthenticationConfiguration;
+import org.apereo.cas.config.CasCoreServicesConfiguration;
+import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
+import org.apereo.cas.config.CasCoreTicketsConfiguration;
+import org.apereo.cas.config.CasCoreUtilConfiguration;
+import org.apereo.cas.config.CasCoreWebConfiguration;
+import org.apereo.cas.config.CasPersonDirectoryConfiguration;
+import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** 
+ * This test makes sure the default X509 config loads without errors.
+ * It purposely has minimal configuration and the defined crlFetcher is the default.
+*/
+@SpringBootTest(classes = {X509AuthenticationConfiguration.class,
+    RefreshAutoConfiguration.class,
+    CasCoreAuthenticationPrincipalConfiguration.class,
+    CasCoreAuthenticationPolicyConfiguration.class,
+    CasCoreAuthenticationMetadataConfiguration.class,
+    CasCoreAuthenticationSupportConfiguration.class,
+    CasCoreAuthenticationHandlersConfiguration.class,
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasCoreHttpConfiguration.class,
+    CasCoreUtilConfiguration.class,
+    CasCoreTicketCatalogConfiguration.class,
+    CasCoreTicketsConfiguration.class,
+    CasPersonDirectoryConfiguration.class,
+    CasCoreAuthenticationConfiguration.class,
+    CasCoreWebConfiguration.class,
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasCoreServicesAuthenticationConfiguration.class,
+    CasCoreServicesConfiguration.class})
+@TestPropertySource(properties="cas.authn.x509.crlFetcher=resource")
+public class DefaultX509ConfigTests {
+
+    @Autowired
+    @Qualifier("crlFetcher")
+    private CRLFetcher fetcher;
+
+    /**
+     * If there was a problem, this test would have failed to start up.
+     * Confirm that config was loaded by ensuring bean was autowired.
+     */
+    @Test
+    public void testContextLoaded() {
+        assertNotNull(fetcher);
+    }
+}

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/DefaultX509ConfigTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/DefaultX509ConfigTests.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.adaptors.x509.config;
 
-
 import org.apereo.cas.adaptors.x509.authentication.CRLFetcher;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;


### PR DESCRIPTION
If I take a clean overlay (6.1-RC2-SNAPSHOT) and add this dependency:
```gradle
compile "org.apereo.cas:cas-server-support-x509-webflow:${casServerVersion}"
```
then the CAS server fails to start b/c it is trying to create an ldaptiveResourceCRLFetcher that isn't configured (default crlFetcher is resource type). 
I was having trouble testing this outside of overlay but I don't see any references to these beans (only the crlFetcher bean) so I think it is safe to remove these annotations. 

This is the error that occurs. 
```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.apereo.cas.adaptors.x509.authentication.CRLFetcher]: Factory method 'ldaptiveResourceCRLFetcher' threw exception; nested exception is java.lang.IllegalArgumentException: LDAP url cannot be empty/blank
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:185)
        at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:622)
        ... 37 more
Caused by: java.lang.IllegalArgumentException: LDAP url cannot be empty/blank
        at org.apereo.cas.util.LdapUtils.newLdaptiveConnectionConfig(LdapUtils.java:739)
        at org.apereo.cas.adaptors.x509.config.X509AuthenticationConfiguration.ldaptiveResourceCRLFetcher(X509AuthenticationConfiguration.java:197)
        at org.apereo.cas.adaptors.x509.config.X509AuthenticationConfiguration$$EnhancerBySpringCGLIB$$6b1466da.CGLIB$ldaptiveResourceCRLFetcher$11(<generated>)
        at org.apereo.cas.adaptors.x509.config.X509AuthenticationConfiguration$$EnhancerBySpringCGLIB$$6b1466da$$FastClassBySpringCGLIB$$96c1b29a.invoke(<generated>)
```

It looks like that change was made on 6.0.x in October and I am not seeing the problem on 6.0.1-SNAPSHOT, but I don't know why, b/c it seems like that bean should get created (since it is annotated as a bean) but there is not config that would allow it to be created. 