### PR TITLE
Limit the Redis TTL to Integer.MAX_VALUE

### DIFF
--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -41,7 +41,9 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
      */
     private static Long getTimeout(final Ticket ticket) {
         val ttl = ticket.getExpirationPolicy().getTimeToLive();
-        if (ttl <= 0) {
+        if (ttl > Integer.MAX_VALUE) {
+            return (long) Integer.MAX_VALUE;
+        } else if (ttl <= 0) {
             return 1L;
         }
         return ttl;


### PR DESCRIPTION
In Redis, the TTL must be an integer value while in CAS, we may use bigger values up to `Long.MAX_VALUE`. This PR fixes the issue by limiting the TTL value to `Integer.MAX_VALUE`.