### PR TITLE
enable duoSecurityPrincipalMultifactorAuthenticationProviderBypass

### DIFF
--- a/support/cas-server-support-duo/src/main/java/org/apereo/cas/adaptors/duo/config/DuoSecurityMultifactorProviderBypassConfiguration.java
+++ b/support/cas-server-support-duo/src/main/java/org/apereo/cas/adaptors/duo/config/DuoSecurityMultifactorProviderBypassConfiguration.java
@@ -41,6 +41,7 @@ public class DuoSecurityMultifactorProviderBypassConfiguration {
     public ChainingMultifactorAuthenticationProviderBypass duoSecurityBypassEvaluator() {
         val bypass = new DefaultChainingMultifactorAuthenticationBypassProvider();
         bypass.addMultifactorAuthenticationProviderBypass(duoSecurityRegisteredServiceMultifactorAuthenticationProviderBypass());
+        bypass.addMultifactorAuthenticationProviderBypass(duoSecurityPrincipalMultifactorAuthenticationProviderBypass());
         bypass.addMultifactorAuthenticationProviderBypass(duoSecurityAuthenticationMultifactorAuthenticationProviderBypass());
         bypass.addMultifactorAuthenticationProviderBypass(duoSecurityCredentialMultifactorAuthenticationProviderBypass());
         bypass.addMultifactorAuthenticationProviderBypass(duoSecurityHttpRequestMultifactorAuthenticationProviderBypass());


### PR DESCRIPTION
ChainingMultifactorAuthenticationProviderBypass setup for Duo was neglecting to include         duoSecurityPrincipalMultifactorAuthenticationProviderBypass() in the chain. Without this, attribute-based bypass doesn't work.


