### PR TITLE
Remove unused ServiceRegistry.findServiceById(String) method

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistry.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistry.java
@@ -46,14 +46,6 @@ public interface ServiceRegistry {
     RegisteredService findServiceById(long id);
 
     /**
-     * Find service by the service id.
-     *
-     * @param id the id
-     * @return the registered service
-     */
-    RegisteredService findServiceById(String id);
-
-    /**
      * Find a service by an exact match of the service id.
      *
      * @param id the id

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServiceRegistry.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServiceRegistry.java
@@ -84,15 +84,6 @@ public class ChainingServiceRegistry extends AbstractServiceRegistry {
     }
 
     @Override
-    public RegisteredService findServiceById(final String id) {
-        return serviceRegistries.stream()
-            .map(registry -> registry.findServiceById(id))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
-    }
-
-    @Override
     public RegisteredService findServiceByExactServiceId(final String id) {
         return serviceRegistries.stream()
             .map(registry -> registry.findServiceByExactServiceId(id))

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/InMemoryServiceRegistry.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/InMemoryServiceRegistry.java
@@ -45,11 +45,6 @@ public class InMemoryServiceRegistry extends AbstractServiceRegistry {
     }
 
     @Override
-    public RegisteredService findServiceById(final String id) {
-        return this.registeredServices.stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-    }
-
-    @Override
     public Collection<RegisteredService> load() {
         val services = new ArrayList<RegisteredService>();
         registeredServices

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/resource/AbstractResourceBasedServiceRegistry.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/resource/AbstractResourceBasedServiceRegistry.java
@@ -191,12 +191,6 @@ public abstract class AbstractResourceBasedServiceRegistry extends AbstractServi
     }
 
     @Override
-    public RegisteredService findServiceById(final String id) {
-        val service = this.serviceMap.values().stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-        return this.registeredServiceReplicationStrategy.getRegisteredServiceFromCacheIfAny(service, id, this);
-    }
-
-    @Override
     @SneakyThrows
     public synchronized boolean delete(final RegisteredService service) {
 

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServiceRegistryTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServiceRegistryTests.java
@@ -113,7 +113,6 @@ public abstract class AbstractServiceRegistryTests {
     @Test
     public void verifyNonExistingService() {
         assertNull(this.serviceRegistry.findServiceById(9999991));
-        assertNull(this.serviceRegistry.findServiceById("9999991"));
     }
 
     @ParameterizedTest

--- a/support/cas-server-support-cassandra-service-registry/src/main/java/org/apereo/cas/adaptors/cassandra/services/CassandraServiceRegistry.java
+++ b/support/cas-server-support-cassandra-service-registry/src/main/java/org/apereo/cas/adaptors/cassandra/services/CassandraServiceRegistry.java
@@ -117,11 +117,6 @@ public class CassandraServiceRegistry extends AbstractServiceRegistry implements
     }
 
     @Override
-    public RegisteredService findServiceById(final String id) {
-        return load().stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-    }
-
-    @Override
     public void destroy() {
         this.cassandraSession.close();
     }

--- a/support/cas-server-support-cosmosdb-service-registry/src/main/java/org/apereo/cas/services/CosmosDbServiceRegistry.java
+++ b/support/cas-server-support-cosmosdb-service-registry/src/main/java/org/apereo/cas/services/CosmosDbServiceRegistry.java
@@ -130,18 +130,6 @@ public class CosmosDbServiceRegistry extends AbstractServiceRegistry {
         return null;
     }
 
-    @Override
-    public RegisteredService findServiceById(final String id) {
-        val query = String.format("SELECT * FROM %s c WHERE CONTAINS(c.body,'%s')", this.collectionName, id);
-        val results = queryDocuments(query);
-        val it = results.getQueryIterator();
-        if (it.hasNext()) {
-            val doc = it.next();
-            return getRegisteredServiceFromDocumentBody(doc);
-        }
-        return null;
-    }
-
     private FeedResponse<Document> queryDocuments(final String query) {
         val sql = new SqlQuerySpec(query);
         val feed = new FeedOptions();

--- a/support/cas-server-support-couchbase-service-registry/src/main/java/org/apereo/cas/services/CouchbaseServiceRegistry.java
+++ b/support/cas-server-support-couchbase-service-registry/src/main/java/org/apereo/cas/services/CouchbaseServiceRegistry.java
@@ -139,12 +139,6 @@ public class CouchbaseServiceRegistry extends AbstractServiceRegistry implements
         return null;
     }
 
-    @Override
-    public RegisteredService findServiceById(final String id) {
-        LOGGER.debug("Lookup for service string: [{}]", id);
-        return load().stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-    }
-
     /**
      * Stops the couchbase client and cancels the initialization task if uncompleted.
      */

--- a/support/cas-server-support-couchdb-service-registry/src/main/java/org/apereo/cas/services/CouchDbServiceRegistry.java
+++ b/support/cas-server-support-couchdb-service-registry/src/main/java/org/apereo/cas/services/CouchDbServiceRegistry.java
@@ -95,19 +95,6 @@ public class CouchDbServiceRegistry extends AbstractServiceRegistry {
     }
 
     @Override
-    public RegisteredService findServiceById(final String id) {
-        try {
-            val doc = dbClient.get(id);
-            if (doc != null) {
-                return doc.getService();
-            }
-        } catch (final DocumentNotFoundException e) {
-            LOGGER.info(e.getMessage());
-        }
-        return null;
-    }
-
-    @Override
     public RegisteredService findServiceByExactServiceId(final String id) {
         val doc = dbClient.findByServiceId(id);
         if (doc == null) {

--- a/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/services/DynamoDbServiceRegistry.java
+++ b/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/services/DynamoDbServiceRegistry.java
@@ -54,11 +54,6 @@ public class DynamoDbServiceRegistry extends AbstractServiceRegistry {
     }
 
     @Override
-    public RegisteredService findServiceById(final String id) {
-        return dbTableService.get(id);
-    }
-
-    @Override
     public long size() {
         return dbTableService.count();
     }

--- a/support/cas-server-support-git-service-registry/src/main/java/org/apereo/cas/services/GitServiceRegistry.java
+++ b/support/cas-server-support-git-service-registry/src/main/java/org/apereo/cas/services/GitServiceRegistry.java
@@ -127,11 +127,6 @@ public class GitServiceRegistry extends AbstractServiceRegistry {
         return this.registeredServices.stream().filter(r -> r.getId() == id).findFirst().orElse(null);
     }
 
-    @Override
-    public RegisteredService findServiceById(final String id) {
-        return this.registeredServices.stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-    }
-
     private List<RegisteredService> parseGitObjectContentIntoRegisteredService(final GitRepository.GitObject obj) {
         return this.registeredServiceSerializers
             .stream()

--- a/support/cas-server-support-jpa-service-registry/src/main/java/org/apereo/cas/services/JpaServiceRegistry.java
+++ b/support/cas-server-support-jpa-service-registry/src/main/java/org/apereo/cas/services/JpaServiceRegistry.java
@@ -75,11 +75,6 @@ public class JpaServiceRegistry extends AbstractServiceRegistry {
     }
 
     @Override
-    public RegisteredService findServiceById(final String id) {
-        return load().stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-    }
-
-    @Override
     public long size() {
         val query = String.format("select count(r) from %s r", ENTITY_NAME);
         return this.entityManager.createQuery(query, Long.class).getSingleResult();

--- a/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/LdapServiceRegistry.java
+++ b/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/LdapServiceRegistry.java
@@ -193,11 +193,6 @@ public class LdapServiceRegistry extends AbstractServiceRegistry {
         return null;
     }
 
-    @Override
-    public RegisteredService findServiceById(final String id) {
-        return load().stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-    }
-
     /**
      * Search for service by id.
      *

--- a/support/cas-server-support-mongo-service-registry/src/main/java/org/apereo/cas/services/MongoDbServiceRegistry.java
+++ b/support/cas-server-support-mongo-service-registry/src/main/java/org/apereo/cas/services/MongoDbServiceRegistry.java
@@ -12,7 +12,6 @@ import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.Collection;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -54,12 +53,6 @@ public class MongoDbServiceRegistry extends AbstractServiceRegistry {
     @Override
     public RegisteredService findServiceById(final long svcId) {
         return this.mongoTemplate.findOne(new Query(Criteria.where("id").is(svcId)), RegisteredService.class, this.collectionName);
-    }
-
-    @Override
-    public RegisteredService findServiceById(final String id) {
-        val pattern = Pattern.compile(id, Pattern.CASE_INSENSITIVE);
-        return this.mongoTemplate.findOne(new Query(Criteria.where("serviceId").regex(pattern)), RegisteredService.class, this.collectionName);
     }
 
     @Override

--- a/support/cas-server-support-redis-service-registry/src/main/java/org/apereo/cas/adaptors/redis/services/RedisServiceRegistry.java
+++ b/support/cas-server-support-redis-service-registry/src/main/java/org/apereo/cas/adaptors/redis/services/RedisServiceRegistry.java
@@ -113,13 +113,6 @@ public class RedisServiceRegistry extends AbstractServiceRegistry {
         return null;
     }
 
-    @Override
-    public RegisteredService findServiceById(final String id) {
-        val registeredService = load().stream().filter(r -> r.matches(id)).findFirst().orElse(null);
-        LOGGER.trace("Registered service by identifier [{}] is [{}]", id, registeredService);
-        return registeredService;
-    }
-
     private static String getRegisteredServiceRedisKey(final RegisteredService registeredService) {
         return getRegisteredServiceRedisKey(registeredService.getId());
     }

--- a/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
+++ b/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
@@ -80,12 +80,7 @@ public class RestfulServiceRegistry extends AbstractServiceRegistry {
 
     @Override
     public RegisteredService findServiceById(final long id) {
-        return findServiceById(String.valueOf(id));
-    }
-
-    @Override
-    public RegisteredService findServiceById(final String id) {
-        val completeUrl = StringUtils.appendIfMissing(this.url, "/").concat(id);
+        val completeUrl = StringUtils.appendIfMissing(this.url, "/").concat(Long.toString(id));
         val responseEntity = restTemplate.exchange(completeUrl, HttpMethod.GET,
             new HttpEntity<>(id, this.headers), RegisteredService.class);
         if (responseEntity.getStatusCode().is2xxSuccessful()) {


### PR DESCRIPTION
Builds on #4071 to remove the findServiceById method as it's now unused.

Also note that the various implementations of `ServiceRegistry.findServiceById(String id)` across all the repository types were completely different:

The following all load every service into a collection and returns find the first `serviceId` that regex matches the parameter:
- `AbstractResourceBasedServiceRegistry`
- `CouchbaseServiceRegistry`
 - `InMemoryServiceRegistry`
- `JpaServiceRegistry`
- `LdapServiceRegistry`
- `RedisServiceRegistry`

`CosmosDbServiceRegistry`: find a service with the parameter in the document body
`CouchDbServiceRegistry`: find a service with the `id` equal to the parameter
`DynamoDbServiceRegistry`: find a service with the `id` equal to the parameter
`MongoDbServiceRegistry`: find a service with parameter regex matching `serviceId` (ie the reverse of the big group above)
