### PR TITLE
OidcScopeAttributeReleasePolicy: fix release of custom claims

### DIFF
--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
@@ -88,9 +88,11 @@ public abstract class BaseOidcScopeAttributeReleasePolicy extends AbstractRegist
         LOGGER.debug("Attempting to process claim [{}]", claim);
         if (attributeToScopeClaimMapper.containsMappedAttribute(claim)) {
             val mappedAttr = attributeToScopeClaimMapper.getMappedAttribute(claim);
-            val value = resolvedAttributes.get(mappedAttr);
-            LOGGER.debug("Found mapped attribute [{}] with value [{}] for claim [{}]", mappedAttr, value, claim);
-            return Pair.of(claim, value);
+            if (resolvedAttributes.containsKey(mappedAttr)) {
+                val value = resolvedAttributes.get(mappedAttr);
+                LOGGER.debug("Found mapped attribute [{}] with value [{}] for claim [{}]", mappedAttr, value, claim);
+                return Pair.of(claim, value);
+            }
         }
         val value = resolvedAttributes.get(claim);
         LOGGER.debug("No mapped attribute is defined for claim [{}]; Used [{}] to locate value [{}]", claim, claim, value);

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/mapping/DefaultOidcAttributeToScopeClaimMapperTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/mapping/DefaultOidcAttributeToScopeClaimMapperTests.java
@@ -1,11 +1,17 @@
 package org.apereo.cas.oidc.claims.mapping;
 
+import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.oidc.AbstractOidcTests;
+import org.apereo.cas.oidc.OidcConstants;
+import org.apereo.cas.oidc.claims.OidcEmailScopeAttributeReleasePolicy;
 import org.apereo.cas.util.CollectionUtils;
 
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -15,6 +21,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
+@TestPropertySource(properties = {
+        "cas.authn.oidc.claimsMap.email=mail",
+        "cas.authn.oidc.claimsMap.email_verified=mail_confirmed"
+})
 @Tag("OIDC")
 public class DefaultOidcAttributeToScopeClaimMapperTests extends AbstractOidcTests {
 
@@ -23,6 +33,29 @@ public class DefaultOidcAttributeToScopeClaimMapperTests extends AbstractOidcTes
         val mapper = new DefaultOidcAttributeToScopeClaimMapper(CollectionUtils.wrap("name", "givenName"));
         assertTrue(mapper.containsMappedAttribute("name"));
         assertEquals("givenName", mapper.getMappedAttribute("name"));
+    }
 
+    @Test
+    public void verifyClaimMapOperation() {
+        val policy = new OidcEmailScopeAttributeReleasePolicy();
+        assertEquals(OidcConstants.StandardScopes.EMAIL.getScope(), policy.getScopeType());
+        assertNotNull(policy.getAllowedAttributes());
+
+        val principal = CoreAuthenticationTestUtils.getPrincipal(CollectionUtils.wrap("mail", List.of("cas@example.org"),
+                "mail_confirmed", List.of("cas@example.org"), "phone", List.of("0000000000")));
+        val attrs = policy.getAttributes(principal,
+                CoreAuthenticationTestUtils.getService(),
+                CoreAuthenticationTestUtils.getRegisteredService());
+        assertEquals(List.of("cas@example.org"), attrs.get("email"));
+        assertEquals(List.of("cas@example.org"), attrs.get("email_verified"));
+        assertFalse(attrs.containsKey("phone"));
+
+        val serviceTicketPrincipal = CoreAuthenticationTestUtils.getPrincipal(attrs);
+        val releaseAttrs = policy.getAttributes(serviceTicketPrincipal,
+                CoreAuthenticationTestUtils.getService(),
+                CoreAuthenticationTestUtils.getRegisteredService());
+        assertEquals(List.of("cas@example.org"), releaseAttrs.get("email"));
+        assertEquals(List.of("cas@example.org"), releaseAttrs.get("email_verified"));
+        assertFalse(releaseAttrs.containsKey("phone"));
     }
 }


### PR DESCRIPTION
Since #4217, the `OidcScopeAttributeReleasePolicy` is applied twice:

- once during the creation of the service ticket,
- once during the generation of the JWT ticket.

This causes a bug where custom claims cannot be resolved.

## Example

Mapping:

    cas.authn.oidc.claimsMap.email=mail

If resolved attributes are:
- name: foo
- mail: my@email.com
- unknownAttribute: bar
- ...

The `OidcScopeAttributeReleasePolicy` is applied during the generation of the service ticket.

Then, the `Principal` passed to `OidcProfileScopeToAttributesFilter` during the JWT generation (which is `authentication.getPrincipal()` in [OidcIdTokenGeneratorService](https://github.com/apereo/cas/blob/775162461b776db4cad1545c3bcc39fa14dbe973/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorService.java#L93)) has the following attributes:

- name: foo
- **email**: my@email.com

The `OidcProfileScopeToAttributesFilter` calls `OidcScopeAttributeReleasePolicy.getAttributes` a second time and looks for a property named `mail` (mapping for claim `email`) and does not find it.

This PR fixes this issue by looking at both mapped and not mapped attributes. A more elegant way to fix it would be to call `OidcProfileScopeToAttributesFilter` with the _original_ `Principal` (not the already transformed one) but I don't see how to do that.

Cf. https://groups.google.com/a/apereo.org/forum/#!topic/cas-dev/Fn08B3lhhAI and #4264.