### PR TITLE
Support Global Principal Attribute from ldap for MFA

### DIFF
--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
@@ -160,7 +160,7 @@ public class MultifactorAuthenticationUtils {
                                                             final Optional<RequestContext> context,
                                                             final MultifactorAuthenticationProvider provider,
                                                             final Predicate<String> predicate) {
-        if (attributeValue instanceof Collection and attributeValue.size() == 1) {
+        if (attributeValue instanceof Collection && attributeValue.size() == 1) {
             attributeValue = attributeValue.iterator().next();
         }
         if (!(attributeValue instanceof Collection)) {

--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
@@ -160,6 +160,9 @@ public class MultifactorAuthenticationUtils {
                                                             final Optional<RequestContext> context,
                                                             final MultifactorAuthenticationProvider provider,
                                                             final Predicate<String> predicate) {
+        if (attributeValue instanceof Collection and attributeValue.size() == 1) {
+            attributeValue = attributeValue.iterator().next();
+        }
         if (!(attributeValue instanceof Collection)) {
             LOGGER.debug("Attribute value [{}] is a single-valued attribute", attributeValue);
             if (predicate.test(attributeValue.toString())) {


### PR DESCRIPTION
I have recently started using CAS and i wanted to pass the MFA provider do use via LDAP.  however it seems that values retrieved via ldap always end up in a collection even if the ldap attribute is a SINGLE-VAULE[1] .  This means i always seem to hit the following error

2019-08-14 17:56:04,202 DEBUG [org.apereo.cas.authentication.MultifactorAuthenticationUtils] - <Attribute value [[mfa-gauth]] is not a single-valued attribute>   

This patch attempts to fix this so that collections of size one are also considered.  Apologizes in advance for the quality, its been some time since i looked at java

More details of my specific issue can be found on the cas-users google group[2]

[1]https://ldapwiki.com/wiki/SINGLE-VALUE
[2]https://groups.google.com/forum/#!topic/jasig-cas-user/6R4hFG74MG0