### PR TITLE
minor spotbug changes and suppress false positive tomcat CVE

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManager.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManager.java
@@ -203,13 +203,13 @@ public class PolicyBasedAuthenticationManager implements AuthenticationManager {
         publishEvent(new CasAuthenticationTransactionSuccessfulEvent(this, credential));
         var principal = result.getPrincipal();
 
-        val resolverName = resolver != null ? resolver.getName(): "N/A";
         if (resolver == null) {
             LOGGER.debug("No principal resolution is configured for [{}]. Falling back to handler principal [{}]", authenticationHandlerName, principal);
         } else {
             principal = resolvePrincipal(handler, resolver, credential, principal);
             if (principal == null) {
                 if (this.principalResolutionFailureFatal) {
+                    val resolverName = resolver != null ? resolver.getName(): "N/A";
                     LOGGER.warn("Principal resolution handled by [{}] produced a null principal for: [{}]"
                         + "CAS is configured to treat principal resolution failures as fatal.", resolverName, credential);
                     throw new UnresolvedPrincipalException();

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/support/jaas/AccountsPreDefinedLoginModule.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/support/jaas/AccountsPreDefinedLoginModule.java
@@ -70,8 +70,8 @@ public class AccountsPreDefinedLoginModule implements LoginModule {
         }
 
         val username = nameCallback.getName();
-        val password = new String(passwordCallback.getPassword());
         if (accounts.containsKey(username)) {
+            val password = new String(passwordCallback.getPassword());
             this.succeeded = accounts.get(username).equals(password);
             subject.getPrincipals().add(new StaticPrincipal(username));
             return true;

--- a/style/dependency-check-suppressions.xml
+++ b/style/dependency-check-suppressions.xml
@@ -787,13 +787,14 @@
         <cve>CVE-2018-7489</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[ file name: old Tomcat CVEs false positives on latest Tomcat 9.0.14 ]]></notes>
+        <notes><![CDATA[ file name: old Tomcat CVEs false positives on latest Tomcat 9.0.x ]]></notes>
         <cve>CVE-2014-0230</cve>
         <cve>CVE-2011-3190</cve>
         <cve>CVE-2016-8735</cve>
         <cve>CVE-2016-1240</cve>
         <cve>CVE-2016-9774</cve>
         <cve>CVE-2016-9775</cve>
+        <cve>CVE-2017-12615</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
This moves some variable declarations and assignments inside block where they are used to make spotbugs BAS_BLOATED_ASSIGNMENT_SCOPE go away. 

Also suppress Tomcat 7 CVE.