### PR TITLE
add equals method to chaining attribute release policy

### DIFF
--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ChainingAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ChainingAttributeReleasePolicy.java
@@ -4,6 +4,7 @@ import org.apereo.cas.authentication.CoreAuthenticationUtils;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 @Setter
 @Getter
 @Slf4j
+@EqualsAndHashCode
 public class ChainingAttributeReleasePolicy implements RegisteredServiceAttributeReleasePolicy {
 
     private static final long serialVersionUID = 3795054936775326709L;

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/DenyAllAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/DenyAllAttributeReleasePolicy.java
@@ -3,6 +3,7 @@ package org.apereo.cas.services;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,6 +19,7 @@ import java.util.Map;
  */
 @Slf4j
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class DenyAllAttributeReleasePolicy extends AbstractRegisteredServiceAttributeReleasePolicy {
 
     private static final long serialVersionUID = -6215588543966639050L;

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/GroovyScriptAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/GroovyScriptAttributeReleasePolicy.java
@@ -6,6 +6,7 @@ import org.apereo.cas.util.ResourceUtils;
 import org.apereo.cas.util.scripting.ScriptingUtils;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,6 +29,7 @@ import java.util.Map;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class GroovyScriptAttributeReleasePolicy extends AbstractRegisteredServiceAttributeReleasePolicy {
 
     private static final long serialVersionUID = 1703080077563402223L;

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ScriptedRegisteredServiceAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ScriptedRegisteredServiceAttributeReleasePolicy.java
@@ -1,12 +1,12 @@
 package org.apereo.cas.services;
 
-import lombok.EqualsAndHashCode;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.scripting.ScriptingUtils;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ScriptedRegisteredServiceAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ScriptedRegisteredServiceAttributeReleasePolicy.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.services;
 
+import lombok.EqualsAndHashCode;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.util.CollectionUtils;
@@ -30,6 +31,7 @@ import java.util.regex.Matcher;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 public class ScriptedRegisteredServiceAttributeReleasePolicy extends AbstractRegisteredServiceAttributeReleasePolicy {
 
     private static final long serialVersionUID = -979532578142774128L;

--- a/support/cas-server-support-ws-idp-api/src/main/java/org/apereo/cas/ws/idp/services/WSFederationClaimsReleasePolicy.java
+++ b/support/cas-server-support-ws-idp-api/src/main/java/org/apereo/cas/ws/idp/services/WSFederationClaimsReleasePolicy.java
@@ -7,6 +7,7 @@ import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.ws.idp.WSFederationClaims;
 
 import com.google.common.collect.Maps;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,7 @@ import java.util.TreeMap;
 @Slf4j
 @Getter
 @Setter
+@EqualsAndHashCode(callSuper = true)
 public class WSFederationClaimsReleasePolicy extends AbstractRegisteredServiceAttributeReleasePolicy {
 
     private static final long serialVersionUID = -2814928645221579489L;


### PR DESCRIPTION
without this method, oidc services get saved (without actual changes)
every minute by OidcProfileScopeToAttributesFilter.reconcile method
(at least in some configurations)
