### PR TITLE
Configuration metadata: prevent NPE if source.getType() is null

### DIFF
--- a/core/cas-server-core-configuration-metadata-repository/src/main/java/org/springframework/boot/configurationmetadata/CasConfigurationMetadataRepositoryJsonBuilder.java
+++ b/core/cas-server-core-configuration-metadata-repository/src/main/java/org/springframework/boot/configurationmetadata/CasConfigurationMetadataRepositoryJsonBuilder.java
@@ -9,6 +9,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This is {@link CasConfigurationMetadataRepositoryJsonBuilder}
@@ -105,7 +106,7 @@ public class CasConfigurationMetadataRepositoryJsonBuilder {
         val name = idx > 0 ? item.getId().substring(0, idx) : StringUtils.EMPTY;
 
         return metadata.getSources().stream()
-            .filter(source -> source.getType().equals(item.getSourceType()) && name.equals(source.getGroupId()))
+            .filter(source -> Objects.equals(source.getType(), item.getSourceType()) && name.equals(source.getGroupId()))
             .findFirst()
             .orElse(null);
 


### PR DESCRIPTION
The old code threw an NullPointerException if `org.springframework.boot.configurationmetadata.ConfigurationMetadataSource#getType` retuned `null`