### PR TITLE
Adds a SystemHealthIndicator to Monitors

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
@@ -53,6 +53,10 @@ public class MonitorProperties implements Serializable {
 
     /**
      * Options for monitoring the Load on a production server.
+     * Load averages are "system load averages" that show the running thread
+     * (task) demand on the system as an average number of running plus waiting
+     * threads. This measures demand, which can be greater than what the system
+     * is currently processing.
      */
     private Load load = new Load();
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
@@ -52,6 +52,11 @@ public class MonitorProperties implements Serializable {
     private St st = new St();
 
     /**
+     * Options for monitoring the Load on a production server.
+     */
+    private Load load = new Load();
+
+    /**
      * Warning options that generally deal with cache-based resources, etc.
      */
     @NestedConfigurationProperty
@@ -108,6 +113,20 @@ public class MonitorProperties implements Serializable {
          */
         @NestedConfigurationProperty
         private MonitorWarningProperties warn = new MonitorWarningProperties(10000);
+    }
+
+    @RequiresModule(name = "cas-server-core-monitor", automated = true)
+    @Getter
+    @Setter
+    public static class Load implements Serializable {
+
+        private static final long serialVersionUID = 5504478373010611957L;
+
+        /**
+         * Warning settings for this monitor.
+         */
+        @NestedConfigurationProperty
+        private MonitorWarningProperties warn = new MonitorWarningProperties(25);
     }
 
     @RequiresModule(name = "cas-server-core-monitor", automated = true)

--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/ExpirationPolicyBuilder.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/ExpirationPolicyBuilder.java
@@ -14,7 +14,17 @@ import java.io.Serializable;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 public interface ExpirationPolicyBuilder<T extends Ticket> extends Serializable {
 
+    /**
+     * Method build ticket expiration policy.
+     *
+     * @return - the policy
+     */
     ExpirationPolicy buildTicketExpirationPolicy();
 
+    /**
+     * Returns the implementation class of the ticket.
+     *
+     * @return - class implementing the ticket
+     */
     Class<T> getTicketType();
 }

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/SystemMonitorHealthIndicator.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/SystemMonitorHealthIndicator.java
@@ -1,0 +1,54 @@
+package org.apereo.cas.monitor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.metrics.MetricsEndpoint;
+
+import java.util.List;
+
+/**
+ * Monitors JVM system load and memory.
+ *
+ * @author Travis Schmidt
+ * @since 6.1.0
+ */
+@RequiredArgsConstructor
+public class SystemMonitorHealthIndicator extends AbstractHealthIndicator {
+
+    private final MetricsEndpoint metrics;
+    private final int threshold;
+
+    @Override
+    protected void doHealthCheck(final Health.Builder builder) {
+        val systemUsage = metrics.metric("system.cpu.usage", null).getMeasurements().get(0).getValue();
+        val systemLoad = metrics.metric("system.load.average.1m", null).getMeasurements().get(0).getValue();
+        val processUsage = metrics.metric("process.cpu.usage", null).getMeasurements().get(0).getValue();
+        val jvmUsed = metrics.metric("jvm.memory.used", null).getMeasurements().get(0).getValue();
+        val jvmCommitted = metrics.metric("jvm.memory.committed", null).getMeasurements().get(0).getValue();
+        val heapUsed = metrics.metric("jvm.memory.used", List.of("area:heap")).getMeasurements().get(0).getValue();
+        val heapCommitted = metrics.metric("jvm.memory.committed", List.of("area:heap")).getMeasurements().get(0).getValue();
+        val uptime = metrics.metric("process.uptime", null).getMeasurements().get(0).getValue();
+        val reqs = metrics.metric("http.server.requests", null);
+
+        builder
+                .withDetail("systemUsage", systemUsage)
+                .withDetail("systemLoad", systemLoad)
+                .withDetail("processUsage", processUsage)
+                .withDetail("jvmUsed", jvmUsed)
+                .withDetail("jvmCommitted", jvmCommitted)
+                .withDetail("heapUsed", heapUsed)
+                .withDetail("heapCommitted", heapCommitted)
+                .withDetail("uptime", uptime)
+                .withDetail("requests", reqs != null ? reqs.getMeasurements().get(0).getValue() : 0)
+                .withDetail("maxRequest", reqs != null ? reqs.getMeasurements().get(2).getValue() : 0);
+
+        if (systemLoad > threshold) {
+            builder.status("WARN");
+        } else {
+            builder.status(Status.UP);
+        }
+    }
+}

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/config/CasCoreMonitorConfiguration.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/config/CasCoreMonitorConfiguration.java
@@ -17,7 +17,6 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/config/CasCoreMonitorConfiguration.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/config/CasCoreMonitorConfiguration.java
@@ -2,6 +2,7 @@ package org.apereo.cas.monitor.config;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.monitor.MemoryMonitorHealthIndicator;
+import org.apereo.cas.monitor.SystemMonitorHealthIndicator;
 import org.apereo.cas.monitor.TicketRegistryHealthIndicator;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.metrics.MetricsEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +36,10 @@ public class CasCoreMonitorConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
+
+    @Autowired
+    @Qualifier("metricsEndpoint")
+    private ObjectProvider<MetricsEndpoint> metricsEndpoint;
 
     @ConditionalOnMissingBean(name = "memoryHealthIndicator")
     @Bean
@@ -59,5 +65,13 @@ public class CasCoreMonitorConfiguration {
             return new TicketRegistryHealthIndicator(ticketRegistry.getIfAvailable(), warnSt.getThreshold(), warnTgt.getThreshold());
         }
         return () -> Health.up().build();
+    }
+
+    @ConditionalOnMissingBean(name = "systemHealthIndicator")
+    @Bean
+    @ConditionalOnEnabledHealthIndicator("systemHealthIndicator")
+    public HealthIndicator systemHealthIndicator() {
+        val warnLoad = casProperties.getMonitor().getLoad().getWarn();
+        return new SystemMonitorHealthIndicator(metricsEndpoint.getIfAvailable(), warnLoad.getThreshold());
     }
 }

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/config/CasCoreMonitorConfiguration.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/config/CasCoreMonitorConfiguration.java
@@ -11,11 +11,13 @@ import lombok.val;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -70,6 +72,7 @@ public class CasCoreMonitorConfiguration {
     @ConditionalOnMissingBean(name = "systemHealthIndicator")
     @Bean
     @ConditionalOnEnabledHealthIndicator("systemHealthIndicator")
+    @ConditionalOnAvailableEndpoint(endpoint = MetricsEndpoint.class)
     public HealthIndicator systemHealthIndicator() {
         val warnLoad = casProperties.getMonitor().getLoad().getWarn();
         return new SystemMonitorHealthIndicator(metricsEndpoint.getIfAvailable(), warnLoad.getThreshold());

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -678,6 +678,7 @@ The following health indicator names are available, given the presence of the ap
 | Health Indicator          | Description
 |----------------------|------------------------------------------------------------------------------------------
 | `memoryHealthIndicator`   | Reports back on the health status of CAS JVM memory usage, etc.
+| `systemHealthIndicator`   | Reports back on the health of the system of the CAS server.(Load, Uptime, Heap, CPU etc.)
 | `sessionHealthIndicator`   | Reports back on the health status of CAS tickets and SSO session usage.
 | `duoSecurityHealthIndicator`   | Reports back on the health status of Duo Security APIs.
 | `ehcacheHealthIndicator`   | Reports back on the health status of Ehcache caches.
@@ -3746,6 +3747,13 @@ Decide how CAS should monitor the generation of STs.
 ```properties
 # cas.monitor.st.warn.threshold=10
 # cas.monitor.st.warn.evictionThreshold=0
+```
+### Load 
+
+Decide how CAS should monitor system load of a CAS Server.  
+
+```properties
+# cas.monitor.load.warn.threshold=25
 ```
 
 ### Cache Monitors


### PR DESCRIPTION
PR adds  new SystemHealthIndicator to the current list of health monitors that can be configured.  It can be used to monitor and alert when system load of a CAS server exceeds a threshold.   It also provides system information that is used on the /dashboard endpoint for CAS Management web application.