### PR TITLE
exclude duplicate version of jquery webjar with different directory structure

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3575,6 +3575,7 @@ ext.libraries = [
                     force = true
                 },
                 dependencies.create("org.webjars.bower:bootstrap-select:$bootstrapSelectVersion") {
+                    exclude(group: "org.webjars.bower", module: "jquery")
                     force = true
                 }
         ]


### PR DESCRIPTION
There are currently two jquery-3.4.1.jar files in war and they have different directory structure (org.webjars.bower version includes dist folder). The one you get in your overlay will be random but the current layout.xhtml template references the non-bower non-dist version. 