### PR TITLE
wip - recreate stack overflow error

### DIFF
--- a/support/cas-server-support-person-directory/src/test/resources/log4j2.xml
+++ b/support/cas-server-support-person-directory/src/test/resources/log4j2.xml
@@ -15,9 +15,8 @@
         </RollingFile>
     </Appenders>
     <Loggers>
-        <Logger name="org.apereo" level="off" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
+        <Logger name="org.apereo" level="warn"/>
+        <Logger name="org.apereo.cas.CachingAttributeRepositoryTests" level="debug" />
         <Root level="off">
             <AppenderRef ref="console"/>
         </Root>


### PR DESCRIPTION
I have seen a StackOverflowError a couple times in production and was able to recreate it in this unit test. You have to run this test with -XX:MaxJavaStackTraceDepth=100000 to get full stack trace but the important part is below. The issue seems related to garbage collection because it doesn't always happen at same place and if I set breakpoint at debug statement after the first 10000 iterations and then step through debugger (F8) it will get error on next iteration (possibly because garbage collection is disabled during debugging?). Outside of debugger (still running from intellij) it happens for me during the fourth major iteration through 25K users. I tried to recreate this in person-directory since most of the code is from there but it didn't happen. I suspect Caffeine cache used when creating the `cachingAttributeRepository` might be the difference and I am wondering if they are using weak references or something that builds up but then "can" be garbage collected. There are various reports on-line of stack overflows in Collections$UnmodifiableList.get() and one cause may be continually wrapping an already unmodifiable collection but I haven't found where that is happening in this code. I am still looking into this and hopefully this PR will turn into a fix and this unit test will go away.

```
	at java.util.Collections$UnmodifiableList.get(Collections.java:1308) ~[?:?]
	at java.util.Collections$UnmodifiableList.get(Collections.java:1308) ~[?:?]
	at java.util.Collections$UnmodifiableList.get(Collections.java:1308) ~[?:?]
	at java.util.Collections$UnmodifiableList.get(Collections.java:1308) ~[?:?]
	at java.util.Collections$UnmodifiableList.get(Collections.java:1308) ~[?:?]
	at java.util.Collections$UnmodifiableList.get(Collections.java:1308) ~[?:?]
	at java.util.Collections$UnmodifiableList.get(Collections.java:1308) ~[?:?]
	at org.apereo.services.persondir.support.BasePersonImpl.buildImmutableAttributeMap(BasePersonImpl.java:75) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.BasePersonImpl.<init>(BasePersonImpl.java:50) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.AttributeNamedPersonImpl.<init>(AttributeNamedPersonImpl.java:38) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.StubPersonAttributeDao.setBackingMap(StubPersonAttributeDao.java:130) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.NamedStubPersonAttributeDao.getPeopleWithMultivaluedAttributes(NamedStubPersonAttributeDao.java:58) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.MergingPersonAttributeDaoImpl.getAttributesFromDao(MergingPersonAttributeDaoImpl.java:53) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.AbstractAggregatingDefaultQueryPersonAttributeDao.getPeopleWithMultivaluedAttributes(AbstractAggregatingDefaultQueryPersonAttributeDao.java:154) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.CachingPersonAttributeDaoImpl.getPeopleWithMultivaluedAttributes(CachingPersonAttributeDaoImpl.java:354) ~[person-directory-impl-1.8.13.jar:?]
	at org.apereo.services.persondir.support.AbstractDefaultAttributePersonAttributeDao.getPerson(AbstractDefaultAttributePersonAttributeDao.java:86) ~[person-directory-impl-1.8.13.jar:?]
```