### PR TITLE
Skip delegation when SSO session present (5.3.x branch)

### DIFF
--- a/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
+++ b/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
@@ -173,7 +173,12 @@ public interface CasWebflowConstants {
      * The view state 'error'.
      */
     String VIEW_ID_ERROR = "error";
-
+    
+    /**
+     * The transition state 'resume'.
+     */
+    String TRANSITION_ID_RESUME = "resume";
+    
     /**
      * The view state 'showAuthenticationWarningMessages'.
      */

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationWebflowConfigurer.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationWebflowConfigurer.java
@@ -68,6 +68,7 @@ public class DelegatedAuthenticationWebflowConfigurer extends AbstractCasWebflow
         final TransitionSet transitionSet = actionState.getTransitionSet();
         transitionSet.add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS, CasWebflowConstants.STATE_ID_CREATE_TICKET_GRANTING_TICKET));
         transitionSet.add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, getStartState(flow).getId()));
+        transitionSet.add(createTransition(CasWebflowConstants.TRANSITION_ID_RESUME, getStartState(flow).getId()));
         transitionSet.add(createTransition(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, CasWebflowConstants.STATE_ID_STOP_WEBFLOW));
         transitionSet.add(createTransition(CasWebflowConstants.TRANSITION_ID_WARN, CasWebflowConstants.STATE_ID_WARN));
         transitionSet.add(createTransition(CasWebflowConstants.TRANSITION_ID_STOP, CasWebflowConstants.STATE_ID_STOP_WEBFLOW));

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
@@ -154,7 +154,7 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
 
         if (singleSignOnSessionExists(context)) {
             LOGGER.debug("An existing single sign-on session already exists. Skipping delegation and routing back to CAS authentication flow");
-            return super.doExecute(context);
+            return resumeWebflow();
         }
 
         final String clientName = request.getParameter(Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER);
@@ -345,6 +345,15 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
      */
     protected Event stopWebflow() {
         return new Event(this, CasWebflowConstants.TRANSITION_ID_STOP);
+    }
+    
+    /**
+     * Resume webflow event.
+     *
+     * @return the event
+     */
+    protected Event resumeWebflow() {
+        return new Event(this, CasWebflowConstants.TRANSITION_ID_RESUME);
     }
 
     /**


### PR DESCRIPTION
When an SSO session is present, immediately exit DelegatedClientAuthenticationAction.doExecute() with an explicit "resumeWebflow" event that continues to the next state in the webflow.  Avoids issuance of ST without a credential challenge when the "renew" parameter is present.  Models behavior in current master branch (6.1.x).