### PR TITLE
Fix logo header overlap in IE 11

### DIFF
--- a/webapp/resources/static/themes/apereo/css/cas.css
+++ b/webapp/resources/static/themes/apereo/css/cas.css
@@ -7880,6 +7880,7 @@ a {
   color: #257bb2; }
 
 .logo {
+  height: 40px;
   width: 80px;
   display: block; }
 


### PR DESCRIPTION
Applying same changes in pull request #3909 to master branch.

Added height property to logo class so that header containing CAS logo displays properly in IE 11.