### PR TITLE
travis ci - need to double escape backslash in env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
     - JAVA_OPTS="-Xms512m -Xmx4048m -Xss128m -XX:ReservedCodeCacheSize=512m -XX:+UseG1GC -Xverify:none -server"
     - GRADLE_OPTS="-Xms512m -Xmx1024m -Xss128m -XX:ReservedCodeCacheSize=512m -XX:+UseG1GC -Xverify:none -server"
     - SPRING_MAIN_BANNER-MODE="off"
-    - DEPENDENCY_BOT_RE=^renovatebot\(deps\)
+    - DEPENDENCY_BOT_RE=^renovatebot\\(deps\\)
     - secure: "ScUSTo0if5m7ddnwUA7EaYucc6yzEUrKLk0DzCvkMfjn2h5taUFSKHx+S0hd2EzJofv+Em4eI5qncSK5LTxgD7HhHR1e3iZp+SqJenhhOnbuciZfg4QA+tUGw3XUdmREac5cz2l0qhi1q4vsnnZARj2d4vvf2HWuNtEOBu/ZAKI="
     - secure: "iWPPLKSS3zBs2adqLPkMiHfCj2hSLyD5BoV3oodhR7Ne83Kpn1khRcEWFoHF3Ed11eSU+glNdPSzUpc8TzwTZGx5B3RU2Qp36hZFyjuzNWJARmoVPYMiEg3FFBQrUR75w+Tbtn6zPkiAk6nl0K5ewmY0/xixVdnTLXL5HjpE2rc="
     - secure: "f3mDIZ8m6NYJXI8KvWD/sZRSeCCyIyfgPRy3Q6o9u9WyHZuYaJf95Ia0eJQ3gxUDS1TKL31Vk08dhFKrfIcKgifFPa2uQ2uyJkvGxlarMTQ+tpqsZYp4zAJgKc9r4xdZasvF2k4xqr+pl9AFjlpXB4jDD59XPXt3DcRABOYA9sM="
@@ -81,7 +81,7 @@ jobs:
       name: "Build CAS"
     - stage: build
       script: ./ci/html-proofer-docs.sh
-      if: branch =~ /^\d+\.\d+\.x$/ or branch = master
+      if: NOT (commit_message =~ env(DEPENDENCY_BOT_RE) and type = pull_request) and (branch =~ /^\d+\.\d+\.x$/ or branch = master)
       name: "Validate Documentation"
       ############################################
     - stage: postbuild


### PR DESCRIPTION
also avoid doc validation on dependency update

tested with travis-conditions:

travis-conditions eval "NOT (commit_message =~ env(DEPENDENCY_BOT_RE) and type = pull_request)" --data '{"type": "pull_request", "commit_message": "renovatebot(deps): update amazonsdk to v1.11.613", "env": ["DEPENDENCY_BOT_RE=^renovatebot\\(deps\\)"]}'
false

travis-conditions eval "NOT (commit_message =~ env(DEPENDENCY_BOT_RE) and type = pull_request)" --data '{"type": "pull_request", "commit_message": "regular update", "env": ["DEPENDENCY_BOT_RE=^renovatebot\\(deps\\)"]}'
true

