### PR TITLE
[skip ci]

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
@@ -93,7 +93,6 @@ public class DelegatedClientWebflowManager {
         if (client instanceof OidcClient) {
             val oidcClient = (OidcClient) client;
             val config = oidcClient.getConfiguration();
-            config.addCustomParam(PARAMETER_CLIENT_ID, ticketId);
             config.setWithState(true);
             config.setStateGenerator(new StaticOrRandomStateGenerator(ticketId));
         }


### PR DESCRIPTION
In the package org.apereo.cas.web, the Java class DelegatedClientWebflowManager uses the attribute PARAMETER_CLIENT_ID, a string whose value is delegatedclientid.
This attribute plays role of an HTTP parameter for different authentication protocols.
FranceConnect implements the OpenID Connect protocol and refuses this HTTP parameter in its workflow.
Precisely, in the 39812c171e6f5f1f2e3800d335b3cfaa96f19203 "clean up findbugs" commit, concerning the OidcClient condition, the following code line should not be written:
config.addCustomParam(PARAMETER_CLIENT_ID, ticketId);

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
