### PR TITLE
Fix jwt service token without encryption key

### DIFF
--- a/support/cas-server-support-token-core/src/main/java/org/apereo/cas/token/cipher/RegisteredServiceTokenTicketCipherExecutor.java
+++ b/support/cas-server-support-token-core/src/main/java/org/apereo/cas/token/cipher/RegisteredServiceTokenTicketCipherExecutor.java
@@ -25,8 +25,8 @@ public class RegisteredServiceTokenTicketCipherExecutor extends TokenTicketCiphe
             final RegisteredService registeredService = service.get();
             if (supports(registeredService)) {
                 LOGGER.debug("Found signing and/or encryption keys for [{}] in service registry to decode", registeredService.getServiceId());
-                final String encryptionKey = getEncryptionKey(registeredService).get();
-                final String signingKey = getSigningKey(registeredService).get();
+                final String encryptionKey = getEncryptionKey(registeredService).orElse(StringUtils.EMPTY);
+                final String signingKey = getSigningKey(registeredService).orElse(StringUtils.EMPTY);
                 final TokenTicketCipherExecutor cipher = new TokenTicketCipherExecutor(encryptionKey, signingKey,
                     StringUtils.isNotBlank(encryptionKey), StringUtils.isNotBlank(signingKey));
                 if (cipher.isEnabled()) {
@@ -43,8 +43,8 @@ public class RegisteredServiceTokenTicketCipherExecutor extends TokenTicketCiphe
             final RegisteredService registeredService = service.get();
             if (supports(registeredService)) {
                 LOGGER.debug("Found signing and/or encryption keys for [{}] in service registry to encode", registeredService.getServiceId());
-                final String encryptionKey = getEncryptionKey(registeredService).get();
-                final String signingKey = getSigningKey(registeredService).get();
+                final String encryptionKey = getEncryptionKey(registeredService).orElse(StringUtils.EMPTY);
+                final String signingKey = getSigningKey(registeredService).orElse(StringUtils.EMPTY);
                 final TokenTicketCipherExecutor cipher = new TokenTicketCipherExecutor(encryptionKey, signingKey,
                     StringUtils.isNotBlank(encryptionKey), StringUtils.isNotBlank(signingKey));
                 if (cipher.isEnabled()) {

--- a/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/BaseJWTTokenTicketBuilderTests.java
+++ b/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/BaseJWTTokenTicketBuilderTests.java
@@ -42,17 +42,17 @@ import java.util.List;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {
-    RefreshAutoConfiguration.class,
-    CasCoreTicketsConfiguration.class,
-    CasCoreServicesConfiguration.class,
-    CasCoreUtilConfiguration.class,
-    CasRegisteredServicesTestConfiguration.class,
-    BaseJWTTokenTicketBuilderTests.TokenTicketBuilderTestConfiguration.class,
-    CasCoreTicketCatalogConfiguration.class,
-    CasCoreTicketIdGeneratorsConfiguration.class,
-    CasCoreHttpConfiguration.class,
-    CasDefaultServiceTicketIdGeneratorsConfiguration.class,
-    TokenCoreConfiguration.class
+        RefreshAutoConfiguration.class,
+        CasCoreTicketsConfiguration.class,
+        CasCoreServicesConfiguration.class,
+        CasCoreUtilConfiguration.class,
+        CasRegisteredServicesTestConfiguration.class,
+        BaseJWTTokenTicketBuilderTests.TokenTicketBuilderTestConfiguration.class,
+        CasCoreTicketCatalogConfiguration.class,
+        CasCoreTicketIdGeneratorsConfiguration.class,
+        CasCoreHttpConfiguration.class,
+        CasDefaultServiceTicketIdGeneratorsConfiguration.class,
+        TokenCoreConfiguration.class
 })
 @Slf4j
 public abstract class BaseJWTTokenTicketBuilderTests {
@@ -78,19 +78,28 @@ public abstract class BaseJWTTokenTicketBuilderTests {
         @PostConstruct
         public void init() {
             inMemoryRegisteredServices.add(RegisteredServiceTestUtils.getRegisteredService("https://cas.example.org.+"));
-            final AbstractRegisteredService registeredService = RegisteredServiceTestUtils.getRegisteredService("https://jwt.example.org/cas.*");
+            inMemoryRegisteredServices.add(createRegisteredService("https://jwt.example.org/cas.*", true, true));
+            inMemoryRegisteredServices.add( createRegisteredService("https://jwt.no-encryption-key.example.org/cas.*", true, false));
+        }
 
-            final DefaultRegisteredServiceProperty signingKey = new DefaultRegisteredServiceProperty();
-            signingKey.addValue("pR3Vizkn5FSY5xCg84cIS4m-b6jomamZD68C8ash-TlNmgGPcoLgbgquxHPoi24tRmGpqHgM4mEykctcQzZ-Xg");
-            registeredService.getProperties().put(
-                RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET_SIGNING_KEY.getPropertyName(), signingKey);
+        private AbstractRegisteredService createRegisteredService(String id, boolean hasSigningKey, boolean hasEncryptionKey) {
+            final AbstractRegisteredService registeredService = RegisteredServiceTestUtils.getRegisteredService(id);
 
-            final DefaultRegisteredServiceProperty encKey = new DefaultRegisteredServiceProperty();
-            encKey.addValue("0KVXaN-nlXafRUwgsr3H_l6hkufY7lzoTy7OVI5pN0E");
-            registeredService.getProperties().put(
-                RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET_ENCRYPTION_KEY.getPropertyName(), encKey);
+            if (hasSigningKey) {
+                final DefaultRegisteredServiceProperty signingKey = new DefaultRegisteredServiceProperty();
+                signingKey.addValue("pR3Vizkn5FSY5xCg84cIS4m-b6jomamZD68C8ash-TlNmgGPcoLgbgquxHPoi24tRmGpqHgM4mEykctcQzZ-Xg");
+                registeredService.getProperties().put(
+                        RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET_SIGNING_KEY.getPropertyName(), signingKey);
+            }
+            if (hasEncryptionKey) {
+                final DefaultRegisteredServiceProperty encKey = new DefaultRegisteredServiceProperty();
+                encKey.addValue("0KVXaN-nlXafRUwgsr3H_l6hkufY7lzoTy7OVI5pN0E");
+                registeredService.getProperties().put(
+                        RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET_ENCRYPTION_KEY.getPropertyName(), encKey);
 
-            inMemoryRegisteredServices.add(registeredService);
+                inMemoryRegisteredServices.add(registeredService);
+            }
+            return registeredService;
         }
 
         @Bean

--- a/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/BaseJWTTokenTicketBuilderTests.java
+++ b/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/BaseJWTTokenTicketBuilderTests.java
@@ -79,10 +79,10 @@ public abstract class BaseJWTTokenTicketBuilderTests {
         public void init() {
             inMemoryRegisteredServices.add(RegisteredServiceTestUtils.getRegisteredService("https://cas.example.org.+"));
             inMemoryRegisteredServices.add(createRegisteredService("https://jwt.example.org/cas.*", true, true));
-            inMemoryRegisteredServices.add( createRegisteredService("https://jwt.no-encryption-key.example.org/cas.*", true, false));
+            inMemoryRegisteredServices.add(createRegisteredService("https://jwt.no-encryption-key.example.org/cas.*", true, false));
         }
 
-        private AbstractRegisteredService createRegisteredService(String id, boolean hasSigningKey, boolean hasEncryptionKey) {
+        private AbstractRegisteredService createRegisteredService(final String id, final boolean hasSigningKey, final boolean hasEncryptionKey) {
             final AbstractRegisteredService registeredService = RegisteredServiceTestUtils.getRegisteredService(id);
 
             if (hasSigningKey) {

--- a/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/JWTTokenTicketBuilderWithoutEncryptionTests.java
+++ b/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/JWTTokenTicketBuilderWithoutEncryptionTests.java
@@ -1,10 +1,16 @@
 package org.apereo.cas.token;
 
 import com.nimbusds.jwt.JWTClaimsSet;
+import lombok.val;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.authentication.principal.Service;
+import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.token.cipher.RegisteredServiceTokenTicketCipherExecutor;
 import org.apereo.cas.util.EncodingUtils;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -23,6 +29,24 @@ public class JWTTokenTicketBuilderWithoutEncryptionTests extends BaseJWTTokenTic
         assertNotNull(jwt);
         final Object result = tokenCipherExecutor.decode(jwt);
         final JWTClaimsSet claims = JWTClaimsSet.parse(result.toString());
+        assertEquals("casuser", claims.getSubject());
+    }
+
+    @Test
+    public void verifyJwtForServiceTicketWithoutEncryptionKey() throws Exception {
+
+        final Service service = CoreAuthenticationTestUtils.getService("https://jwt.no-encryption-key.example.org/cas");
+
+        final String jwt = tokenTicketBuilder.build("ST-123456", service);
+        assertNotNull(jwt);
+        final Object result = tokenCipherExecutor.decode(jwt);
+        assertNull(result);
+
+        final RegisteredService registeredService = servicesManager.findServiceBy(service);
+        final RegisteredServiceTokenTicketCipherExecutor cipher = new RegisteredServiceTokenTicketCipherExecutor();
+        assertTrue(cipher.supports(registeredService));
+        val decoded = cipher.decode(jwt, Optional.of(registeredService));
+        val claims = JWTClaimsSet.parse(decoded);
         assertEquals("casuser", claims.getSubject());
     }
 

--- a/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/JWTTokenTicketBuilderWithoutEncryptionTests.java
+++ b/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/JWTTokenTicketBuilderWithoutEncryptionTests.java
@@ -36,7 +36,6 @@ public class JWTTokenTicketBuilderWithoutEncryptionTests extends BaseJWTTokenTic
     public void verifyJwtForServiceTicketWithoutEncryptionKey() throws Exception {
 
         final Service service = CoreAuthenticationTestUtils.getService("https://jwt.no-encryption-key.example.org/cas");
-
         final String jwt = tokenTicketBuilder.build("ST-123456", service);
         assertNotNull(jwt);
         final Object result = tokenCipherExecutor.decode(jwt);

--- a/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/JWTTokenTicketBuilderWithoutEncryptionTests.java
+++ b/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/JWTTokenTicketBuilderWithoutEncryptionTests.java
@@ -44,8 +44,8 @@ public class JWTTokenTicketBuilderWithoutEncryptionTests extends BaseJWTTokenTic
         final RegisteredService registeredService = servicesManager.findServiceBy(service);
         final RegisteredServiceTokenTicketCipherExecutor cipher = new RegisteredServiceTokenTicketCipherExecutor();
         assertTrue(cipher.supports(registeredService));
-        val decoded = cipher.decode(jwt, Optional.of(registeredService));
-        val claims = JWTClaimsSet.parse(decoded);
+        final val decoded = cipher.decode(jwt, Optional.of(registeredService));
+        final val claims = JWTClaimsSet.parse(decoded);
         assertEquals("casuser", claims.getSubject());
     }
 


### PR DESCRIPTION
Description
Fix for jwt service ticket bug. It should be possible from sources  to disable encryption or fall back to default encryption key  if custom encryption keys are not set for service.

Secondary effects
If custom encryption or signing keys are not set for service it should allow to fall back into default configuration for signing and encrypting. From documentation it should be possible.

Test cases
JWTTokenTicketBuilderWithoutEncryptionTests -> verifyJwtForServiceTicketWithoutEncryptionKey
