### PR TITLE
Support FileUrlResource for OIDC JWK

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeystoreGeneratorService.java
@@ -16,6 +16,7 @@ import org.springframework.core.io.FileUrlResource;
 import org.springframework.core.io.Resource;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -61,20 +62,22 @@ public class OidcJsonWebKeystoreGeneratorService {
             val rsaJsonWebKey = RsaJwkGenerator.generateJwk(bits);
             val jsonWebKeySet = new JsonWebKeySet(rsaJsonWebKey);
             val data = jsonWebKeySet.toJson(JsonWebKey.OutputControlLevel.INCLUDE_PRIVATE);
-            File location;
-
-            if (file instanceof FileSystemResource) {
-                location = file.getFile();
-            } else if (file instanceof FileUrlResource) {
-                location = file.getFile();
-            } else {
-                location = DEFAULT_JWKS_LOCATION;
-            }
+            val location = resolveLocation(file);
 
             FileUtils.write(location, data, StandardCharsets.UTF_8);
             LOGGER.debug("Generated JSON web keystore at [{}]", location);
         } else {
             LOGGER.debug("Located JSON web keystore at [{}]", file);
         }
+    }
+
+    private File resolveLocation(final Resource file) throws IOException {
+        if (file instanceof FileSystemResource) {
+            return file.getFile();
+        } else if (file instanceof FileUrlResource) {
+            return file.getFile();
+        }
+
+        return DEFAULT_JWKS_LOCATION;
     }
 }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeystoreGeneratorService.java
@@ -12,6 +12,7 @@ import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jwk.RsaJwkGenerator;
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.FileUrlResource;
 import org.springframework.core.io.Resource;
 
 import java.io.File;
@@ -60,9 +61,16 @@ public class OidcJsonWebKeystoreGeneratorService {
             val rsaJsonWebKey = RsaJwkGenerator.generateJwk(bits);
             val jsonWebKeySet = new JsonWebKeySet(rsaJsonWebKey);
             val data = jsonWebKeySet.toJson(JsonWebKey.OutputControlLevel.INCLUDE_PRIVATE);
-            val location = file instanceof FileSystemResource
-                ? FileSystemResource.class.cast(file).getFile()
-                : DEFAULT_JWKS_LOCATION;
+            File location;
+
+            if (file instanceof FileSystemResource) {
+                location = file.getFile();
+            } else if (file instanceof FileUrlResource) {
+                location = file.getFile();
+            } else {
+                location = DEFAULT_JWKS_LOCATION;
+            }
+
             FileUtils.write(location, data, StandardCharsets.UTF_8);
             LOGGER.debug("Generated JSON web keystore at [{}]", location);
         } else {


### PR DESCRIPTION
When setting a custom location for the keystore via `cas.authn.oidc.jwksFile=file:/my/custom/folder/keystore.jwks`, the resulting `Resource` implementation `org.apereo.cas.configuration.model.support.oidc.OidcProperties#getJwksFile` is of type `FileUrlResource` instead of `FileSystemResource`