### PR TITLE
Fix NPE from null attribute values

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolver.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolver.java
@@ -27,8 +27,11 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Resolves principals by querying a data source using the Person Directory API.
@@ -198,18 +201,17 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
      * @param attributes           the attributes
      * @return the pair
      */
+    @SuppressWarnings("unchecked")
     protected Pair<String, Map<String, List<Object>>> convertPersonAttributesToPrincipal(final String extractedPrincipalId,
                                                                                          final Map<String, List<Object>> attributes) {
         val convertedAttributes = new LinkedHashMap<String, List<Object>>();
         attributes.forEach((key, attrValue) -> {
-            val values = CollectionUtils.toCollection(attrValue, ArrayList.class);
+            val values = ((List<Object>) CollectionUtils.toCollection(attrValue, ArrayList.class))
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .collect(toList());
             LOGGER.debug("Found attribute [{}] with value(s) [{}]", key, values);
-            if (values.size() == 1) {
-                val value = CollectionUtils.firstElement(values).get();
-                convertedAttributes.put(key, CollectionUtils.wrapList(value));
-            } else {
-                convertedAttributes.put(key, values);
-            }
+            convertedAttributes.put(key, values);
         });
 
         var principalId = extractedPrincipalId;

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/AllAuthenticationTestsSuite.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/AllAuthenticationTestsSuite.java
@@ -9,6 +9,7 @@ import org.apereo.cas.authentication.handler.ByCredentialTypeAuthenticationHandl
 import org.apereo.cas.authentication.policy.GroovyScriptAuthenticationPolicyTests;
 import org.apereo.cas.authentication.principal.PrincipalNameTransformerUtilsTests;
 import org.apereo.cas.authentication.principal.resolvers.InternalGroovyScriptDaoTests;
+import org.apereo.cas.authentication.principal.resolvers.PersonDirectoryPrincipalResolverTests;
 import org.apereo.cas.authentication.support.password.DefaultPasswordPolicyHandlingStrategyTests;
 import org.apereo.cas.authentication.support.password.GroovyPasswordEncoderTests;
 import org.apereo.cas.authentication.support.password.PasswordExpiringWarningMessageDescriptorTests;
@@ -29,6 +30,7 @@ import org.junit.platform.suite.api.SelectClasses;
     BlackDotIPAddressIntelligenceServiceTests.class,
     GroovyScriptAuthenticationPolicyTests.class,
     InternalGroovyScriptDaoTests.class,
+    PersonDirectoryPrincipalResolverTests.class,
     PrincipalNameTransformerUtilsTests.class,
     AuthenticationCredentialTypeMetaDataPopulatorTests.class,
     DefaultPrincipalFactoryTests.class,

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolverTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolverTests.java
@@ -1,23 +1,25 @@
-package org.apereo.cas.authentication.principal;
+package org.apereo.cas.authentication.principal.resolvers;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler;
-import org.apereo.cas.authentication.principal.resolvers.ChainingPrincipalResolver;
-import org.apereo.cas.authentication.principal.resolvers.EchoingPrincipalResolver;
-import org.apereo.cas.authentication.principal.resolvers.PersonDirectoryPrincipalResolver;
 import org.apereo.cas.util.CollectionUtils;
 
+import com.google.common.collect.Maps;
 import lombok.val;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
 import org.apereo.services.persondir.support.StubPersonAttributeDao;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -45,6 +47,18 @@ public class PersonDirectoryPrincipalResolverTests {
         val c = CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword();
         val p = resolver.resolve(c, null);
         assertNull(p);
+    }
+
+    @Test
+    public void verifyNullAttributeValues() {
+        val attributes = new ArrayList<Object>();
+        attributes.add(null);
+        val resolver = new PersonDirectoryPrincipalResolver(
+                new StubPersonAttributeDao(Map.of("a", attributes))
+        );
+        val principal = resolver.resolve((Credential) () -> "a");
+
+        assertThat(principal.getAttributes()).containsExactly(Maps.immutableEntry("a", new ArrayList<>()));
     }
 
     @Test

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -20,7 +20,6 @@ import org.apereo.cas.authentication.policy.UniquePrincipalAuthenticationPolicyT
 import org.apereo.cas.authentication.principal.ChainingPrincipalResolverTests;
 import org.apereo.cas.authentication.principal.DefaultPrincipalFactoryTests;
 import org.apereo.cas.authentication.principal.NullPrincipalTests;
-import org.apereo.cas.authentication.principal.PersonDirectoryPrincipalResolverTests;
 import org.apereo.cas.authentication.principal.RememberMeAuthenticationMetaDataPopulatorTests;
 import org.apereo.cas.authentication.principal.SimplePrincipalFactoryTests;
 import org.apereo.cas.authentication.principal.SimplePrincipalTests;
@@ -37,7 +36,6 @@ import org.junit.platform.suite.api.SelectClasses;
  */
 @SelectClasses({
     TrustedProxyAuthenticationTrustStoreSslSocketFactoryTests.class,
-    PersonDirectoryPrincipalResolverTests.class,
     SimplePrincipalTests.class,
     CachingPrincipalAttributesRepositoryTests.class,
     ChainingPrincipalResolverTests.class,


### PR DESCRIPTION
Fix a crash when a person directory returns a null attribute value introduced in 5.3.something.

Rationale for needing this is I have a JDBC attribute source that can return null values in attribute result sets.