### PR TITLE
OIDC: Redirect to Original url with error code as login required.

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupport.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupport.java
@@ -3,6 +3,7 @@ package org.apereo.cas.oidc.util;
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.oidc.OidcConstants;
+import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.web.cookie.CasCookieBuilder;
 
@@ -93,6 +94,13 @@ public class OidcAuthorizationRequestSupport {
     public static Optional<CommonProfile> isAuthenticationProfileAvailable(final JEEContext context) {
         val manager = new ProfileManager<CommonProfile>(context, context.getSessionStore());
         return manager.get(true);
+    }
+
+    @SneakyThrows
+    public static String getRedirectUrlWithError(final String originalRedirectUrl, final String errorCode) {
+        val uriBuilder = new URIBuilder(originalRedirectUrl)
+                .addParameter(OAuth20Constants.ERROR, errorCode);
+        return uriBuilder.build().toASCIIString();
     }
 
     @SneakyThrows

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
@@ -2,7 +2,6 @@ package org.apereo.cas.oidc.web;
 
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.oidc.util.OidcAuthorizationRequestSupport;
-import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.web.views.OAuth20CallbackAuthorizeViewResolver;
 
 import lombok.RequiredArgsConstructor;
@@ -12,9 +11,8 @@ import org.pac4j.core.context.JEEContext;
 import org.pac4j.core.profile.ProfileManager;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
-import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
-import java.util.HashMap;
+import static org.apereo.cas.oidc.util.OidcAuthorizationRequestSupport.getRedirectUrlWithError;
 
 /**
  * This is {@link OidcCallbackAuthorizeViewResolver}.
@@ -35,9 +33,7 @@ public class OidcCallbackAuthorizeViewResolver implements OAuth20CallbackAuthori
                 return new ModelAndView(url);
             }
             LOGGER.warn("Unable to detect an authenticated user profile for prompt-less login attempts");
-            val model = new HashMap<String, String>();
-            model.put(OAuth20Constants.ERROR, OidcConstants.LOGIN_REQUIRED);
-            return new ModelAndView(new MappingJackson2JsonView(), model);
+            return new ModelAndView(new RedirectView(getRedirectUrlWithError(ctx.getFullRequestURL(), OidcConstants.LOGIN_REQUIRED)));
         }
         if (prompt.contains(OidcConstants.PROMPT_LOGIN)) {
             LOGGER.trace("Removing login prompt from URL [{}]", url);

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupportTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcAuthorizationRequestSupportTests.java
@@ -66,4 +66,11 @@ public class OidcAuthorizationRequestSupportTests {
         context.setRequestAttribute(Pac4jConstants.USER_PROFILES, new CommonProfile());
         assertTrue(OidcAuthorizationRequestSupport.isAuthenticationProfileAvailable(context).isPresent());
     }
+
+    @Test
+    public void verifyGetRedirectUrlWithError() {
+        val originalRedirectUrl = "https://www.example.org";
+        val expectedUrlWithError = originalRedirectUrl + "?error=login_required";
+        assertEquals(expectedUrlWithError, OidcAuthorizationRequestSupport.getRedirectUrlWithError(originalRedirectUrl, OidcConstants.LOGIN_REQUIRED));
+    }
 }


### PR DESCRIPTION
Summary: When using CAS as OpenId Connect Provider and using silent authentication (prompt=none), if the user logged in session is not active, then redirect to original redirect url with error code as `login_required`

https://openid.net/specs/openid-connect-core-1_0.html#AuthError

When we set `prompt=none`, then if the user authenticated session is valid, CAS is redirecting to original redirect url with new Auth Code.
If the user authenticated session is not valid, then currently CAS is showing `..\oauth2.0/callbackAuthorize?..` with error code `{
"error": "login_required"
}`

But expected behaviour is to redirect back to the service redirect url with error code in url param.
Such as `https://www.example.org?error=login_required`. This will enable the service to act upon this response further such as redirecting back to login page or any other flow.

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targetted at the master branch, if applicable
- [x] Any documentation on how to configure, test
- [x] Any possible limitations, side effects, etc: None
- [x] Reference any other pull requests that might be related:None

