### PR TITLE
Make properties available for JPA

### DIFF
--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
@@ -13,6 +13,7 @@ import org.apereo.cas.ticket.registry.support.JpaLockingStrategy;
 import org.apereo.cas.ticket.registry.support.LockingStrategy;
 import org.apereo.cas.util.CoreTicketUtils;
 import org.apereo.cas.util.InetAddressUtils;
+import org.apereo.cas.util.spring.ApplicationContextProvider;
 
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -26,6 +27,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -54,6 +56,9 @@ public class JpaTicketRegistryConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;
 
+    @Autowired
+    private ApplicationContext applicationContext;
+
     @Bean
     public List<String> ticketPackagesToScan() {
         val reflections =
@@ -70,6 +75,7 @@ public class JpaTicketRegistryConfiguration {
     @Lazy
     @Bean
     public LocalContainerEntityManagerFactoryBean ticketEntityManagerFactory() {
+        ApplicationContextProvider.holdApplicationContext(applicationContext);
         return JpaBeans.newHibernateEntityManagerFactoryBean(
             new JpaConfigDataHolder(
                 JpaBeans.newHibernateJpaVendorAdapter(casProperties.getJdbc()),


### PR DESCRIPTION
When I add the `cas-server-support-jpa-ticket-registry` dependency, I get a bunch of errors like: `2019-04-08 15:24:14,911 ERROR [org.apereo.cas.jpa.CasHibernatePhysicalNamingStrategy] - <Could not load configuration settings to determine case insensitivity.>`.

It seems that the `ApplicationContextProvider` has not been initialized with the `ApplicationContext` when the `CasHibernatePhysicalNamingStrategy` is called.

This PR fixes this issue.
