### PR TITLE
[WIP]: fix wrong flow order in logout process

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationWebflowConfigurer.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationWebflowConfigurer.java
@@ -50,7 +50,7 @@ public class DelegatedAuthenticationWebflowConfigurer extends AbstractCasWebflow
 
     private void createSaml2ClientLogoutAction() {
         val logoutFlow = getLogoutFlow();
-        val state = getState(logoutFlow, CasWebflowConstants.STATE_ID_FINISH_LOGOUT, DecisionState.class);
+        val state = getState(logoutFlow, CasWebflowConstants.STATE_ID_PROPAGATE_LOGOUT_REQUESTS, DecisionState.class);
         state.getEntryActionList().add(saml2ClientLogoutAction);
     }
 


### PR DESCRIPTION
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [x] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [x] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->

The logout event for a delegated Auth with pac4j appear too late in the Logout process and need that the `ProfileManager` exist. For that the `DelegatedAuthenticationSAML2ClientLogoutAction` class should be called before `org.apereo.cas.web.flow.logout.TerminateSessionAction.destroyApplicationSession()`
