### PR TITLE
OIDC missing response type validator

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuthConfiguration.java
@@ -517,6 +517,7 @@ public class CasOAuthConfiguration {
         validators.add(oauthAuthorizationCodeResponseTypeRequestValidator());
         validators.add(oauthIdTokenResponseTypeRequestValidator());
         validators.add(oauthTokenResponseTypeRequestValidator());
+        validators.add(oauthIdTokenAndTokenResponseTypeRequestValidator());
         return validators;
     }
 


### PR DESCRIPTION
In class OidcProperties default supported response types are "code", "token", "id_token token". If you use id_token token reposne type you get an exception because the validator oauthIdTokenAndTokenResponseTypeRequestValidator is not added.
