### PR TITLE
Fix missing clean-up of Auth Codes when using JPA+OAuth2.0/OIDC

### DIFF
--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -4,6 +4,7 @@ import org.apereo.cas.monitor.SessionHealthIndicatorJpaTests;
 import org.apereo.cas.ticket.registry.JpaTicketRegistryCleanerTests;
 import org.apereo.cas.ticket.registry.JpaTicketRegistryTests;
 import org.apereo.cas.ticket.registry.OauthJpaTicketRegistryCleanerTests;
+import org.apereo.cas.ticket.registry.OauthJpaTicketRegistryTests;
 import org.apereo.cas.ticket.registry.PostgresOauthJpaTicketRegistryCleanerTests;
 import org.apereo.cas.ticket.registry.support.JpaLockingStrategyTests;
 
@@ -23,6 +24,7 @@ import org.junit.runner.RunWith;
     JpaLockingStrategyTests.class,
     JpaTicketRegistryCleanerTests.class,
     OauthJpaTicketRegistryCleanerTests.class,
+    OauthJpaTicketRegistryTests.class,
     PostgresOauthJpaTicketRegistryCleanerTests.class
 })
 @RunWith(JUnitPlatform.class)

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/OauthJpaTicketRegistryTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/OauthJpaTicketRegistryTests.java
@@ -54,8 +54,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * Unit test for {@link JpaTicketRegistry} class in context of OAuth 2.0.
  *
- * @author Marvin S. Addison
- * @since 3.0.0
+ * @author mtritschler
+ * @since 6.1.0
  */
 @SpringBootTest(classes = {
     JpaTicketRegistryTicketCatalogConfiguration.class,

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/OauthJpaTicketRegistryTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/OauthJpaTicketRegistryTests.java
@@ -1,0 +1,106 @@
+package org.apereo.cas.ticket.registry;
+
+import lombok.val;
+import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.*;
+import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
+import org.apereo.cas.config.support.EnvironmentConversionServiceInitializer;
+import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
+import org.apereo.cas.services.RegisteredServiceTestUtils;
+import org.apereo.cas.ticket.TicketFactory;
+import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.TicketGrantingTicketFactory;
+import org.apereo.cas.ticket.code.OAuthCodeFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit test for {@link JpaTicketRegistry} class in context of OAuth 2.0.
+ *
+ * @author Marvin S. Addison
+ * @since 3.0.0
+ */
+@SpringBootTest(classes = {
+    JpaTicketRegistryTicketCatalogConfiguration.class,
+    JpaTicketRegistryConfiguration.class,
+    CasOAuthConfiguration.class,
+    RefreshAutoConfiguration.class,
+    AopAutoConfiguration.class,
+    CasCoreUtilConfiguration.class,
+    CasCoreAuthenticationConfiguration.class,
+    CasCoreServicesAuthenticationConfiguration.class,
+    CasCoreAuthenticationPrincipalConfiguration.class,
+    CasCoreAuthenticationPolicyConfiguration.class,
+    CasCoreAuthenticationMetadataConfiguration.class,
+    CasCoreAuthenticationSupportConfiguration.class,
+    CasCoreAuthenticationHandlersConfiguration.class,
+    CasCoreHttpConfiguration.class,
+    CasCoreServicesConfiguration.class,
+    CasPersonDirectoryConfiguration.class,
+    CasCoreLogoutConfiguration.class,
+    CasCoreConfiguration.class,
+    CasCoreAuthenticationServiceSelectionStrategyConfiguration.class,
+    CasCoreTicketsConfiguration.class,
+    CasCoreTicketCatalogConfiguration.class,
+    CasCoreWebConfiguration.class,
+    OAuthProtocolTicketCatalogConfiguration.class,
+    CasWebApplicationServiceFactoryConfiguration.class,
+    CasWsSecurityTokenTicketCatalogConfiguration.class
+})
+@ContextConfiguration(initializers = EnvironmentConversionServiceInitializer.class)
+@Transactional(transactionManager = "ticketTransactionManager", isolation = Isolation.SERIALIZABLE, propagation = Propagation.REQUIRED)
+@ResourceLock("oauth-jpa-tickets")
+@Tag("OAuth")
+public class OauthJpaTicketRegistryTests {
+
+    @Autowired
+    @Qualifier("defaultTicketFactory")
+    private TicketFactory ticketFactory;
+
+    @Autowired
+    @Qualifier("ticketRegistry")
+    private TicketRegistry ticketRegistry;
+
+    @Autowired
+    @Qualifier("defaultOAuthCodeFactory")
+    private OAuthCodeFactory oAuthCodeFactory;
+
+    @AfterEach
+    public void cleanup() {
+        ticketRegistry.deleteAll();
+    }
+
+    @Test
+    public void verifyLogoutCascades() {
+        val originalAuthn = CoreAuthenticationTestUtils.getAuthentication();
+        val tgtFactory = (TicketGrantingTicketFactory) ticketFactory.get(TicketGrantingTicket.class);
+        val tgt = tgtFactory.create(RegisteredServiceTestUtils.getAuthentication(), TicketGrantingTicket.class);
+        this.ticketRegistry.addTicket(tgt);
+
+        val oAuthCode = oAuthCodeFactory.create(RegisteredServiceTestUtils.getService(),
+                originalAuthn, tgt, Collections.emptySet(), "challenge", "challenge_method",
+                "client_id", Collections.emptyMap());
+
+        this.ticketRegistry.addTicket(oAuthCode);
+
+        assertNotNull(this.ticketRegistry.getTicket(oAuthCode.getId()));
+        this.ticketRegistry.deleteTicket(tgt.getId());
+        assertNull(this.ticketRegistry.getTicket(oAuthCode.getId()));
+    }
+}

--- a/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/OauthJpaTicketRegistryTests.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/OauthJpaTicketRegistryTests.java
@@ -1,8 +1,27 @@
 package org.apereo.cas.ticket.registry;
 
-import lombok.val;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
-import org.apereo.cas.config.*;
+import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationMetadataConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationPolicyConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationServiceSelectionStrategyConfiguration;
+import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
+import org.apereo.cas.config.CasCoreConfiguration;
+import org.apereo.cas.config.CasCoreHttpConfiguration;
+import org.apereo.cas.config.CasCoreServicesAuthenticationConfiguration;
+import org.apereo.cas.config.CasCoreServicesConfiguration;
+import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
+import org.apereo.cas.config.CasCoreTicketsConfiguration;
+import org.apereo.cas.config.CasCoreUtilConfiguration;
+import org.apereo.cas.config.CasCoreWebConfiguration;
+import org.apereo.cas.config.CasOAuthConfiguration;
+import org.apereo.cas.config.CasPersonDirectoryConfiguration;
+import org.apereo.cas.config.CasWsSecurityTokenTicketCatalogConfiguration;
+import org.apereo.cas.config.JpaTicketRegistryConfiguration;
+import org.apereo.cas.config.JpaTicketRegistryTicketCatalogConfiguration;
+import org.apereo.cas.config.OAuthProtocolTicketCatalogConfiguration;
 import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
 import org.apereo.cas.config.support.EnvironmentConversionServiceInitializer;
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
@@ -11,6 +30,8 @@ import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketFactory;
 import org.apereo.cas.ticket.code.OAuthCodeFactory;
+
+import lombok.val;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/code/OAuthCodeImpl.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/code/OAuthCodeImpl.java
@@ -13,6 +13,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.apache.commons.lang3.ObjectUtils;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
@@ -54,6 +56,7 @@ public class OAuthCodeImpl extends AbstractTicket implements OAuthCode {
      * The {@link TicketGrantingTicket} this is associated with.
      */
     @ManyToOne(targetEntity = TicketGrantingTicketImpl.class)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JsonProperty("ticketGrantingTicket")
     private TicketGrantingTicket ticketGrantingTicket;
 


### PR DESCRIPTION
When using OAuth/OIDC together with JPA, we can run into a situation where we want to delete a TGT (i.e. after logout), while an Auth Code related to that SSO session has been created and still exists in the database. In this case, logging out results in an exception

```
2019-07-15 12:36:37,322 DEBUG [org.apereo.cas.web.FlowExecutionExceptionResolver] - <Ignoring the received exception due to a type mismatch>org.postgresql.util.PSQLException: ERROR: update or delete on table "ticketgrantingticket" violates foreign key constraint "fk2yj68mj21qq1k3h6jaq1n3gl9" on table "oauth_tokens"  Detail: Key (id)=(TGT-1-4BzyjhqHd0-drYrTyuXZeheoEDD-den8Nk2WSM7q5afLvrUuhwsF-9N9jomNjfgtrM0-cip-84d6cb956d-85wr8) is still referenced from table "oauth_tokens".
at org.apereo.cas.ticket.registry.JpaTicketRegistry.deleteTicketGrantingTickets(JpaTicketRegistry.java:206) ~[cas-server-support-jpa-ticket-registry-6.1.0-RC5-SNAPSHOT.jar!/:6.1.0-RC5-SNAPSHOT]
at org.apereo.cas.ticket.registry.JpaTicketRegistry.deleteSingleTicket(JpaTicketRegistry.java:164) ~[cas-server-support-jpa-ticket-registry-6.1.0-RC5-SNAPSHOT.jar!/:6.1.0-RC5-SNAPSHOT]
```

Other entities mapping to CAS ticket types whose prefix (i.e. `ST`, `TGT`) is known in the JPA context get cleaned up manually before the TGT in question is deleted. The same mechanism can't be applied to Auth Codes, since their prefix (`OC`) is not known in the `cas-server-support-jpa-ticket-registry` module.

Adding an `@OnDelete` on the many-to-one relationship between OAuthCode and TGT ensures that deleting the TGT doesn't violate the FK constraint created by the relationship, by also deleting the OC.

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targetted at the master branch, if applicable
- [x] Any documentation on how to configure, test: None, it's a bugfix
- [x] Any possible limitations, side effects, etc: None
- [x] Reference any other pull requests that might be related: None

