### PR TITLE
Fix CasVersion.getDateTime for vfs and remove JBoss VFS casting

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
@@ -66,13 +66,7 @@ public class CasVersion {
                 return DateTimeUtils.zonedDateTimeOf(file.lastModified());
             }
             if ("vfs".equals(resource.getProtocol())) {
-                val content = resource.openConnection().getContent();
-                val virtualFile = Thread.currentThread().getContextClassLoader().loadClass("org.jboss.vfs.VirtualFile");
-                if (virtualFile.isAssignableFrom(content.getClass())) {
-                    val file = new VfsResource(resource.openConnection().getContent(new Class[] {virtualFile})).getFile();
-                    return DateTimeUtils.zonedDateTimeOf(file.lastModified());
-                }
-                return ZonedDateTime.now(ZoneOffset.UTC);
+                return DateTimeUtils.zonedDateTimeOf(resource.openConnection().getLastModified());
             }
         } catch (final Exception e) {
             LOGGER.warn(e.getMessage(), e);


### PR DESCRIPTION
Follow up to commit c5138a1e510a476ce6c4dbdc177d7ed2ae8ab9b2

URLConnection.getLastModified() returns the the last modified date.  Referencing JBoss VFS classes is not required.
There was a bug fixed in JBoss VFS https://issues.jboss.org/browse/JBVFS-206 where
JBoss VFS was incorrectly returning JBoss VFS VirtualFile when it should have returned the Content.

In the CasVersion use case, it is using ClassLoader.getResource(CasVersion.class) and trying to get the last modified time
The content is cannot be assumed to be a file since classes are almost always in a jar file or in 2 layers or zipped archives
The URLConnection (and the classes that extend it that handle Jars, Files, etc) has a getLastModified(), so this can be used without having to reference JBoss VFS
https://docs.oracle.com/javase/7/docs/api/java/net/URLConnection.html#getLastModified()