### PR TITLE
Transactional DistributedJ2ESessionStore and OAuth20DefaultTokenGenerator to get jpa working

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/OAuth20DefaultTokenGenerator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/OAuth20DefaultTokenGenerator.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -39,6 +40,7 @@ import java.util.LinkedHashSet;
  * @author Misagh Moayyed
  * @since 5.2.0
  */
+@Transactional(transactionManager = "ticketTransactionManager")
 @Slf4j
 @RequiredArgsConstructor
 public class OAuth20DefaultTokenGenerator implements OAuth20TokenGenerator {

--- a/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/integration/pac4j/DistributedJ2ESessionStore.java
+++ b/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/integration/pac4j/DistributedJ2ESessionStore.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.context.session.J2ESessionStore;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
@@ -25,6 +26,7 @@ import java.util.HashMap;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
+@Transactional(transactionManager = "ticketTransactionManager")
 @RequiredArgsConstructor
 @Slf4j
 public class DistributedJ2ESessionStore extends J2ESessionStore implements HttpSessionListener, LogoutPostProcessor {


### PR DESCRIPTION
JPA ticket registry with OIDC does not work at the moment because `DistributedJ2ESessionStore` and `OAuth20DefaultTokenGenerator` both make use of the `ticketRegistry` without using transactions. This PR should resolve this by making these classes `Transactional`.