### PR TITLE
Open up a little the authentication delegation

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
@@ -243,7 +243,13 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
         }
     }
 
-    private boolean isLogoutRequest(final HttpServletRequest request) {
+    /**
+     * Is this a SAML logout request?
+     *
+     * @param request the HTTP request
+     * @return whether it is a SAML logout request
+     */
+    protected boolean isLogoutRequest(final HttpServletRequest request) {
         return request.getParameter(SAML2ServiceProviderMetadataResolver.LOGOUT_ENDPOINT_PARAMETER) != null;
     }
 


### PR DESCRIPTION
For a customization of the `DelegatedClientAuthenticationAction`, I have needed to use the `isLogoutRequest` method in a subclass.