### PR TITLE
Doc fix: syntax error in setting java.util.logging.ConsoleHandler.level

### DIFF
--- a/docs/cas-server-documentation/installation/Configuring-Servlet-Container.md
+++ b/docs/cas-server-documentation/installation/Configuring-Servlet-Container.md
@@ -107,7 +107,7 @@ of Tomcat's internal components such as valves, etc.
 ```properties
 handlers = java.util.logging.ConsoleHandler
 .level = ALL
-java.util.logging.ConsoleHandler.level = DEBUG
+java.util.logging.ConsoleHandler.level = FINER
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 ```
 


### PR DESCRIPTION
Example of setting up logging.properties file needs to use java.util.logging levels ("FINE", "FINEST", etc.) "DEBUG" is not a valid choice