### PR TITLE
refactor usage of pwd.example.org

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/messages.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/messages.properties
@@ -24,7 +24,7 @@ screen.welcome.label.navto=Navigating to authentication provider. Please wait...
 
 screen.pm.button.submit=SUBMIT
 screen.pm.button.cancel=CANCEL
-screen.pm.button.forgotpwd=<a href="https://pwd.example.org">Forgot your password? </a>
+screen.pm.button.forgotpwd=<a href="{0}">Forgot your password? </a>
 screen.pm.button.resetPassword=Reset your password
 screen.pm.button.forgotUsername=Forgot your username?
 screen.pm.reset.username=Username:
@@ -277,9 +277,9 @@ screen.accountdisabled.message=Please contact the system administrator to regain
 screen.accountlocked.heading=This account has been locked.
 screen.accountlocked.message=Please contact the system administrator to regain access.
 screen.expiredpass.heading=Your password has expired.
-screen.expiredpass.message=Please <a href="https://changepsw.exampple.org">change your password</a>.
+screen.expiredpass.message=Please <a href="{0}">change your password</a>.
 screen.mustchangepass.heading=You must change your password.
-screen.mustchangepass.message=Please <a href="https://changepsw.exampple.org">change your password</a>.
+screen.mustchangepass.message=Please <a href="{0}">change your password</a>.
 screen.badhours.heading=Your account is forbidden to login at this time.
 screen.badhours.message=Please try again later.
 screen.authnblocked.heading=Authentication attempt is blocked.

--- a/webapp/cas-server-webapp-resources/src/main/resources/messages_de.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/messages_de.properties
@@ -23,7 +23,7 @@ screen.cookies.disabled.message=Ihr Browser akzeptiert keine Cookies. Das Single
 
 screen.pm.button.submit=ABSENDEN
 screen.pm.button.cancel=ABBRECHEN
-screen.pm.button.forgotpwd=<a href="https://pwd.example.org">Passwort vergessen?</a>
+screen.pm.button.forgotpwd=<a href="{0}">Passwort vergessen?</a>
 screen.pm.button.resetPassword=Passwort zurücksetzen
 screen.pm.reset.username=Benutzername:
 screen.pm.reset.heading=Zurücksetzen des Passworts fehlgeschlagen

--- a/webapp/cas-server-webapp-resources/src/main/resources/messages_fr.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/messages_fr.properties
@@ -22,7 +22,7 @@ screen.cookies.disabled.message=Votre navigateur ne supporte pas les cookies. L'
 
 screen.pm.button.submit=SOUMETTRE
 screen.pm.button.cancel=ANNULER
-screen.pm.button.forgotpwd=<a href="https://pwd.example.org">Mot de passe oublié ?</a>
+screen.pm.button.forgotpwd=<a href="{0}">Mot de passe oublié ?</a>
 screen.pm.button.resetPassword=Réinitialiser votre mot de passe
 screen.pm.reset.username=Identifiant :
 screen.pm.reset.heading=Echec de la réinitialisation du mot de passe

--- a/webapp/cas-server-webapp-resources/src/main/resources/messages_pl.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/messages_pl.properties
@@ -310,7 +310,7 @@ screen.mdui.infolink.text                         = <a href="{0}" target="_blank
 screen.mdui.privacylink.text                      = <a href="{0}" target="_blank">O\u015Bwiadczenie o ochronie prywatno\u015Bci dla aplikacji</a>.
 # LPPE Password Must be changed
 screen.mustchangepass.heading                     = Musisz zmieni\u0107 has\u0142o.
-screen.mustchangepass.message                     = Prosz\u0119 <a href="https://changepsw.exampple.org">zmieni\u0107 has\u0142o</a>.
+screen.mustchangepass.message                     = Prosz\u0119 <a href="{0}">zmieni\u0107 has\u0142o</a>.
 screen.nonsecure.message                          = \u0141\u0105czysz si\u0119 do CAS niezabezpieczonym po\u0142\u0105czeniem. Pojedyncze logowanie NIE B\u0118DZIE DZIA\u0141A\u0141O. Aby pojedyncze logowanie funkcjonowa\u0142o, MUSISZ uwierzytelni\u0107 si\u0119 po HTTPS.
 screen.nonsecure.title                            = Po\u0142\u0105czenie niezabezpieczone
 screen.oauth.confirm.allow                        = Zezw\u00F3l
@@ -334,7 +334,7 @@ screen.pac4j.unauthz.login                        = Powr\u00F3t do CAS
 screen.pac4j.unauthz.message                      = Albo \u017C\u0105danie uwierzytelnienia zosta\u0142o odrzucone/anulowane, albo dostawca uwierzytelnienia odm\u00F3wi\u0142 dost\u0119pu z powodu uprawnie\u0144 lub podobnej przyczyny. Przejrzyj dzienniki, aby znale\u017A\u0107 pierwotn\u0105 przyczyn\u0119 problemu.
 screen.pac4j.unauthz.pagetitle                    = Nieautoryzowany dost\u0119p
 screen.pm.button.cancel                           = ANULUJ
-screen.pm.button.forgotpwd                        = <a href="https://pwd.example.org">Zapomnia\u0142e\u015B has\u0142a? </a>
+screen.pm.button.forgotpwd                        = <a href="{0}">Zapomnia\u0142e\u015B has\u0142a? </a>
 screen.pm.button.resetPassword                    = Zresetuj swoje has\u0142o
 screen.pm.button.submit                           = ZATWIERD\u0179
 screen.pm.confirmpsw                              = Potwierd\u017A has\u0142o:

--- a/webapp/cas-server-webapp-resources/src/main/resources/messages_sk.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/messages_sk.properties
@@ -22,7 +22,7 @@ screen.cookies.disabled.message=Váš browser nepodporuje cookies. Single Sign O
 
 screen.pm.button.submit=OK
 screen.pm.button.cancel=ZRUŠIŤ
-screen.pm.button.forgotpwd=<a href="https://pwd.example.org">Zabudli ste heslo? </a>
+screen.pm.button.forgotpwd=<a href="{0}">Zabudli ste heslo? </a>
 screen.pm.button.resetPassword=Zmeniť heslo
 screen.pm.reset.username=Používateľské meno:
 screen.pm.reset.heading=Neúspešná zmena hesla

--- a/webapp/cas-server-webapp-resources/src/main/resources/messages_vi.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/messages_vi.properties
@@ -25,7 +25,7 @@ screen.cookies.disabled.message = Trình duyệt của bạn không bật cookie
 
 screen.pm.button.submit = GỬI
 screen.pm.button.cancel = HỦY
-screen.pm.button.forgotpwd = <a href="https://example.com/forgot_password.php"> Quên mật khẩu của bạn? </a>
+screen.pm.button.forgotpwd = <a href="{0}"> Quên mật khẩu của bạn? </a>
 screen.pm.button.resetPassword = Đặt lại mật khẩu của bạn
 screen.pm.reset.username = Tên đăng nhập:
 screen.pm.reset.heading = Đặt lại mật khẩu không thành công
@@ -205,9 +205,9 @@ screen.accountdisabled.message = Vui lòng liên hệ với quản trị viên h
 screen.accountlocked.heading = Tài khoản này đã bị khóa.
 screen.accountlocked.message = Vui lòng liên hệ với quản trị viên hệ thống để lấy lại quyền truy cập.
 screen.expiredpass.heading = Mật khẩu của bạn đã hết hạn.
-screen.expiredpass.message = Hãy <a href="https://example.com/forgot_password.php"> thay đổi mật khẩu của bạn </a>.
+screen.expiredpass.message = Hãy <a href="{0}"> thay đổi mật khẩu của bạn </a>.
 screen.mustchangepass.heading = Bạn phải thay đổi mật khẩu.
-screen.mustchangepass.message = Hãy <a href="https://example.com/forgot_password.php"> thay đổi mật khẩu của bạn </a>.
+screen.mustchangepass.message = Hãy <a href="{0}"> thay đổi mật khẩu của bạn </a>.
 screen.badhours.heading = Tài khoản của bạn bị cấm đăng nhập tại thời điểm này.
 screen.badhours.message = Vui lòng thử lại sau.
 screen.authnblocked.heading = Cố gắng xác thực bị chặn.

--- a/webapp/cas-server-webapp-resources/src/main/resources/templates/fragments/loginform.html
+++ b/webapp/cas-server-webapp-resources/src/main/resources/templates/fragments/loginform.html
@@ -216,7 +216,7 @@
                     <div th:unless="${passwordManagementEnabled}">
                         <br/>
                         <span class="fa fa-question-circle"></span>
-                        <span th:utext="#{screen.pm.button.forgotpwd}">Forgot your password?</span>
+                        <span th:utext="#{screen.pm.button.forgotpwd('https://pwd.example.org')}">Forgot your password?</span>
                         <p/>
                     </div>
 

--- a/webapp/cas-server-webapp-resources/src/main/resources/templates/fragments/pwdupdateform.html
+++ b/webapp/cas-server-webapp-resources/src/main/resources/templates/fragments/pwdupdateform.html
@@ -86,7 +86,7 @@
             </div>
         </form>
         <p th:unless="${passwordManagementEnabled}"
-           th:utext="${expiredPass} ? #{screen.expiredpass.message} : #{screen.mustchangepass.message}">Expired/Must
+           th:utext="${expiredPass} ? #{screen.expiredpass.message('https://pwd.example.org')} : #{screen.mustchangepass.message('https://pwd.example.org')}">Expired/Must
             Change Password text</p>
     </div>
 </main>


### PR DESCRIPTION
there is incosistent usage of pwd.example.org or changepsw.exampple.org in messages. Some translations expects URL as parameter, some not, but parameter was not set. 

The better place for customization of URL is template file. The best would be to provide configurable parameter. In that case we could solve also reference in expiring password warning.

# Use cases
- as  user open login page and check URL provided in _Forgot password_
- as user with expired password try to login and check URL provided in error message
