### PR TITLE
avoid bean cycle in ldap monitor config class

### DIFF
--- a/core/cas-server-core-authentication-mfa/build.gradle
+++ b/core/cas-server-core-authentication-mfa/build.gradle
@@ -14,9 +14,12 @@ dependencies {
     testImplementation project(":core:cas-server-core-logout")
     testImplementation project(":core:cas-server-core-cookie")
     testImplementation project(":core:cas-server-core")
+    testImplementation project(":core:cas-server-core-tickets")
+    testImplementation project(":core:cas-server-core-web")
     testImplementation project(":core:cas-server-core-webflow")
     testImplementation project(":core:cas-server-core-webflow-mfa")
     testImplementation project(":core:cas-server-core-util-api")
+    testImplementation project(":support:cas-server-support-person-directory")
 
     testImplementation project(path: ":core:cas-server-core-authentication-mfa-api", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-util-api", configuration: "tests")

--- a/core/cas-server-core-authentication-mfa/src/test/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationProviderResolverTests.java
+++ b/core/cas-server-core-authentication-mfa/src/test/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationProviderResolverTests.java
@@ -1,11 +1,17 @@
 package org.apereo.cas.authentication;
 
 import org.apereo.cas.authentication.mfa.TestMultifactorAuthenticationProvider;
+import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationSupportConfiguration;
 import org.apereo.cas.config.CasCoreConfiguration;
+import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.CasCoreMultifactorAuthenticationAuditConfiguration;
 import org.apereo.cas.config.CasCoreMultifactorAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
+import org.apereo.cas.config.CasCoreTicketIdGeneratorsConfiguration;
+import org.apereo.cas.config.CasCoreTicketsConfiguration;
+import org.apereo.cas.config.CasCoreWebConfiguration;
+import org.apereo.cas.config.CasPersonDirectoryConfiguration;
 import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.apereo.cas.util.CollectionUtils;
@@ -45,7 +51,10 @@ import static org.mockito.Mockito.*;
  */
 @SpringBootTest(classes = {
     RefreshAutoConfiguration.class,
+    CasCoreAuthenticationPrincipalConfiguration.class,
     CasCoreServicesConfiguration.class,
+    CasCoreHttpConfiguration.class,
+    CasCoreWebConfiguration.class,
     CasCoreWebflowConfiguration.class,
     CasWebflowContextConfiguration.class,
     CasWebApplicationServiceFactoryConfiguration.class,
@@ -55,7 +64,10 @@ import static org.mockito.Mockito.*;
     CasCoreMultifactorAuthenticationAuditConfiguration.class,
     CasCoreConfiguration.class,
     CasCoreLogoutConfiguration.class,
-    CasCookieConfiguration.class
+    CasCoreTicketsConfiguration.class,
+    CasCoreTicketIdGeneratorsConfiguration.class,
+    CasCookieConfiguration.class,
+    CasPersonDirectoryConfiguration.class
 })
 @DirtiesContext
 public class DefaultMultifactorAuthenticationProviderResolverTests {

--- a/core/cas-server-core-tickets/build.gradle
+++ b/core/cas-server-core-tickets/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation project(":core:cas-server-core-util")
     
     compileOnly project(":core:cas-server-core-services")
-    
+
     testImplementation project(":core:cas-server-core-services")
     testImplementation project(":core:cas-server-core-web")
     testImplementation project(":core:cas-server-core-cookie")
@@ -23,6 +23,7 @@ dependencies {
     testImplementation project(":core:cas-server-core-authentication-mfa")
     testImplementation project(":core:cas-server-core")
     testImplementation project(":core:cas-server-core-logout-api")
+    testImplementation project(":core:cas-server-core-web")
 
     testImplementation project(path: ":core:cas-server-core-authentication-api", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-util-api", configuration: "tests")

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/DefaultTicketCatalogTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/DefaultTicketCatalogTests.java
@@ -11,6 +11,7 @@ import org.apereo.cas.config.CasCoreUtilConfiguration;
 import org.apereo.cas.config.CasCoreWebConfiguration;
 import org.apereo.cas.config.CasDefaultServiceTicketIdGeneratorsConfiguration;
 import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
+import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.apereo.cas.mock.MockTicketGrantingTicket;
 import org.apereo.cas.web.config.CasCookieConfiguration;
 
@@ -42,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreWebConfiguration.class,
     CasCoreHttpConfiguration.class,
     CasCookieConfiguration.class,
-    CasCoreConfiguration.class
+    CasCoreConfiguration.class,
+    CasCoreLogoutConfiguration.class
 })
 public class DefaultTicketCatalogTests {
     @Autowired

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/TicketSerializersTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/TicketSerializersTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket;
 
+import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.CasCoreServicesAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
 import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreTicketsConfiguration.class,
     CasCoreTicketIdGeneratorsConfiguration.class,
     CasDefaultServiceTicketIdGeneratorsConfiguration.class,
+    CasCoreHttpConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
     CasCoreTicketsSerializationConfiguration.class,
     CasWebApplicationServiceFactoryConfiguration.class,

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/factory/BaseTicketFactoryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/factory/BaseTicketFactoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.ticket.factory;
 
+import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
 import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
 import org.apereo.cas.config.CasCoreTicketComponentSerializationConfiguration;
@@ -34,6 +35,7 @@ import java.util.List;
  */
 @SpringBootTest(classes = {
     BaseTicketFactoryTests.TicketFactoryTestConfiguration.class,
+    CasCoreHttpConfiguration.class,
     CasCoreServicesConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
     CasCoreTicketsConfiguration.class,

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.ticket.registry;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
 import org.apereo.cas.config.CasCoreTicketIdGeneratorsConfiguration;
 import org.apereo.cas.config.CasCoreTicketsConfiguration;
@@ -52,6 +53,7 @@ import static org.junit.jupiter.api.Assumptions.*;
  */
 @Slf4j
 @SpringBootTest(classes = {
+    CasCoreHttpConfiguration.class,
     CasCoreTicketsConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
     CasCoreTicketIdGeneratorsConfiguration.class,

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/serialization/DefaultTicketStringSerializationManagerTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/serialization/DefaultTicketStringSerializationManagerTests.java
@@ -1,6 +1,8 @@
 package org.apereo.cas.ticket.serialization;
 
+import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.CasCoreTicketCatalogConfiguration;
+import org.apereo.cas.config.CasCoreTicketIdGeneratorsConfiguration;
 import org.apereo.cas.config.CasCoreTicketsConfiguration;
 import org.apereo.cas.config.CasCoreTicketsSerializationConfiguration;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
@@ -25,9 +27,11 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @SpringBootTest(classes = {
     RefreshAutoConfiguration.class,
+    CasCoreHttpConfiguration.class,
     CasCoreTicketsConfiguration.class,
     CasCoreTicketCatalogConfiguration.class,
-    CasCoreTicketsSerializationConfiguration.class
+    CasCoreTicketsSerializationConfiguration.class,
+    CasCoreTicketIdGeneratorsConfiguration.class
 })
 public class DefaultTicketStringSerializationManagerTests {
     @Autowired

--- a/core/cas-server-core/src/test/java/org/apereo/cas/BaseCasCoreTests.java
+++ b/core/cas-server-core/src/test/java/org/apereo/cas/BaseCasCoreTests.java
@@ -31,6 +31,7 @@ import org.apereo.cas.ticket.expiration.NeverExpiresExpirationPolicy;
 import org.apereo.cas.validation.config.CasCoreValidationConfiguration;
 import org.apereo.cas.web.config.CasCookieConfiguration;
 import org.apereo.cas.web.flow.config.CasCoreWebflowConfiguration;
+import org.apereo.cas.web.flow.config.CasMultifactorAuthenticationWebflowConfiguration;
 import org.apereo.cas.web.flow.config.CasWebflowContextConfiguration;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,6 +79,7 @@ import org.springframework.test.annotation.DirtiesContext;
     CasCoreServicesAuthenticationConfiguration.class,
     AopAutoConfiguration.class,
     CasCoreMultifactorAuthenticationConfiguration.class,
+    CasMultifactorAuthenticationWebflowConfiguration.class,
     CasPersonDirectoryTestConfiguration.class,
     CasWebflowContextConfiguration.class,
     CasCoreWebflowConfiguration.class,

--- a/support/cas-server-support-discovery-profile/src/test/java/org/apereo/cas/discovery/CasServerProfileRegistrarTests.java
+++ b/support/cas-server-support-discovery-profile/src/test/java/org/apereo/cas/discovery/CasServerProfileRegistrarTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.discovery;
 
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
 import org.apereo.cas.authentication.mfa.TestMultifactorAuthenticationProvider;
+import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationPrincipalConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
 import org.apereo.cas.config.CasCoreTicketIdGeneratorsConfiguration;
@@ -38,7 +39,8 @@ import static org.junit.jupiter.api.Assertions.*;
     CasCoreAuditConfiguration.class,
     CasCoreTicketIdGeneratorsConfiguration.class,
     CasCoreTicketsConfiguration.class,
-    CasCoreAuthenticationPrincipalConfiguration.class
+    CasCoreAuthenticationPrincipalConfiguration.class,
+    CasCoreAuthenticationHandlersConfiguration.class
 })
 @DirtiesContext
 public class CasServerProfileRegistrarTests {

--- a/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
+++ b/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
@@ -8,16 +8,11 @@ import org.apereo.cas.util.LdapUtils;
 import lombok.val;
 import org.ldaptive.pool.SearchValidator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.scheduling.concurrent.ThreadPoolExecutorFactoryBean;
-
-import java.util.concurrent.ExecutorService;
 
 /**
  * This is {@link LdapMonitorConfiguration}.
@@ -32,17 +27,11 @@ public class LdapMonitorConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;
 
-    @Lazy
-    @Bean
-    public ThreadPoolExecutorFactoryBean pooledConnectionFactoryMonitorExecutorService() {
-        return Beans.newThreadPoolExecutorFactoryBean(casProperties.getMonitor().getLdap().getPool());
-    }
-
-    @Autowired
     @Bean
     @ConditionalOnEnabledHealthIndicator("pooledLdapConnectionFactoryHealthIndicator")
-    public HealthIndicator pooledLdapConnectionFactoryHealthIndicator(@Qualifier("pooledConnectionFactoryMonitorExecutorService") final ExecutorService executor) {
+    public HealthIndicator pooledLdapConnectionFactoryHealthIndicator() {
         val ldap = casProperties.getMonitor().getLdap();
+        val executor = Beans.newThreadPoolExecutorFactoryBean(casProperties.getMonitor().getLdap().getPool()).getObject();
         val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
         return new PooledLdapConnectionFactoryHealthIndicator(Beans.newDuration(ldap.getMaxWait()).toMillis(),
             connectionFactory, executor, new SearchValidator());


### PR DESCRIPTION
There was a dependency cycle ("Requested bean is currently in creation") when this module was used due to some changes after 6.1.RC5. I couldn't get the cycle to happen in a unit test but this fixes it when I tested it with "bc". 