### PR TITLE
Refactor: Determine last-modified-date for CASVersion correctly

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
@@ -3,7 +3,6 @@ package org.apereo.cas.util;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.springframework.core.io.VfsResource;
 
 import java.io.File;
 import java.time.ZoneOffset;
@@ -57,17 +56,7 @@ public class CasVersion {
         val clazz = CasVersion.class;
         val resource = clazz.getResource(clazz.getSimpleName() + ".class");
         try {
-            if ("file".equals(resource.getProtocol())) {
-                return DateTimeUtils.zonedDateTimeOf(new File(resource.toURI()).lastModified());
-            }
-            if ("jar".equals(resource.getProtocol())) {
-                val path = resource.getPath();
-                val file = new File(path.substring(JAR_PROTOCOL_STARTING_INDEX, path.indexOf('!')));
-                return DateTimeUtils.zonedDateTimeOf(file.lastModified());
-            }
-            if ("vfs".equals(resource.getProtocol())) {
-                return DateTimeUtils.zonedDateTimeOf(resource.openConnection().getLastModified());
-            }
+            return DateTimeUtils.zonedDateTimeOf(resource.openConnection().getLastModified());
         } catch (final Exception e) {
             LOGGER.warn(e.getMessage(), e);
         }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
@@ -66,13 +66,7 @@ public class CasVersion {
                 return DateTimeUtils.zonedDateTimeOf(file.lastModified());
             }
             if ("vfs".equals(resource.getProtocol())) {
-                val content = resource.openConnection().getContent();
-                val virtualFile = Thread.currentThread().getContextClassLoader().loadClass("org.jboss.vfs.VirtualFile");
-                if (virtualFile.isAssignableFrom(content.getClass())) {
-                    val file = new VfsResource(resource.openConnection().getContent(new Class[] {virtualFile})).getFile();
-                    return DateTimeUtils.zonedDateTimeOf(file.lastModified());
-                }
-                return ZonedDateTime.now(ZoneOffset.UTC);
+                return DateTimeUtils.zonedDateTimeOf(resource.openConnection().getLastModified());
             }
         } catch (final Exception e) {
             LOGGER.warn(e.getMessage(), e);


### PR DESCRIPTION
Follow up to commit c5138a1e510a476ce6c4dbdc177d7ed2ae8ab9b2
    
`URLConnection.getLastModified()` returns the the last modified date.  Referencing JBoss VFS classes is not required.
There was a bug fixed in JBoss VFS https://issues.jboss.org/browse/JBVFS-206 where
JBoss VFS was incorrectly returning JBoss VFS VirtualFile when it should have returned the Content.
    
In the `CasVersion` use case, it is using `ClassLoader.getResource(CasVersion.class)` and trying to get the last modified time
The content is cannot be assumed to be a file since classes are almost always in a jar file or in 2 layers or zipped archives
The URLConnection (and the classes that extend it that handle Jars, Files, etc) has a `getLastModified()`, so this can be used without having to reference JBoss VFS
https://docs.oracle.com/javase/7/docs/api/java/net/URLConnection.html#getLastModified()
    
So there does not appear to be any reason to switch on the file/jar/vfs, you can just use `resource.openConnection().getLastModified()` and allow the URL Handler to handle it. Also note the current 'file' would be if the classes are not in a jar and it would return the file last modified, the 'jar' looks like it returns the last modified of the jar not the class, so they are not testing the same thing.
