### PR TITLE
Service Registry: Fix regex for service YAML file names

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/resource/RegisteredServiceResourceNamingStrategy.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/resource/RegisteredServiceResourceNamingStrategy.java
@@ -37,6 +37,9 @@ public interface RegisteredServiceResourceNamingStrategy {
         if (extensions.length > 0) {
             pattern = String.join("|", extensions);
         }
+        if (extensions.length > 1) {
+            pattern = "(" + pattern + ")";
+        }
         return RegexUtils.createPattern("(\\w+)-(\\d+)\\.".concat(pattern));
     }
 }


### PR DESCRIPTION
When using YAML service registry, CAS warns in the logs that the service file name does not match the recommended pattern `(\w+)-(\d+)\.yml|yaml`. That's because the regex should be: `(\w+)-(\d+)\.(yml|yaml)`.

The error message is logged here: https://github.com/apereo/cas/blob/f7666b51df/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/resource/AbstractResourceBasedServiceRegistry.java#L267  but the regex is built in `RegisteredServiceResourceNamingStrategy`.

This PR fixes the regex building.
