### PR TITLE
Add Acceptto's Logo to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://user-images.githubusercontent.com/1205228/30969994-e2fe6bf0-a470-11e7-80f9-d54d1e4d348e.png">
+<img src="https://user-images.githubusercontent.com/2813838/66173345-91b00380-e604-11e9-95f4-546767cc134c.png">
 </p>
 
 # Central Authentication Service (CAS)


### PR DESCRIPTION
Adding [Acceptto](https://www.acceptto.com/)'s logo to the README file as [Accpetto's MFA module](https://github.com/apereo/cas/blob/master/docs/cas-server-documentation/mfa/Acceptto-Authentication.md) has already been implemented and added to CAS.