### PR TITLE
CI: retry java install if it fails

### DIFF
--- a/ci/init-travis-build.sh
+++ b/ci/init-travis-build.sh
@@ -38,8 +38,15 @@ sudo mkdir -p /etc/cas/config /etc/cas/saml /etc/cas/services
 echo -e "Installing Java...\n"
 url="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_11.0.5_10.tar.gz"
 wget https://github.com/sormuras/bach/raw/master/install-jdk.sh && chmod +x install-jdk.sh
-export JAVA_HOME=$(./install-jdk.sh --emit-java-home --url ${url} -c | tail --lines 1) &&
-echo $JAVA_HOME
+for i in {1..5}; do
+    export JAVA_HOME=$(./install-jdk.sh --emit-java-home --url ${url} -c | tail --lines 1)
+    if [[ -d ${JAVA_HOME} ]] ; then
+        break;
+    fi
+    echo -e "Trying download again... [${i}]\n"
+    sleep 5
+done
+echo JAVA_HOME=${JAVA_HOME}
 
 echo -e "Installing Groovy...\n"
 groovyVersion=3.0.0-alpha-3


### PR DESCRIPTION
I have seen several travis jobs fail because the java install failed. This retries it a few times if it fails. 