### PR TITLE
REST Authentication: enable to configure the charset used to encode the credentials

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/rest/RestAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/rest/RestAuthenticationProperties.java
@@ -32,7 +32,6 @@ public class RestAuthenticationProperties implements Serializable {
     /**
      * Charset to encode the credentials sent to the REST endpoint.
      */
-    @RequiredProperty
     private String charset = "US-ASCII";
 
     /**

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/rest/RestAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/rest/RestAuthenticationProperties.java
@@ -30,6 +30,12 @@ public class RestAuthenticationProperties implements Serializable {
     private String uri;
 
     /**
+     * Charset to encode the credentials sent to the REST endpoint.
+     */
+    @RequiredProperty
+    private String charset = "US-ASCII";
+
+    /**
      * Password encoder settings for REST authentication.
      */
     @NestedConfigurationProperty

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpUtils.java
@@ -426,11 +426,23 @@ public class HttpUtils {
      * @return the org . springframework . http . http headers
      */
     public static org.springframework.http.HttpHeaders createBasicAuthHeaders(final String basicAuthUser, final String basicAuthPassword) {
+        return HttpUtils.createBasicAuthHeaders(basicAuthUser, basicAuthPassword, "US-ASCII");
+    }
+
+    /**
+     * Create headers org . springframework . http . http headers.
+     *
+     * @param basicAuthUser     the basic auth user
+     * @param basicAuthPassword the basic auth password
+     * @param basicCharset      The charset used to encode auth header
+     * @return the org . springframework . http . http headers
+     */
+    public static org.springframework.http.HttpHeaders createBasicAuthHeaders(final String basicAuthUser, final String basicAuthPassword, final String basicCharset) {
         val acceptHeaders = new org.springframework.http.HttpHeaders();
         acceptHeaders.setAccept(CollectionUtils.wrap(MediaType.APPLICATION_JSON));
         if (StringUtils.isNotBlank(basicAuthUser) && StringUtils.isNotBlank(basicAuthPassword)) {
             val authorization = basicAuthUser + ':' + basicAuthPassword;
-            val basic = EncodingUtils.encodeBase64(authorization.getBytes(Charset.forName("US-ASCII")));
+            val basic = EncodingUtils.encodeBase64(authorization.getBytes(Charset.forName(basicCharset)));
             acceptHeaders.set(org.springframework.http.HttpHeaders.AUTHORIZATION, "Basic " + basic);
         }
         return acceptHeaders;

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -1925,6 +1925,7 @@ To learn more about this topic, [please review this guide](../installation/Rest-
 ```properties
 # cas.authn.rest.uri=https://...
 # cas.authn.rest.name=
+# cas.authn.rest.charset=US-ASCII
 ```
 
 ## Google Apps Authentication

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationApi.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationApi.java
@@ -20,10 +20,12 @@ public class RestAuthenticationApi {
 
     private final transient RestTemplate restTemplate;
     private final String authenticationUri;
+    private final String charset;
 
-    public RestAuthenticationApi(final RestTemplate restTemplate, final String authenticationUri) {
+    public RestAuthenticationApi(final RestTemplate restTemplate, final String authenticationUri, final String charset) {
         this.restTemplate = restTemplate;
         this.authenticationUri = authenticationUri;
+        this.charset = charset;
     }
 
     /**
@@ -33,7 +35,7 @@ public class RestAuthenticationApi {
      * @return the response entity
      */
     public ResponseEntity<SimplePrincipal> authenticate(final UsernamePasswordCredential c) {
-        val entity = new HttpEntity<Object>(HttpUtils.createBasicAuthHeaders(c.getUsername(), c.getPassword()));
+        val entity = new HttpEntity<Object>(HttpUtils.createBasicAuthHeaders(c.getUsername(), c.getPassword(), this.charset));
         return restTemplate.exchange(authenticationUri, HttpMethod.POST, entity, SimplePrincipal.class);
     }
 }

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/config/CasRestAuthenticationConfiguration.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/config/CasRestAuthenticationConfiguration.java
@@ -64,7 +64,7 @@ public class CasRestAuthenticationConfiguration {
     @Bean
     @RefreshScope
     public RestAuthenticationApi restAuthenticationApi() {
-        return new RestAuthenticationApi(restAuthenticationTemplate(), casProperties.getAuthn().getRest().getUri());
+        return new RestAuthenticationApi(restAuthenticationTemplate(), casProperties.getAuthn().getRest().getUri(), casProperties.getAuthn().getRest().getCharset());
     }
 
     @Bean


### PR DESCRIPTION
I'm working on the integration of CAS in a project, using the [REST Authentication API](https://apereo.github.io/cas/6.0.x/installation/Rest-Authentication.html)

It works quite well, but we had some issues with usernames or password which contains non-ascii characters (for example: "cépafô"), as the Auth header encoding was hard-coded into ASCII.

This PR adds a configuration property `cas.authn.rest.charset` (still "US-ASCII" by default) to enable to use credentials in another charset.

How to test:
* Create an external REST API endpoint that meets CAS REST Authentication API, and add there a user which credentials contain some non-ascii characters, encoded in UTF-8.
* Configure CAS to call the endpoint above, and add following property: `cas.authn.rest.charset=UTF-8`
* Try to authenticate
