### PR TITLE
Make OIDC support more extensible

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -315,6 +315,7 @@ public class OidcConfiguration implements WebMvcConfigurer, CasWebflowExecutionP
     }
 
     @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcIdTokenGenerator")
     @Bean
     public IdTokenGeneratorService oidcIdTokenGenerator() {
         return new OidcIdTokenGeneratorService(
@@ -324,6 +325,7 @@ public class OidcConfiguration implements WebMvcConfigurer, CasWebflowExecutionP
             ticketRegistry.getIfAvailable());
     }
 
+    @ConditionalOnMissingBean(name = "oidcAccessTokenResponseGenerator")
     @Bean
     @RefreshScope
     public OAuth20AccessTokenResponseGenerator oidcAccessTokenResponseGenerator() {


### PR DESCRIPTION
As a customization, I may want to override the ID token generator and the access token response generator in the OIDC support.