### PR TITLE
Added missing class registrations for kryo + memcached

### DIFF
--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
@@ -47,6 +47,7 @@ import org.apereo.cas.services.UnauthorizedServiceForPrincipalException;
 import org.apereo.cas.services.UnauthorizedSsoServiceException;
 import org.apereo.cas.services.consent.DefaultRegisteredServiceConsentPolicy;
 import org.apereo.cas.services.support.RegisteredServiceRegexAttributeFilter;
+import org.apereo.cas.support.saml.authentication.principal.GoogleAccountsService;
 import org.apereo.cas.ticket.ProxyGrantingTicketImpl;
 import org.apereo.cas.ticket.ProxyTicketImpl;
 import org.apereo.cas.ticket.ServiceTicketImpl;
@@ -63,6 +64,7 @@ import org.apereo.cas.ticket.support.ThrottledUseAndTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.support.TicketGrantingTicketExpirationPolicy;
 import org.apereo.cas.ticket.support.TimeoutExpirationPolicy;
 import org.apereo.cas.util.crypto.PublicKeyFactoryBean;
+import org.apereo.cas.validation.ValidationResponseType;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.pool.KryoFactory;
@@ -233,6 +235,7 @@ public class CloseableKryoFactory implements KryoFactory {
         kryo.register(DefaultRegisteredServiceConsentPolicy.class);
         kryo.register(DefaultRegisteredServiceMultifactorPolicy.class);
         kryo.register(DefaultRegisteredServiceUsernameProvider.class);
+        kryo.register(GoogleAccountsService.class);
         kryo.register(GeneralSecurityException.class, new ThrowableSerializer());
         kryo.register(PreventedException.class);
         kryo.register(AccountNotFoundException.class, new ThrowableSerializer());
@@ -246,6 +249,7 @@ public class CloseableKryoFactory implements KryoFactory {
         kryo.register(UnauthorizedServiceException.class);
         kryo.register(UnauthorizedServiceForPrincipalException.class);
         kryo.register(UnauthorizedSsoServiceException.class);
+        kryo.register(ValidationResponseType.class);
     }
 
     private static void registerCasTicketsWithKryo(final Kryo kryo) {

--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
@@ -47,7 +47,7 @@ import org.apereo.cas.services.UnauthorizedServiceForPrincipalException;
 import org.apereo.cas.services.UnauthorizedSsoServiceException;
 import org.apereo.cas.services.consent.DefaultRegisteredServiceConsentPolicy;
 import org.apereo.cas.services.support.RegisteredServiceRegexAttributeFilter;
-import org.apereo.cas.support.saml.authentication.principal.GoogleAccountsService;
+import org.apereo.cas.support.saml.authentication.principal.GoogleAccountsServiceFactory;
 import org.apereo.cas.ticket.ProxyGrantingTicketImpl;
 import org.apereo.cas.ticket.ProxyTicketImpl;
 import org.apereo.cas.ticket.ServiceTicketImpl;

--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
@@ -47,7 +47,6 @@ import org.apereo.cas.services.UnauthorizedServiceForPrincipalException;
 import org.apereo.cas.services.UnauthorizedSsoServiceException;
 import org.apereo.cas.services.consent.DefaultRegisteredServiceConsentPolicy;
 import org.apereo.cas.services.support.RegisteredServiceRegexAttributeFilter;
-import org.apereo.cas.support.saml.authentication.principal.GoogleAccountsService;
 import org.apereo.cas.ticket.ProxyGrantingTicketImpl;
 import org.apereo.cas.ticket.ProxyTicketImpl;
 import org.apereo.cas.ticket.ServiceTicketImpl;
@@ -235,7 +234,6 @@ public class CloseableKryoFactory implements KryoFactory {
         kryo.register(DefaultRegisteredServiceConsentPolicy.class);
         kryo.register(DefaultRegisteredServiceMultifactorPolicy.class);
         kryo.register(DefaultRegisteredServiceUsernameProvider.class);
-        kryo.register(GoogleAccountsService.class);
         kryo.register(GeneralSecurityException.class, new ThrowableSerializer());
         kryo.register(PreventedException.class);
         kryo.register(AccountNotFoundException.class, new ThrowableSerializer());

--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
@@ -47,7 +47,7 @@ import org.apereo.cas.services.UnauthorizedServiceForPrincipalException;
 import org.apereo.cas.services.UnauthorizedSsoServiceException;
 import org.apereo.cas.services.consent.DefaultRegisteredServiceConsentPolicy;
 import org.apereo.cas.services.support.RegisteredServiceRegexAttributeFilter;
-import org.apereo.cas.support.saml.authentication.principal.GoogleAccountsServiceFactory;
+import org.apereo.cas.support.saml.authentication.principal.GoogleAccountsService;
 import org.apereo.cas.ticket.ProxyGrantingTicketImpl;
 import org.apereo.cas.ticket.ProxyTicketImpl;
 import org.apereo.cas.ticket.ServiceTicketImpl;

--- a/support/cas-server-support-saml-googleapps/src/main/java/org/apereo/cas/support/saml/config/SamlGoogleAppsComponentSerializationConfiguration.java
+++ b/support/cas-server-support-saml-googleapps/src/main/java/org/apereo/cas/support/saml/config/SamlGoogleAppsComponentSerializationConfiguration.java
@@ -1,0 +1,24 @@
+package org.apereo.cas.support.saml.config;
+
+import org.apereo.cas.ComponentSerializationPlan;
+import org.apereo.cas.ComponentSerializationPlanConfigurator;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.support.saml.authentication.principal.GoogleAccountsService;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This is {@link SamlGoogleAppsComponentSerializationConfiguration}.
+ *
+ * @author Doug Campbell
+ * @since 6.0.5
+ */
+@Configuration("samlGoogleAppsComponentSerializationConfiguration")
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class SamlGoogleAppsComponentSerializationConfiguration implements ComponentSerializationPlanConfigurator {
+    @Override
+    public void configureComponentSerializationPlan(final ComponentSerializationPlan plan) {
+        plan.registerSerializableClass(GoogleAccountsService.class);
+    }
+}

--- a/support/cas-server-support-saml-googleapps/src/main/resources/META-INF/spring.factories
+++ b/support/cas-server-support-saml-googleapps/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.support.saml.config.SamlGoogleAppsConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.support.saml.config.SamlGoogleAppsConfiguration,\
+  org.apereo.cas.support.saml.config.SamlGoogleAppsComponentSerializationConfiguration


### PR DESCRIPTION
Class registrations were missing for `GoogleAccountsService` and ValidationResponseType classes preventing error free use of the KRYO transcoder for memcached serialization.