### PR TITLE
exclude old ehcache-core dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -208,6 +208,7 @@ ext.libraries = [
                     exclude(group: "org.openldap", module: "accelerator-impl")
                     exclude(group: "org.openldap", module: "accelerator-api")
                     exclude(group: "commons-lang", module: "commons-lang")
+                    exclude(group: "net.sf.ehcache", module: "ehcache-core")
                 }
         ],
         cassandra               : [
@@ -1553,6 +1554,7 @@ ext.libraries = [
                     exclude(group: "org.springframework", module: "spring-context-support")
                     exclude(group: "org.springframework", module: "spring-core")
                     exclude(group: "commons-lang", module: "commons-lang")
+                    exclude(group: "net.sf.ehcache", module: "ehcache-core")
                     force = true
                 },
                 dependencies.create("gnu.getopt:java-getopt:1.0.13") {


### PR DESCRIPTION
If ehcache is needed by jradius or fortress (and it may not be) then it needs to be ehcache artifact rather than the older ehcache-core. 