### PR TITLE
Revert "fix: jquery dist path changed"

### DIFF
--- a/core/cas-server-core-web/src/main/resources/cas_common_messages.properties
+++ b/core/cas-server-core-web/src/main/resources/cas_common_messages.properties
@@ -8,7 +8,7 @@ webjars.headmin.js=/webjars/headjs/${headjsVersion}/head.min.js
 webjars.bootstrapmin.js=/webjars/bootstrap/${bootstrapVersion}/js/bootstrap.bundle.min.js
 webjars.bootstrapmin.css=/webjars/bootstrap/${bootstrapVersion}/css/bootstrap.min.css
 webjars.jqueryui.js=/webjars/jquery-ui/${jqueryUiVersion}/jquery-ui.min.js
-webjars.jquerymin.js=/webjars/jquery/${jqueryVersion}/dist/jquery.min.js
+webjars.jquerymin.js=/webjars/jquery/${jqueryVersion}/jquery.min.js
 webjars.zxcvbn.js=/webjars/zxcvbn/${zxcvbnVersion}/zxcvbn.js
 
 webjars.fontawesomemin.css=/webjars/font-awesome/${fontAwesomeVersion}/css/all.min.css


### PR DESCRIPTION
Reverts apereo/cas#3894. 

The original path is correct. Using `dist` in the path creates a 404 as the webjar has no such path in it.