### PR TITLE
Bug with tryAll in AtLeastOneCredentialValidatedAuthenticationPolicy

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/AtLeastOneCredentialValidatedAuthenticationPolicy.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/AtLeastOneCredentialValidatedAuthenticationPolicy.java
@@ -33,7 +33,7 @@ public class AtLeastOneCredentialValidatedAuthenticationPolicy implements Authen
     public boolean isSatisfiedBy(final Authentication authn, final Set<AuthenticationHandler> authenticationHandlers) throws Exception {
         if (this.tryAll) {
             val sum = authn.getSuccesses().size() + authn.getFailures().size();
-            if (authn.getCredentials().size() != sum) {
+            if (authenticationHandlers.size() != sum) {
                 LOGGER.warn("Number of provided credentials [{}] does not match the sum of authentication successes and failures [{}]", authn.getCredentials().size(), sum);
                 return false;
             }

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManagerTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManagerTests.java
@@ -106,7 +106,7 @@ public class PolicyBasedAuthenticationManagerTests {
         val auth = manager.authenticate(transaction);
         assertEquals(1, auth.getSuccesses().size());
         assertEquals(1, auth.getFailures().size());
-        assertEquals(2, auth.getCredentials().size());
+        assertEquals(2, map.size());
     }
 
     protected static ServicesManager mockServicesManager() {


### PR DESCRIPTION
According to the documentation at https://apereo.github.io/cas/development/configuration/Configuration-Properties.html#any , this policy should make sure, that every handler is checked if the tryAll flag is set.
Instead the function checked, if the amount of provided credentials equals the amount of checked handlers, which is not the same.
