### PR TITLE
recaptcha: Add required class to automatically bind the challenge to …

### DIFF
--- a/webapp/resources/templates/fragments/loginform.html
+++ b/webapp/resources/templates/fragments/loginform.html
@@ -156,7 +156,7 @@
                                    type="submit"
                                    value="Login3"
                             />
-                            <button class="btn btn-block btn-submit"
+                            <button class="btn btn-block btn-submit g-recaptcha"
                                     th:if="${recaptchaSiteKey != null AND recaptchaInvisible != null AND recaptchaInvisible}"
                                     th:attr="data-sitekey=${recaptchaSiteKey}, data-badge=${recaptchaPosition}"
                                     data-callback="onRecaptchaV2Submit"


### PR DESCRIPTION
**- [] Brief description of changes applied**
When using the invisible catpcha V2, the captcha badge is not displayed and the cchallenge is not bound correctly. See required attributes on the documentation:
https://developers.google.com/recaptcha/docs/invisible#auto_render

**- [] Test cases for all modified changes, where applicable**
Without the changes, captcha validation fails

**- [] The same pull request targetted at the master branch, if applicable**
N/A

**- [] Any documentation on how to configure, test**

```
googleRecaptcha:
        enabled: true
        invisible: true
        position: bottomright
        secret: {my-secret}
        siteKey: {my-key}
        verifyUrl: https://www.google.com/recaptcha/api/siteverify
```

**- [] Any possible limitations, side effects, etc**
Not that I am aware

**- [] Reference any other pull requests that might be related**
N/A

