### PR TITLE
Open up a little the DelegatedClientAuthenticationAction

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
@@ -247,7 +247,13 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
         return request.getParameter(SAML2ServiceProviderMetadataResolver.LOGOUT_ENDPOINT_PARAMETER) != null;
     }
 
-    private boolean singleSignOnSessionExists(final RequestContext requestContext) {
+    /**
+     * Is there a current SSO session?
+     *
+     * @param requestContext the request context
+     * @return whether there is a current SSO session
+     */
+    protected boolean singleSignOnSessionExists(final RequestContext requestContext) {
         val tgtId = WebUtils.getTicketGrantingTicketId(requestContext);
         if (StringUtils.isBlank(tgtId)) {
             LOGGER.trace("No ticket-granting ticket could be located in the webflow context");


### PR DESCRIPTION
As a customisation, I may want to force the delegated authentication to always override the current SSO session by not detecting an existing one. For that, I extend this class and override the `singleSignOnSessionExists` method to always return `false`.