### PR TITLE
Fix missing hyphen before suffix in ticket id generation code

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/util/DefaultUniqueTicketIdGenerator.java
@@ -103,7 +103,9 @@ public class DefaultUniqueTicketIdGenerator implements UniqueTicketIdGenerator {
     public String getNewTicketId(final String prefix) {
         val number = this.numericGenerator.getNextNumberAsString();
         val ticketBody = this.randomStringGenerator.getNewString().replace('_', '-');
-        return prefix + '-' + number + '-' + ticketBody + StringUtils.defaultString(this.suffix);
+        val origSuffix = StringUtils.defaultString(this.suffix);
+        val finalizedSuffix = StringUtils.isEmpty(origSuffix) ? origSuffix : '-' + origSuffix;
+        return prefix + '-' + number + '-' + ticketBody + finalizedSuffix;
     }
 
     /**

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/DefaultUniqueTicketIdGeneratorTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/DefaultUniqueTicketIdGeneratorTests.java
@@ -23,15 +23,15 @@ public class DefaultUniqueTicketIdGeneratorTests {
         val suffix = "suffix";
         val generator = new DefaultUniqueTicketIdGenerator(10, suffix);
 
-        assertTrue(generator.getNewTicketId("test").endsWith(suffix));
+        assertTrue(generator.getNewTicketId("test").endsWith('-' + suffix));
     }
 
     @Test
     public void verifyNullSuffix() {
         val lengthWithoutSuffix = 23;
         val generator = new DefaultUniqueTicketIdGenerator(12, null);
-
         val ticketId = generator.getNewTicketId("test");
+
         assertEquals(lengthWithoutSuffix, ticketId.length());
     }
 }


### PR DESCRIPTION
Hyphen before suffix used to be added in the `setSuffix` method. Now that the setter is synthesized by lombok, that hyphen is gone. This breaks some clients and tools that rely upon this hyphen being there. This commit adds hyphen back.

This needs to be backported to `6.0.4`