### PR TITLE
Lacking interruptSkipped transition

### DIFF
--- a/support/cas-server-support-interrupt-webflow/src/main/java/org/apereo/cas/interrupt/webflow/InterruptWebflowConfigurer.java
+++ b/support/cas-server-support-interrupt-webflow/src/main/java/org/apereo/cas/interrupt/webflow/InterruptWebflowConfigurer.java
@@ -97,7 +97,7 @@ public class InterruptWebflowConfigurer extends AbstractCasWebflowConfigurer {
 
         val target = getRealSubmissionState(flow).getTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS).getTargetStateId();
 
-        val noInterruptTransition = createTransition(CasWebflowConstants.TRANSITION_ID_INTERRUPT_REQUIRED, target);
+        val noInterruptTransition = createTransition(CasWebflowConstants.TRANSITION_ID_INTERRUPT_SKIPPED, target);
         val transitionSet = inquireState.getTransitionSet();
         transitionSet.add(noInterruptTransition);
 


### PR DESCRIPTION
I've encountered following exception:

No transition was matched on the event(s) signaled by the [1] action(s) that executed in this action state 'inquireInterruptAction' of flow 'login'; transitions must be defined to handle action result outcomes -- possible flow configuration error? Note: the eventIds signaled were: 'array<String>['interruptSkipped']', while the supported set of transitional criteria for this action state is 'array<TransitionCriteria>[interruptRequired, interruptRequired]'

I believe InquireInterruptAction has the 'interruptRequired' transition attached twice and no 'interruptSkipped' at all.
