### PR TITLE
avoid calling load from service manager during bean creation

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.inspektr.audit.annotation.Audit;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  */
 @Slf4j
 @RequiredArgsConstructor
-public abstract class AbstractServicesManager implements ServicesManager, InitializingBean {
+public abstract class AbstractServicesManager implements ServicesManager {
 
     private final ServiceRegistry serviceRegistry;
     private final transient ApplicationEventPublisher eventPublisher;
@@ -179,11 +179,6 @@ public abstract class AbstractServicesManager implements ServicesManager, Initia
             publishEvent(new CasRegisteredServiceSavedEvent(this, r));
         }
         return r;
-    }
-
-    @Override
-    public void afterPropertiesSet() {
-        load();
     }
 
     /**

--- a/webapp/resources/log4j2.xml
+++ b/webapp/resources/log4j2.xml
@@ -96,6 +96,7 @@
         <AsyncLogger name="org.springframework.scheduling" level="warn" includeLocation="true"/>
         <AsyncLogger name="org.springframework.context.annotation" level="off" includeLocation="true"/>
         <AsyncLogger name="org.springframework.web.socket" level="warn" includeLocation="true"/>
+        <AsyncLogger name="org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter" level="debug" includeLocation="true"/>
 
         <AsyncLogger name="com.couchbase" level="warn" includeLocation="true" />
         <AsyncLogger name="org.apache" level="error" includeLocation="true"/>


### PR DESCRIPTION
If the load() method is called in afterPropertiesSet() of the service manager, it may fire events that end up modifying a service and saving it with a call to servicesManager.save() (e.g. OidcProfileScopeToAttributesFilter) and that will fail b/c the servicesManager bean is in the process of being created. The services should be loaded by the serviceRegistryInitializer bean which also calls serviceManager.load().

