### PR TITLE
make some service registries conditional on required properties

### DIFF
--- a/support/cas-server-support-git-service-registry/src/main/java/org/apereo/cas/config/GitServiceRegistryConfiguration.java
+++ b/support/cas-server-support-git-service-registry/src/main/java/org/apereo/cas/config/GitServiceRegistryConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -33,6 +34,7 @@ import java.util.Collection;
  * @since 6.1.0
  */
 @Configuration("gitServiceRegistryConfiguration")
+@ConditionalOnProperty(prefix = "cas.serviceRegistry.git", name = "repositoryUrl")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class GitServiceRegistryConfiguration {
     @Autowired

--- a/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/config/LdapServiceRegistryConfiguration.java
+++ b/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/config/LdapServiceRegistryConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -29,6 +30,7 @@ import java.util.Collection;
  * @since 5.0.0
  */
 @Configuration("ldapServiceRegistryConfiguration")
+@ConditionalOnProperty(prefix = "cas.serviceRegistry.ldap", name = "ldapUrl")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class LdapServiceRegistryConfiguration {
 


### PR DESCRIPTION
I want to be able to be able choose between json and git service registries for the same CAS image (war). This PR makes the git service registry conditional on one of its required properties. I also made ldap service registry conditional on properties although I don't personally plan on using it. Json and Yaml service registries are already conditional on properties and rest is conditional although it is conditional on the service registry bean rather than the whole configuration class. 

I backed out change to make JpaServiceRegistry conditional on url property b/c there are some unit tests that don't set a appear to set a url and it wasn't clear to me how they worked. 