### PR TITLE
Implement MongoDbServiceRegistry queries as mongo queries

### DIFF
--- a/support/cas-server-support-mongo-service-registry/src/main/java/org/apereo/cas/services/MongoDbServiceRegistry.java
+++ b/support/cas-server-support-mongo-service-registry/src/main/java/org/apereo/cas/services/MongoDbServiceRegistry.java
@@ -63,6 +63,16 @@ public class MongoDbServiceRegistry extends AbstractServiceRegistry {
     }
 
     @Override
+    public RegisteredService findServiceByExactServiceId(final String id) {
+        return this.mongoTemplate.findOne(new Query(Criteria.where("serviceId").is(id)), RegisteredService.class, this.collectionName);
+    }
+
+    @Override
+    public RegisteredService findServiceByExactServiceName(final String name) {
+        return this.mongoTemplate.findOne(new Query(Criteria.where("name").is(name)), RegisteredService.class, this.collectionName);
+    }
+
+    @Override
     public Collection<RegisteredService> load() {
         val list = this.mongoTemplate.findAll(RegisteredService.class, this.collectionName);
         return list


### PR DESCRIPTION
Use mongo queries to implement `findServiceBy` methods.