### PR TITLE
clear surrogate username from request context on auth failure.

### DIFF
--- a/support/cas-server-support-surrogate-authentication/build.gradle
+++ b/support/cas-server-support-surrogate-authentication/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(":core:cas-server-core-audit-api")
     implementation project(":core:cas-server-core-tickets-api")
     implementation project(":core:cas-server-core-configuration-api")
+    implementation project(":core:cas-server-core-webflow-api")
     implementation project(":support:cas-server-support-surrogate-api")
 
     testImplementation project(":core:cas-server-core-services")

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/SurrogateAuthenticationExceptionHandlerAction.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/SurrogateAuthenticationExceptionHandlerAction.java
@@ -1,0 +1,36 @@
+package org.apereo.cas.authentication;
+
+import static java.util.Objects.nonNull;
+
+import java.util.Set;
+
+import org.apereo.cas.authentication.credential.RememberMeUsernamePasswordCredential;
+import org.apereo.cas.web.flow.actions.AuthenticationExceptionHandlerAction;
+import org.apereo.cas.web.support.WebUtils;
+import org.springframework.webflow.execution.RequestContext;
+
+public class SurrogateAuthenticationExceptionHandlerAction extends AuthenticationExceptionHandlerAction {
+
+    public SurrogateAuthenticationExceptionHandlerAction(Set<Class<? extends Throwable>> errors, String messageBundlePrefix) {
+        super(errors, messageBundlePrefix);
+    }
+
+    @Override
+    protected String handleAuthenticationException(AuthenticationException e, RequestContext requestContext) {
+        String handlerErrorName = super.handleAuthenticationException(e, requestContext);
+        revertSurrogateCredential(requestContext);
+        return handlerErrorName;
+    }
+
+    private void revertSurrogateCredential(RequestContext requestContext) {
+        Credential credential = WebUtils.getCredential(requestContext);
+        if (nonNull(credential) && credential instanceof SurrogateUsernamePasswordCredential) {
+            SurrogateUsernamePasswordCredential surrogateCred = (SurrogateUsernamePasswordCredential) credential;
+            RememberMeUsernamePasswordCredential revertedCred = new RememberMeUsernamePasswordCredential();
+            revertedCred.setUsername(surrogateCred.getUsername());
+            revertedCred.setPassword(surrogateCred.getPassword());
+            revertedCred.setRememberMe(surrogateCred.isRememberMe());
+            WebUtils.putCredential(requestContext, revertedCred);
+        }
+    }
+}

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationConfiguration.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/config/SurrogateAuthenticationConfiguration.java
@@ -5,6 +5,7 @@ import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationPostProcessor;
 import org.apereo.cas.authentication.PrincipalElectionStrategy;
+import org.apereo.cas.authentication.SurrogateAuthenticationExceptionHandlerAction;
 import org.apereo.cas.authentication.SurrogateAuthenticationPostProcessor;
 import org.apereo.cas.authentication.SurrogatePrincipalBuilder;
 import org.apereo.cas.authentication.SurrogatePrincipalElectionStrategy;
@@ -19,6 +20,7 @@ import org.apereo.cas.authentication.surrogate.JsonResourceSurrogateAuthenticati
 import org.apereo.cas.authentication.surrogate.SimpleSurrogateAuthenticationService;
 import org.apereo.cas.authentication.surrogate.SurrogateAuthenticationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.core.web.MessageBundleProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.ExpirationPolicy;
 import org.apereo.cas.ticket.support.HardTimeoutExpirationPolicy;
@@ -39,10 +41,12 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
+import org.springframework.webflow.execution.Action;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This is {@link SurrogateAuthenticationConfiguration}.
@@ -117,6 +121,12 @@ public class SurrogateAuthenticationConfiguration {
         su.getSimple().getSurrogates().forEach((k, v) -> accounts.put(k, new ArrayList<>(StringUtils.commaDelimitedListToSet(v))));
         LOGGER.debug("Using accounts [{}] for surrogate authentication", accounts);
         return new SimpleSurrogateAuthenticationService(accounts, servicesManager.getIfAvailable());
+    }
+
+    @Bean
+    public Action authenticationExceptionHandler(Set<Class<? extends Throwable>> handledAuthenticationExceptions) {
+        return new SurrogateAuthenticationExceptionHandlerAction(handledAuthenticationExceptions,
+            MessageBundleProperties.DEFAULT_BUNDLE_PREFIX_AUTHN_FAILURE);
     }
 
     @ConditionalOnMissingBean(name = "surrogateAuthenticationPostProcessor")

--- a/support/cas-server-support-surrogate-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-surrogate-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -1,6 +1,7 @@
 
 package org.apereo.cas;
 
+import org.apereo.cas.authentication.SurrogateAuthenticationExceptionHandlerActionTests;
 import org.apereo.cas.authentication.SurrogateAuthenticationMetaDataPopulatorTests;
 import org.apereo.cas.authentication.SurrogateAuthenticationPostProcessorTests;
 import org.apereo.cas.authentication.SurrogatePrincipalElectionStrategyTests;
@@ -28,7 +29,8 @@ import org.junit.runner.RunWith;
     SimpleSurrogateAuthenticationServiceTests.class,
     JsonResourceSurrogateAuthenticationServiceTests.class,
     SurrogatePrincipalElectionStrategyTests.class,
-    SurrogateSessionExpirationPolicyJsonSerializerTests.class
+    SurrogateSessionExpirationPolicyJsonSerializerTests.class,
+    SurrogateAuthenticationExceptionHandlerActionTests.class
 })
 @RunWith(JUnitPlatform.class)
 public class AllTestsSuite {

--- a/support/cas-server-support-surrogate-authentication/src/test/java/org/apereo/cas/authentication/SurrogateAuthenticationExceptionHandlerActionTests.java
+++ b/support/cas-server-support-surrogate-authentication/src/test/java/org/apereo/cas/authentication/SurrogateAuthenticationExceptionHandlerActionTests.java
@@ -1,0 +1,74 @@
+package org.apereo.cas.authentication;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import javax.security.auth.login.AccountNotFoundException;
+
+import org.apereo.cas.authentication.credential.RememberMeUsernamePasswordCredential;
+import org.apereo.cas.configuration.model.core.web.MessageBundleProperties;
+import org.apereo.cas.web.support.WebUtils;
+import org.junit.Test;
+import org.springframework.binding.message.MessageContext;
+import org.springframework.webflow.core.collection.LocalAttributeMap;
+import org.springframework.webflow.execution.RequestContext;
+
+import lombok.val;
+
+public class SurrogateAuthenticationExceptionHandlerActionTests {
+
+    @Test
+    public void handleAuthenticationNonSurrogateCredential() {
+        val ctx = mock(RequestContext.class);
+        when(ctx.getMessageContext()).thenReturn(mock(MessageContext.class));
+        RememberMeUsernamePasswordCredential rememberMeUsernamePasswordCredential = new RememberMeUsernamePasswordCredential();
+        rememberMeUsernamePasswordCredential.setUsername("casuser");
+        rememberMeUsernamePasswordCredential.setPassword("mellon");
+
+        val requestScope = new LocalAttributeMap<Object>();
+        requestScope.put("credential", rememberMeUsernamePasswordCredential);
+        when(ctx.getRequestScope()).thenReturn(requestScope);
+        when(ctx.getFlowScope()).thenReturn(new LocalAttributeMap<>());
+        when(ctx.getConversationScope()).thenReturn(new LocalAttributeMap<>());
+
+        val map = new HashMap<String, Throwable>();
+        map.put("notFound", new AccountNotFoundException());
+        val handler = new SurrogateAuthenticationExceptionHandlerAction(Set.of(AccountNotFoundException.class),
+            MessageBundleProperties.DEFAULT_BUNDLE_PREFIX_AUTHN_FAILURE);
+
+        val id = handler.handleAuthenticationException(new AuthenticationException(map), ctx);
+        assertEquals(AccountNotFoundException.class.getSimpleName(), id);
+        assertTrue(WebUtils.getCredential(ctx) instanceof RememberMeUsernamePasswordCredential);
+    }
+
+    @Test
+    public void handleAuthenticationSurrogateCredential() {
+        val ctx = mock(RequestContext.class);
+        when(ctx.getMessageContext()).thenReturn(mock(MessageContext.class));
+        SurrogateUsernamePasswordCredential surrogateCredential = new SurrogateUsernamePasswordCredential();
+        surrogateCredential.setUsername("casuser");
+        surrogateCredential.setPassword("mellon");
+        surrogateCredential.setSurrogateUsername("surrogate");
+
+        val requestScope = new LocalAttributeMap<Object>();
+        requestScope.put("credential", surrogateCredential);
+        when(ctx.getRequestScope()).thenReturn(requestScope);
+        when(ctx.getFlowScope()).thenReturn(new LocalAttributeMap<>());
+        when(ctx.getConversationScope()).thenReturn(new LocalAttributeMap<>());
+
+        val map = new HashMap<String, Throwable>();
+        map.put("notFound", new AccountNotFoundException());
+        val handler = new SurrogateAuthenticationExceptionHandlerAction(Set.of(AccountNotFoundException.class),
+            MessageBundleProperties.DEFAULT_BUNDLE_PREFIX_AUTHN_FAILURE);
+
+        val id = handler.handleAuthenticationException(new AuthenticationException(map), ctx);
+        assertEquals(AccountNotFoundException.class.getSimpleName(), id);
+        assertTrue(WebUtils.getCredential(ctx) instanceof RememberMeUsernamePasswordCredential);
+    }
+
+}


### PR DESCRIPTION
fixes bug where the wrong principal is resolved if the user decides to abandon the surrogate flow.