### PR TITLE
Make idToken @Lob so jpa makes it more than varchar(255)

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/AccessTokenImpl.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/AccessTokenImpl.java
@@ -13,7 +13,6 @@ import lombok.Setter;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.persistence.Lob;
 import java.util.Collection;
 import java.util.Map;
 
@@ -32,8 +31,7 @@ public class AccessTokenImpl extends OAuthCodeImpl implements AccessToken {
 
     private static final long serialVersionUID = 2339545346159721563L;
 
-    @Lob
-    @Column
+    @Column(length = 2048)
     private String idToken;
 
     public AccessTokenImpl(final String id, final Service service,

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/AccessTokenImpl.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/AccessTokenImpl.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import javax.persistence.Lob;
 import java.util.Collection;
 import java.util.Map;
 
@@ -31,6 +32,7 @@ public class AccessTokenImpl extends OAuthCodeImpl implements AccessToken {
 
     private static final long serialVersionUID = 2339545346159721563L;
 
+    @Lob
     @Column
     private String idToken;
 


### PR DESCRIPTION
Oauth ID tokens can contain more than 255 characters of text. JPA ticket registry thus fails to insert the id token data into the column. This PR adds the `@Lob` annotation to `idToken` which ensures the column type will be `text` or similar in the db.