### PR TITLE
Removes a Service Domain if all services are removed

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DomainServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DomainServicesManager.java
@@ -46,6 +46,9 @@ public class DomainServicesManager extends AbstractServicesManager {
     protected void deleteInternal(final RegisteredService service) {
         val domain = extractDomain(service.getServiceId());
         this.domains.get(domain).remove(service);
+        if (this.domains.get(domain).isEmpty()) {
+            this.domains.remove(domain);
+        }
     }
 
     @Override


### PR DESCRIPTION
When using CAS Mangement or other means to delete the last service in under a domain when using DomainServicesManager, the domain remains in the list of domains.  This PR adds a check if the last service in  domain is removed, it also removes the domain form the TreeMap.