### PR TITLE
Open up a little the authentication delegation

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
@@ -460,7 +460,13 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
         return authenticationRequestServiceSelectionStrategies.resolveService(service);
     }
 
-    private static boolean isLogoutRequest(final HttpServletRequest request) {
+    /**
+     * Is this a SAML logout request?
+     *
+     * @param request the HTTP request
+     * @return whether it is a SAML logout request
+     */
+    protected static boolean isLogoutRequest(final HttpServletRequest request) {
         return request.getParameter(SAML2ServiceProviderMetadataResolver.LOGOUT_ENDPOINT_PARAMETER) != null;
     }
 


### PR DESCRIPTION
For a customization of the `DelegatedClientAuthenticationAction`, I have needed to use the `isLogoutRequest` method in a subclass.