### PR TITLE
Fix Pac4jOidcClientProperties generic prop type

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/Pac4jOidcClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/Pac4jOidcClientProperties.java
@@ -43,6 +43,6 @@ public class Pac4jOidcClientProperties implements Serializable {
      * Settings specific to delegating authentication to keycloak.
      */
     @NestedConfigurationProperty
-    private Pac4jKeyCloakOidcClientProperties generic = new Pac4jKeyCloakOidcClientProperties();
+    private Pac4jGenericOidcClientProperties generic = new Pac4jGenericOidcClientProperties();
 
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/Pac4jOidcClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/Pac4jOidcClientProperties.java
@@ -40,7 +40,7 @@ public class Pac4jOidcClientProperties implements Serializable {
     private Pac4jKeyCloakOidcClientProperties keycloak = new Pac4jKeyCloakOidcClientProperties();
 
     /**
-     * Settings specific to delegating authentication to keycloak.
+     * Settings specific to delegating authentication to generic oidc.
      */
     @NestedConfigurationProperty
     private Pac4jGenericOidcClientProperties generic = new Pac4jGenericOidcClientProperties();


### PR DESCRIPTION
Fix the generic property type `generic`. Change from type `Pac4jKeyCloakOidcClientProperties` to `Pac4jGenericOidcClientProperties`.  