### PR TITLE
password management: add support for Active Directory "change password" vs "reset password"

### DIFF
--- a/ci/tests/ldap/reset-ad-server.sh
+++ b/ci/tests/ldap/reset-ad-server.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DEFAULT_TESTUSER_PASSWORD=P@ssw0rd
+echo "Resetting passwords of all users (in case tests changed them)"
+
+docker exec samba bash -c "samba-tool user setpassword admin --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+docker exec samba bash -c "samba-tool user setpassword aburr --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+docker exec samba bash -c "samba-tool user setpassword aham --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+docker exec samba bash -c "samba-tool user setpassword expireduser --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+docker exec samba bash -c "samba-tool user setpassword disableduser --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+docker exec samba bash -c "samba-tool user setpassword changepassword --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+docker exec samba bash -c "samba-tool user setpassword changepasswordnoreset --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+

--- a/ci/tests/ldap/run-ad-server.sh
+++ b/ci/tests/ldap/run-ad-server.sh
@@ -102,10 +102,19 @@ docker exec samba bash -c "samba-tool user create aham $DEFAULT_TESTUSER_PASSWOR
 docker exec samba bash -c "samba-tool user create expireduser $DEFAULT_TESTUSER_PASSWORD --use-username-as-cn"
 docker exec samba bash -c "samba-tool user create disableduser $DEFAULT_TESTUSER_PASSWORD --use-username-as-cn"
 docker exec samba bash -c "samba-tool user create changepassword $DEFAULT_TESTUSER_PASSWORD --use-username-as-cn --mail-address=changepassword@example.org --telephone-number=1234567890 --department='DepartmentQuestion' --company='CompanyAnswer' --description='DescriptionQuestion' --physical-delivery-office=PhysicalDeliveryOfficeAnswer "
+docker exec samba bash -c "samba-tool user create changepasswordnoreset $DEFAULT_TESTUSER_PASSWORD --use-username-as-cn"
 docker exec samba bash -c "samba-tool user setexpiry --days 0 expireduser"
 docker exec samba bash -c "samba-tool user disable disableduser"
 docker exec samba bash -c "samba-tool user list"
 docker exec samba bash -c "samba-tool group addmembers 'Account Operators' admin"
+
+#Disable password history at the domain level.
+docker exec samba bash -c "samba-tool domain passwordsettings set --history-length=0"
+
+#Disable password min-age at the domain level
+docker exec samba bash -c "samba-tool domain passwordsettings set --min-pwd-age=0"
+
+
 
 # Copying certificate out of the container so it can be put in a Java certificate trust store.
 echo Putting cert in trust store for use by unit test

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -816,13 +816,13 @@ public class LdapUtils {
                 LOGGER.trace("Creating LDAP SSL configuration with truststore [{}]", l.getTrustStore());
                 cfg.setTrustStore(l.getTrustStore());
                 cfg.setTrustStoreType(l.getTrustStoreType());
-                cfg.setTrustStorePassword(getStorePassword(l.getTrustStoreType(), l.getTrustStorePassword()));
+                cfg.setTrustStorePassword(l.getTrustStorePassword());
             }
             if (l.getKeystore() != null) {
                 LOGGER.trace("Creating LDAP SSL configuration via keystore [{}]", l.getKeystore());
                 cfg.setKeyStore(l.getKeystore());
                 cfg.setKeyStoreType(l.getKeystoreType());
-                cfg.setKeyStorePassword(getStorePassword(l.getKeystoreType(), l.getKeystorePassword()));
+                cfg.setKeyStorePassword(l.getKeystorePassword());
             }
             cc.setSslConfig(new SslConfig(cfg));
         } else {
@@ -886,19 +886,6 @@ public class LdapUtils {
         val sc = new GssApiConfig();
         sc.setRealm(l.getSaslRealm());
         return sc;
-    }
-
-    /**
-     * Get default password depending on pki store type.
-     *
-     * @param storeType JKS or PKCS12
-     * @return storePassword password to access the pki material store
-     */
-    private static String getStorePassword(final String storeType, final String storePassword) {
-        if (StringUtils.isBlank(storePassword) && "JKS".equalsIgnoreCase(storeType)) {
-            return "changeit";
-        }
-        return storePassword;
     }
 
     /**

--- a/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/pm/LdapPasswordManagementService.java
+++ b/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/pm/LdapPasswordManagementService.java
@@ -64,7 +64,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
             }
             LOGGER.error("Could not locate an LDAP entry for [{}] and base DN [{}]", filter.format(), ldap.getBaseDn());
         } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error("Error finding username: {}", e.getMessage(), e);
         }
         return null;
     }
@@ -103,7 +103,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
             }
             LOGGER.error("Could not locate an LDAP entry for [{}] and base DN [{}]", filter.format(), ldap.getBaseDn());
         } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error("Error finding email: {}", e.getMessage(), e);
         }
         return null;
     }
@@ -138,7 +138,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
             }
             LOGGER.error("Could not locate an LDAP entry for [{}] and base DN [{}]", filter.format(), ldap.getBaseDn());
         } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error("Error finding phone: {}", e.getMessage(), e);
         }
         return null;
     }
@@ -148,12 +148,10 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
         try {
             val ldap = properties.getLdap();
             val c = (UsernamePasswordCredential) credential;
-
             val filter = LdapUtils.newLdaptiveSearchFilter(ldap.getSearchFilter(),
                 LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME,
                 CollectionUtils.wrap(c.getId()));
             LOGGER.debug("Constructed LDAP filter [{}] to update account password", filter);
-
 
             val response = LdapUtils.executeSearchOperation(this.ldapConnectionFactory, ldap.getBaseDn(), filter, ldap.getPageSize());
             LOGGER.debug("LDAP response to update password is [{}]", response);
@@ -171,7 +169,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
                 LOGGER.error("Could not locate an LDAP entry for [{}] and base DN [{}]", filter.format(), ldap.getBaseDn());
             }
         } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error("Error changing password: {}", e.getMessage(), e);
         }
         return false;
     }
@@ -211,7 +209,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
                 LOGGER.debug("LDAP response did not contain a result for security questions");
             }
         } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error("Error getting security questions: {}", e.getMessage(), e);
         }
         return set;
     }

--- a/support/cas-server-support-pm-ldap/src/test/java/org/apereo/cas/pm/ADPasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm-ldap/src/test/java/org/apereo/cas/pm/ADPasswordManagementServiceTests.java
@@ -10,6 +10,7 @@ import org.apereo.cas.util.junit.EnabledIfPortOpen;
 
 import lombok.SneakyThrows;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.inspektr.common.web.ClientInfo;
 import org.apereo.inspektr.common.web.ClientInfoHolder;
 import org.junit.jupiter.api.BeforeAll;
@@ -72,8 +73,8 @@ public class ADPasswordManagementServiceTests {
     }
 
     @Test
-    public void verifyPasswordChange() {
-        val credential = new UsernamePasswordCredential("changepassword", "P@ssw0rd");
+    public void verifyPasswordReset() {
+        val credential = new UsernamePasswordCredential("changepassword", StringUtils.EMPTY);
         val bean = new PasswordChangeRequest();
         bean.setConfirmedPassword("P@ssw0rdMellon");
         bean.setPassword("P@ssw0rdMellon");
@@ -81,13 +82,12 @@ public class ADPasswordManagementServiceTests {
         assertTrue(passwordChangeService.change(credential, bean));
     }
 
-
     @Test
-    public void verifyPasswordReset() {
-        val credential = new UsernamePasswordCredential("changepassword", "P@ssw0rd");
+    public void verifyPasswordChange() {
+        val credential = new UsernamePasswordCredential("changepasswordnoreset", "P@ssw0rd");
         val bean = new PasswordChangeRequest();
-        bean.setConfirmedPassword("P@ssw0rdMellon");
-        bean.setPassword("P@ssw0rdMellon");
+        bean.setConfirmedPassword("P@ssw0rd2");
+        bean.setPassword("P@ssw0rd2");
         bean.setUsername(credential.getUsername());
         assertTrue(passwordChangeService.change(credential, bean));
     }


### PR DESCRIPTION
The previous change password code, when LDAP type was AD, wasn't using the old password. This may have been OK if the changing of an expiring password was done after login where the old password was validated on login, but using a "reset password" (without old password) vs. a "change password" that requires old password isn't really the same. The reset password requires the bind user to have more privileges and it doesn't respect some domain password policies such as history and minimum age. 

I think this should make the AD handling comparable to the non-AD LDAP handling which used the old password if it was not blank. 

This also sets a default JKS store password of "changeit" if the password field is empty. Since JKS keystores require passwords, might as well use one that is more likely to work.  

