### PR TITLE
Fix password change error message stickiness

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
@@ -37,8 +37,6 @@ public class PasswordChangeAction extends AbstractAction {
     private static final String PASSWORD_VALIDATION_FAILURE_CODE = "pm.validationFailure";
     private static final String DEFAULT_MESSAGE = "Could not update the account password";
 
-    private static final MessageBuilder ERROR_MSG_BUILDER = new MessageBuilder().error();
-
     private final PasswordManagementService passwordManagementService;
     private final PasswordValidationService passwordValidationService;
     private final CommunicationsManager communicationsManager;
@@ -75,7 +73,7 @@ public class PasswordChangeAction extends AbstractAction {
     }
 
     private Event getErrorEvent(final RequestContext ctx, final String code, final String message, final Object... params) {
-        ctx.getMessageContext().addMessage(ERROR_MSG_BUILDER.code(code).defaultText(message).args(params).build());
+        ctx.getMessageContext().addMessage(new MessageBuilder().error().code(code).defaultText(message).args(params).build());
         return error();
     }
 }


### PR DESCRIPTION
This PR fixes an issue we've found with password change validation errors. When using custom errors for specific validation failures only the first message encountered is ever displayed to all users (the first message becomes the message always displayed).

I've tested this change and it resolves the issue, there should be zero side effects.

I'll also follow up with a PR for the 6.0.x branch. Let me know if I can provide any further information.