### PR TITLE
Fix the null ticketSerializationManager for cassandra integration

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3397,7 +3397,7 @@ Allows CAS to act as an OAuth2 provider. Here you can control how long various t
 To learn more about this topic, [please review this guide](../installation/OAuth-OpenId-Authentication.html).
 
 ```properties
-# cas.authn.oidc.replicateSessions=false
+# cas.authn.oauth.replicateSessions=false
 
 # cas.authn.oauth.refreshToken.timeToKillInSeconds=2592000
 

--- a/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/config/CassandraTicketRegistryConfiguration.java
+++ b/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/config/CassandraTicketRegistryConfiguration.java
@@ -34,7 +34,7 @@ public class CassandraTicketRegistryConfiguration {
     private CasConfigurationProperties casProperties;
 
     @Autowired
-    @Qualifier("ticketSerializationManager;")
+    @Qualifier("ticketSerializationManager")
     private ObjectProvider<TicketSerializationManager> ticketSerializationManager;
 
     @Autowired


### PR DESCRIPTION
The `ticketSerializationManager` in `CassandraTicketRegistry` is null I suspect because of the `;` in the spring qualifier. 