### PR TITLE
ServiceRegistryInitializer: Doing a regex match on service id leads to false positives

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ServiceRegistryInitializer.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ServiceRegistryInitializer.java
@@ -54,14 +54,9 @@ public class ServiceRegistryInitializer {
 
     private boolean findExistingMatchForService(final RegisteredService r) {
         if (StringUtils.isNotBlank(r.getServiceId())) {
-            val match = this.serviceRegistry.findServiceById(r.getServiceId());
-            if (match != null && match.getClass().equals(r.getClass())) {
+            val match = this.serviceRegistry.findServiceByExactServiceId(r.getServiceId());
+            if (match != null) {
                 LOGGER.warn("Skipping [{}] JSON service definition as a matching service [{}] is found in the registry", r.getName(), match.getName());
-                return true;
-            }
-            val match2 = this.serviceRegistry.findServiceByExactServiceId(r.getServiceId());
-            if (match2 != null) {
-                LOGGER.warn("Skipping [{}] JSON service definition as a matching service [{}] is found in the registry", r.getName(), match2.getName());
                 return true;
             }
         }


### PR DESCRIPTION
eg the automatic oauth callback can cause a false positive match to a catch all on the same domain with the Mongo Service registry.

A combination of exact service id and numeric id checks should be sufficient to prevent duplicates being inserted and implementations of `findServiceById(String)` all work differently.
