### PR TITLE
Pac4j delegation: Add missing setAcceptedSkew

### DIFF
--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
@@ -397,6 +397,7 @@ public class DelegatedClientFactory {
                 cfg.setForceAuth(saml.isForceAuth());
                 cfg.setPassive(saml.isPassive());
                 cfg.setSignMetadata(saml.isSignServiceProviderMetadata());
+                cfg.setAcceptedSkew(saml.getAcceptedSkew());
 
                 if (StringUtils.isNotBlank(saml.getPrincipalIdAttribute())) {
                     cfg.setAttributeAsId(saml.getPrincipalIdAttribute());


### PR DESCRIPTION
Add the missing `setAcceptedMethod` method call when configuring the SAML client