### PR TITLE
Fix ticketCatalog usage in the cassandra ticket registry

### DIFF
--- a/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CassandraTicketRegistry.java
+++ b/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CassandraTicketRegistry.java
@@ -123,6 +123,13 @@ public class CassandraTicketRegistry extends AbstractTicketRegistry implements D
     }
 
     private Ticket deserialize(final CassandraTicketHolder holder) {
+        if (!isCipherExecutorEnabled()) {
+            var definition = ticketCatalog.find(holder.getId());
+            if (definition == null) {
+                throw new IllegalArgumentException("Ticket catalog has not registered a ticket definition for " + holder.getId());
+            }
+            return ticketSerializationManager.deserializeTicket(holder.getData(), definition.getImplementationClass());
+        }
         return ticketSerializationManager.deserializeTicket(holder.getData(), EncodedTicket.class);
     }
 


### PR DESCRIPTION
In the `CassandraTicketRegistry`, the `findCatalog` method was being called with the encoded ticket id and so missing the prefix to determine which definition to return. This meant `getTicket` would always return `null`. Also, `deserialize` would fail for the same reason. All tickets in Cassandra will be `EncodedTicket` so that is used instead of asking for the definition. 