### PR TITLE
Update spring-boot to 2.2.0-BUILD-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://repo.spring.io/plugins-release" }
         maven { url "https://repo.spring.io/libs-milestone" }
+        maven { url "http://repo.spring.io/snapshot" }
     }
 
     dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -92,7 +92,7 @@ sentryRavenVersion=8.0.3
 # Spring versions
 ###############################
 
-springBootVersion=2.2.0.M4
+springBootVersion=2.2.0.BUILD-SNAPSHOT
 springBootAdminVersion=2.1.6
 
 springRetryVersion=1.2.4.RELEASE


### PR DESCRIPTION
This is to pick up new version of spring framework (also snapshot) that fixes concurrency bug. Spring version was already updated but without pointing to new spring boot that references it, cas overlay dependencies will still pick up the older milestone release of spring in addition and there will be duplicate versions of the spring jars in the resulting war.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
