### PR TITLE
WIP: Introduce reusable configuration holder object

### DIFF
--- a/core/cas-server-core-webflow-mfa/src/test/java/org/apereo/cas/BaseCasWebflowMultifactorAuthenticationTests.java
+++ b/core/cas-server-core-webflow-mfa/src/test/java/org/apereo/cas/BaseCasWebflowMultifactorAuthenticationTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas;
 
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -75,7 +76,8 @@ import org.springframework.test.annotation.DirtiesContext;
     CasPersonDirectoryTestConfiguration.class,
     CasCoreWebflowConfiguration.class,
     CasCoreValidationConfiguration.class,
-    AdaptiveMultifactorAuthenticationPolicyEventResolverTests.GeoLocationServiceTestConfiguration.class
+    AdaptiveMultifactorAuthenticationPolicyEventResolverTests.GeoLocationServiceTestConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableAspectJAutoProxy
 @DirtiesContext

--- a/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.ContextualAuthenticationPolicyFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.Service;
+import org.apereo.cas.config.CasCommonComponents;
 import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServiceContext;
@@ -19,7 +20,6 @@ import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.UnsatisfiedAuthenticationPolicyException;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.Synchronized;
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @Setter
-@AllArgsConstructor
 public abstract class AbstractCentralAuthenticationService implements CentralAuthenticationService, Serializable, ApplicationEventPublisherAware {
 
     private static final long serialVersionUID = -7572316677901391166L;
@@ -102,6 +101,22 @@ public abstract class AbstractCentralAuthenticationService implements CentralAut
      * since the access strategy is not usually managed as a Spring bean.
      */
     protected final AuditableExecution registeredServiceAccessStrategyEnforcer;
+
+    @SuppressWarnings("Unchecked")
+    public AbstractCentralAuthenticationService(final CasCommonComponents casCommonComponents,
+                                                final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies,
+                                                final ContextualAuthenticationPolicyFactory<ServiceContext> serviceContextAuthenticationPolicyFactory) {
+
+        this.ticketRegistry = casCommonComponents.getTicketRegistry();
+        this.servicesManager = casCommonComponents.getServicesManager();
+        this.logoutManager = casCommonComponents.getLogoutManager();
+        this.ticketFactory = casCommonComponents.getTicketFactory();
+        this.authenticationRequestServiceSelectionStrategies = authenticationRequestServiceSelectionStrategies;
+        this.serviceContextAuthenticationPolicyFactory = serviceContextAuthenticationPolicyFactory;
+        this.principalFactory = casCommonComponents.getPrincipalFactory();
+        this.cipherExecutor = casCommonComponents.getProtocolTicketCipherExecutor();
+        this.registeredServiceAccessStrategyEnforcer = casCommonComponents.getRegisteredServiceAccessStrategyEnforcer();
+    }
 
     /**
      * Publish CAS events.

--- a/core/cas-server-core/src/main/java/org/apereo/cas/DefaultCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/DefaultCentralAuthenticationService.java
@@ -1,7 +1,6 @@
 package org.apereo.cas;
 
 import org.apereo.cas.audit.AuditableContext;
-import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.AuthenticationCredentialsThreadLocalBinder;
 import org.apereo.cas.authentication.AuthenticationException;
@@ -11,14 +10,12 @@ import org.apereo.cas.authentication.ContextualAuthenticationPolicyFactory;
 import org.apereo.cas.authentication.DefaultAuthenticationBuilder;
 import org.apereo.cas.authentication.PrincipalException;
 import org.apereo.cas.authentication.exceptions.MixedPrincipalException;
-import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.Service;
-import org.apereo.cas.logout.LogoutManager;
+import org.apereo.cas.config.CasCommonComponents;
 import org.apereo.cas.logout.slo.SingleLogoutRequest;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceAccessStrategyUtils;
 import org.apereo.cas.services.ServiceContext;
-import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.services.UnauthorizedProxyingException;
 import org.apereo.cas.services.UnauthorizedSsoServiceException;
 import org.apereo.cas.support.events.ticket.CasProxyGrantingTicketCreatedEvent;
@@ -31,7 +28,6 @@ import org.apereo.cas.ticket.AbstractTicketException;
 import org.apereo.cas.ticket.InvalidTicketException;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.ServiceTicketFactory;
-import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketFactory;
 import org.apereo.cas.ticket.UnrecognizableServiceForServiceTicketValidationException;
@@ -39,7 +35,6 @@ import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.proxy.ProxyGrantingTicketFactory;
 import org.apereo.cas.ticket.proxy.ProxyTicket;
 import org.apereo.cas.ticket.proxy.ProxyTicketFactory;
-import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.util.DigestUtils;
 import org.apereo.cas.validation.Assertion;
 import org.apereo.cas.validation.DefaultAssertionBuilder;
@@ -47,7 +42,6 @@ import org.apereo.cas.validation.DefaultAssertionBuilder;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.audit.annotation.Audit;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -72,19 +66,11 @@ public class DefaultCentralAuthenticationService extends AbstractCentralAuthenti
 
     private final transient Object serviceTicketValidationLock = new Object();
 
-    public DefaultCentralAuthenticationService(final ApplicationEventPublisher applicationEventPublisher,
-                                               final TicketRegistry ticketRegistry,
-                                               final ServicesManager servicesManager,
-                                               final LogoutManager logoutManager,
-                                               final TicketFactory ticketFactory,
+    public DefaultCentralAuthenticationService(final CasCommonComponents casCommonComponents,
                                                final AuthenticationServiceSelectionPlan authenticationRequestServiceSelectionStrategies,
-                                               final ContextualAuthenticationPolicyFactory<ServiceContext> serviceContextAuthenticationPolicyFactory,
-                                               final PrincipalFactory principalFactory,
-                                               final CipherExecutor<String, String> cipherExecutor,
-                                               final AuditableExecution registeredServiceAccessStrategyEnforcer) {
-        super(applicationEventPublisher, ticketRegistry, servicesManager, logoutManager, ticketFactory,
-            authenticationRequestServiceSelectionStrategies, serviceContextAuthenticationPolicyFactory,
-            principalFactory, cipherExecutor, registeredServiceAccessStrategyEnforcer);
+                                               final ContextualAuthenticationPolicyFactory<ServiceContext> serviceContextAuthenticationPolicyFactory
+                                               ) {
+        super(casCommonComponents, authenticationRequestServiceSelectionStrategies, serviceContextAuthenticationPolicyFactory);
     }
 
     @Audit(

--- a/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponents.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponents.java
@@ -1,0 +1,47 @@
+package org.apereo.cas.config;
+
+import org.apereo.cas.CipherExecutor;
+import org.apereo.cas.audit.AuditableExecution;
+import org.apereo.cas.authentication.principal.PrincipalFactory;
+import org.apereo.cas.logout.LogoutManager;
+import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.ticket.TicketFactory;
+import org.apereo.cas.ticket.registry.TicketRegistry;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * Class encapsulating references to core internal components used throughout CAS server.
+ *
+ * The purpose is to reduce complexity of big argument lists constructors of CAS classes needing these objects.
+ *
+ * Typical usage of this class is at Spring constructor injection sites for beans needing these common components which
+ * will reduce the size of exposed constructors, etc.
+ *
+ * @author Dmitriy Kopylenko
+ * @since 6.1.0
+ */
+@RequiredArgsConstructor
+@Getter
+public class CasCommonComponents {
+
+    private final AuditableExecution registeredServiceAccessStrategyEnforcer;
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    private final TicketRegistry ticketRegistry;
+
+    private final ServicesManager servicesManager;
+
+    private final LogoutManager logoutManager;
+
+    private final TicketFactory ticketFactory;
+
+    private final PrincipalFactory principalFactory;
+
+    private final CipherExecutor protocolTicketCipherExecutor;
+
+}

--- a/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponentsConfiguration.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponentsConfiguration.java
@@ -1,0 +1,71 @@
+package org.apereo.cas.config;
+
+import org.apereo.cas.CipherExecutor;
+import org.apereo.cas.audit.AuditableExecution;
+import org.apereo.cas.authentication.principal.PrincipalFactory;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.logout.LogoutManager;
+import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.ticket.TicketFactory;
+import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configuration class for {@link CasCommonComponents}.
+ *
+ * @author Dmitriy Kopylenko
+ * @since 6.1.0
+ */
+public class CasCommonComponentsConfiguration {
+
+    @Autowired
+    @Qualifier("registeredServiceAccessStrategyEnforcer")
+    private ObjectProvider<AuditableExecution> registeredServiceAccessStrategyEnforcer;
+
+    @Autowired
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    private CasConfigurationProperties casProperties;
+
+    @Autowired
+    @Qualifier("ticketRegistry")
+    private ObjectProvider<TicketRegistry> ticketRegistry;
+
+    @Autowired
+    @Qualifier("servicesManager")
+    private ObjectProvider<ServicesManager> servicesManager;
+
+    @Autowired
+    @Qualifier("logoutManager")
+    private ObjectProvider<LogoutManager> logoutManager;
+
+    @Autowired
+    @Qualifier("defaultTicketFactory")
+    private ObjectProvider<TicketFactory> ticketFactory;
+
+    @Autowired
+    @Qualifier("principalFactory")
+    private ObjectProvider<PrincipalFactory> principalFactory;
+
+    @Autowired
+    @Qualifier("protocolTicketCipherExecutor")
+    private ObjectProvider<CipherExecutor> protocolTicketCipherExecutor;
+
+    @Bean
+    public CasCommonComponents casCommonComponents() {
+        return new CasCommonComponents(
+                registeredServiceAccessStrategyEnforcer.getIfAvailable(),
+                applicationEventPublisher,
+                ticketRegistry.getIfAvailable(),
+                servicesManager.getIfAvailable(),
+                logoutManager.getIfAvailable(),
+                ticketFactory.getIfAvailable(),
+                principalFactory.getIfAvailable(),
+                protocolTicketCipherExecutor.getIfAvailable());
+    }
+}

--- a/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponentsConfiguration.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponentsConfiguration.java
@@ -30,9 +30,6 @@ public class CasCommonComponentsConfiguration {
     private ApplicationEventPublisher applicationEventPublisher;
 
     @Autowired
-    private CasConfigurationProperties casProperties;
-
-    @Autowired
     @Qualifier("ticketRegistry")
     private ObjectProvider<TicketRegistry> ticketRegistry;
 

--- a/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponentsConfiguration.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCommonComponentsConfiguration.java
@@ -3,7 +3,6 @@ package org.apereo.cas.config;
 import org.apereo.cas.CipherExecutor;
 import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
-import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.TicketFactory;

--- a/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCoreConfiguration.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/config/CasCoreConfiguration.java
@@ -1,32 +1,25 @@
 package org.apereo.cas.config;
 
 import org.apereo.cas.CentralAuthenticationService;
-import org.apereo.cas.CipherExecutor;
 import org.apereo.cas.DefaultCentralAuthenticationService;
-import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionStrategyConfigurer;
 import org.apereo.cas.authentication.ContextualAuthenticationPolicyFactory;
 import org.apereo.cas.authentication.DefaultAuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.policy.AcceptAnyAuthenticationPolicyFactory;
 import org.apereo.cas.authentication.policy.RequiredHandlerAuthenticationPolicyFactory;
-import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.services.ServiceContext;
-import org.apereo.cas.services.ServicesManager;
-import org.apereo.cas.ticket.TicketFactory;
-import org.apereo.cas.ticket.registry.TicketRegistry;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+
 import org.apache.commons.lang3.RegExUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -46,38 +39,11 @@ import java.util.List;
 public class CasCoreConfiguration {
 
     @Autowired
-    @Qualifier("registeredServiceAccessStrategyEnforcer")
-    private ObjectProvider<AuditableExecution> registeredServiceAccessStrategyEnforcer;
-
-    @Autowired
-    private ApplicationEventPublisher applicationEventPublisher;
-
-    @Autowired
     private CasConfigurationProperties casProperties;
 
     @Autowired
-    @Qualifier("ticketRegistry")
-    private ObjectProvider<TicketRegistry> ticketRegistry;
-
-    @Autowired
-    @Qualifier("servicesManager")
-    private ObjectProvider<ServicesManager> servicesManager;
-
-    @Autowired
-    @Qualifier("logoutManager")
-    private ObjectProvider<LogoutManager> logoutManager;
-
-    @Autowired
-    @Qualifier("defaultTicketFactory")
-    private ObjectProvider<TicketFactory> ticketFactory;
-
-    @Autowired
-    @Qualifier("principalFactory")
-    private ObjectProvider<PrincipalFactory> principalFactory;
-
-    @Autowired
-    @Qualifier("protocolTicketCipherExecutor")
-    private ObjectProvider<CipherExecutor> cipherExecutor;
+    @Qualifier("casCommonComponents")
+    private ObjectProvider<CasCommonComponents> casCommonComponents;
 
     @Bean
     @ConditionalOnMissingBean(name = "authenticationPolicyFactory")
@@ -107,16 +73,11 @@ public class CasCoreConfiguration {
     @Autowired
     @ConditionalOnMissingBean(name = "centralAuthenticationService")
     public CentralAuthenticationService centralAuthenticationService(
-        @Qualifier("authenticationServiceSelectionPlan") final AuthenticationServiceSelectionPlan authenticationServiceSelectionPlan) {
-        return new DefaultCentralAuthenticationService(applicationEventPublisher,
-            ticketRegistry.getIfAvailable(),
-            servicesManager.getIfAvailable(),
-            logoutManager.getIfAvailable(),
-            ticketFactory.getIfAvailable(),
-            authenticationServiceSelectionPlan,
-            authenticationPolicyFactory(),
-            principalFactory.getIfAvailable(),
-            cipherExecutor.getIfAvailable(),
-            registeredServiceAccessStrategyEnforcer.getIfAvailable());
+            @Qualifier("authenticationServiceSelectionPlan") final AuthenticationServiceSelectionPlan authenticationServiceSelectionPlan) {
+
+        return new DefaultCentralAuthenticationService(
+                casCommonComponents.getIfAvailable(),
+                authenticationServiceSelectionPlan,
+                authenticationPolicyFactory());
     }
 }

--- a/core/cas-server-core/src/main/resources/META-INF/spring.factories
+++ b/core/cas-server-core/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.config.CasCoreConfiguration,\
-org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration
+    org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration,\
+    org.apereo.cas.config.CasCommonComponentsConfiguration
+

--- a/core/cas-server-core/src/test/java/org/apereo/cas/BaseCasCoreTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/BaseCasCoreTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas;
 
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -73,7 +74,8 @@ import org.springframework.test.annotation.DirtiesContext;
     AopAutoConfiguration.class,
     CasPersonDirectoryTestConfiguration.class,
     CasCoreWebflowConfiguration.class,
-    CasCoreValidationConfiguration.class
+    CasCoreValidationConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableAspectJAutoProxy
 @DirtiesContext

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceMockitoTests.java
@@ -14,6 +14,7 @@ import org.apereo.cas.authentication.policy.AcceptAnyAuthenticationPolicyFactory
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactory;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
+import org.apereo.cas.config.CasCommonComponents;
 import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.services.DefaultRegisteredServiceAccessStrategy;
 import org.apereo.cas.services.DefaultRegisteredServiceUsernameProvider;
@@ -175,18 +176,22 @@ public class DefaultCentralAuthenticationServiceMockitoTests extends BaseCasCore
         val authenticationRequestServiceSelectionStrategies = new DefaultAuthenticationServiceSelectionPlan(new DefaultAuthenticationServiceSelectionStrategy());
         val enforcer = mock(AuditableExecution.class);
         when(enforcer.execute(any())).thenReturn(new AuditableExecutionResult());
+        val eventPublisher = mock(ApplicationEventPublisher.class);
+        val common = new CasCommonComponents(
+                enforcer,
+                eventPublisher,
+                ticketRegMock,
+                smMock,
+                mock(LogoutManager.class),
+                factory,
+                new DefaultPrincipalFactory(),
+                CipherExecutor.noOpOfStringToString());
+
         this.cas = new DefaultCentralAuthenticationService(
-            mock(ApplicationEventPublisher.class),
-            ticketRegMock,
-            smMock,
-            mock(LogoutManager.class),
-            factory,
-            authenticationRequestServiceSelectionStrategies,
-            new AcceptAnyAuthenticationPolicyFactory(),
-            new DefaultPrincipalFactory(),
-            CipherExecutor.noOpOfStringToString(),
-            enforcer);
-        this.cas.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+                common,
+                authenticationRequestServiceSelectionStrategies,
+                new AcceptAnyAuthenticationPolicyFactory());
+        this.cas.setApplicationEventPublisher(eventPublisher);
     }
 
     private static TicketFactory getTicketFactory() {

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
@@ -419,7 +419,7 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
         registry.addTicket(tgt);
         val commonComponents = new CasCommonComponents(
                 mock(AuditableExecution.class), null, registry, null,
-                logoutManager, null, null,null);
+                logoutManager, null, null, null);
 
         val cas = new DefaultCentralAuthenticationService(commonComponents,
                 null, null);

--- a/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/DefaultCentralAuthenticationServiceTests.java
@@ -11,6 +11,7 @@ import org.apereo.cas.authentication.exceptions.MixedPrincipalException;
 import org.apereo.cas.authentication.principal.AbstractWebApplicationService;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
+import org.apereo.cas.config.CasCommonComponents;
 import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.UnauthorizedServiceException;
@@ -416,11 +417,15 @@ public class DefaultCentralAuthenticationServiceTests extends AbstractCentralAut
                 return null;
             });
         registry.addTicket(tgt);
-        val cas = new DefaultCentralAuthenticationService(
-            mock(ApplicationEventPublisher.class), registry, null, logoutManager,
-            null, null,
-            null, null, null,
-            mock(AuditableExecution.class));
+        val commonComponents = new CasCommonComponents(
+                mock(AuditableExecution.class), null, registry, null,
+                logoutManager, null, null,null);
+
+        val cas = new DefaultCentralAuthenticationService(commonComponents,
+                null, null);
+
+        cas.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+
         cas.destroyTicketGrantingTicket(tgt.getId());
     }
 }

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionSsoTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionSsoTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -78,7 +79,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreUtilConfiguration.class,
     CasCookieConfiguration.class,
     RefreshAutoConfiguration.class,
-    CasCoreServicesConfiguration.class
+    CasCoreServicesConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
 @TestPropertySource(properties = "cas.sso.allowMissingServiceParameter=false")

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -57,7 +58,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreWebConfiguration.class,
     CasCoreWebflowConfiguration.class,
     CasWebflowContextConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public class InitialFlowSetupActionTests extends AbstractWebflowActionsTests {
     @Autowired

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/SendTicketGrantingTicketActionSsoTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/SendTicketGrantingTicketActionSsoTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.web.flow;
 
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.principal.WebApplicationService;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -67,7 +68,8 @@ import static org.mockito.Mockito.*;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
-    CasCoreUtilConfiguration.class
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @TestPropertySource(properties = "cas.sso.createSsoCookieOnRenewAuthn=false")

--- a/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/aup/BaseAcceptableUsagePolicyRepositoryTests.java
+++ b/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/aup/BaseAcceptableUsagePolicyRepositoryTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.aup;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.config.CasAcceptableUsagePolicyWebflowConfiguration;
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
@@ -65,7 +66,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasAuthenticationEventExecutionPlanTestConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
+    CasCoreAuthenticationPrincipalConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public abstract class BaseAcceptableUsagePolicyRepositoryTests {
     @Autowired

--- a/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/web/flow/BaseAcceptableUsagePolicyActionTests.java
+++ b/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/web/flow/BaseAcceptableUsagePolicyActionTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.config.CasAcceptableUsagePolicyWebflowConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
@@ -43,7 +44,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasCoreTicketCatalogConfiguration.class,
     CasWebApplicationServiceFactoryConfiguration.class,
     CasCoreAuthenticationPrincipalConfiguration.class,
-    CasPersonDirectoryTestConfiguration.class
+    CasPersonDirectoryTestConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public abstract class BaseAcceptableUsagePolicyActionTests {
     public abstract void verifyAction() throws Exception;

--- a/support/cas-server-support-captcha/src/test/java/org/apereo/cas/web/flow/ValidateCaptchaActionTests.java
+++ b/support/cas-server-support-captcha/src/test/java/org/apereo/cas/web/flow/ValidateCaptchaActionTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -78,7 +79,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreLogoutConfiguration.class,
     CasCookieConfiguration.class,
     CasThemesConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 },
     properties = "cas.googleRecaptcha.verifyUrl=http://localhost:9294"
 )

--- a/support/cas-server-support-consent-webflow/src/test/java/org/apereo/cas/web/flow/BaseConsentActionTests.java
+++ b/support/cas-server-support-consent-webflow/src/test/java/org/apereo/cas/web/flow/BaseConsentActionTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasConsentCoreConfiguration;
 import org.apereo.cas.config.CasConsentWebflowConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
@@ -42,7 +43,8 @@ import org.springframework.webflow.execution.Action;
     CasCoreWebConfiguration.class,
     CasCoreHttpConfiguration.class,
     CasCoreUtilConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public abstract class BaseConsentActionTests {
     @Autowired

--- a/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerTests.java
+++ b/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication;
 
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
@@ -55,7 +56,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasAuthenticationEventExecutionPlanTestConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
+    CasCoreAuthenticationPrincipalConfiguration.class,
+        CasCommonComponentsConfiguration.class
 },
     properties = {"cas.authn.couchbase.password=password", "cas.authn.couchbase.bucket=testbucket"})
 public class CouchbaseAuthenticationHandlerTests {

--- a/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbasePersonAttributeDaoTests.java
+++ b/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbasePersonAttributeDaoTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication;
 
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
@@ -57,7 +58,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasAuthenticationEventExecutionPlanTestConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
+    CasCoreAuthenticationPrincipalConfiguration.class,
+        CasCommonComponentsConfiguration.class
 },
     properties = {"cas.authn.attributeRepository.couchbase.password=password", "cas.authn.attributeRepository.couchbase.bucket=testbucket"})
 public class CouchbasePersonAttributeDaoTests {

--- a/support/cas-server-support-couchbase-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistryTests.java
+++ b/support/cas-server-support-couchbase-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/CouchbaseTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -55,7 +56,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasCoreAuthenticationPrincipalConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    RefreshAutoConfiguration.class},
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class},
     properties = {"cas.ticket.registry.couchbase.password=password", "cas.ticket.registry.couchbase.bucket=testbucket"})
 public class CouchbaseTicketRegistryTests extends BaseTicketRegistryTests {
 

--- a/support/cas-server-support-couchdb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/CouchDbTicketRegistryTests.java
+++ b/support/cas-server-support-couchdb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/CouchDbTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -58,7 +59,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasCoreAuthenticationPrincipalConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 },
     properties = {
         "cas.ticket.registry.couchDb.username=cas",

--- a/support/cas-server-support-dynamodb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryFacilitatorTests.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryFacilitatorTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.ticket.registry;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -69,7 +70,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuthenticationPrincipalConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    RefreshAutoConfiguration.class})
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @Tag("DynamoDb")
 public class DynamoDbTicketRegistryFacilitatorTests {
 

--- a/support/cas-server-support-dynamodb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryTests.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistryTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.ticket.registry;
 
 import org.apereo.cas.CipherExecutor;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -73,7 +74,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuthenticationPrincipalConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(locations = "classpath:/dynamodb-ticketregistry.properties")
 //@EnabledIfContinuousIntegration

--- a/support/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
+++ b/support/cas-server-support-ehcache-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/EhCacheTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -62,7 +63,8 @@ import static org.mockito.Mockito.*;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CasCoreServicesConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 public class EhCacheTicketRegistryTests extends BaseTicketRegistryTests {
 
     @Autowired

--- a/support/cas-server-support-electrofence/src/test/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculatorTests.java
+++ b/support/cas-server-support-electrofence/src/test/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculatorTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.impl.calcs;
 import org.apereo.cas.api.AuthenticationRiskEvaluator;
 import org.apereo.cas.api.AuthenticationRiskNotifier;
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -79,7 +80,8 @@ import org.springframework.test.annotation.DirtiesContext;
     CasCoreUtilConfiguration.class,
     CasCoreAuditConfiguration.class,
     CasEventsInMemoryRepositoryConfiguration.class,
-    CasCoreEventsConfiguration.class})
+    CasCoreEventsConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @DirtiesContext
 @EnableScheduling
 public abstract class BaseAuthenticationRequestRiskCalculatorTests {

--- a/support/cas-server-support-gauth-couchdb/src/test/java/org/apereo/cas/gauth/credential/CouchDbGoogleAuthenticatorTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth-couchdb/src/test/java/org/apereo/cas/gauth/credential/CouchDbGoogleAuthenticatorTokenCredentialRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.gauth.credential;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -71,7 +72,8 @@ import org.springframework.test.context.ContextConfiguration;
         CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
         CasCoreUtilConfiguration.class,
         RefreshAutoConfiguration.class,
-        CasCoreWebConfiguration.class},
+        CasCoreWebConfiguration.class,
+            CasCommonComponentsConfiguration.class},
     properties = {
         "cas.authn.mfa.gauth.crypto.enabled=false",
         "cas.authn.mfa.gauth.couchDb.username=cas",

--- a/support/cas-server-support-gauth-couchdb/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorCouchDbTokenRepositoryTests.java
+++ b/support/cas-server-support-gauth-couchdb/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorCouchDbTokenRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.gauth.token;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -70,7 +71,8 @@ import org.springframework.test.context.ContextConfiguration;
         CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
         CasCoreUtilConfiguration.class,
         RefreshAutoConfiguration.class,
-        CasCoreWebConfiguration.class},
+        CasCoreWebConfiguration.class,
+            CasCommonComponentsConfiguration.class},
     properties = {
         "cas.authn.mfa.gauth.crypto.enabled=false",
         "cas.authn.mfa.gauth.couchDb.dbName=gauth_token",

--- a/support/cas-server-support-gauth-jpa/src/test/java/org/apereo/cas/gauth/credential/JpaGoogleAuthenticatorTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth-jpa/src/test/java/org/apereo/cas/gauth/credential/JpaGoogleAuthenticatorTokenCredentialRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.gauth.credential;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -68,7 +69,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     AopAutoConfiguration.class,
     RefreshAutoConfiguration.class,
-    CasCoreWebConfiguration.class},
+    CasCoreWebConfiguration.class,
+        CasCommonComponentsConfiguration.class},
     properties = "cas.authn.mfa.gauth.crypto.enabled=false")
 @EnableTransactionManagement(proxyTargetClass = true)
 @EnableAspectJAutoProxy(proxyTargetClass = true)

--- a/support/cas-server-support-gauth-jpa/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorJpaTokenRepositoryTests.java
+++ b/support/cas-server-support-gauth-jpa/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorJpaTokenRepositoryTests.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.gauth.token;
 
+import org.apereo.cas.config.CasCommonComponents;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -59,7 +61,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     AopAutoConfiguration.class,
     RefreshAutoConfiguration.class,
-    CasCoreWebConfiguration.class
+    CasCoreWebConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableTransactionManagement(proxyTargetClass = true)
 @EnableAspectJAutoProxy(proxyTargetClass = true)

--- a/support/cas-server-support-gauth-jpa/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorJpaTokenRepositoryTests.java
+++ b/support/cas-server-support-gauth-jpa/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorJpaTokenRepositoryTests.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.gauth.token;
 
-import org.apereo.cas.config.CasCommonComponents;
 import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;

--- a/support/cas-server-support-gauth-mongo/src/test/java/org/apereo/cas/gauth/credential/MongoDbGoogleAuthenticatorTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth-mongo/src/test/java/org/apereo/cas/gauth/credential/MongoDbGoogleAuthenticatorTokenCredentialRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.gauth.credential;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -75,7 +76,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CasCoreUtilConfiguration.class,
     RefreshAutoConfiguration.class,
-    CasCoreWebConfiguration.class})
+    CasCoreWebConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @EnableTransactionManagement(proxyTargetClass = true)
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 @TestPropertySource(properties = {

--- a/support/cas-server-support-gauth-mongo/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorMongoDbTokenRepositoryTests.java
+++ b/support/cas-server-support-gauth-mongo/src/test/java/org/apereo/cas/gauth/token/GoogleAuthenticatorMongoDbTokenRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.gauth.token;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -72,7 +73,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
         CasCoreUtilConfiguration.class,
         RefreshAutoConfiguration.class,
-        CasCoreWebConfiguration.class})
+        CasCoreWebConfiguration.class,
+            CasCommonComponentsConfiguration.class})
 @EnableTransactionManagement(proxyTargetClass = true)
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 @TestPropertySource(properties = {

--- a/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/JsonGoogleAuthenticatorTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/JsonGoogleAuthenticatorTokenCredentialRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.gauth.credential;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
@@ -38,7 +39,8 @@ import java.io.File;
     CasCoreTicketsConfiguration.class,
     CasCookieConfiguration.class,
     CasCoreConfiguration.class,
-    CasCoreUtilConfiguration.class
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class
     },
     properties = {"cas.authn.mfa.gauth.json.location=classpath:/repository.json"})
 @Getter

--- a/support/cas-server-support-generic-remote-webflow/src/test/java/org/apereo/cas/adaptors/generic/remote/RemoteAddressAuthenticationHandlerTests.java
+++ b/support/cas-server-support-generic-remote-webflow/src/test/java/org/apereo/cas/adaptors/generic/remote/RemoteAddressAuthenticationHandlerTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.adaptors.generic.remote;
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPolicyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
@@ -66,7 +67,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasAuthenticationEventExecutionPlanTestConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
+    CasCoreAuthenticationPrincipalConfiguration.class,
+        CasCommonComponentsConfiguration.class
 },
     properties = "cas.authn.remoteAddress.ipAddressRange=192.168.1.0/255.255.255.0")
 public class RemoteAddressAuthenticationHandlerTests {

--- a/support/cas-server-support-grouper/src/test/java/org/apereo/cas/web/flow/GrouperMultifactorAuthenticationPolicyEventResolverTests.java
+++ b/support/cas-server-support-grouper/src/test/java/org/apereo/cas/web/flow/GrouperMultifactorAuthenticationPolicyEventResolverTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.web.flow;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.mfa.TestMultifactorAuthenticationProvider;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -74,7 +75,8 @@ import static org.mockito.Mockito.*;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CasCoreUtilConfiguration.class,
     GrouperMultifactorAuthenticationPolicyEventResolverTests.GrouperTestConfiguration.class,
-    GrouperMultifactorAuthenticationConfiguration.class
+    GrouperMultifactorAuthenticationConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = "cas.authn.mfa.grouperGroupField=name")
 public class GrouperMultifactorAuthenticationPolicyEventResolverTests {

--- a/support/cas-server-support-gua/src/test/java/org/apereo/cas/web/flow/AbstractGraphicalAuthenticationActionTests.java
+++ b/support/cas-server-support-gua/src/test/java/org/apereo/cas/web/flow/AbstractGraphicalAuthenticationActionTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -62,7 +63,8 @@ import org.springframework.webflow.execution.Action;
     RefreshAutoConfiguration.class,
     CasCookieConfiguration.class,
     CasCoreHttpConfiguration.class,
-    CasCoreUtilConfiguration.class
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = "cas.authn.gua.resource.location=classpath:image.jpg")
 public abstract class AbstractGraphicalAuthenticationActionTests {

--- a/support/cas-server-support-hazelcast-monitor/src/test/java/org/apereo/cas/monitor/HazelcastHealthIndicatorTests.java
+++ b/support/cas-server-support-hazelcast-monitor/src/test/java/org/apereo/cas/monitor/HazelcastHealthIndicatorTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.monitor;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -68,7 +69,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreServicesConfiguration.class,
     CasCoreLogoutConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {"cas.ticket.registry.hazelcast.cluster.instanceName=testlocalmonitor"})
 public class HazelcastHealthIndicatorTests {

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DefaultHazelcastInstanceConfigurationTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DefaultHazelcastInstanceConfigurationTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -72,7 +73,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreServicesConfiguration.class,
     CasCoreLogoutConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
 @DirtiesContext
 @Slf4j

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -57,7 +58,8 @@ import org.springframework.test.context.TestPropertySource;
     CasCoreServicesConfiguration.class,
     CasCoreLogoutConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {"cas.ticket.registry.hazelcast.cluster.instanceName=testlocalhostinstance"})
 public class HazelcastTicketRegistryTests extends BaseTicketRegistryTests {

--- a/support/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -58,7 +59,8 @@ import org.springframework.test.context.TestPropertySource;
     CasCoreServicesConfiguration.class,
     CasCoreLogoutConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {
     "cas.ticket.registry.ignite.ticketsCache.writeSynchronizationMode=FULL_ASYNC",

--- a/support/cas-server-support-jms-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JmsTicketRegistryTests.java
+++ b/support/cas-server-support-jms-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JmsTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -55,7 +56,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasCoreAuthenticationPrincipalConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 },
     properties = {"spring.activemq.pool.enabled=false", "spring.activemq.packages.trust-all=true"})
 public class JmsTicketRegistryTests extends BaseTicketRegistryTests {

--- a/support/cas-server-support-jms-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/queue/AbstractTicketMessageQueueCommandTests.java
+++ b/support/cas-server-support-jms-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/queue/AbstractTicketMessageQueueCommandTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry.queue;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -52,7 +53,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     AopAutoConfiguration.class,
     RefreshAutoConfiguration.class,
-    CasCoreWebConfiguration.class})
+    CasCoreWebConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 public abstract class AbstractTicketMessageQueueCommandTests {
     @Autowired
     @Qualifier("ticketRegistry")

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/monitor/SessionHealthIndicatorJpaTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/monitor/SessionHealthIndicatorJpaTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.monitor;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -78,7 +79,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreTicketsConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
 public class SessionHealthIndicatorJpaTests {
     private static final ExpirationPolicy TEST_EXP_POLICY = new HardTimeoutExpirationPolicy(10000);

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JpaTicketRegistryCleanerTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JpaTicketRegistryCleanerTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -78,7 +79,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreTicketsConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
 @Transactional(transactionManager = "ticketTransactionManager", isolation = Isolation.SERIALIZABLE, propagation = Propagation.REQUIRED)

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JpaTicketRegistryTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/JpaTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -63,7 +64,8 @@ import org.springframework.transaction.annotation.Transactional;
     CasCoreTicketsConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
 @Transactional(transactionManager = "ticketTransactionManager", isolation = Isolation.SERIALIZABLE, propagation = Propagation.REQUIRED)

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/JpaLockingStrategyTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/support/JpaLockingStrategyTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry.support;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPolicyConfiguration;
@@ -86,7 +87,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreTicketCatalogConfiguration.class,
     CasPersonDirectoryConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
 @DirtiesContext
 @Slf4j

--- a/support/cas-server-support-mongo-monitor/src/test/java/org/apereo/cas/monitor/MongoDbHealthIndicatorTests.java
+++ b/support/cas-server-support-mongo-monitor/src/test/java/org/apereo/cas/monitor/MongoDbHealthIndicatorTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.monitor;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -69,7 +70,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreServicesConfiguration.class,
     CasCoreLogoutConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {
     "cas.monitor.mongo.userId=root",

--- a/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -65,7 +66,8 @@ import org.springframework.test.context.TestPropertySource;
     CasCoreTicketCatalogConfiguration.class,
     CasCoreTicketsSerializationConfiguration.class,
     CasCoreWebConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableScheduling
 @TestPropertySource(properties = {

--- a/support/cas-server-support-oauth-webflow/src/test/java/org/apereo/cas/support/oauth/web/flow/OAuth20RegisteredServiceUIActionTests.java
+++ b/support/cas-server-support-oauth-webflow/src/test/java/org/apereo/cas/support/oauth/web/flow/OAuth20RegisteredServiceUIActionTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.oauth.web.flow;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -80,7 +81,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreServicesAuthenticationConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CasOAuthAuthenticationServiceSelectionStrategyConfiguration.class,
-    CasOAuthWebflowConfiguration.class})
+    CasOAuthWebflowConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 public class OAuth20RegisteredServiceUIActionTests {
     @Autowired
     @Qualifier("oauth20RegisteredServiceUIAction")

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/AbstractOAuth20Tests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/AbstractOAuth20Tests.java
@@ -10,6 +10,7 @@ import org.apereo.cas.authentication.credential.BasicIdentifiableCredential;
 import org.apereo.cas.authentication.metadata.BasicCredentialMetaData;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -139,7 +140,8 @@ import static org.junit.jupiter.api.Assertions.*;
     RefreshAutoConfiguration.class,
     CasCoreLogoutConfiguration.class,
     CasCoreUtilConfiguration.class,
-    CasCoreWebConfiguration.class})
+    CasCoreWebConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @DirtiesContext
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/BaseOAuthExpirationPolicyTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/BaseOAuthExpirationPolicyTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.ticket;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
@@ -62,7 +63,8 @@ import java.util.ArrayList;
     CasCoreLogoutConfiguration.class,
     CasOAuthComponentSerializationConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasOAuthAuthenticationServiceSelectionStrategyConfiguration.class
+    CasOAuthAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public abstract class BaseOAuthExpirationPolicyTests {
     protected static final File JSON_FILE = new File(FileUtils.getTempDirectoryPath(), "oAuthTokenExpirationPolicy.json");

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.oidc;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -100,7 +101,8 @@ import java.util.Optional;
     CasOAuthThrottleConfiguration.class,
     CasMultifactorAuthenticationWebflowConfiguration.class,
     CasOAuthAuthenticationServiceSelectionStrategyConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @DirtiesContext
 @Tag("FileSystem")

--- a/support/cas-server-support-openid/src/test/java/org/apereo/cas/support/openid/AbstractOpenIdTests.java
+++ b/support/cas-server-support-openid/src/test/java/org/apereo/cas/support/openid/AbstractOpenIdTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.support.openid;
 
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -83,7 +84,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     OpenIdUniqueTicketIdGeneratorConfiguration.class,
     OpenIdServiceFactoryConfiguration.class,
     OpenIdAuthenticationEventExecutionPlanConfiguration.class,
-    ThymeleafAutoConfiguration.class
+    ThymeleafAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public class AbstractOpenIdTests {
     @Autowired

--- a/support/cas-server-support-otp-mfa/src/test/java/org/apereo/cas/otp/repository/token/CachingOneTimeTokenRepositoryTests.java
+++ b/support/cas-server-support-otp-mfa/src/test/java/org/apereo/cas/otp/repository/token/CachingOneTimeTokenRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.otp.repository.token;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -56,7 +57,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     AopAutoConfiguration.class,
     RefreshAutoConfiguration.class,
-    CasCoreWebConfiguration.class
+    CasCoreWebConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @Getter
 public class CachingOneTimeTokenRepositoryTests extends BaseOneTimeTokenRepositoryTests {

--- a/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/impl/account/GroovyPasswordlessUserAccountStoreTests.java
+++ b/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/impl/account/GroovyPasswordlessUserAccountStoreTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.impl.account;
 
 import org.apereo.cas.api.PasswordlessUserAccountStore;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -67,7 +68,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreLogoutConfiguration.class,
     CasCookieConfiguration.class,
     CasThemesConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @Tag("Groovy")
 @TestPropertySource(properties = "cas.authn.passwordless.accounts.groovy.location=classpath:PasswordlessAccount.groovy")

--- a/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/impl/account/RestfulPasswordlessUserAccountStoreTests.java
+++ b/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/impl/account/RestfulPasswordlessUserAccountStoreTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.impl.account;
 
 import org.apereo.cas.api.PasswordlessUserAccount;
 import org.apereo.cas.api.PasswordlessUserAccountStore;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -75,7 +76,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreLogoutConfiguration.class,
     CasCookieConfiguration.class,
     CasThemesConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = "cas.authn.passwordless.accounts.rest.url=http://localhost:9291")
 @Tag("RestfulApi")

--- a/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/impl/token/RestfulPasswordlessTokenRepositoryTests.java
+++ b/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/impl/token/RestfulPasswordlessTokenRepositoryTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.impl.token;
 
 import org.apereo.cas.CipherExecutor;
 import org.apereo.cas.api.PasswordlessTokenRepository;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -76,7 +77,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreLogoutConfiguration.class,
     CasCookieConfiguration.class,
     CasThemesConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = "cas.authn.passwordless.tokens.rest.url=http://localhost:9293")
 @Tag("RestfulApi")

--- a/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/web/flow/BasePasswordlessAuthenticationActionTests.java
+++ b/support/cas-server-support-passwordless/src/test/java/org/apereo/cas/web/flow/BasePasswordlessAuthenticationActionTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -60,7 +61,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasAuthenticationEventExecutionPlanTestConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
+    CasCoreAuthenticationPrincipalConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public class BasePasswordlessAuthenticationActionTests {
 }

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.pm.web.flow.actions;
 
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -66,7 +67,8 @@ import org.springframework.webflow.execution.Action;
     CasCoreWebConfiguration.class,
     CasCoreWebflowConfiguration.class,
     CasCoreHttpConfiguration.class,
-    CasWebflowContextConfiguration.class
+    CasWebflowContextConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(locations = "classpath:cas-pm-webflow.properties")
 @EnableConfigurationProperties(CasConfigurationProperties.class)

--- a/support/cas-server-support-radius/src/test/java/org/apereo/cas/config/RadiusConfigurationTests.java
+++ b/support/cas-server-support-radius/src/test/java/org/apereo/cas/config/RadiusConfigurationTests.java
@@ -43,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.*;
     RadiusConfiguration.class,
     CasCoreConfiguration.class,
     CasCoreUtilConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {
     "cas.authn.radius.client.sharedSecret=NoSecret",

--- a/support/cas-server-support-rest-tokens/src/test/java/org/apereo/cas/tokens/BaseTicketResourceEntityResponseFactoryTests.java
+++ b/support/cas-server-support-rest-tokens/src/test/java/org/apereo/cas/tokens/BaseTicketResourceEntityResponseFactoryTests.java
@@ -4,6 +4,7 @@ import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.CipherExecutor;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPolicyConfiguration;
@@ -81,7 +82,8 @@ import java.util.List;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasRestTokensConfiguration.class,
     CasRestConfiguration.class,
-    CasCoreTicketsConfiguration.class
+    CasCoreTicketsConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public abstract class BaseTicketResourceEntityResponseFactoryTests {
     @Autowired

--- a/support/cas-server-support-saml-idp-metadata-aws-s3/src/test/java/org/apereo/cas/support/saml/idp/metadata/AmazonS3SamlIdPMetadataGeneratorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-aws-s3/src/test/java/org/apereo/cas/support/saml/idp/metadata/AmazonS3SamlIdPMetadataGeneratorTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.support.saml.idp.metadata;
 
 import org.apereo.cas.config.AmazonS3SamlIdPMetadataConfiguration;
 import org.apereo.cas.config.AmazonS3SamlMetadataConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -59,7 +60,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreUtilConfiguration.class,
     AmazonS3SamlMetadataConfiguration.class,
     AmazonS3SamlIdPMetadataConfiguration.class,
-    SamlIdPMetadataConfiguration.class
+    SamlIdPMetadataConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {
     "cas.authn.samlIdp.metadata.amazonS3.idpMetadataBucketName=thebucket",

--- a/support/cas-server-support-saml-idp-metadata-couchdb/src/test/java/org/apereo/cas/support/saml/metadata/resolver/CouchDbSamlRegisteredServiceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata-couchdb/src/test/java/org/apereo/cas/support/saml/metadata/resolver/CouchDbSamlRegisteredServiceMetadataResolverTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.saml.metadata.resolver;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -104,7 +105,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CoreSamlConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    CasCoreUtilConfiguration.class})
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @EnableTransactionManagement(proxyTargetClass = true)
 @Slf4j

--- a/support/cas-server-support-saml-idp-metadata-jpa/src/test/java/org/apereo/cas/support/saml/BaseJpaSamlMetadataTests.java
+++ b/support/cas-server-support-saml-idp-metadata-jpa/src/test/java/org/apereo/cas/support/saml/BaseJpaSamlMetadataTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.saml;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -83,7 +84,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CoreSamlConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    CasCoreUtilConfiguration.class})
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @EnableTransactionManagement(proxyTargetClass = true)
 public abstract class BaseJpaSamlMetadataTests {

--- a/support/cas-server-support-saml-idp-metadata-mongo/src/test/java/org/apereo/cas/support/saml/BaseMongoDbSamlMetadataTests.java
+++ b/support/cas-server-support-saml-idp-metadata-mongo/src/test/java/org/apereo/cas/support/saml/BaseMongoDbSamlMetadataTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.saml;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -85,7 +86,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CoreSamlConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    CasCoreUtilConfiguration.class})
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public abstract class BaseMongoDbSamlMetadataTests {
     @Autowired

--- a/support/cas-server-support-saml-idp-metadata-rest/src/test/java/org/apereo/cas/support/saml/metadata/resolver/RestSamlRegisteredServiceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata-rest/src/test/java/org/apereo/cas/support/saml/metadata/resolver/RestSamlRegisteredServiceMetadataResolverTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.saml.metadata.resolver;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -98,7 +99,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CoreSamlConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    CasCoreUtilConfiguration.class})
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @TestPropertySource(properties = {
     "cas.authn.samlIdp.metadata.rest.url=http://localhost:8078",
     "cas.authn.samlIdp.metadata.location=file:/tmp"

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/BaseSamlIdPConfigurationTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/BaseSamlIdPConfigurationTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.saml;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -107,7 +108,8 @@ import static org.mockito.Mockito.*;
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CoreSamlConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    CasCoreUtilConfiguration.class
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public abstract class BaseSamlIdPConfigurationTests {

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/AbstractOpenSamlTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/AbstractOpenSamlTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.saml;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -79,7 +80,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreLogoutConfiguration.class,
     CasCoreUtilConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
-    CasCoreConfiguration.class
+    CasCoreConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public abstract class AbstractOpenSamlTests {
     protected static final String SAML_REQUEST = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"

--- a/support/cas-server-support-scim/src/test/java/org/apereo/cas/web/flow/PrincipalScimV1ProvisionerActionTests.java
+++ b/support/cas-server-support-scim/src/test/java/org/apereo/cas/web/flow/PrincipalScimV1ProvisionerActionTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
@@ -55,7 +56,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreUtilConfiguration.class,
     CasCoreConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {
     "cas.scim.target=http://localhost:8215",

--- a/support/cas-server-support-scim/src/test/java/org/apereo/cas/web/flow/PrincipalScimV2ProvisionerActionTests.java
+++ b/support/cas-server-support-scim/src/test/java/org/apereo/cas/web/flow/PrincipalScimV2ProvisionerActionTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
@@ -51,7 +52,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreUtilConfiguration.class,
     CasCoreConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = "cas.scim.target=http://localhost:8218")
 public class PrincipalScimV2ProvisionerActionTests {

--- a/support/cas-server-support-soap-authentication/src/test/java/org/apereo/cas/authentication/SoapAuthenticationHandlerTests.java
+++ b/support/cas-server-support-soap-authentication/src/test/java/org/apereo/cas/authentication/SoapAuthenticationHandlerTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.authentication;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
 import org.apereo.cas.config.CasCoreUtilConfiguration;
 import org.apereo.cas.config.CasRegisteredServicesTestConfiguration;
@@ -33,7 +34,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreServicesConfiguration.class,
     CasRegisteredServicesTestConfiguration.class,
     CasCoreUtilConfiguration.class,
-    SoapAuthenticationConfiguration.class
+    SoapAuthenticationConfiguration.class,
+        CasCommonComponentsConfiguration.class
 },
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @TestPropertySource(properties = {"server.port=8080", "cas.authn.soap.url=http://localhost:8080/ws/users"})

--- a/support/cas-server-support-spnego-webflow/src/test/java/org/apereo/cas/web/flow/AbstractSpnegoTests.java
+++ b/support/cas-server-support-spnego-webflow/src/test/java/org/apereo/cas/web/flow/AbstractSpnegoTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -60,7 +61,8 @@ import org.springframework.webflow.execution.Action;
     CasCoreAuthenticationMetadataConfiguration.class,
     CasCoreAuthenticationSupportConfiguration.class,
     CasCoreAuthenticationHandlersConfiguration.class,
-    CasCoreHttpConfiguration.class})
+    CasCoreHttpConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 public abstract class AbstractSpnegoTests {
     @Autowired
     @Qualifier("ldapSpnegoClientAction")

--- a/support/cas-server-support-surrogate-authentication-couchdb/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateCouchDbAuthenticationTests.java
+++ b/support/cas-server-support-surrogate-authentication-couchdb/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateCouchDbAuthenticationTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.authentication.surrogate;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -76,7 +77,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasThemesConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
-    CasCoreTicketsConfiguration.class
+    CasCoreTicketsConfiguration.class,
+        CasCommonComponentsConfiguration.class
     }, properties = {
         "cas.authn.surrogate.couchDb.username=cas",
         "cas.authn.surrogate.couchdb.password=password"

--- a/support/cas-server-support-surrogate-authentication-couchdb/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateCouchDbProfileAuthenticationServiceTests.java
+++ b/support/cas-server-support-surrogate-authentication-couchdb/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateCouchDbProfileAuthenticationServiceTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.authentication.surrogate;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -78,7 +79,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
     CasCoreLogoutConfiguration.class,
     CasCookieConfiguration.class,
     CasThemesConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
     }, properties = {
     "cas.authn.surrogate.couchDb.dbName=surrogate_profile",
     "cas.authn.surrogate.couchDb.profileBased=true",

--- a/support/cas-server-support-surrogate-authentication-ldap/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateLdapAuthenticationServiceTests.java
+++ b/support/cas-server-support-surrogate-authentication-ldap/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateLdapAuthenticationServiceTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication.surrogate;
 
 import org.apereo.cas.adaptors.ldap.LdapIntegrationTestsOperations;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -78,7 +79,8 @@ import org.springframework.test.context.TestPropertySource;
     CasCoreLogoutConfiguration.class,
     CasCookieConfiguration.class,
     CasThemesConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {
     "cas.authn.surrogate.ldap.ldapUrl=ldap://localhost:10389",

--- a/support/cas-server-support-surrogate-authentication-rest/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationServiceTests.java
+++ b/support/cas-server-support-surrogate-authentication-rest/src/test/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationServiceTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication.surrogate;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -84,7 +85,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreLogoutConfiguration.class,
     CasCookieConfiguration.class,
     CasThemesConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = "cas.authn.surrogate.rest.url=http://localhost:9301")
 @Getter

--- a/support/cas-server-support-surrogate-webflow/src/test/java/org/apereo/cas/web/flow/action/BaseSurrogateInitialAuthenticationActionTests.java
+++ b/support/cas-server-support-surrogate-webflow/src/test/java/org/apereo/cas/web/flow/action/BaseSurrogateInitialAuthenticationActionTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.web.flow.action;
 import org.apereo.cas.authentication.AcceptUsersAuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPolicyConfiguration;
@@ -68,7 +69,8 @@ import org.springframework.test.context.TestPropertySource;
     CasCookieConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
     CasWebApplicationServiceFactoryConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = {"cas.authn.surrogate.simple.surrogates.casuser=cassurrogate"})
 public class BaseSurrogateInitialAuthenticationActionTests {

--- a/support/cas-server-support-swivel/src/test/java/org/apereo/cas/adaptors/swivel/SwivelAuthenticationHandlerTests.java
+++ b/support/cas-server-support-swivel/src/test/java/org/apereo/cas/adaptors/swivel/SwivelAuthenticationHandlerTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.adaptors.swivel;
 
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -84,7 +85,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasThemesConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     SwivelConfiguration.class,
-    SwivelAuthenticationEventExecutionPlanConfiguration.class})
+    SwivelAuthenticationEventExecutionPlanConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @TestPropertySource(properties = {
     "cas.authn.mfa.swivel.swivelUrl=http://localhost:9191",
     "cas.authn.mfa.swivel.sharedSecret=$ecret",

--- a/support/cas-server-support-themes/src/test/java/org/apereo/cas/services/web/ServiceThemeResolverTests.java
+++ b/support/cas-server-support-themes/src/test/java/org/apereo/cas/services/web/ServiceThemeResolverTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.services.web;
 
 import org.apereo.cas.CasProtocolConstants;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
@@ -55,7 +56,8 @@ import static org.mockito.Mockito.*;
     CasCoreConfiguration.class,
     CasCoreUtilConfiguration.class,
     ThymeleafAutoConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(properties = "cas.theme.defaultThemeName=test")
 public class ServiceThemeResolverTests {

--- a/support/cas-server-support-throttle-couchdb/src/test/java/org/apereo/cas/web/support/CouchDbThrottledSubmissionHandlerInterceptorAdapterTests.java
+++ b/support/cas-server-support-throttle-couchdb/src/test/java/org/apereo/cas/web/support/CouchDbThrottledSubmissionHandlerInterceptorAdapterTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.support;
 
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -69,7 +70,8 @@ import org.springframework.test.context.TestPropertySource;
     CasCoreWebConfiguration.class,
     CasRegisteredServicesTestConfiguration.class,
     CasThrottlingConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @TestPropertySource(properties = {
     "cas.audit.couchDb.dbName=throttle",
     "cas.audit.couchDb.asynchronous=false",

--- a/support/cas-server-support-throttle-jdbc/src/test/java/org/apereo/cas/web/support/JdbcThrottledSubmissionHandlerInterceptorAdapterTests.java
+++ b/support/cas-server-support-throttle-jdbc/src/test/java/org/apereo/cas/web/support/JdbcThrottledSubmissionHandlerInterceptorAdapterTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.web.support;
 
 import org.apereo.cas.audit.config.CasSupportJdbcAuditConfiguration;
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -62,7 +63,8 @@ import org.springframework.test.context.TestPropertySource;
     CasSupportJdbcAuditConfiguration.class,
     CasCoreWebConfiguration.class,
     CasRegisteredServicesTestConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @TestPropertySource(properties = {
     "cas.authn.throttle.usernameParameter=username",
     "cas.authn.throttle.failure.code=AUTHENTICATION_FAILED",

--- a/support/cas-server-support-throttle-mongo/src/test/java/org/apereo/cas/web/support/MongoDbThrottledSubmissionHandlerInterceptorAdapterTests.java
+++ b/support/cas-server-support-throttle-mongo/src/test/java/org/apereo/cas/web/support/MongoDbThrottledSubmissionHandlerInterceptorAdapterTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.support;
 
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -65,7 +66,8 @@ import org.springframework.test.context.TestPropertySource;
     CasSupportMongoDbAuditConfiguration.class,
     CasCoreWebConfiguration.class,
     CasRegisteredServicesTestConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @TestPropertySource(properties = {
     "cas.authn.throttle.usernameParameter=username",
     "cas.audit.mongo.databaseName=throttle",

--- a/support/cas-server-support-throttle/src/test/java/org/apereo/cas/web/support/InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapterTests.java
+++ b/support/cas-server-support-throttle/src/test/java/org/apereo/cas/web/support/InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapterTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.support;
 
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -60,7 +61,8 @@ import org.springframework.test.context.TestPropertySource;
     CasCoreHttpConfiguration.class,
     CasCoreWebConfiguration.class,
     CasRegisteredServicesTestConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @Getter
 public class InMemoryThrottledSubmissionByIpAddressAndUsernameHandlerInterceptorAdapterTests
     extends BaseThrottledSubmissionHandlerInterceptorAdapterTests {

--- a/support/cas-server-support-throttle/src/test/java/org/apereo/cas/web/support/InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapterTests.java
+++ b/support/cas-server-support-throttle/src/test/java/org/apereo/cas/web/support/InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapterTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.support;
 
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -59,7 +60,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     CasCoreHttpConfiguration.class,
     CasCoreWebConfiguration.class,
     CasRegisteredServicesTestConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class})
+    CasWebApplicationServiceFactoryConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @Getter
 public class InMemoryThrottledSubmissionByIpAddressHandlerInterceptorAdapterTests
     extends BaseThrottledSubmissionHandlerInterceptorAdapterTests {

--- a/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
+++ b/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.principal.ResponseBuilder;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -80,7 +81,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuthenticationSupportConfiguration.class,
     CasCoreAuthenticationHandlersConfiguration.class,
     CasCoreHttpConfiguration.class,
-    CasCoreAuthenticationConfiguration.class
+    CasCoreAuthenticationConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 @EnableScheduling

--- a/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/ProxyControllerTests.java
+++ b/support/cas-server-support-validation/src/test/java/org/apereo/cas/web/ProxyControllerTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.web;
 import org.apereo.cas.AbstractCentralAuthenticationServiceTests;
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -59,7 +60,8 @@ import static org.junit.jupiter.api.Assertions.*;
     AopAutoConfiguration.class,
     ProxyControllerTests.ProxyTestConfiguration.class,
     CasProtocolViewsConfiguration.class,
-    CasValidationConfiguration.class
+    CasValidationConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 public class ProxyControllerTests extends AbstractCentralAuthenticationServiceTests {
 

--- a/support/cas-server-support-ws-idp/src/test/java/org/apereo/cas/authentication/SecurityTokenServiceTokenFetcherTests.java
+++ b/support/cas-server-support-ws-idp/src/test/java/org/apereo/cas/authentication/SecurityTokenServiceTokenFetcherTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication;
 
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
@@ -62,7 +63,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasWebApplicationServiceFactoryConfiguration.class,
     CasAuthenticationEventExecutionPlanTestConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
+    CasCoreAuthenticationPrincipalConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(locations = "classpath:ws-idp.properties")
 public class SecurityTokenServiceTokenFetcherTests {

--- a/support/cas-server-support-wsfederation-webflow/src/test/java/org/apereo/cas/web/flow/WsFederationActionTests.java
+++ b/support/cas-server-support-wsfederation-webflow/src/test/java/org/apereo/cas/web/flow/WsFederationActionTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPolicyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
@@ -62,7 +63,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuthenticationSupportConfiguration.class,
     WsFedAuthenticationEventExecutionPlanConfiguration.class,
     WsFederationAuthenticationWebflowConfiguration.class,
-    WsFederationAuthenticationConfiguration.class
+    WsFederationAuthenticationConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @TestPropertySource(locations = "classpath:wsfedauthn.properties")
 public class WsFederationActionTests {

--- a/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/AbstractWsFederationTests.java
+++ b/support/cas-server-support-wsfederation/src/test/java/org/apereo/cas/support/wsfederation/AbstractWsFederationTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.wsfederation;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -80,7 +81,8 @@ import java.util.Collection;
     CasCoreConfiguration.class,
     CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
     CasPersonDirectoryConfiguration.class,
-    CasCoreUtilConfiguration.class})
+    CasCoreUtilConfiguration.class,
+        CasCommonComponentsConfiguration.class})
 @TestPropertySource(locations = {"classpath:/wsfed.properties"})
 @ContextConfiguration(locations = {"classpath:/applicationContext.xml"})
 public class AbstractWsFederationTests extends AbstractOpenSamlTests {

--- a/support/cas-server-support-yubikey-couchdb/src/test/java/org/apereo/cas/adaptors/yubikey/dao/CouchDbYubiKeyAccountRegistryTests.java
+++ b/support/cas-server-support-yubikey-couchdb/src/test/java/org/apereo/cas/adaptors/yubikey/dao/CouchDbYubiKeyAccountRegistryTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.adaptors.yubikey.dao;
 
 import org.apereo.cas.adaptors.yubikey.AbstractYubiKeyAccountRegistryTests;
 import org.apereo.cas.adaptors.yubikey.YubiKeyAccountRegistry;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -74,7 +75,8 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
         CasCoreTicketCatalogConfiguration.class,
         CasDefaultServiceTicketIdGeneratorsConfiguration.class,
         CasWebApplicationServiceFactoryConfiguration.class,
-        RefreshAutoConfiguration.class
+        RefreshAutoConfiguration.class,
+            CasCommonComponentsConfiguration.class
     },
     properties = {
         "cas.authn.mfa.yubikey.clientId=18423",

--- a/support/cas-server-support-yubikey-jpa/src/test/java/org/apereo/cas/adaptors/yubikey/dao/JpaYubiKeyAccountRegistryTests.java
+++ b/support/cas-server-support-yubikey-jpa/src/test/java/org/apereo/cas/adaptors/yubikey/dao/JpaYubiKeyAccountRegistryTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.adaptors.yubikey.dao;
 
 import org.apereo.cas.adaptors.yubikey.YubiKeyAccountRegistry;
 import org.apereo.cas.adaptors.yubikey.YubiKeyAccountValidator;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -71,7 +72,8 @@ import static org.junit.jupiter.api.Assertions.*;
         CasCoreTicketCatalogConfiguration.class,
         CasDefaultServiceTicketIdGeneratorsConfiguration.class,
         CasWebApplicationServiceFactoryConfiguration.class,
-        RefreshAutoConfiguration.class
+        RefreshAutoConfiguration.class,
+            CasCommonComponentsConfiguration.class
     })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @TestPropertySource(locations = {"classpath:/yubikey-jpa.properties"})

--- a/support/cas-server-support-yubikey-mongo/src/test/java/org/apereo/cas/adaptors/yubikey/dao/MongoDbYubiKeyAccountRegistryTests.java
+++ b/support/cas-server-support-yubikey-mongo/src/test/java/org/apereo/cas/adaptors/yubikey/dao/MongoDbYubiKeyAccountRegistryTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.adaptors.yubikey.dao;
 
 import org.apereo.cas.adaptors.yubikey.YubiKeyAccountRegistry;
 import org.apereo.cas.adaptors.yubikey.YubiKeyAccountValidator;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -73,7 +74,8 @@ import static org.junit.jupiter.api.Assertions.*;
         CasCoreTicketCatalogConfiguration.class,
         CasDefaultServiceTicketIdGeneratorsConfiguration.class,
         CasWebApplicationServiceFactoryConfiguration.class,
-        RefreshAutoConfiguration.class
+        RefreshAutoConfiguration.class,
+            CasCommonComponentsConfiguration.class
     })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @TestPropertySource(properties = {

--- a/support/cas-server-support-yubikey/src/test/java/org/apereo/cas/adaptors/yubikey/JsonYubiKeyAccountRegistryTests.java
+++ b/support/cas-server-support-yubikey/src/test/java/org/apereo/cas/adaptors/yubikey/JsonYubiKeyAccountRegistryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.adaptors.yubikey;
 
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
@@ -68,7 +69,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreTicketCatalogConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
     CasWebApplicationServiceFactoryConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @TestPropertySource(locations = {"classpath:/yubikey-json.properties"})

--- a/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/BaseCasWebflowSessionContextConfigurationTests.java
+++ b/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/BaseCasWebflowSessionContextConfigurationTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.DefaultAuthenticationResultBuilder;
 import org.apereo.cas.authentication.PrincipalElectionStrategy;
 import org.apereo.cas.authentication.principal.SimpleWebApplicationServiceImpl;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -118,7 +119,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuditConfiguration.class,
     CasPersonDirectoryConfiguration.class,
     AopAutoConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @EnableAspectJAutoProxy(proxyTargetClass = true)

--- a/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/WiringConfigurationTests.java
+++ b/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/WiringConfigurationTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas;
 
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.config.CasCommonComponentsConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
@@ -81,7 +82,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasPersonDirectoryConfiguration.class,
     ThymeleafAutoConfiguration.class,
     AopAutoConfiguration.class,
-    RefreshAutoConfiguration.class
+    RefreshAutoConfiguration.class,
+        CasCommonComponentsConfiguration.class
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @WebAppConfiguration


### PR DESCRIPTION
Useful to gather common dependencies needed by various CAS components
which reduces the complexity and size of constructors in configuration
code.