### PR TITLE
[OpenID Connect (OIDC)] fix prompt=login login api query parameter

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupport.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupport.java
@@ -19,6 +19,7 @@ import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.profile.UserProfile;
 
+import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Optional;
@@ -177,5 +178,29 @@ public class OidcAuthorizationRequestSupport {
         }
         val dt = ZonedDateTime.parse(authTime.toString());
         return isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, dt);
+    }
+
+    /**
+     * Removes prompt parameter and returne new url.
+     *
+     * @param url the url to update
+     * @param prompt the query parameters to remove
+     * @return String
+     * @throws URISyntaxException uri syntax exception
+     */
+    public static String removeOidcPromptFromAuthorizationRequest(final String url, final String prompt) throws URISyntaxException {
+        val uriBuilder = new URIBuilder(url);
+        val currentQueryParams = uriBuilder.getQueryParams();
+        val newParams = currentQueryParams
+            .stream()
+            .filter(p -> !OidcConstants.PROMPT.equals(p.getName()) || !p.getValue().equalsIgnoreCase(prompt))
+            .collect(Collectors.toList());
+        if (newParams.size() != currentQueryParams.size()) {
+            return uriBuilder.removeQuery()
+                .addParameters(newParams)
+                .build()
+                .toASCIIString();
+        }
+        return url;
     }
 }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
@@ -6,13 +6,16 @@ import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.web.views.OAuth20CallbackAuthorizeViewResolver;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+
 import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.profile.ProfileManager;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
+import java.net.URISyntaxException;
 import java.util.HashMap;
 
 /**
@@ -21,11 +24,23 @@ import java.util.HashMap;
  * @author Misagh Moayyed
  * @since 5.1.0
  */
+@Slf4j
 @RequiredArgsConstructor
 public class OidcCallbackAuthorizeViewResolver implements OAuth20CallbackAuthorizeViewResolver {
     @Override
     public ModelAndView resolve(final J2EContext ctx, final ProfileManager manager, final String url) {
         val prompt = OidcAuthorizationRequestSupport.getOidcPromptFromAuthorizationRequest(url);
+        if (prompt.contains(OidcConstants.PROMPT_LOGIN)) {
+            LOGGER.trace("Removing prompt query parameter from URL [{}]", url);
+            try {
+                val newUrl = OidcAuthorizationRequestSupport.removeOidcPromptFromAuthorizationRequest(url, OidcConstants.PROMPT_LOGIN);
+                LOGGER.trace("Redirecting to URL [{}]", newUrl);
+                return new ModelAndView(new RedirectView(newUrl));
+            } catch (final URISyntaxException e) {
+                LOGGER.error("Error removing prompt query parameter from URL [{}]", e.getMessage());
+                return null;
+            }
+        }
         if (prompt.contains(OidcConstants.PROMPT_NONE)) {
             val result = manager.get(true);
             if (result.isPresent()) {

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupportTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupportTests.java
@@ -8,6 +8,8 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.profile.CommonProfile;
 
+import java.net.URISyntaxException;
+
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -58,4 +60,23 @@ public class OidcAuthorizationRequestSupportTests {
         when(context.getRequestAttribute(anyString())).thenReturn(new CommonProfile());
         assertTrue(OidcAuthorizationRequestSupport.isAuthenticationProfileAvailable(context).isPresent());
     }
+
+    @Test
+    public void verifyUrlAfterOidcPromptQueryParameterDeletion() throws URISyntaxException {
+        val baseUrl = "https://tralala.whapi.com/something";
+        val urlOnlyPrompt = baseUrl + "?" + OidcConstants.PROMPT + "=" + OidcConstants.PROMPT_LOGIN;
+        var newUrlOnlyPrompt = OidcAuthorizationRequestSupport.removeOidcPromptFromAuthorizationRequest(urlOnlyPrompt, OidcConstants.PROMPT_LOGIN);
+        assertEquals(baseUrl, newUrlOnlyPrompt);
+
+        val otherOneParameter = "otherOne=value";
+        val urlWithOthers = baseUrl + "?" + otherOneParameter + "&" + OidcConstants.PROMPT + "=" + OidcConstants.PROMPT_LOGIN;
+        val urlWithOthersExpected = baseUrl + "?" + otherOneParameter;
+        var newUrlWithOthers = OidcAuthorizationRequestSupport.removeOidcPromptFromAuthorizationRequest(urlWithOthers, OidcConstants.PROMPT_LOGIN);
+        assertEquals(urlWithOthersExpected, newUrlWithOthers);
+
+        val urlWithOthersFirst = baseUrl + "?" + OidcConstants.PROMPT + "=" + OidcConstants.PROMPT_LOGIN + "&" + otherOneParameter;
+        var newUrlWithOthersFirst = OidcAuthorizationRequestSupport.removeOidcPromptFromAuthorizationRequest(urlWithOthersFirst, OidcConstants.PROMPT_LOGIN);
+        assertEquals(urlWithOthersExpected, newUrlWithOthersFirst);
+    }
+
 }


### PR DESCRIPTION
Context: Authentication with OpenID Connect (OIDC) identity layer

I need renew parameter in the login url, so I use prompt query parameter with 'login' as value.

prompt parameter is used to rewrite login url but is never removed from original url. It throws infinite loop on login.

In this PR I remove prompt parameter before redirect url rewrite (containing renew parameter). The parameter is already used by the pre-handler to know if the parameter renew is added or not to redirect url.

This PR fixes infinite login loop. 