### PR TITLE
Make webflow i18n support placeholder when handle authentication exceptions

### DIFF
--- a/api/cas-server-core-api-logout/src/main/java/org/apereo/cas/logout/slo/SingleLogoutMessage.java
+++ b/api/cas-server-core-api-logout/src/main/java/org/apereo/cas/logout/slo/SingleLogoutMessage.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  */
 @Getter
 @Builder
-@ToString(of = {"payload"})
+@ToString(of = "payload")
 public class SingleLogoutMessage<T> implements Serializable {
     private static final long serialVersionUID = -7763669015027355811L;
 

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/OneTimePasswordCredential.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/OneTimePasswordCredential.java
@@ -22,7 +22,7 @@ import lombok.ToString;
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true, exclude = {"password"})
+@ToString(callSuper = true, exclude = "password")
 public class OneTimePasswordCredential extends BasicIdentifiableCredential {
 
     /**

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/UsernamePasswordCredential.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/UsernamePasswordCredential.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * @author Marvin S. Addison
  * @since 3.0.0
  */
-@ToString(exclude = {"password"})
+@ToString(exclude = "password")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/AbstractRegisteredService.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/AbstractRegisteredService.java
@@ -51,7 +51,7 @@ import java.util.Map;
 @ToString
 @Getter
 @Setter
-@EqualsAndHashCode(exclude = {"id"})
+@EqualsAndHashCode(exclude = "id")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class AbstractRegisteredService implements RegisteredService {
 

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceDelegatedAuthenticationPolicy.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceDelegatedAuthenticationPolicy.java
@@ -23,7 +23,7 @@ import java.util.LinkedHashSet;
 @ToString
 @Getter
 @Setter
-@EqualsAndHashCode(exclude = {"allowedProviders"})
+@EqualsAndHashCode(exclude = "allowedProviders")
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/AbstractTicket.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/AbstractTicket.java
@@ -40,7 +40,7 @@ import java.time.ZonedDateTime;
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @NoArgsConstructor
-@EqualsAndHashCode(of = {"id"})
+@EqualsAndHashCode(of = "id")
 @Setter
 @Slf4j
 public abstract class AbstractTicket implements Ticket, TicketState {

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/EncodedTicket.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/EncodedTicket.java
@@ -27,10 +27,10 @@ import java.time.ZonedDateTime;
  * @since 4.2
  */
 @Slf4j
-@ToString(of = {"id"})
+@ToString(of = "id")
 @Getter
 @NoArgsConstructor
-@EqualsAndHashCode(of = {"id"})
+@EqualsAndHashCode(of = "id")
 @AllArgsConstructor
 public class EncodedTicket implements Ticket {
 

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/mock/MockServiceTicket.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/mock/MockServiceTicket.java
@@ -27,7 +27,7 @@ import java.time.ZonedDateTime;
  */
 @Getter
 @Setter
-@EqualsAndHashCode(of = {"id"})
+@EqualsAndHashCode(of = "id")
 public class MockServiceTicket implements ServiceTicket, TicketState {
 
     private static final long serialVersionUID = 8203377063087967768L;

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/mock/MockTicketGrantingTicket.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/mock/MockTicketGrantingTicket.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * @since 3.0.0
  */
 @Getter
-@EqualsAndHashCode(of = {"id"})
+@EqualsAndHashCode(of = "id")
 public class MockTicketGrantingTicket implements TicketGrantingTicket, TicketState {
 
     public static final UniqueTicketIdGenerator ID_GENERATOR = new DefaultUniqueTicketIdGenerator();

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/PlaceholderCapableException.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/PlaceholderCapableException.java
@@ -1,0 +1,24 @@
+package org.apereo.cas.web.flow;
+
+/**
+ * Perform placeHolder for i18n when handle authentication exceptions.
+ *
+ * @author Qimiao Chen
+ * @since 6.0.0
+ */
+
+public interface PlaceholderCapableException {
+    /**
+     * Get all args.
+     * 
+     * @return Object[] the args
+     */
+    Object[] getArgs();
+
+    /**
+     * Set all args.
+     *
+     * @param args the args
+     */
+    void setArgs(Object... args);
+}

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/AuthenticationExceptionHandlerAction.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/AuthenticationExceptionHandlerAction.java
@@ -5,12 +5,14 @@ import org.apereo.cas.configuration.model.core.web.MessageBundleProperties;
 import org.apereo.cas.services.UnauthorizedServiceForPrincipalException;
 import org.apereo.cas.ticket.AbstractTicketException;
 import org.apereo.cas.web.flow.CasWebflowConstants;
+import org.apereo.cas.web.flow.PlaceholderCapableException;
 import org.apereo.cas.web.support.WebUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.binding.message.MessageBuilder;
+import org.springframework.util.CollectionUtils;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.action.EventFactorySupport;
 import org.springframework.webflow.execution.Event;

--- a/support/cas-server-support-duo-core-mfa/src/main/java/org/apereo/cas/adaptors/duo/authn/DuoSecurityCredential.java
+++ b/support/cas-server-support-duo-core-mfa/src/main/java/org/apereo/cas/adaptors/duo/authn/DuoSecurityCredential.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(of = {"username"}, callSuper = true)
+@EqualsAndHashCode(of = "username", callSuper = true)
 public class DuoSecurityCredential extends AbstractCredential implements MultifactorAuthenticationCredential {
 
     private static final long serialVersionUID = -7570600733132111037L;

--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/web/flow/fingerprint/GeoLocationDeviceFingerprintComponentExtractor.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/web/flow/fingerprint/GeoLocationDeviceFingerprintComponentExtractor.java
@@ -10,7 +10,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.inspektr.common.web.ClientInfoHolder;
 import org.springframework.webflow.execution.RequestContext;
 
 import java.util.Optional;


### PR DESCRIPTION
Previously ,the developer can't passing information through placeholders, when handler which extends ```AbstractPreAndPostProcessingAuthenticationHandler``` throw an exception.
Now, I want to provide an interface named ```PlaceholderCapableException```,if any exception implements the interface, the placeholder can be used.