### PR TITLE
Check for old scalar boolean attributes to prevent old style ticket attributes crashing the ticket cleaner

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicy.java
@@ -53,9 +53,11 @@ public class RememberMeDelegatingExpirationPolicy extends BaseDelegatingExpirati
     @Override
     protected String getExpirationPolicyNameFor(final TicketState ticketState) {
         final Map<String, Object> attrs = ticketState.getAuthentication().getAttributes();
-        final Collection c = (Collection) attrs.get(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
+        final Object o = attrs.get(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME);
 
-        if (c == null || c.contains(Boolean.FALSE)) {
+        if (o == null
+            || o instanceof Boolean && !((Boolean) o)
+            || o instanceof Collection && ((Collection) o).contains(Boolean.FALSE)) {
             LOGGER.debug("Ticket is not associated with a remember-me authentication.");
             return PolicyTypes.DEFAULT.name();
         }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicyTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/support/RememberMeDelegatingExpirationPolicyTests.java
@@ -64,8 +64,32 @@ public class RememberMeDelegatingExpirationPolicyTests {
     }
 
     @Test
+    public void verifyTicketExpirationWithOldRememberMe() {
+        final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication(
+                this.principalFactory.createPrincipal("test"),
+                Collections.singletonMap(
+                        RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, true));
+        final TicketGrantingTicketImpl t = new TicketGrantingTicketImpl("111", authentication, this.p);
+        assertFalse(t.isExpired());
+        t.grantServiceTicket("55", RegisteredServiceTestUtils.getService(), this.p, false, true);
+        assertTrue(t.isExpired());
+    }
+
+    @Test
     public void verifyTicketExpirationWithoutRememberMe() {
         final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication();
+        final TicketGrantingTicketImpl t = new TicketGrantingTicketImpl("111", authentication, this.p);
+        assertFalse(t.isExpired());
+        t.grantServiceTicket("55", RegisteredServiceTestUtils.getService(), this.p, false, true);
+        assertFalse(t.isExpired());
+    }
+
+    @Test
+    public void verifyTicketExpirationWithoutOldRememberMe() {
+        final Authentication authentication = CoreAuthenticationTestUtils.getAuthentication(
+                this.principalFactory.createPrincipal("test"),
+                Collections.singletonMap(
+                        RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, false));
         final TicketGrantingTicketImpl t = new TicketGrantingTicketImpl("111", authentication, this.p);
         assertFalse(t.isExpired());
         t.grantServiceTicket("55", RegisteredServiceTestUtils.getService(), this.p, false, true);


### PR DESCRIPTION
The ticket registry cleaner crashes after upgrading to 5.3.11 from an earlier version with scalar attributes.  This patch allows our CAS to migrate cleanly from scalar attributes to collections the other.

IMHO this patch is only necessary for 5.3 so that I can upgrade but happy to port forward to 6.0 and master if necessary.