### PR TITLE
Allow disabling HTTP headers on a per-service basis

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
@@ -40,7 +40,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
             if (shouldInject.get()) {
                 super.insertContentSecurityPolicyHeader(httpServletResponse, httpServletRequest);
             } else {
-                LOGGER.debug("ContentSecurityPolicy header disabled by service definition");
+                LOGGER.trace("ContentSecurityPolicy header disabled by service definition");
             }
         } else {
             super.decideInsertContentSecurityPolicyHeader(httpServletResponse, httpServletRequest);
@@ -54,7 +54,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
             if (shouldInject.get()) {
                 super.insertXSSProtectionHeader(httpServletResponse, httpServletRequest);
             } else {
-                LOGGER.debug("XSSProtection header disabled by service definition");
+                LOGGER.trace("XSSProtection header disabled by service definition");
             }
         } else {
             super.decideInsertXSSProtectionHeader(httpServletResponse, httpServletRequest);
@@ -71,7 +71,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
                 val xFrameOptions = getStringProperty(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_XFRAME_OPTIONS);
                 super.insertXFrameOptionsHeader(httpServletResponse, httpServletRequest, xFrameOptions);    
             } else {
-                LOGGER.debug("XFrameOptions header disabled by service definition");
+                LOGGER.trace("XFrameOptions header disabled by service definition");
             }
         } else {
             super.decideInsertXFrameOptionsHeader(httpServletResponse, httpServletRequest);
@@ -85,7 +85,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
             if (shouldInject.get()) {
                 super.insertXContentTypeOptionsHeader(httpServletResponse, httpServletRequest);
             } else {
-                LOGGER.debug("XContentOptions header disabled by service definition");
+                LOGGER.trace("XContentOptions header disabled by service definition");
             }
         } else {
             super.decideInsertXContentTypeOptionsHeader(httpServletResponse, httpServletRequest);
@@ -99,7 +99,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
             if (shouldInject.get()) {
                 super.insertCacheControlHeader(httpServletResponse, httpServletRequest);
             } else {
-                LOGGER.debug("EnableCacheControl header disabled by service definition");
+                LOGGER.trace("EnableCacheControl header disabled by service definition");
             }
         } else {
             super.decideInsertCacheControlHeader(httpServletResponse, httpServletRequest);
@@ -113,7 +113,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
             if (shouldInject.get()) {
                 super.insertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
             } else {
-                LOGGER.debug("StrictTransportSecurity header disabled by service definition");
+                LOGGER.trace("StrictTransportSecurity header disabled by service definition");
             }
         } else {
             super.decideInsertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
@@ -9,6 +9,8 @@ import org.apereo.cas.web.support.ArgumentExtractor;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.BooleanUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -23,6 +25,7 @@ import java.util.Optional;
  * @since 5.3.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseHeadersEnforcementFilter {
     private final ServicesManager servicesManager;
     private final ArgumentExtractor argumentExtractor;
@@ -30,9 +33,15 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
 
     @Override
     protected void decideInsertContentSecurityPolicyHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
-        if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
-            RegisteredServiceProperties.HTTP_HEADER_ENABLE_CONTENT_SECURITY_POLICY)) {
-            super.insertContentSecurityPolicyHeader(httpServletResponse, httpServletRequest);
+
+        val shouldInject = shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_ENABLE_CONTENT_SECURITY_POLICY);
+
+        if (shouldInject.isPresent()) {
+            if (shouldInject.get()) {
+                super.insertContentSecurityPolicyHeader(httpServletResponse, httpServletRequest);
+            } else {
+                LOGGER.debug("ContentSecurityPolicy header disabled by service definition");
+            }
         } else {
             super.decideInsertContentSecurityPolicyHeader(httpServletResponse, httpServletRequest);
         }
@@ -40,9 +49,13 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
 
     @Override
     protected void decideInsertXSSProtectionHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
-        if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
-            RegisteredServiceProperties.HTTP_HEADER_ENABLE_XSS_PROTECTION)) {
-            super.insertXSSProtectionHeader(httpServletResponse, httpServletRequest);
+        val shouldInject = shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_ENABLE_XSS_PROTECTION);
+        if (shouldInject.isPresent()) {
+            if (shouldInject.get()) {
+                super.insertXSSProtectionHeader(httpServletResponse, httpServletRequest);
+            } else {
+                LOGGER.debug("XSSProtection header disabled by service definition");
+            }
         } else {
             super.decideInsertXSSProtectionHeader(httpServletResponse, httpServletRequest);
         }
@@ -50,10 +63,16 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
 
     @Override
     protected void decideInsertXFrameOptionsHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
-        if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
-            RegisteredServiceProperties.HTTP_HEADER_ENABLE_XFRAME_OPTIONS)) {
-            val xFrameOptions = getStringProperty(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_XFRAME_OPTIONS);
-            super.insertXFrameOptionsHeader(httpServletResponse, httpServletRequest, xFrameOptions);
+
+        val shouldInject = shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_ENABLE_XFRAME_OPTIONS);
+
+        if (shouldInject.isPresent()) {
+            if (shouldInject.get()) {
+                val xFrameOptions = getStringProperty(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_XFRAME_OPTIONS);
+                super.insertXFrameOptionsHeader(httpServletResponse, httpServletRequest, xFrameOptions);    
+            } else {
+                LOGGER.debug("XFrameOptions header disabled by service definition");
+            }
         } else {
             super.decideInsertXFrameOptionsHeader(httpServletResponse, httpServletRequest);
         }
@@ -61,9 +80,13 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
 
     @Override
     protected void decideInsertXContentTypeOptionsHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
-        if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
-            RegisteredServiceProperties.HTTP_HEADER_ENABLE_XCONTENT_OPTIONS)) {
-            super.insertXContentTypeOptionsHeader(httpServletResponse, httpServletRequest);
+        val shouldInject = shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_ENABLE_XCONTENT_OPTIONS);
+        if (shouldInject.isPresent()) {
+            if (shouldInject.get()) {
+                super.insertXContentTypeOptionsHeader(httpServletResponse, httpServletRequest);
+            } else {
+                LOGGER.debug("XContentOptions header disabled by service definition");
+            }
         } else {
             super.decideInsertXContentTypeOptionsHeader(httpServletResponse, httpServletRequest);
         }
@@ -71,20 +94,28 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
 
     @Override
     protected void decideInsertCacheControlHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
-        if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
-            RegisteredServiceProperties.HTTP_HEADER_ENABLE_CACHE_CONTROL)) {
-            super.insertCacheControlHeader(httpServletResponse, httpServletRequest);
-        } else {
+        val shouldInject = shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_ENABLE_CACHE_CONTROL);
+        if (shouldInject.isPresent()) {
+            if (shouldInject.get()) {
+                super.insertCacheControlHeader(httpServletResponse, httpServletRequest);
+            } else {
+                LOGGER.debug("EnableCacheControl header disabled by service definition");
+            }
+       } else {
             super.decideInsertCacheControlHeader(httpServletResponse, httpServletRequest);
         }
     }
 
     @Override
     protected void decideInsertStrictTransportSecurityHeader(final HttpServletResponse httpServletResponse, final HttpServletRequest httpServletRequest) {
-        if (shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest,
-            RegisteredServiceProperties.HTTP_HEADER_ENABLE_STRICT_TRANSPORT_SECURITY)) {
-            super.insertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
-        } else {
+        val shouldInject = shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_ENABLE_STRICT_TRANSPORT_SECURITY);
+        if (shouldInject.isPresent()) {
+            if (shouldInject.get()) {
+               super.insertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
+            } else {
+                LOGGER.debug("StrictTransportSecurity header disabled by service definition");
+            }
+       } else {
             super.decideInsertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
         }
     }
@@ -101,11 +132,22 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
         }
         return null;
     }
+    
+    /**
+     * Check if the service is configured to include/not include the specified header.
+     * 
+     * @param request
+     * @param property
+     * @return Optional(true/false value of property); empty() if property not set
+     */
+    private Optional<Boolean> shouldHttpHeaderBeInjectedIntoResponse(final HttpServletRequest request,
+                                                      final RegisteredServiceProperties property) {
 
-    private boolean shouldHttpHeaderBeInjectedIntoResponse(final HttpServletRequest request,
-                                                           final RegisteredServiceProperties property) {
-        val result = getRegisteredServiceFromRequest(request);
-        return result.filter(registeredService -> property.isAssignedTo(registeredService, BooleanUtils::toBoolean)).isPresent();
+        val propValue = getStringProperty(request, property);
+        if (propValue != null) {
+            return Optional.of(BooleanUtils.toBoolean(propValue));
+        }
+        return Optional.empty();
     }
 
     /**

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
@@ -8,8 +8,8 @@ import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.web.support.ArgumentExtractor;
 
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 import org.apache.commons.lang3.BooleanUtils;
 
@@ -101,7 +101,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
             } else {
                 LOGGER.debug("EnableCacheControl header disabled by service definition");
             }
-       } else {
+        } else {
             super.decideInsertCacheControlHeader(httpServletResponse, httpServletRequest);
         }
     }
@@ -111,11 +111,11 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
         val shouldInject = shouldHttpHeaderBeInjectedIntoResponse(httpServletRequest, RegisteredServiceProperties.HTTP_HEADER_ENABLE_STRICT_TRANSPORT_SECURITY);
         if (shouldInject.isPresent()) {
             if (shouldInject.get()) {
-               super.insertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
+                super.insertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
             } else {
                 LOGGER.debug("StrictTransportSecurity header disabled by service definition");
             }
-       } else {
+        } else {
             super.decideInsertStrictTransportSecurityHeader(httpServletResponse, httpServletRequest);
         }
     }

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceResponseHeadersEnforcementFilter.java
@@ -136,8 +136,8 @@ public class RegisteredServiceResponseHeadersEnforcementFilter extends ResponseH
     /**
      * Check if the service is configured to include/not include the specified header.
      * 
-     * @param request
-     * @param property
+     * @param request the http request
+     * @param property the registered service property
      * @return Optional(true/false value of property); empty() if property not set
      */
     private Optional<Boolean> shouldHttpHeaderBeInjectedIntoResponse(final HttpServletRequest request,

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceResponseHeadersEnforcementFilterTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceResponseHeadersEnforcementFilterTests.java
@@ -49,6 +49,17 @@ public class RegisteredServiceResponseHeadersEnforcementFilterTests {
     }
 
     @Test
+    public void verifyCacheControlDisabled() throws Exception {
+        val filter = getFilterForProperty(Pair.of(RegisteredServiceProperties.HTTP_HEADER_ENABLE_CACHE_CONTROL, "false"));  
+        filter.setEnableCacheControl(true);
+        val response = new MockHttpServletResponse();
+        val request = new MockHttpServletRequest();
+        request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
+        filter.doFilter(request, response, new MockFilterChain());
+        assertNull(response.getHeader("Cache-Control"));
+    }
+
+    @Test
     public void verifyContentSecurityPolicy() throws Exception {
         val filter = getFilterForProperty(RegisteredServiceProperties.HTTP_HEADER_ENABLE_CONTENT_SECURITY_POLICY);
         val response = new MockHttpServletResponse();
@@ -72,6 +83,19 @@ public class RegisteredServiceResponseHeadersEnforcementFilterTests {
     }
 
     @Test
+    public void verifyStrictTransportDisabled() throws Exception {
+        val filter = getFilterForProperty(Pair.of(RegisteredServiceProperties.HTTP_HEADER_ENABLE_STRICT_TRANSPORT_SECURITY, "false"));
+        filter.setEnableStrictTransportSecurity(true);
+        val response = new MockHttpServletResponse();
+        val request = new MockHttpServletRequest();
+        request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
+        request.setSecure(true);
+        filter.doFilter(request, response, new MockFilterChain());
+        filter.doFilter(request, response, new MockFilterChain());
+        assertNull(response.getHeader("Strict-Transport-Security"));
+    }
+
+    @Test
     public void verifyXContentOptions() throws Exception {
         val filter = getFilterForProperty(RegisteredServiceProperties.HTTP_HEADER_ENABLE_XCONTENT_OPTIONS);
         val response = new MockHttpServletResponse();
@@ -79,6 +103,17 @@ public class RegisteredServiceResponseHeadersEnforcementFilterTests {
         request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
         filter.doFilter(request, response, new MockFilterChain());
         assertNotNull(response.getHeader("X-Content-Type-Options"));
+    }
+
+    @Test
+    public void verifyXContentOptionsDisabled() throws Exception {
+        val filter = getFilterForProperty(Pair.of(RegisteredServiceProperties.HTTP_HEADER_ENABLE_XCONTENT_OPTIONS, "false"));
+        filter.setEnableXContentTypeOptions(true);
+        val response = new MockHttpServletResponse();
+        val request = new MockHttpServletRequest();
+        request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
+        filter.doFilter(request, response, new MockFilterChain());
+        assertNull(response.getHeader("X-Content-Type-Options"));
     }
 
     @Test
@@ -102,6 +137,25 @@ public class RegisteredServiceResponseHeadersEnforcementFilterTests {
     }
 
     @Test
+    public void verifyXframeOptionsDisabled() throws Exception {
+        val filter = getFilterForProperty(Pair.of(RegisteredServiceProperties.HTTP_HEADER_ENABLE_XFRAME_OPTIONS, "false"));
+
+        filter.setXFrameOptions("some-other-value");
+        filter.setEnableXFrameOptions(true);
+
+        var response = new MockHttpServletResponse();
+        val request = new MockHttpServletRequest();
+        request.setParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
+        filter.doFilter(request, response, new MockFilterChain());
+        assertNull(response.getHeader("X-Frame-Options"));
+
+        response = new MockHttpServletResponse();
+        request.setParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-something-else");
+        filter.doFilter(request, response, new MockFilterChain());
+        assertEquals("some-other-value", response.getHeader("X-Frame-Options"));
+    }
+
+    @Test
     public void verifyXssProtection() throws Exception {
         val filter = getFilterForProperty(RegisteredServiceProperties.HTTP_HEADER_ENABLE_XSS_PROTECTION);
         val response = new MockHttpServletResponse();
@@ -109,6 +163,17 @@ public class RegisteredServiceResponseHeadersEnforcementFilterTests {
         request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
         filter.doFilter(request, response, new MockFilterChain());
         assertNotNull(response.getHeader("X-XSS-Protection"));
+    }
+
+    @Test
+    public void verifyXssProtectionDisabled() throws Exception {
+        val filter = getFilterForProperty(Pair.of(RegisteredServiceProperties.HTTP_HEADER_ENABLE_XSS_PROTECTION, "false"));
+        filter.setEnableXSSProtection(true);
+        val response = new MockHttpServletResponse();
+        val request = new MockHttpServletRequest();
+        request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
+        filter.doFilter(request, response, new MockFilterChain());
+        assertNull(response.getHeader("X-XSS-Protection"));
     }
 
     private static RegisteredServiceResponseHeadersEnforcementFilter getFilterForProperty(final RegisteredServiceProperties p) {


### PR DESCRIPTION
Update RegisteredServiceResponseHeadersEnforcementFilter to support disabling  HTTP security headers on a per-service basis.

For each security header property (e.g. "httpHeaderEnableXContentOptions"), there are 3 cases:

  - service definition sets it "true"  ==> include the header
  - service definition sets it "false" ==> do not include the header
  - service definition does not specify any value ==> use the global (cas-security-filter) setting

Previous code did not distinguish between "false" and "not present", leaving no way to disable a header for a single specific service.