### PR TITLE
Override the Spring Boot mongo driver version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -120,7 +120,6 @@ casClientVersion=3.5.1
 casSecurityFilterVersion=2.0.10.4
 
 fongoVersion=2.1.1
-mongoDriverVersion=3.8.2
 jtaVersion=1.1
 
 splunkLoggingVersion=1.5.3

--- a/gradle/overrides.gradle
+++ b/gradle/overrides.gradle
@@ -30,6 +30,7 @@ ext["postgresqlVersion"] = "42.2.5"
 ext["mariaDbVersion"] = "2.2.4"
 ext["jtdsVersion"] = "1.3.1"
 ext["mssqlServerVersion"] = "6.4.0.jre8"
+ext["mongoDriverVersion"] = "3.8.2"
 
 ext["couchbase-client.version"] = ext["couchbaseVersion"]
 ext["caffeine.version"] = ext["caffeinVersion"]
@@ -55,3 +56,4 @@ ext["postgresql.version"] = ext["postgresqlVersion"]
 ext["mariadb.version"] = ext["mariaDbVersion"]
 ext["jtds.version"] = ext["jtdsVersion"]
 ext["mssql-jdbc.version"] = ext["mssqlServerVersion"]
+ext["mongodb.version"] = ext["mongoDriverVersion"]


### PR DESCRIPTION
so the correct version ends up in the .war file.  Not necessary to port forward as spring boot dependency management appears to have changed (?)