### PR TITLE
store custom scopes by name instead of "custom"

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcProfileScopeToAttributesFilter.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcProfileScopeToAttributesFilter.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.oidc.claims.BaseOidcScopeAttributeReleasePolicy;
+import org.apereo.cas.oidc.claims.OidcCustomScopeAttributeReleasePolicy;
 import org.apereo.cas.services.OidcRegisteredService;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20ProfileScopeToAttributesFilter;
@@ -41,11 +42,11 @@ public class OidcProfileScopeToAttributesFilter extends DefaultOAuth20ProfileSco
 
     private final PrincipalFactory principalFactory;
     private final CasConfigurationProperties casProperties;
-    private final Collection<BaseOidcScopeAttributeReleasePolicy> userScopes;
+    private final Collection<OidcCustomScopeAttributeReleasePolicy> userScopes;
 
     public OidcProfileScopeToAttributesFilter(final PrincipalFactory principalFactory,
                                               final CasConfigurationProperties casProperties,
-                                              final Collection<BaseOidcScopeAttributeReleasePolicy> userScopes) {
+                                              final Collection<OidcCustomScopeAttributeReleasePolicy> userScopes) {
         this.principalFactory = principalFactory;
         this.casProperties = casProperties;
         this.userScopes = userScopes;
@@ -173,7 +174,7 @@ public class OidcProfileScopeToAttributesFilter extends DefaultOAuth20ProfileSco
 
         if (!userScopes.isEmpty()) {
             LOGGER.debug("Configuring attributes release policies for user-defined scopes [{}]", userScopes);
-            userScopes.forEach(t -> attributeReleasePolicies.put(t.getScopeType(), t));
+            userScopes.forEach(t -> attributeReleasePolicies.put(t.getScopeName(), t));
         }
     }
 }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -639,7 +639,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
 
     @RefreshScope
     @Bean
-    public Collection<BaseOidcScopeAttributeReleasePolicy> userDefinedScopeBasedAttributeReleasePolicies() {
+    public Collection<OidcCustomScopeAttributeReleasePolicy> userDefinedScopeBasedAttributeReleasePolicies() {
         val oidc = casProperties.getAuthn().getOidc();
         return oidc.getUserDefinedScopes().entrySet()
             .stream()


### PR DESCRIPTION
Per the first part of this cas dev post:
https://groups.google.com/a/apereo.org/forum/#!topic/cas-dev/Fn08B3lhhAI

The custom scopes to release need to be stored in map by name rather than the type "custom". Standard scopes are stored by their standard types as the key, they don't have names. 