### PR TITLE
add back decryption check to cas shell encrypt function

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
@@ -97,6 +97,18 @@ public class CasConfigurationJasyptCipherExecutor implements CipherExecutor<Stri
     }
 
     /**
+     * Sets algorithm (possibly to bad algorithm, for unit test usage).
+     *
+     * @param alg the alg
+     */
+    protected void setAlgorithmForce(final String alg) {
+        if (StringUtils.isNotBlank(alg)) {
+            LOGGER.debug("Configured Jasypt algorithm [{}]", alg);
+            jasyptInstance.setAlgorithm(alg);
+        }
+    }
+
+    /**
      * Sets password.
      *
      * @param psw the psw

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
@@ -89,7 +89,7 @@ public class CasConfigurationJasyptCipherExecutor implements CipherExecutor<Stri
     public void setAlgorithm(final String alg) {
         if (StringUtils.isNotBlank(alg)) {
             if (ALGORITHM_BLACKLIST_SET.contains(alg)) {
-                throw new IllegalArgumentException(String.format("Configured Jasypt algorithm [{}] doesn't work for decryption due to Jasypt bug", alg));
+                throw new IllegalArgumentException(String.format("Configured Jasypt algorithm [%s] doesn't work for decryption due to Jasypt bug", alg));
             }
             LOGGER.debug("Configured Jasypt algorithm [{}]", alg);
             jasyptInstance.setAlgorithm(alg);

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
@@ -89,7 +89,7 @@ public class CasConfigurationJasyptCipherExecutor implements CipherExecutor<Stri
     public void setAlgorithm(final String alg) {
         if (StringUtils.isNotBlank(alg)) {
             if (ALGORITHM_BLACKLIST_SET.contains(alg)) {
-                LOGGER.warn("Configured Jasypt algorithm [{}] doesn't work for decryption due to Jasypt bug", alg);
+                throw new IllegalArgumentException(String.format("Configured Jasypt algorithm [{}] doesn't work for decryption due to Jasypt bug", alg));
             }
             LOGGER.debug("Configured Jasypt algorithm [{}]", alg);
             jasyptInstance.setAlgorithm(alg);

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
@@ -2,6 +2,7 @@ package org.apereo.cas.configuration.support;
 
 import org.apereo.cas.CipherExecutor;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -18,13 +19,33 @@ import java.security.Security;
  * @author Misagh Moayyed
  * @since 5.1.0
  */
-
-
 public class CasConfigurationJasyptCipherExecutor implements CipherExecutor<String, String> {
     /**
      * Prefix inserted at the beginning of a value to indicate it's encrypted.
      */
     public static final String ENCRYPTED_VALUE_PREFIX = "{cas-cipher}";
+
+    /**
+     * These algorithms don't work with Jasypt 1.9.2.
+     */
+    private static final String[] ALGORITHM_BLACKLIST = new String[] {
+        "PBEWITHHMACSHA1ANDAES_128",
+        "PBEWITHHMACSHA1ANDAES_256",
+        "PBEWITHHMACSHA224ANDAES_128",
+        "PBEWITHHMACSHA224ANDAES_256",
+        "PBEWITHHMACSHA256ANDAES_128",
+        "PBEWITHHMACSHA256ANDAES_256",
+        "PBEWITHHMACSHA384ANDAES_128",
+        "PBEWITHHMACSHA384ANDAES_256",
+        "PBEWITHHMACSHA512ANDAES_128",
+        "PBEWITHHMACSHA512ANDAES_256"
+    };
+
+    /**
+     * List version of blacklisted algorithms (due to Jasypt 1.9.2 bug).
+     */
+    public static final ImmutableSet<String> ALGORITHM_BLACKLIST_SET = ImmutableSet.copyOf(ALGORITHM_BLACKLIST);
+
     /**
      * The Jasypt instance.
      */
@@ -67,6 +88,9 @@ public class CasConfigurationJasyptCipherExecutor implements CipherExecutor<Stri
      */
     public void setAlgorithm(final String alg) {
         if (StringUtils.isNotBlank(alg)) {
+            if (ALGORITHM_BLACKLIST_SET.contains(alg)) {
+                LOGGER.warn("Configured Jasypt algorithm [{}] doesn't work for decryption due to Jasypt bug", alg);
+            }
             LOGGER.debug("Configured Jasypt algorithm [{}]", alg);
             jasyptInstance.setAlgorithm(alg);
         }

--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
@@ -91,7 +91,7 @@ public class CasConfigurationJasyptCipherExecutorTests {
 
     private boolean isAlgorithmFunctional(final String algorithm) {
         val jasyptTest = new CasConfigurationJasyptCipherExecutor(this.environment);
-        jasyptTest.setAlgorithm(algorithm);
+        jasyptTest.setAlgorithmForce(algorithm);
         val testValue = "Testing_" + algorithm;
         val value = jasyptTest.encryptValue(testValue);
         val result = jasyptTest.decode(value, ArrayUtils.EMPTY_OBJECT_ARRAY);

--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
@@ -1,13 +1,18 @@
 package org.apereo.cas.configuration.support;
 
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jasypt.registry.AlgorithmRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.core.env.Environment;
+
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest(classes = {
     RefreshAutoConfiguration.class
 })
+@Slf4j
 public class CasConfigurationJasyptCipherExecutorTests {
     static {
         System.setProperty(CasConfigurationJasyptCipherExecutor.JasyptEncryptionParameters.PASSWORD.getPropertyName(), "P@$$w0rd");
@@ -64,6 +70,32 @@ public class CasConfigurationJasyptCipherExecutorTests {
         val result = jasypt.decode(value, ArrayUtils.EMPTY_OBJECT_ARRAY);
         assertNotNull(result);
         assertEquals("Testing", result);
+    }
+
+    /**
+     * Test all algorithms and verify that algorithms known not to work still don't work.
+     * https://sourceforge.net/p/jasypt/bugs/32/
+     */
+    @Test
+    public void verifyAlgorithms() {
+        val algorithms = (Set<String>) AlgorithmRegistry.getAllPBEAlgorithms();
+        val goodAlgorithms = Sets.difference(algorithms, CasConfigurationJasyptCipherExecutor.ALGORITHM_BLACKLIST_SET);
+
+        for (val algorithm : goodAlgorithms) {
+            assertTrue(isAlgorithmFunctional(algorithm));
+        }
+        for (val algorithm : CasConfigurationJasyptCipherExecutor.ALGORITHM_BLACKLIST_SET) {
+            assertFalse(isAlgorithmFunctional(algorithm));
+        }
+    }
+
+    private boolean isAlgorithmFunctional(final String algorithm) {
+        val jasyptTest = new CasConfigurationJasyptCipherExecutor(this.environment);
+        jasyptTest.setAlgorithm(algorithm);
+        val testValue = "Testing_" + algorithm;
+        val value = jasyptTest.encryptValue(testValue);
+        val result = jasyptTest.decode(value, ArrayUtils.EMPTY_OBJECT_ARRAY);
+        return testValue.equals(result);
     }
 }
 

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -113,7 +113,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
 
     @Override
     public RegisteredService findServiceBy(final long id) {
-        var result = this.services.get(id);
+        val result = this.services.get(id);
         return validateRegisteredService(result);
     }
 
@@ -191,7 +191,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
             .collect(Collectors.toConcurrentMap(r -> {
                 LOGGER.debug("Adding registered service [{}]", r.getServiceId());
                 return r.getId();
-            }, Function.identity(), (r, s) -> s == null ? r : s));
+            }, Function.identity(), (r, s) -> s));
         loadInternal();
         publishEvent(new CasRegisteredServicesLoadedEvent(this, getAllServices()));
         evaluateExpiredServiceDefinitions();
@@ -209,7 +209,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
     private void evaluateExpiredServiceDefinitions() {
         this.services.values()
             .stream()
-            .filter((Predicate<RegisteredService>) getRegisteredServicesFilteringPredicate().negate())
+            .filter(getRegisteredServicesFilteringPredicate().negate())
             .filter(Objects::nonNull)
             .forEach(this::processExpiredRegisteredService);
     }

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
@@ -59,5 +59,12 @@ public class JasyptEncryptPropertyCommand {
         cipher.setKeyObtentionIterations(iterations);
         val encrypted = cipher.encryptValue(value);
         LOGGER.info("==== Encrypted Value ====\n{}", encrypted);
+        try {
+            cipher.decryptValue(encrypted);
+        } catch (final Exception e) {
+            LOGGER.error("Decryption failed for value: [{}] with provider [{}]", encrypted, provider, e);
+            LOGGER.error("Failure is likely due to this Jasypt bug: https://sourceforge.net/p/jasypt/bugs/32/");
+            LOGGER.error("Choose a non-AES algorithm or use the BouncyCastle Provider");
+        }
     }
 }

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
@@ -59,12 +59,5 @@ public class JasyptEncryptPropertyCommand {
         cipher.setKeyObtentionIterations(iterations);
         val encrypted = cipher.encryptValue(value);
         LOGGER.info("==== Encrypted Value ====\n{}", encrypted);
-        try {
-            cipher.decryptValue(encrypted);
-        } catch (final Exception e) {
-            LOGGER.error("Decryption failed for value: [{}] with provider [{}]", encrypted, provider, e);
-            LOGGER.error("Failure is likely due to this Jasypt bug: https://sourceforge.net/p/jasypt/bugs/32/");
-            LOGGER.error("Choose a non-AES algorithm or use the BouncyCastle Provider");
-        }
     }
 }


### PR DESCRIPTION
Due to https://sourceforge.net/p/jasypt/bugs/32/ bug, test whether encrypted value can be decrypted by jasypt. 

@mmoayyed You suggested writing some tests related to this issue. Which module would those go in? Note that there is already a JasyptTestAlgorithmsCommand command in the shell that tests all the algorithms (in the shell, not during CI). 
