### PR TITLE
SAML condition clock skew allowance applies 'before' as well as 'after'

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/conditions/SamlProfileSamlConditionsBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/conditions/SamlProfileSamlConditionsBuilder.java
@@ -77,7 +77,7 @@ public class SamlProfileSamlConditionsBuilder extends AbstractSaml20ObjectBuilde
             val audiences = org.springframework.util.StringUtils.commaDelimitedListToSet(service.getAssertionAudiences());
             audienceUrls.addAll(audiences);
         }
-        return newConditions(currentDateTime,
+        return newConditions(currentDateTime.minusSeconds(skewAllowance),
             currentDateTime.plusSeconds(skewAllowance),
             audienceUrls.toArray(ArrayUtils.EMPTY_STRING_ARRAY));
     }


### PR DESCRIPTION
Make the 'skewAllowance' setting in the SAML assertion conditions apply to the "not before" condition as well as "not after". This accounts for clock skew in either direction.

For example, at assertion generated at 16:22:30 with a skewAllowance of 10 seconds should be valid from 16:22:20 - 16:22:40