### PR TITLE
Fix TicketCatalog.find(Class) (5.3.x)

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/TicketCatalog.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/TicketCatalog.java
@@ -41,10 +41,10 @@ public interface TicketCatalog {
     TicketDefinition find(String ticketId);
 
     /**
-     * Find collection.
+     * Find all ticket definitions that implement the given ticketClass.
      *
      * @param ticketClass the ticket class
-     * @return the collection
+     * @return the matching ticket definitions
      */
     Collection<TicketDefinition> find(Class<? extends Ticket> ticketClass);
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketCatalog.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketCatalog.java
@@ -41,7 +41,7 @@ public class DefaultTicketCatalog implements TicketCatalog {
 
     @Override
     public Collection<TicketDefinition> find(final Class<? extends Ticket> ticketClass) {
-        final List list = ticketMetadataMap.values().stream().filter(t -> t.getImplementationClass().isAssignableFrom(ticketClass)).collect(Collectors.toList());
+        final List list = ticketMetadataMap.values().stream().filter(t -> ticketClass.isAssignableFrom(t.getImplementationClass())).collect(Collectors.toList());
         OrderComparator.sort(list);
         LOGGER.debug("Located all registered and known sorted ticket definitions [{}] that match [{}]", list, ticketClass);
         return list;

--- a/core/cas-server-core-tickets/src/test/groovy/org/apereo/cas/config/AbstractTicketRegistryTicketCatalogConfigTests.groovy
+++ b/core/cas-server-core-tickets/src/test/groovy/org/apereo/cas/config/AbstractTicketRegistryTicketCatalogConfigTests.groovy
@@ -1,6 +1,8 @@
 package org.apereo.cas.config
 
 import org.apereo.cas.ticket.*
+import org.apereo.cas.ticket.proxy.ProxyGrantingTicket
+import org.apereo.cas.ticket.proxy.ProxyTicket
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -71,5 +73,85 @@ abstract class AbstractTicketRegistryTicketCatalogConfigTests extends Specificat
         assert ticketDefinition.implementationClass == ProxyTicketImpl
         assert ticketDefinition.prefix == 'PT'
         assert ticketDefinition.properties.storageName == PT_storageNameForConcreteTicketRegistry()
+    }
+
+    def "should find TGT definitions based on ticket class"() {
+        when: 'Ticket Class is the TGT implementation class'
+        def definitions = ticketCatalog.find(TGT_TICKET.class)
+
+        then: 'find by class returns the TGT and PGT definitions'
+        assert definitions.size() == 2
+        assert definitions*.implementationClass as Set == [TicketGrantingTicketImpl, ProxyGrantingTicketImpl] as Set
+        assert definitions*.prefix as Set == ['TGT', 'PGT'] as Set
+        assert definitions*.properties*.storageName as Set == [TGT_storageNameForConcreteTicketRegistry(), PGT_storageNameForConcreteTicketRegistry()] as Set
+
+        when: 'Ticket Class is the TGT interface'
+        definitions = ticketCatalog.find(TicketGrantingTicket.class)
+
+        then: 'find by class returns the TGT and PGT definition'
+        assert definitions.size() == 2
+        assert definitions*.implementationClass as Set == [TicketGrantingTicketImpl, ProxyGrantingTicketImpl] as Set
+        assert definitions*.prefix as Set == ['TGT', 'PGT'] as Set
+        assert definitions*.properties*.storageName as Set == [TGT_storageNameForConcreteTicketRegistry(), PGT_storageNameForConcreteTicketRegistry()] as Set
+    }
+
+    def "should find PGT definition based on ticket class"() {
+        when: 'Ticket Class is PGT implementation class'
+        def definitions = ticketCatalog.find(PGT_TICKET.class)
+
+        then: 'find by class returns the PGT definition'
+        assert definitions.size() == 1
+        assert definitions*.implementationClass as Set == [ProxyGrantingTicketImpl]  as Set
+        assert definitions*.prefix  as Set == ['PGT'] as Set
+        assert definitions*.properties*.storageName as Set == [PGT_storageNameForConcreteTicketRegistry()] as Set
+
+        when: 'Ticket Class is the PGT interface'
+        definitions = ticketCatalog.find(ProxyGrantingTicket.class)
+
+        then: 'find by class returns the PGT definition'
+        assert definitions.size() == 1
+        assert definitions*.implementationClass as Set == [ProxyGrantingTicketImpl] as Set
+        assert definitions*.prefix as Set == ['PGT'] as Set
+        assert definitions*.properties*.storageName as Set == [PGT_storageNameForConcreteTicketRegistry()] as Set
+    }
+
+    def "should find ST definitions based on ticket class"() {
+        when: 'Ticket Class is ST implementation class'
+        def definitions = ticketCatalog.find(ST_TICKET.class)
+
+        then: 'find by class returns the ST and PT definitions'
+        assert definitions.size() == 2
+        assert definitions*.implementationClass as Set == [ServiceTicketImpl, ProxyTicketImpl] as Set
+        assert definitions*.prefix as Set == ['ST', 'PT'] as Set
+        assert definitions*.properties*.storageName as Set == [ST_storageNameForConcreteTicketRegistry(), PT_storageNameForConcreteTicketRegistry()] as Set
+
+        when: 'Ticket Class is the ST interface'
+        definitions = ticketCatalog.find(ServiceTicket.class)
+
+        then: 'find by class returns the ST and PT definitions'
+        assert definitions.size() == 2
+        assert definitions*.implementationClass as Set == [ServiceTicketImpl, ProxyTicketImpl] as Set
+        assert definitions*.prefix as Set == ['ST', 'PT'] as Set
+        assert definitions*.properties*.storageName as Set == [ST_storageNameForConcreteTicketRegistry(), PT_storageNameForConcreteTicketRegistry()] as Set
+    }
+
+    def "should find PT definition based on ticket class"() {
+        when: 'Ticket Class is PT implementation class'
+        def definitions = ticketCatalog.find(PT_TICKET.class)
+
+        then: 'find by class returns the PT definition'
+        assert definitions.size() == 1
+        assert definitions*.implementationClass as Set == [ProxyTicketImpl]  as Set
+        assert definitions*.prefix  as Set == ['PT'] as Set
+        assert definitions*.properties*.storageName as Set == [PT_storageNameForConcreteTicketRegistry()] as Set
+
+        when: 'Ticket Class is the PT interface'
+        definitions = ticketCatalog.find(ProxyTicket.class)
+
+        then: 'find by class returns the PT definition'
+        assert definitions.size() == 1
+        assert definitions*.implementationClass as Set == [ProxyTicketImpl]  as Set
+        assert definitions*.prefix  as Set == ['PT'] as Set
+        assert definitions*.properties*.storageName as Set == [PT_storageNameForConcreteTicketRegistry()] as Set
     }
 }

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -287,6 +287,39 @@ public abstract class BaseTicketRegistryTests {
     }
 
     @Test
+    public void verifyTicketCountsEqualToTicketsAdded() {
+        Assume.assumeTrue(isIterableRegistry());
+        final Collection<Ticket> tgts = new ArrayList<>();
+        final Collection<Ticket> sts = new ArrayList<>();
+
+        for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
+            final Authentication a = CoreAuthenticationTestUtils.getAuthentication();
+            final Service s = RegisteredServiceTestUtils.getService();
+            final TicketGrantingTicket ticketGrantingTicket = new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX + i,
+                    a, new NeverExpiresExpirationPolicy());
+            final ServiceTicket st = ticketGrantingTicket.grantServiceTicket("ST" + i,
+                    s,
+                    new NeverExpiresExpirationPolicy(), false, true);
+            tgts.add(ticketGrantingTicket);
+            sts.add(st);
+            this.ticketRegistry.addTicket(ticketGrantingTicket);
+            this.ticketRegistry.addTicket(st);
+        }
+
+        try {
+            final long sessionCount = this.ticketRegistry.sessionCount();
+            assertEquals("The sessionCount is not the same as the collection.",
+                    tgts.size(), sessionCount);
+
+            final long ticketCount = this.ticketRegistry.serviceTicketCount();
+            assertEquals("The serviceTicketCount is not the same as the collection.",
+                    sts.size(), ticketCount);
+        } catch (final Exception e) {
+            throw new AssertionError(EXCEPTION_CAUGHT_NONE_EXPECTED + e.getMessage(), e);
+        }
+    }
+
+    @Test
     @Transactional
     public void verifyDeleteTicketWithChildren() {
         try {


### PR DESCRIPTION
The class comparison was inverted in the `DefaultTicketCatalog.find(Class)` method.

I've added tests for this method in `AbstractTicketRegistryTicketCatalogConfigTests` but it seems these tests have been removed in 6.0+?  As a proxy for this I've added `verifyTicketCountsEqualToTicketsAdded`, which will exercise the `.find(Class)` method via the `MongoDbTicketRegistryTests` (as well as verify the `sessionCount` and `serviceTicketCount` methods) since that's the only use of `DefaultTicketCatalog.find(Class)`.

