### PR TITLE
Fix password check for Couchbase when using BCrypt

### DIFF
--- a/support/cas-server-support-couchbase-authentication/src/main/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandler.java
+++ b/support/cas-server-support-couchbase-authentication/src/main/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandler.java
@@ -63,7 +63,8 @@ public class CouchbaseAuthenticationHandler extends AbstractUsernamePasswordAuth
             throw new FailedLoginException("No password attribute found for " + transformedCredential.getId());
         }
 
-        if (!value.get(couchbaseProperties.getPasswordAttribute()).equals(transformedCredential.getPassword())) {
+        val entryPassword = (String) value.get(couchbaseProperties.getPasswordAttribute());
+        if (!getPasswordEncoder().matches(originalPassword, entryPassword)) {
             LOGGER.warn("Account password on record for [{}] does not match the given/encoded password", transformedCredential.getId());
             throw new FailedLoginException();
         }

--- a/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -1,6 +1,6 @@
-
 package org.apereo.cas;
 
+import org.apereo.cas.authentication.CouchbaseAuthenticationHandlerIntegrationTests;
 import org.apereo.cas.authentication.CouchbaseAuthenticationHandlerTests;
 import org.apereo.cas.authentication.CouchbasePersonAttributeDaoTests;
 
@@ -16,7 +16,8 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     CouchbasePersonAttributeDaoTests.class,
-    CouchbaseAuthenticationHandlerTests.class
+    CouchbaseAuthenticationHandlerTests.class,
+    CouchbaseAuthenticationHandlerIntegrationTests.class
 })
 public class AllTestsSuite {
 }

--- a/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerIntegrationTests.java
+++ b/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerIntegrationTests.java
@@ -1,0 +1,94 @@
+package org.apereo.cas.authentication;
+
+import org.apereo.cas.category.CouchbaseCategory;
+import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
+import org.apereo.cas.config.CasCoreConfiguration;
+import org.apereo.cas.config.CasCoreHttpConfiguration;
+import org.apereo.cas.config.CasCoreServicesConfiguration;
+import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
+import org.apereo.cas.config.CasCoreTicketIdGeneratorsConfiguration;
+import org.apereo.cas.config.CasCoreTicketsConfiguration;
+import org.apereo.cas.config.CasCoreUtilConfiguration;
+import org.apereo.cas.config.CasCoreWebConfiguration;
+import org.apereo.cas.config.CasDefaultServiceTicketIdGeneratorsConfiguration;
+import org.apereo.cas.config.CasPersonDirectoryTestConfiguration;
+import org.apereo.cas.config.CasRegisteredServicesTestConfiguration;
+import org.apereo.cas.config.CouchbaseAuthenticationConfiguration;
+import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
+import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
+import org.apereo.cas.util.junit.ConditionalIgnore;
+import org.apereo.cas.util.junit.ConditionalIgnoreRule;
+import org.apereo.cas.util.junit.RunningContinuousIntegrationCondition;
+
+import lombok.val;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+
+import static org.junit.Assert.*;
+
+/**
+ * This is {@link CouchbaseAuthenticationHandlerIntegrationTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.3.0
+ */
+@Category(CouchbaseCategory.class)
+@ConditionalIgnore(condition = RunningContinuousIntegrationCondition.class)
+@SpringBootTest(classes = {
+    RefreshAutoConfiguration.class,
+    CouchbaseAuthenticationConfiguration.class,
+    CasCoreConfiguration.class,
+    CasCoreTicketsConfiguration.class,
+    CasCoreLogoutConfiguration.class,
+    CasCoreServicesConfiguration.class,
+    CasCoreTicketIdGeneratorsConfiguration.class,
+    CasCoreTicketCatalogConfiguration.class,
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+    CasCoreHttpConfiguration.class,
+    CasCoreWebConfiguration.class,
+    CasPersonDirectoryTestConfiguration.class,
+    CasCoreUtilConfiguration.class,
+    CasRegisteredServicesTestConfiguration.class,
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasAuthenticationEventExecutionPlanTestConfiguration.class,
+    CasDefaultServiceTicketIdGeneratorsConfiguration.class,
+    CasCoreAuthenticationPrincipalConfiguration.class
+},
+    properties = {"cas.authn.couchbase.password=password", "cas.authn.couchbase.bucket=testbucket"})
+public class CouchbaseAuthenticationHandlerIntegrationTests {
+
+    @ClassRule
+    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+
+    @Rule
+    public final ConditionalIgnoreRule conditionalIgnoreRule = new ConditionalIgnoreRule();
+
+    @Autowired
+    @Qualifier("couchbaseAuthenticationHandler")
+    private AuthenticationHandler couchbaseAuthenticationHandler;
+
+    @Test
+    public void verifyAccount() throws Exception {
+        val c = CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword("casuser", "Mellon");
+        val result = couchbaseAuthenticationHandler.authenticate(c);
+        assertNotNull(result);
+        assertEquals("casuser", result.getPrincipal().getId());
+        val attributes = result.getPrincipal().getAttributes();
+        assertEquals(2, attributes.size());
+        assertTrue(attributes.containsKey("firstname"));
+        assertTrue(attributes.containsKey("lastname"));
+    }
+}

--- a/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerTests.java
+++ b/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerTests.java
@@ -18,6 +18,7 @@ import org.junit.rules.ExpectedException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.StandardPasswordEncoder;
 
 import javax.security.auth.login.FailedLoginException;
 import java.util.ArrayList;
@@ -55,6 +56,21 @@ public class CouchbaseAuthenticationHandlerTests {
         this.thrown.expect(FailedLoginException.class);
 
         internalAutenticate(NoOpPasswordEncoder.getInstance(), new SimplePrincipal(), BAD_PASSWORD);
+    }
+
+    @Test
+    public void sha256EncryptionGoodPassword() throws Exception {
+        val principal = new SimplePrincipal();
+        val result = internalAutenticate(new StandardPasswordEncoder(), principal, GOOD_PASSWORD);
+
+        assertEquals(principal, result.getPrincipal());
+    }
+
+    @Test
+    public void sha256EncryptionBadPassword() throws Exception {
+        this.thrown.expect(FailedLoginException.class);
+
+        internalAutenticate(new StandardPasswordEncoder(), new SimplePrincipal(), BAD_PASSWORD);
     }
 
     @Test

--- a/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerTests.java
+++ b/support/cas-server-support-couchbase-authentication/src/test/java/org/apereo/cas/authentication/CouchbaseAuthenticationHandlerTests.java
@@ -1,94 +1,103 @@
 package org.apereo.cas.authentication;
 
-import org.apereo.cas.category.CouchbaseCategory;
-import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
-import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
-import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
-import org.apereo.cas.config.CasCoreConfiguration;
-import org.apereo.cas.config.CasCoreHttpConfiguration;
-import org.apereo.cas.config.CasCoreServicesConfiguration;
-import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
-import org.apereo.cas.config.CasCoreTicketIdGeneratorsConfiguration;
-import org.apereo.cas.config.CasCoreTicketsConfiguration;
-import org.apereo.cas.config.CasCoreUtilConfiguration;
-import org.apereo.cas.config.CasCoreWebConfiguration;
-import org.apereo.cas.config.CasDefaultServiceTicketIdGeneratorsConfiguration;
-import org.apereo.cas.config.CasPersonDirectoryTestConfiguration;
-import org.apereo.cas.config.CasRegisteredServicesTestConfiguration;
-import org.apereo.cas.config.CouchbaseAuthenticationConfiguration;
-import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
-import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
-import org.apereo.cas.util.junit.ConditionalIgnore;
-import org.apereo.cas.util.junit.ConditionalIgnoreRule;
-import org.apereo.cas.util.junit.RunningContinuousIntegrationCondition;
+import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.authentication.principal.PrincipalFactory;
+import org.apereo.cas.authentication.principal.SimplePrincipal;
+import org.apereo.cas.configuration.model.support.couchbase.authentication.CouchbaseAuthenticationProperties;
+import org.apereo.cas.couchbase.core.CouchbaseClientFactory;
+import org.apereo.cas.services.ServicesManager;
 
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.query.DefaultN1qlQueryResult;
+import com.couchbase.client.java.query.N1qlQueryRow;
 import lombok.val;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.junit.rules.ExpectedException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.security.auth.login.FailedLoginException;
+import java.util.ArrayList;
+import java.util.Map;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
- * This is {@link CouchbaseAuthenticationHandlerTests}.
+ * Basic unit tests on the {@link CouchbaseAuthenticationHandler} to ensure the password check behavior.
  *
- * @author Misagh Moayyed
- * @since 5.3.0
+ * @author Jerome LELEU
+ * @since 6.0.4
  */
-@Category(CouchbaseCategory.class)
-@ConditionalIgnore(condition = RunningContinuousIntegrationCondition.class)
-@SpringBootTest(classes = {
-    RefreshAutoConfiguration.class,
-    CouchbaseAuthenticationConfiguration.class,
-    CasCoreConfiguration.class,
-    CasCoreTicketsConfiguration.class,
-    CasCoreLogoutConfiguration.class,
-    CasCoreServicesConfiguration.class,
-    CasCoreTicketIdGeneratorsConfiguration.class,
-    CasCoreTicketCatalogConfiguration.class,
-    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
-    CasCoreHttpConfiguration.class,
-    CasCoreWebConfiguration.class,
-    CasPersonDirectoryTestConfiguration.class,
-    CasCoreUtilConfiguration.class,
-    CasRegisteredServicesTestConfiguration.class,
-    CasWebApplicationServiceFactoryConfiguration.class,
-    CasAuthenticationEventExecutionPlanTestConfiguration.class,
-    CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
-},
-    properties = {"cas.authn.couchbase.password=password", "cas.authn.couchbase.bucket=testbucket"})
 public class CouchbaseAuthenticationHandlerTests {
 
-    @ClassRule
-    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+    private static final String BUCKET_NAME = "default";
+    private static final String LOGIN = "login";
+    private static final String GOOD_PASSWORD = "good";
+    private static final String BAD_PASSWORD = "bad";
 
     @Rule
-    public final SpringMethodRule springMethodRule = new SpringMethodRule();
-
-    @Rule
-    public final ConditionalIgnoreRule conditionalIgnoreRule = new ConditionalIgnoreRule();
-
-    @Autowired
-    @Qualifier("couchbaseAuthenticationHandler")
-    private AuthenticationHandler couchbaseAuthenticationHandler;
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void verifyAccount() throws Exception {
-        val c = CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword("casuser", "Mellon");
-        val result = couchbaseAuthenticationHandler.authenticate(c);
-        assertNotNull(result);
-        assertEquals("casuser", result.getPrincipal().getId());
-        val attributes = result.getPrincipal().getAttributes();
-        assertEquals(2, attributes.size());
-        assertTrue(attributes.containsKey("firstname"));
-        assertTrue(attributes.containsKey("lastname"));
+    public void noEncryptionGoodPassword() throws Exception {
+        val principal = new SimplePrincipal();
+        val result = internalAutenticate(NoOpPasswordEncoder.getInstance(), principal, GOOD_PASSWORD);
+
+        assertEquals(principal, result.getPrincipal());
+    }
+
+    @Test
+    public void noEncryptionBadPassword() throws Exception {
+        this.thrown.expect(FailedLoginException.class);
+
+        internalAutenticate(NoOpPasswordEncoder.getInstance(), new SimplePrincipal(), BAD_PASSWORD);
+    }
+
+    @Test
+    public void bcryptEncryptionGoodPassword() throws Exception {
+        val principal = new SimplePrincipal();
+        val result = internalAutenticate(new BCryptPasswordEncoder(), principal, GOOD_PASSWORD);
+
+        assertEquals(principal, result.getPrincipal());
+    }
+
+    @Test
+    public void bcryptEncryptionBadPassword() throws Exception {
+        this.thrown.expect(FailedLoginException.class);
+
+        internalAutenticate(new BCryptPasswordEncoder(), new SimplePrincipal(), BAD_PASSWORD);
+    }
+
+    private AuthenticationHandlerExecutionResult internalAutenticate(final PasswordEncoder encoder, final Principal principal, final String userPassword) throws Exception {
+        val factory = mock(CouchbaseClientFactory.class);
+        val defBucket = mock(Bucket.class);
+        when(defBucket.name()).thenReturn(BUCKET_NAME);
+        when(factory.getBucket()).thenReturn(defBucket);
+        val properties = new CouchbaseAuthenticationProperties();
+        val principalFactory = mock(PrincipalFactory.class);
+        when(principalFactory.createPrincipal(any(String.class), any(Map.class))).thenReturn(principal);
+        val handler = new CouchbaseAuthenticationHandler(mock(ServicesManager.class), principalFactory, factory, properties);
+        handler.setPasswordEncoder(encoder);
+        val c = CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword(LOGIN, userPassword);
+
+        val queryResult = mock(DefaultN1qlQueryResult.class);
+        val listRows = new ArrayList<N1qlQueryRow>();
+        val row = mock(N1qlQueryRow.class);
+        val json = JsonObject.empty()
+                .put(properties.getUsernameAttribute(), LOGIN)
+                .put(properties.getPasswordAttribute(), encoder.encode(GOOD_PASSWORD));
+        val bucket = JsonObject.empty()
+                .put(BUCKET_NAME, json);
+        when(row.value()).thenReturn(bucket);
+        listRows.add(row);
+        when(queryResult.allRows()).thenReturn(listRows);
+
+        when(factory.query(properties.getUsernameAttribute(), LOGIN)).thenReturn(queryResult);
+
+        return handler.authenticate(c);
     }
 }


### PR DESCRIPTION
The way to check the password is currently not correct when using the BCrypt password encoder. `equals` does not work, it should be `matches`.

This PR fixes this issue for Couchbase, but other handlers may have the same issue.
