### PR TITLE
CAS Shell encrypt/descrypt verbiage cleanup and provide iterations default

### DIFF
--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
@@ -5,6 +5,7 @@ import org.apereo.cas.configuration.support.CasConfigurationJasyptCipherExecutor
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.jasypt.encryption.pbe.StandardPBEByteEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.shell.standard.ShellCommandGroup;
@@ -34,20 +35,21 @@ public class JasyptDecryptPropertyCommand {
      * @param alg        the alg
      * @param provider   the provider
      * @param password   the password
-     * @param iterations the iterations
+     * @param iterations the iterations- defaults to {@value StandardPBEByteEncryptor#DEFAULT_KEY_OBTENTION_ITERATIONS}
      */
-    @ShellMethod(key = "decrypt-value", value = "Encrypt a CAS property value/setting via Jasypt")
+    @ShellMethod(key = "decrypt-value", value = "Decrypt a CAS property value/setting via Jasypt")
     public void decryptValue(
         @ShellOption(value = {"value"},
-            help = "Value to encrypt") final String value,
+            help = "Value to decrypt") final String value,
         @ShellOption(value = {"alg"},
-            help = "Algorithm to use to encrypt") final String alg,
+            help = "Algorithm to use to decrypt") final String alg,
         @ShellOption(value = {"provider"},
-            help = "Security provider to use to encrypt") final String provider,
+            help = "Security provider to use to decrypt") final String provider,
         @ShellOption(value = {"password"},
-            help = "Password (encryption key) to encrypt") final String password,
+            help = "Password (encryption key) to decrypt") final String password,
         @ShellOption(value = {"iterations"},
-            help = "Key obtention iterations to encrypt") final String iterations) {
+            defaultValue = ShellOption.NULL,
+            help = "Key obtention iterations to decrypt") final String iterations) {
 
         val cipher = new CasConfigurationJasyptCipherExecutor(this.environment);
         cipher.setAlgorithm(alg);
@@ -57,8 +59,8 @@ public class JasyptDecryptPropertyCommand {
         }
         cipher.setProviderName(provider);
         cipher.setKeyObtentionIterations(iterations);
-        val encrypted = cipher.decryptValue(value);
-        LOGGER.info("==== Decrypted Value ====\n{}", encrypted);
+        val decrypted = cipher.decryptValue(value);
+        LOGGER.info("==== Decrypted Value ====\n{}", decrypted);
 
     }
 }

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
@@ -49,7 +49,7 @@ public class JasyptDecryptPropertyCommand {
             help = "Password (encryption key) to decrypt") final String password,
         @ShellOption(value = {"iterations"},
             defaultValue = ShellOption.NULL,
-            help = "Key obtention iterations to decrypt") final String iterations) {
+            help = "Key obtention iterations to decrypt, default 1000") final String iterations) {
 
         val cipher = new CasConfigurationJasyptCipherExecutor(this.environment);
         cipher.setAlgorithm(alg);

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
@@ -49,7 +49,7 @@ public class JasyptEncryptPropertyCommand {
             help = "Password (encryption key) to encrypt") final String password,
         @ShellOption(value = {"iterations"},
             defaultValue = ShellOption.NULL,
-            help = "Key obtention iterations to encrypt") final String iterations) {
+            help = "Key obtention iterations to encrypt, default 1000") final String iterations) {
 
         val cipher = new CasConfigurationJasyptCipherExecutor(this.environment);
         cipher.setAlgorithm(alg);

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
@@ -5,6 +5,7 @@ import org.apereo.cas.configuration.support.CasConfigurationJasyptCipherExecutor
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.jasypt.encryption.pbe.StandardPBEByteEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.shell.standard.ShellCommandGroup;
@@ -34,7 +35,7 @@ public class JasyptEncryptPropertyCommand {
      * @param alg        the alg
      * @param provider   the provider
      * @param password   the password
-     * @param iterations the iterations
+     * @param iterations the iterations - defaults to {@value StandardPBEByteEncryptor#DEFAULT_KEY_OBTENTION_ITERATIONS}
      */
     @ShellMethod(key = "encrypt-value", value = "Encrypt a CAS property value/setting via Jasypt")
     public void encryptValue(
@@ -47,6 +48,7 @@ public class JasyptEncryptPropertyCommand {
         @ShellOption(value = {"password"},
             help = "Password (encryption key) to encrypt") final String password,
         @ShellOption(value = {"iterations"},
+            defaultValue = ShellOption.NULL,
             help = "Key obtention iterations to encrypt") final String iterations) {
 
         val cipher = new CasConfigurationJasyptCipherExecutor(this.environment);


### PR DESCRIPTION
This fixes the decrypt command saying "encrypt" in the help and it makes it easier to leave iterations as the default Jasypt value of 1000. Previously you would have to pass "iterations=" in order to set it to blank which then makes the value the default. If you set the iterations to something other than what you have set in CAS for the `cas.standalone.configurationSecurity.iterations` property (which also defaults to NULL) then CAS won't be able to decrypt. 