### PR TITLE
Add description to ConsentReminderOptions enum (code documentation)

### DIFF
--- a/support/cas-server-support-consent-api/src/main/java/org/apereo/cas/consent/ConsentReminderOptions.java
+++ b/support/cas-server-support-consent-api/src/main/java/org/apereo/cas/consent/ConsentReminderOptions.java
@@ -14,11 +14,13 @@ public enum ConsentReminderOptions {
      */
     ALWAYS(0),
     /**
-     * Always ask for consent.
+     * Ask for consent when there is modification in one of the attribute names or 
+     * if consent is expired.
      */
     ATTRIBUTE_NAME(1),
     /**
-     * Always ask for consent.
+     * Ask for consent when there is modification in one of the attribute names, 
+     * the values contain inside the attributes or if consent is expired
      */
     ATTRIBUTE_VALUE(2);
 


### PR DESCRIPTION
The previous description for ConsentReminderOption enum is 3 duplicate `Always ask for consent.`, which is not correct. This PR will attempt to add back some meaning to the different enum.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
