### PR TITLE
Improvements for the mongo ticket registry

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/TicketCatalog.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/TicketCatalog.java
@@ -46,7 +46,7 @@ public interface TicketCatalog {
      * @param ticketClass the ticket class
      * @return the collection
      */
-    Collection<TicketDefinition> find(Class<Ticket> ticketClass);
+    Collection<TicketDefinition> find(Class<? extends Ticket> ticketClass);
 
     /**
      * Find ticket definition.

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketCatalog.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketCatalog.java
@@ -44,7 +44,7 @@ public class DefaultTicketCatalog implements TicketCatalog {
     }
 
     @Override
-    public Collection<TicketDefinition> find(final Class<Ticket> ticketClass) {
+    public Collection<TicketDefinition> find(final Class<? extends Ticket> ticketClass) {
         val list = ticketMetadataMap.values().stream()
             .filter(t -> t.getImplementationClass().isAssignableFrom(ticketClass))
             .collect(Collectors.toList());

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -1,9 +1,11 @@
 package org.apereo.cas.ticket.registry;
 
 import org.apereo.cas.mongo.MongoDbConnectionFactory;
+import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketCatalog;
 import org.apereo.cas.ticket.TicketDefinition;
+import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketState;
 import org.apereo.cas.ticket.serialization.TicketSerializationManager;
 
@@ -22,6 +24,7 @@ import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.util.StreamUtils;
 
 import java.util.Collection;
 import java.util.Date;
@@ -29,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A Ticket Registry storage backend based on MongoDB.
@@ -179,6 +183,33 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
                 return countTickets;
             })
             .sum();
+    }
+
+    @Override
+    public Stream<Ticket> getTicketsStream() {
+        return ticketCatalog.findAll().stream()
+                .map(this::getTicketCollectionInstanceByMetadata)
+                .map(map -> mongoTemplate.stream(new Query(), TicketHolder.class, map))
+                .flatMap(StreamUtils::createStreamFromIterator)
+                .map(ticket -> decodeTicket(deserializeTicketFromMongoDocument(ticket)));
+    }
+
+    @Override
+    public long serviceTicketCount() {
+        return countTicketsByTicketType(ServiceTicket.class);
+    }
+
+    @Override
+    public long sessionCount() {
+        return countTicketsByTicketType(TicketGrantingTicket.class);
+    }
+
+    private long countTicketsByTicketType(final Class<? extends Ticket> ticketType) {
+        val ticketDefinitions = ticketCatalog.find(ticketType);
+        return ticketDefinitions.stream()
+                .map(this::getTicketCollectionInstanceByMetadata)
+                .mapToLong(map -> mongoTemplate.count(new Query(), map))
+                .sum();
     }
 
     private TicketHolder buildTicketAsDocument(final Ticket ticket) {


### PR DESCRIPTION
 - Override getTicketsStream to provide a cursor backed stream instead of loading all tickets to memory via the Collection method
 - Implement sessionCount and serviceTicketCount by querying the count directly from Mongo