### PR TITLE
Have pac4j delegatedClient endpoint accept HTTP POST requests

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
@@ -102,7 +102,7 @@ public class DelegatedClientNavigationController {
      * @param response   the response
      * @return the view
      */
-    @GetMapping(ENDPOINT_RESPONSE)
+    @RequestMapping(ENDPOINT_RESPONSE)
     public View redirectResponseToFlow(@PathVariable("clientName") final String clientName, final HttpServletRequest request, final HttpServletResponse response) {
         return buildRedirectViewBackToFlow(clientName, request);
     }

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientNavigationController.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -102,7 +103,7 @@ public class DelegatedClientNavigationController {
      * @param response   the response
      * @return the view
      */
-    @RequestMapping(ENDPOINT_RESPONSE)
+    @RequestMapping(value = ENDPOINT_RESPONSE, method = { RequestMethod.GET, RequestMethod.POST })
     public View redirectResponseToFlow(@PathVariable("clientName") final String clientName, final HttpServletRequest request, final HttpServletResponse response) {
         return buildRedirectViewBackToFlow(clientName, request);
     }


### PR DESCRIPTION
**- [] Brief description of changes applied**
I'm using cas 6.0.3 with OIDC and Azure Active Directory as a provider.

After sucessful authentication in the provider I'm redirected back to cas, but the call in to handled because
the endpoint only accepts HTTP GET calls.

**- [] Test cases for all modified changes, where applicable**
Before the changes I received an exception
`org.springframework.web.HttpRequestMethodNotSupportedException: Request method 'POST' not supported`
Which does not occur anymore after the changes

**- [] The same pull request targetted at the master branch, if applicable**
N/A

**- [] Any documentation on how to configure, test**
This is the relevant configuration for the provider:
- azure:
    id: {my-id}
    secret: {my-secret}
    tenant: {my-tenant}
    clientName: AZURE
    autoRedirect: false
    discoveryUri: https://login.microsoftonline.com/{my-tenant}/.well-known/openid-configuration
    logoutUrl: https://login.microsoftonline.com/{my-tenant}/oauth2/logout
    maxClockSkew: 5
    scope: openid profile email
    useNonce: true
    preferredJwsAlgorithm: RS256
    responseMode: form_post
    responseType: id_token

**- [] Any possible limitations, side effects, etc**
Can't think of any

**- [] Reference any other pull requests that might be related**
N/A