### PR TITLE
Fix remember me cookie unit test

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieRetrievingCookieGenerator.java
@@ -126,9 +126,9 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator implements 
         val attributes = auth.getAttributes();
         LOGGER.trace("Located authentication attributes [{}]", attributes);
         if (attributes.containsKey(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME)) {
-            val rememberMeValue = attributes.getOrDefault(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, Boolean.FALSE);
+            val rememberMeValue = CollectionUtils.wrap(attributes.get(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME));
             LOGGER.debug("Located remember-me authentication attribute [{}]", rememberMeValue);
-            return CollectionUtils.wrapSet(rememberMeValue).contains(Boolean.TRUE);
+            return rememberMeValue.contains(Boolean.TRUE);
         }
         return Boolean.FALSE;
     }

--- a/core/cas-server-core-cookie-api/src/test/java/org/apereo/cas/web/support/CookieRetrievingCookieGeneratorTests.java
+++ b/core/cas-server-core-cookie-api/src/test/java/org/apereo/cas/web/support/CookieRetrievingCookieGeneratorTests.java
@@ -45,17 +45,38 @@ public class CookieRetrievingCookieGeneratorTests {
     }
 
     @Test
-    public void verifyCookieForRememberMeByRequestContext() {
-        val gen = new CookieRetrievingCookieGenerator("cas", "/", 1000, true, "example.org", true);
+    public void verifyCookieForRememberMeByRequestContextLegacyAttribute() {
+        val rememberMeMaxAge = 99999;
+        val gen = new CookieRetrievingCookieGenerator("cas", "/", 1000, true, "example.org", new NoOpCookieValueManager(), rememberMeMaxAge, true);
         val context = new MockRequestContext();
         val request = new MockHttpServletRequest();
         val authn = CoreAuthenticationTestUtils.getAuthentication("casuser",
-            CollectionUtils.wrap(RememberMeCredential.REQUEST_PARAMETER_REMEMBER_ME, "true"));
+            CollectionUtils.wrap(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, Boolean.TRUE));
         WebUtils.putAuthentication(authn, context);
         WebUtils.putRememberMeAuthenticationEnabled(context, Boolean.TRUE);
         val response = new MockHttpServletResponse();
         context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, response));
         gen.addCookie(context, "CAS-Cookie-Value");
-        assertTrue(response.getCookies().length > 0);
+        val cookie = response.getCookie("cas");
+        assertNotNull(cookie);
+        assertEquals(rememberMeMaxAge, cookie.getMaxAge());
+    }
+
+    @Test
+    public void verifyCookieForRememberMeByRequestContext() {
+        val rememberMeMaxAge = 99999;
+        val gen = new CookieRetrievingCookieGenerator("cas", "/", 1000, true, "example.org", new NoOpCookieValueManager(), rememberMeMaxAge, true);
+        val context = new MockRequestContext();
+        val request = new MockHttpServletRequest();
+        val authn = CoreAuthenticationTestUtils.getAuthentication("casuser",
+                CollectionUtils.wrap(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, CollectionUtils.wrap(Boolean.TRUE)));
+        WebUtils.putAuthentication(authn, context);
+        WebUtils.putRememberMeAuthenticationEnabled(context, Boolean.TRUE);
+        val response = new MockHttpServletResponse();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, response));
+        gen.addCookie(context, "CAS-Cookie-Value");
+        val cookie = response.getCookie("cas");
+        assertNotNull(cookie);
+        assertEquals(rememberMeMaxAge, cookie.getMaxAge());
     }
 }


### PR DESCRIPTION
The old `CookieRetrievingCookieGeneratorTests` didn't verify that remember me age was applied correctly.

Also fixes handling for multivalue attributes.
