### PR TITLE
fix velocity property keys to avoid deprecation warnings

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PrincipalAttributesProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PrincipalAttributesProperties.java
@@ -65,7 +65,7 @@ public class PrincipalAttributesProperties implements Serializable {
      * <li>{@code REPLACE}: Overwrites existing attribute values, if any.</li>
      * <li>{@code ADD}: Retains existing attribute values if any, and ignores
      * values from subsequent sources in the resolution chain.</li>
-     * <li>{@code MERGE}: Combines all values into a single attribute, essentially creating a multi-valued attribute. </li>
+     * <li>{@code MULTIVALUED}: Combines all values into a single attribute, essentially creating a multi-valued attribute. </li>
      * <li>{@code NONE}: Doesn't merge attributes, ignores attributes from non-authentication attribute repositories </li>
      * </ul>
      */

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PrincipalAttributesProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/PrincipalAttributesProperties.java
@@ -66,6 +66,7 @@ public class PrincipalAttributesProperties implements Serializable {
      * <li>{@code ADD}: Retains existing attribute values if any, and ignores
      * values from subsequent sources in the resolution chain.</li>
      * <li>{@code MERGE}: Combines all values into a single attribute, essentially creating a multi-valued attribute. </li>
+     * <li>{@code NONE}: Doesn't merge attributes, ignores attributes from non-authentication attribute repositories </li>
      * </ul>
      */
     private String merger = "REPLACE";

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/CoreAuthenticationUtils.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/CoreAuthenticationUtils.java
@@ -113,6 +113,7 @@ public class CoreAuthenticationUtils {
             case "multivalued":
             case "multi_valued":
             case "combine":
+            case "merge":
                 return new MultivaluedAttributeMerger();
             case "add":
                 return new NoncollidingAttributeAdder();
@@ -120,7 +121,7 @@ public class CoreAuthenticationUtils {
             case "overwrite":
             case "override":
                 return new ReplacingAttributeAdder();
-            default:
+            case "none":
                 return new BaseAdditiveAttributeMerger() {
                     @Override
                     protected Map<String, List<Object>> mergePersonAttributes(final Map<String, List<Object>> toModify,
@@ -128,6 +129,8 @@ public class CoreAuthenticationUtils {
                         return new LinkedHashMap<>(toModify);
                     }
                 };
+            default:
+                throw new IllegalArgumentException("Unsupported merging policy [" + mergingPolicy + "]");
         }
     }
 

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -903,7 +903,7 @@ and their results are cached and merged.
 # cas.authn.attributeRepository.expirationTime=30
 # cas.authn.attributeRepository.expirationTimeUnit=MINUTES
 # cas.authn.attributeRepository.maximumCacheSize=10000
-# cas.authn.attributeRepository.merger=REPLACE|ADD|MULTIVALUED
+# cas.authn.attributeRepository.merger=REPLACE|ADD|MULTIVALUED|NONE
 ```
 
 <div class="alert alert-info"><strong>Remember This</strong><p>Note that in certain cases,
@@ -957,7 +957,8 @@ The following merging strategies can be used to resolve conflicts when the same 
 |-------------------------|----------------------------------------------------------------------------------------------------
 | `REPLACE`               | Overwrites existing attribute values, if any.
 | `ADD`                   | Retains existing attribute values if any, and ignores values from subsequent sources in the resolution chain.
-| `MERGE`                 | Combines all values into a single attribute, essentially creating a multi-valued attribute.
+| `MULTIVALUED`           | Combines all values into a single attribute, essentially creating a multi-valued attribute.
+| `NONE`                  | Do not merge attributes, only use attributes retrieved during authentication.
 
 ### Stub
 

--- a/gradle/overrides.gradle
+++ b/gradle/overrides.gradle
@@ -17,7 +17,7 @@ ext["springSessionVersion"] = "2.2.0.M2"
 ext["springSessionMongoVersion"] = "2.2.0.M3"
 
 ext["jacksonVersion"] = "2.9.9"
-ext["jacksonCoreVersion"] = "2.9.9.1"
+ext["jacksonCoreVersion"] = "2.9.9.3"
 ext["thymeleafVersion"] = "3.0.11.RELEASE"
 ext["thymeleafDialectVersion"] = "2.4.1"
 ext["hsqlVersion"] = "2.5.0"

--- a/style/dependency-check-suppressions.xml
+++ b/style/dependency-check-suppressions.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
     <suppress>
+        <cve>CVE-2019-14379</cve>
+    </suppress>
+    <suppress>
         <cve>CVE-2019-10102</cve>
     </suppress>
     <suppress>

--- a/support/cas-server-support-configuration-cloud-aws-s3/src/test/java/org/apereo/cas/AmazonS3BucketsCloudConfigBootstrapConfigurationTests.java
+++ b/support/cas-server-support-configuration-cloud-aws-s3/src/test/java/org/apereo/cas/AmazonS3BucketsCloudConfigBootstrapConfigurationTests.java
@@ -65,7 +65,7 @@ public class AmazonS3BucketsCloudConfigBootstrapConfigurationTests {
         environment.setProperty(AmazonS3BucketsCloudConfigBootstrapConfiguration.CAS_CONFIGURATION_PREFIX + '.' + "credentialSecretKey", CREDENTIAL_SECRET_KEY);
 
         val builder = new AmazonEnvironmentAwareClientBuilder(AmazonS3BucketsCloudConfigBootstrapConfiguration.CAS_CONFIGURATION_PREFIX, environment);
-        val s3Client = builder.build(AmazonS3ClientBuilder.standard().disableChunkedEncoding(), AmazonS3.class);
+        val s3Client = builder.build(AmazonS3ClientBuilder.standard(), AmazonS3.class);
 
         deleteBucket(s3Client);
 

--- a/support/cas-server-support-configuration-cloud-aws-s3/src/test/java/org/apereo/cas/AmazonS3BucketsCloudConfigBootstrapConfigurationTests.java
+++ b/support/cas-server-support-configuration-cloud-aws-s3/src/test/java/org/apereo/cas/AmazonS3BucketsCloudConfigBootstrapConfigurationTests.java
@@ -65,7 +65,7 @@ public class AmazonS3BucketsCloudConfigBootstrapConfigurationTests {
         environment.setProperty(AmazonS3BucketsCloudConfigBootstrapConfiguration.CAS_CONFIGURATION_PREFIX + '.' + "credentialSecretKey", CREDENTIAL_SECRET_KEY);
 
         val builder = new AmazonEnvironmentAwareClientBuilder(AmazonS3BucketsCloudConfigBootstrapConfiguration.CAS_CONFIGURATION_PREFIX, environment);
-        val s3Client = builder.build(AmazonS3ClientBuilder.standard(), AmazonS3.class);
+        val s3Client = builder.build(AmazonS3ClientBuilder.standard().disableChunkedEncoding(), AmazonS3.class);
 
         deleteBucket(s3Client);
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20CallbackAuthorizeEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20CallbackAuthorizeEndpointController.java
@@ -45,7 +45,7 @@ public class OAuth20CallbackAuthorizeEndpointController extends BaseOAuth20Contr
     @GetMapping(path = OAuth20Constants.BASE_OAUTH20_URL + '/' + OAuth20Constants.CALLBACK_AUTHORIZE_URL)
     public ModelAndView handleRequest(final HttpServletRequest request, final HttpServletResponse response) {
         val context = new JEEContext(request, response, getOAuthConfigurationContext().getSessionStore());
-        callback.perform(context, getOAuthConfigurationContext().getOauthConfig(), (object, ctx) -> false,
+        callback.perform(context, getOAuthConfigurationContext().getOauthConfig(), (object, ctx) -> Boolean.FALSE,
             context.getFullRequestURL(), Boolean.TRUE, Boolean.FALSE,
             Boolean.FALSE, Authenticators.CAS_OAUTH_CLIENT);
         var url = callback.getRedirectUrl();

--- a/support/cas-server-support-saml-core/src/main/java/org/apereo/cas/config/CoreSamlConfiguration.java
+++ b/support/cas-server-support-saml-core/src/main/java/org/apereo/cas/config/CoreSamlConfiguration.java
@@ -49,12 +49,12 @@ public class CoreSamlConfiguration {
         val properties = new Properties();
         properties.put(RuntimeConstants.INPUT_ENCODING, StandardCharsets.UTF_8.name());
         properties.put(RuntimeConstants.ENCODING_DEFAULT, StandardCharsets.UTF_8.name());
-        properties.put(RuntimeConstants.RESOURCE_LOADER, "file, classpath, string");
+        properties.put(RuntimeConstants.RESOURCE_LOADERS, "file, classpath, string");
         properties.put(RuntimeConstants.FILE_RESOURCE_LOADER_PATH, FileUtils.getTempDirectory().getAbsolutePath());
         properties.put(RuntimeConstants.FILE_RESOURCE_LOADER_CACHE, Boolean.FALSE);
-        properties.put("classpath.resource.loader.class", ClasspathResourceLoader.class.getName());
-        properties.put("string.resource.loader.class", StringResourceLoader.class.getName());
-        properties.put("file.resource.loader.class", FileResourceLoader.class.getName());
+        properties.put("resource.loader.classpath.class", ClasspathResourceLoader.class.getName());
+        properties.put("resource.loader.string.class", StringResourceLoader.class.getName());
+        properties.put("resource.loader.file.class", FileResourceLoader.class.getName());
 
         return new VelocityEngine(properties);
     }

--- a/support/cas-server-support-saml-idp-metadata-aws-s3/src/test/java/org/apereo/cas/support/saml/idp/metadata/AmazonS3SamlIdPMetadataGeneratorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-aws-s3/src/test/java/org/apereo/cas/support/saml/idp/metadata/AmazonS3SamlIdPMetadataGeneratorTests.java
@@ -76,7 +76,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class AmazonS3SamlIdPMetadataGeneratorTests {
     static {
         System.setProperty(SkipMd5CheckStrategy.DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY, "true");
-        System.setProperty("com.amazonaws.services.s3.disableGetObjectMD5Validation", "true");
+        System.setProperty(SkipMd5CheckStrategy.DISABLE_PUT_OBJECT_MD5_VALIDATION_PROPERTY, "true");
     }
 
     @Autowired


### PR DESCRIPTION
WARN [org.apache.velocity.deprecation]
 - <configuration key 'resource.loader' has been
 deprecated in favor of 'resource.loaders'>
WARN [org.apache.velocity.deprecation]
 - <configuration key 'file.resource.loader.class' has been
  deprecated in favor of 'resource.loader.file.class'>
WARN [org.apache.velocity.deprecation]
 - <configuration key 'string.resource.loader.class' has been
  deprecated in favor of 'resource.loader.string.class'>
WARN [org.apache.velocity.deprecation]
 - <configuration key 'classpath.resource.loader.class' has been
 deprecated in favor of 'resource.loader.classpath.class'>
