### PR TITLE
Redirecting to original redirect_uri in the original request when prompt is none.

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
@@ -40,10 +40,10 @@ public class OidcCallbackAuthorizeViewResolver implements OAuth20CallbackAuthori
                 val model = new HashMap<String, String>();
                 model.put(OAuth20Constants.ERROR, OidcConstants.LOGIN_REQUIRED);
                 return new ModelAndView(new MappingJackson2JsonView(), model);
-            } else {
-                LOGGER.warn("Unable to detect an authenticated user profile for prompt-less login attempts. Redirecting to URL[{}]", originalRedirectUrl.get());
-                return new ModelAndView(new RedirectView(OidcAuthorizationRequestSupport.getRedirectUrlWithError(originalRedirectUrl.get(), OidcConstants.LOGIN_REQUIRED)));
             }
+            val redirectUrlWithErrorCode = OidcAuthorizationRequestSupport.getRedirectUrlWithError(originalRedirectUrl.get(), OidcConstants.LOGIN_REQUIRED);
+            LOGGER.warn("Unable to detect an authenticated user profile for prompt-less login attempts. Redirecting to URL[{}]", redirectUrlWithErrorCode);
+            return new ModelAndView(new RedirectView(redirectUrlWithErrorCode));
         }
         if (prompt.contains(OidcConstants.PROMPT_LOGIN)) {
             LOGGER.trace("Removing login prompt from URL [{}]", url);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
@@ -2,6 +2,7 @@ package org.apereo.cas.oidc.web;
 
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.oidc.util.OidcAuthorizationRequestSupport;
+import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.web.views.OAuth20CallbackAuthorizeViewResolver;
 
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,9 @@ public class OidcCallbackAuthorizeViewResolver implements OAuth20CallbackAuthori
                 LOGGER.trace("Redirecting to URL [{}] without prompting for login", url);
                 return new ModelAndView(url);
             }
-            LOGGER.warn("Unable to detect an authenticated user profile for prompt-less login attempts");
-            return new ModelAndView(new RedirectView(OidcAuthorizationRequestSupport.getRedirectUrlWithError(ctx.getFullRequestURL(), OidcConstants.LOGIN_REQUIRED)));
+            val originalRedirectUrl = ctx.getRequestParameter(OAuth20Constants.REDIRECT_URI).orElse(ctx.getFullRequestURL());
+            LOGGER.warn("Unable to detect an authenticated user profile for prompt-less login attempts. Redirecting to URL[{}]", originalRedirectUrl);
+            return new ModelAndView(new RedirectView(OidcAuthorizationRequestSupport.getRedirectUrlWithError(originalRedirectUrl, OidcConstants.LOGIN_REQUIRED)));
         }
         if (prompt.contains(OidcConstants.PROMPT_LOGIN)) {
             LOGGER.trace("Removing login prompt from URL [{}]", url);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
@@ -42,7 +42,7 @@ public class OidcCallbackAuthorizeViewResolver implements OAuth20CallbackAuthori
                 return new ModelAndView(new MappingJackson2JsonView(), model);
             }
             val redirectUrlWithErrorCode = OidcAuthorizationRequestSupport.getRedirectUrlWithError(originalRedirectUrl.get(), OidcConstants.LOGIN_REQUIRED);
-            LOGGER.warn("Unable to detect an authenticated user profile for prompt-less login attempts. Redirecting to URL[{}]", redirectUrlWithErrorCode);
+            LOGGER.warn("Unable to detect an authenticated user profile for prompt-less login attempts. Redirecting to URL [{}]", redirectUrlWithErrorCode);
             return new ModelAndView(new RedirectView(redirectUrlWithErrorCode));
         }
         if (prompt.contains(OidcConstants.PROMPT_LOGIN)) {


### PR DESCRIPTION
Summary: Ref https://github.com/apereo/cas/pull/4227, the URL need to be changed from requestURL, which is url of `callBackAuthorize`, to use `redirect_uri` parameter set in Authorization request.


- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targetted at the master branch, if applicable
- [x] Any documentation on how to configure, test : None
- [x] Any possible limitations, side effects, etc: None
- [x] Reference any other pull requests that might be related: None

