### PR TITLE
Add glibc crypt password encoder

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
@@ -58,7 +58,7 @@ public class PasswordEncoderProperties implements Serializable {
 
     /**
      * The encoding algorithm to use such as 'MD5'.
-     * Relevant when the type used is 'DEFAULT'.
+     * Relevant when the type used is 'DEFAULT' or 'GLIBC_CRYPT'.
      */
     private String encodingAlgorithm;
 
@@ -69,7 +69,7 @@ public class PasswordEncoderProperties implements Serializable {
     private String characterEncoding;
 
     /**
-     * Secret to use with STANDARD, PBKDF2, BCRYPT password encoders.
+     * Secret to use with STANDARD, PBKDF2, BCRYPT, GLIBC_CRYPT password encoders.
      * Secret usually is an optional setting.
      */
     private String secret;
@@ -77,6 +77,7 @@ public class PasswordEncoderProperties implements Serializable {
     /**
      * Strength or number of iterations to use for password hashing.
      * Usually relevant when dealing with PBKDF2 or BCRYPT encoders.
+     * Used by GLIBC_CRYPT encoders as well.
      */
     private int strength = 16;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
@@ -41,7 +41,7 @@ public class PasswordEncoderProperties implements Serializable {
          * Uses {@link org.springframework.security.crypto.password.Pbkdf2PasswordEncoder}.
          */
         PBKDF2, /**
-         * Uses {@link org.apereo.cas.util.crypto.GlibcCryptPasswordEncoder}.
+         * Uses <code>org.apereo.cas.util.crypto.GlibcCryptPasswordEncoder</code> from module <code>server-core-util-api</code>
          */
         GLIBC_CRYPT
     }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
@@ -41,7 +41,7 @@ public class PasswordEncoderProperties implements Serializable {
          * Uses {@link org.springframework.security.crypto.password.Pbkdf2PasswordEncoder}.
          */
         PBKDF2, /**
-         * Uses <code>org.apereo.cas.util.crypto.GlibcCryptPasswordEncoder</code> from module <code>server-core-util-api</code>
+         * Uses <code>org.apereo.cas.util.crypto.GlibcCryptPasswordEncoder</code> from module <code>server-core-util-api</code>.
          */
         GLIBC_CRYPT
     }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PasswordEncoderProperties.java
@@ -40,7 +40,10 @@ public class PasswordEncoderProperties implements Serializable {
         SCRYPT, /**
          * Uses {@link org.springframework.security.crypto.password.Pbkdf2PasswordEncoder}.
          */
-        PBKDF2
+        PBKDF2, /**
+         * Uses {@link org.apereo.cas.util.crypto.GlibcCryptPasswordEncoder}.
+         */
+        GLIBC_CRYPT
     }
 
     /**

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordEncoderUtils.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordEncoderUtils.java
@@ -1,10 +1,12 @@
 package org.apereo.cas.authentication.support.password;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.configuration.model.core.authentication.PasswordEncoderProperties;
 import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.util.crypto.DefaultPasswordEncoder;
+import org.apereo.cas.util.crypto.GlibcCryptPasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -79,6 +81,12 @@ public class PasswordEncoderUtils {
                 }
                 final int hashWidth = 256;
                 return new Pbkdf2PasswordEncoder(properties.getSecret(), properties.getStrength(), hashWidth);
+            case GLIBC_CRYPT:
+                boolean hasSecret = StringUtils.isNotBlank(properties.getSecret());
+                LOGGER.debug("Creating glibc CRYPT encoder with encoding alg [{}], strength [{}] and {}secret",
+                        properties.getEncodingAlgorithm(), properties.getStrength(),
+                        BooleanUtils.toString(hasSecret, StringUtils.EMPTY, "without "));
+                return new GlibcCryptPasswordEncoder(properties.getEncodingAlgorithm(), properties.getStrength(), properties.getSecret());
             case NONE:
             default:
                 LOGGER.debug("No password encoder shall be created given the requested encoder type [{}]", type);

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordEncoderUtils.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordEncoderUtils.java
@@ -82,7 +82,7 @@ public class PasswordEncoderUtils {
                 final int hashWidth = 256;
                 return new Pbkdf2PasswordEncoder(properties.getSecret(), properties.getStrength(), hashWidth);
             case GLIBC_CRYPT:
-                boolean hasSecret = StringUtils.isNotBlank(properties.getSecret());
+                final boolean hasSecret = StringUtils.isNotBlank(properties.getSecret());
                 LOGGER.debug("Creating glibc CRYPT encoder with encoding alg [{}], strength [{}] and {}secret",
                         properties.getEncodingAlgorithm(), properties.getStrength(),
                         BooleanUtils.toString(hasSecret, StringUtils.EMPTY, "without "));

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoder.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoder.java
@@ -1,0 +1,93 @@
+package org.apereo.cas.util.crypto;
+
+import java.security.SecureRandom;
+import java.util.Random;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.Crypt;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * this is {@link GlibcCryptPasswordEncoder}.
+ *
+ * @author Martin Böhmer
+ * @since 5.3.10
+ */
+@Slf4j
+@AllArgsConstructor
+public class GlibcCryptPasswordEncoder implements PasswordEncoder {
+
+    /*
+     * from https://github.com/apache/commons-codec/blob/dd5e46203e5b12f4b65e76ef2e5c34197692b5b4/src/main/java/org/apache/commons/codec/digest/B64.java#L39
+     */
+    static final String B64T_STRING = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    private final String encodingAlgorithm;
+    private final int strength;
+    private final String secret;
+
+    @Override
+    public String encode(CharSequence password) {
+        if (password == null) {
+            return null;
+        }
+
+        if (StringUtils.isBlank(this.encodingAlgorithm)) {
+            LOGGER.warn("No encoding algorithm is defined. Password cannot be encoded; Returning null");
+            return null;
+        }
+        
+        return Crypt.crypt(password.toString(), generateCryptSalt());
+    }
+
+    @Override
+    public boolean matches(final CharSequence rawPassword, final String encodedPassword) {
+        String encodedRawPassword = StringUtils.isNotBlank(rawPassword) ? encode(rawPassword.toString()) : null;
+        boolean matched = StringUtils.equals(encodedRawPassword, encodedPassword);
+        LOGGER.debug("Provided password does{}match the encoded password", BooleanUtils.toString(matched, StringUtils.EMPTY, " not "));
+        return matched;
+    }
+
+    private String generateCryptSalt() {
+        if (StringUtils.isBlank(this.encodingAlgorithm)) {
+            return null;
+        }
+        StringBuilder cryptSalt = new StringBuilder();
+        if ("1".equals(this.encodingAlgorithm) || "MD5".equals(this.encodingAlgorithm.toUpperCase())) {
+            // MD5
+            cryptSalt.append("$1$");
+        } else if ("5".equals(this.encodingAlgorithm) || "SHA-256".equals(this.encodingAlgorithm.toUpperCase())) {
+            // SHA-256
+            cryptSalt.append("$5$");
+            cryptSalt.append("rounds=").append(this.strength).append("$");
+        } else if ("6".equals(this.encodingAlgorithm) || "SHA-512".equals(this.encodingAlgorithm.toUpperCase())) {
+            // SHA-512
+            cryptSalt.append("$6$");
+            cryptSalt.append("rounds=").append(this.strength).append("$");
+        } else {
+            // UNIX Crypt algorithm
+            cryptSalt.append(this.encodingAlgorithm);
+        }
+        // Add real salt
+        if (StringUtils.isBlank(this.secret)) {
+            cryptSalt.append(getRandomSalt(8, new SecureRandom())).append("$");
+        } else {
+            cryptSalt.append(secret).append("$");
+        }
+        return cryptSalt.toString();
+    }
+
+    /*
+     * from https://github.com/apache/commons-codec/blob/dd5e46203e5b12f4b65e76ef2e5c34197692b5b4/src/main/java/org/apache/commons/codec/digest/B64.java#L95
+     */
+    private String getRandomSalt(final int num, final Random random) {
+        final StringBuilder saltString = new StringBuilder(num);
+        for (int i = 1; i <= num; i++) {
+            saltString.append(B64T_STRING.charAt(random.nextInt(B64T_STRING.length())));
+        }
+        return saltString.toString();
+    }
+
+}

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoder.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoder.java
@@ -1,12 +1,11 @@
 package org.apereo.cas.util.crypto;
 
-import java.security.SecureRandom;
-import java.util.Random;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.Crypt;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.util.gen.Base64RandomStringGenerator;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
@@ -19,17 +18,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @AllArgsConstructor
 public class GlibcCryptPasswordEncoder implements PasswordEncoder {
 
-    /*
-     * from https://github.com/apache/commons-codec/blob/dd5e46203e5b12f4b65e76ef2e5c34197692b5b4/src/main/java/org/apache/commons/codec/digest/B64.java#L39
-     */
-    static final String B64T_STRING = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final int SALT_LENGTH = 8;
 
     private final String encodingAlgorithm;
     private final int strength;
     private final String secret;
 
     @Override
-    public String encode(CharSequence password) {
+    public String encode(final CharSequence password) {
         if (password == null) {
             return null;
         }
@@ -38,14 +34,14 @@ public class GlibcCryptPasswordEncoder implements PasswordEncoder {
             LOGGER.warn("No encoding algorithm is defined. Password cannot be encoded; Returning null");
             return null;
         }
-        
+
         return Crypt.crypt(password.toString(), generateCryptSalt());
     }
 
     @Override
     public boolean matches(final CharSequence rawPassword, final String encodedPassword) {
-        String encodedRawPassword = StringUtils.isNotBlank(rawPassword) ? encode(rawPassword.toString()) : null;
-        boolean matched = StringUtils.equals(encodedRawPassword, encodedPassword);
+        final String encodedRawPassword = StringUtils.isNotBlank(rawPassword) ? encode(rawPassword.toString()) : null;
+        final boolean matched = StringUtils.equals(encodedRawPassword, encodedPassword);
         LOGGER.debug("Provided password does{}match the encoded password", BooleanUtils.toString(matched, StringUtils.EMPTY, " not "));
         return matched;
     }
@@ -54,40 +50,30 @@ public class GlibcCryptPasswordEncoder implements PasswordEncoder {
         if (StringUtils.isBlank(this.encodingAlgorithm)) {
             return null;
         }
-        StringBuilder cryptSalt = new StringBuilder();
+        final StringBuilder cryptSalt = new StringBuilder();
         if ("1".equals(this.encodingAlgorithm) || "MD5".equals(this.encodingAlgorithm.toUpperCase())) {
             // MD5
             cryptSalt.append("$1$");
         } else if ("5".equals(this.encodingAlgorithm) || "SHA-256".equals(this.encodingAlgorithm.toUpperCase())) {
             // SHA-256
             cryptSalt.append("$5$");
-            cryptSalt.append("rounds=").append(this.strength).append("$");
+            cryptSalt.append("rounds=").append(this.strength).append('$');
         } else if ("6".equals(this.encodingAlgorithm) || "SHA-512".equals(this.encodingAlgorithm.toUpperCase())) {
             // SHA-512
             cryptSalt.append("$6$");
-            cryptSalt.append("rounds=").append(this.strength).append("$");
+            cryptSalt.append("rounds=").append(this.strength).append('$');
         } else {
             // UNIX Crypt algorithm
             cryptSalt.append(this.encodingAlgorithm);
         }
         // Add real salt
         if (StringUtils.isBlank(this.secret)) {
-            cryptSalt.append(getRandomSalt(8, new SecureRandom())).append("$");
+            final Base64RandomStringGenerator keygen = new Base64RandomStringGenerator(SALT_LENGTH);
+            cryptSalt.append(keygen.getNewString()).append('$');
         } else {
-            cryptSalt.append(secret).append("$");
+            cryptSalt.append(secret).append('$');
         }
         return cryptSalt.toString();
-    }
-
-    /*
-     * from https://github.com/apache/commons-codec/blob/dd5e46203e5b12f4b65e76ef2e5c34197692b5b4/src/main/java/org/apache/commons/codec/digest/B64.java#L95
-     */
-    private String getRandomSalt(final int num, final Random random) {
-        final StringBuilder saltString = new StringBuilder(num);
-        for (int i = 1; i <= num; i++) {
-            saltString.append(B64T_STRING.charAt(random.nextInt(B64T_STRING.length())));
-        }
-        return saltString.toString();
     }
 
 }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoder.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoder.java
@@ -54,24 +54,30 @@ public class GlibcCryptPasswordEncoder implements PasswordEncoder {
         if ("1".equals(this.encodingAlgorithm) || "MD5".equals(this.encodingAlgorithm.toUpperCase())) {
             // MD5
             cryptSalt.append("$1$");
+            LOGGER.debug("Encoding with MD5 algorithm");
         } else if ("5".equals(this.encodingAlgorithm) || "SHA-256".equals(this.encodingAlgorithm.toUpperCase())) {
             // SHA-256
             cryptSalt.append("$5$");
             cryptSalt.append("rounds=").append(this.strength).append('$');
+            LOGGER.debug("Encoding with SHA-256 algorithm and {} rounds", this.strength);
         } else if ("6".equals(this.encodingAlgorithm) || "SHA-512".equals(this.encodingAlgorithm.toUpperCase())) {
             // SHA-512
             cryptSalt.append("$6$");
             cryptSalt.append("rounds=").append(this.strength).append('$');
+            LOGGER.debug("Encoding with SHA-512 algorithm and {} rounds", this.strength);
         } else {
             // UNIX Crypt algorithm
             cryptSalt.append(this.encodingAlgorithm);
+            LOGGER.debug("Encoding with UNIX Crypt algorithm as no indicator for another algorithm was found.");
         }
         // Add real salt
         if (StringUtils.isBlank(this.secret)) {
+            LOGGER.debug("No secret was found. Generating a salt with length {}", SALT_LENGTH);
             final Base64RandomStringGenerator keygen = new Base64RandomStringGenerator(SALT_LENGTH);
             cryptSalt.append(keygen.getNewString()).append('$');
         } else {
-            cryptSalt.append(secret).append('$');
+            LOGGER.debug("The provided secrect is used as a salt");
+            cryptSalt.append(this.secret).append('$');
         }
         return cryptSalt.toString();
     }

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoderTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoderTests.java
@@ -1,0 +1,55 @@
+package org.apereo.cas.util.crypto;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * This tests {@link GlibcCryptPasswordEncoder}.
+ *
+ * @author Martin Böhmer
+ * @since 5.3.10
+ */
+@Slf4j
+public class GlibcCryptPasswordEncoderTests {
+
+    @Test
+    public void testSha512Encoding() {
+        testEncoding("SHA-512");
+        testEncoding("6");
+    }
+
+    @Test
+    public void testSha256Encoding() {
+        testEncoding("SHA-256");
+        testEncoding("5");
+    }
+    
+    @Test
+    public void testMd5Encoding() {
+        testEncoding("MD5");
+        testEncoding("1");
+    }
+    
+    @Test
+    public void testDesUnixCryptEncoding() {
+        testEncoding("aB");
+        testEncoding("42xyz");
+        testEncoding("");
+    }
+
+    private void testEncoding(final String algorithm) {
+        final String passwordClear = "12345abcDEF!$";
+        final GlibcCryptPasswordEncoder encoder = new GlibcCryptPasswordEncoder(algorithm, 0, null);
+        // Encode
+        final String passwordHash = encoder.encode(passwordClear);
+        LOGGER.debug("Password [{}] was encoded by algorithm [{}] to hash [{}]", passwordClear, algorithm, passwordHash);
+        // Match
+        final boolean match = encoder.matches(passwordClear, passwordHash);
+        LOGGER.debug("Encoded password [{}] matches original password [{}]: {}", passwordClear, passwordHash, match);
+        // Check
+        assertTrue(match);
+    }
+
+}

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoderTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoderTests.java
@@ -14,42 +14,53 @@ import static org.junit.Assert.*;
 @Slf4j
 public class GlibcCryptPasswordEncoderTests {
 
+    private final String passwordClear = "12345abcDEF!$";
+
     @Test
     public void sha512EncodingTest() {
-        testEncoding("SHA-512");
-        testEncoding("6");
+        assertTrue(testEncodingRoundtrip("SHA-512"));
+        assertTrue(testEncodingRoundtrip("6"));
+        assertTrue(testMatchWithDifferentSalt("SHA-512", "$6$rounds=1000$df273de606d3609a$GAPcq.K4jO3KkfusCM7Zr8Cci4qf.jOsWj5hkGBpwRg515bKk93afAXHy/lg.2LPr8ZItHoR3AR5X3XOXndZI0"));
     }
 
     @Test
     public void ha256EncodingTest() {
-        testEncoding("SHA-256");
-        testEncoding("5");
-    }
-    
-    @Test
-    public void md5EncodingTest() {
-        testEncoding("MD5");
-        testEncoding("1");
-    }
-    
-    @Test
-    public void desUnixCryptEncodingTest() {
-        testEncoding("aB");
-        testEncoding("42xyz");
-        testEncoding("");
+        assertTrue(testEncodingRoundtrip("SHA-256"));
+        assertTrue(testEncodingRoundtrip("5"));
+        assertTrue(testMatchWithDifferentSalt("SHA-256", "$5$rounds=1000$e98244bb01b64f47$2qphrK8axtGjgmCJFYwaH7czw5iK9feLl7tKjyTlDy0"));
     }
 
-    private void testEncoding(final String algorithm) {
-        final String passwordClear = "12345abcDEF!$";
+    @Test
+    public void md5EncodingTest() {
+        assertTrue(testEncodingRoundtrip("MD5"));
+        assertTrue(testEncodingRoundtrip("1"));
+        assertTrue(testMatchWithDifferentSalt("MD5", "$1$c4676fd0$HOHZ2CYp45lZAAQyvF4C21"));
+    }
+
+    @Test
+    public void desUnixCryptEncodingTest() {
+        assertTrue(testEncodingRoundtrip("aB"));
+        assertTrue(testEncodingRoundtrip("42xyz"));
+        assertTrue(testMatchWithDifferentSalt("aB", "aB4fMcNOggJoQ"));
+    }
+
+    private boolean testEncodingRoundtrip(final String algorithm) {
         final GlibcCryptPasswordEncoder encoder = new GlibcCryptPasswordEncoder(algorithm, 0, null);
         // Encode
         final String passwordHash = encoder.encode(passwordClear);
         LOGGER.debug("Password [{}] was encoded by algorithm [{}] to hash [{}]", passwordClear, algorithm, passwordHash);
         // Match
         final boolean match = encoder.matches(passwordClear, passwordHash);
-        LOGGER.debug("Encoded password [{}] matches original password [{}]: {}", passwordClear, passwordHash, match);
+        LOGGER.debug("Does password [{}] match original password [{}]: {}", passwordHash, passwordClear, match);
         // Check
-        assertTrue(match);
+        return match;
+    }
+
+    private boolean testMatchWithDifferentSalt(final String algorithm, final String encodedPassword) {
+        final GlibcCryptPasswordEncoder encoder = new GlibcCryptPasswordEncoder(algorithm, 0, null);
+        final boolean match = encoder.matches(passwordClear, encodedPassword);
+        LOGGER.debug("Does password [{}] match original password [{}]: {}", encodedPassword, passwordClear, match);
+        return match;
     }
 
 }

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoderTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/crypto/GlibcCryptPasswordEncoderTests.java
@@ -15,25 +15,25 @@ import static org.junit.Assert.*;
 public class GlibcCryptPasswordEncoderTests {
 
     @Test
-    public void testSha512Encoding() {
+    public void sha512EncodingTest() {
         testEncoding("SHA-512");
         testEncoding("6");
     }
 
     @Test
-    public void testSha256Encoding() {
+    public void ha256EncodingTest() {
         testEncoding("SHA-256");
         testEncoding("5");
     }
     
     @Test
-    public void testMd5Encoding() {
+    public void md5EncodingTest() {
         testEncoding("MD5");
         testEncoding("1");
     }
     
     @Test
-    public void testDesUnixCryptEncoding() {
+    public void desUnixCryptEncodingTest() {
         testEncoding("aB");
         testEncoding("42xyz");
         testEncoding("");

--- a/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/installation/Configuration-Properties-Common.md
@@ -116,8 +116,9 @@ The following options are supported:
 | `DEFAULT`               | Use the `DefaultPasswordEncoder` of CAS. For message-digest algorithms via `characterEncoding` and `encodingAlgorithm`.
 | `BCRYPT`                | Use the `BCryptPasswordEncoder` based on the `strength` provided and an optional `secret`.     
 | `SCRYPT`                | Use the `SCryptPasswordEncoder`.
-| `PBKDF2`                | Use the `Pbkdf2PasswordEncoder` based on the `strength` provided and an optional `secret`.  
-| `STANDARD`              | Use the `StandardPasswordEncoder` based on the `secret` provided.  
+| `PBKDF2`                | Use the `Pbkdf2PasswordEncoder` based on the `strength` provided and an optional `secret`.
+| `STANDARD`              | Use the `StandardPasswordEncoder` based on the `secret` provided.
+| `GLIBC_CRYPT`           | Use the `GlibcCryptPasswordEncoder` based on the [`encodingAlgorithm`](https://commons.apache.org/proper/commons-codec/archives/1.10/apidocs/org/apache/commons/codec/digest/Crypt.html), `strength` provided and an optional `secret`.
 | `org.example.MyEncoder` | An implementation of `PasswordEncoder` of your own choosing.
 | `file:///path/to/script.groovy` | Path to a Groovy script charged with handling password encoding operations.
 


### PR DESCRIPTION
I've come across a use case where it is handy to be able to encrypt / hash passwords in CAS like an LDAP-Directory would do using glibc crypt.

This PR adds a corresponding password encoder based on the Apache Codec [`Crypt`](https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/digest/Crypt.java) class.

What do you think?