### PR TITLE
add Active Directory test for password policy warnings due to password expiration

### DIFF
--- a/ci/tests/ldap/run-ad-server.sh
+++ b/ci/tests/ldap/run-ad-server.sh
@@ -93,6 +93,12 @@ docker run --detach \
 sleep 15 # Give it time to come up before we create users
 docker logs samba
 
+#Disable password history at the domain level.
+docker exec samba bash -c "samba-tool domain passwordsettings set --history-length=0"
+
+#Disable password min-age at the domain level
+docker exec samba bash -c "samba-tool domain passwordsettings set --min-pwd-age=0"
+
 # Create users that can be used by various tests (e.g. authenticiation tests, password change tests, etc.
 # If we aren't setting up brand new instance these will fail if they already exist but that is OK.
 echo Creating users for tests
@@ -108,11 +114,10 @@ docker exec samba bash -c "samba-tool user disable disableduser"
 docker exec samba bash -c "samba-tool user list"
 docker exec samba bash -c "samba-tool group addmembers 'Account Operators' admin"
 
-#Disable password history at the domain level.
-docker exec samba bash -c "samba-tool domain passwordsettings set --history-length=0"
-
-#Disable password min-age at the domain level
-docker exec samba bash -c "samba-tool domain passwordsettings set --min-pwd-age=0"
+# create a special password policy and apply it to a user
+docker exec samba bash -c "samba-tool user create expirestomorrow $DEFAULT_TESTUSER_PASSWORD --use-username-as-cn"
+docker exec samba bash -c "samba-tool domain passwordsettings pso create expirepasswordsoon 10 --max-pwd-age=2"
+docker exec samba bash -c "samba-tool domain passwordsettings pso apply expirepasswordsoon expirestomorrow"
 
 
 

--- a/core/cas-server-core-web/src/main/resources/cas_common_messages.properties
+++ b/core/cas-server-core-web/src/main/resources/cas_common_messages.properties
@@ -9,7 +9,7 @@ webjars.bootstrapmin.js=/webjars/bootstrap/${bootstrapVersion}/js/bootstrap.bund
 webjars.bootstrapmin.css=/webjars/bootstrap/${bootstrapVersion}/css/bootstrap.min.css
 webjars.jqueryui.js=/webjars/jquery-ui/${jqueryUiVersion}/jquery-ui.min.js
 webjars.jquerymin.js=/webjars/jquery/${jqueryVersion}/jquery.min.js
-webjars.zxcvbn.js=/webjars/zxcvbn/${zxcvbnVersion}/zxcvbn.js
+webjars.zxcvbn.js=/webjars/zxcvbn/${zxcvbnVersion}/dist/zxcvbn.js
 
 webjars.fontawesomemin.css=/webjars/font-awesome/${fontAwesomeVersion}/css/all.min.css
 webjars.datatables.bootstrapmin.css=/webjars/datatables/${datatablesVersion}/css/jquery.dataTables.min.css

--- a/docs/cas-server-documentation/ux/User-Interface-Customization-CSSJS.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization-CSSJS.md
@@ -89,7 +89,7 @@ For developers modifying CAS, if adding or modifying a 3rd party library, the st
 For example:
 
 ```properties
-webjars.zxcvbn.js=/webjars/zxcvbn/${zxcvbnVersion}/zxcvbn.js
+webjars.zxcvbn.js=/webjars/zxcvbn/${zxcvbnVersion}/dist/zxcvbn.js
 ```
 
 Then Reference the entry from `cas_common_messages.properties` in the relevant view (i.e HTML page) where the entry is `webjars.zxcvbn.js`:

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/AllLdapTestsSuite.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/AllLdapTestsSuite.java
@@ -2,6 +2,7 @@ package org.apereo.cas;
 
 import org.apereo.cas.authentication.ActiveDirectoryJndiSamAccountNameLdapAuthenticationHandlerTests;
 import org.apereo.cas.authentication.ActiveDirectoryJndiUPNLdapAuthenticationHandlerTests;
+import org.apereo.cas.authentication.ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests;
 import org.apereo.cas.authentication.ActiveDirectoryUnboundIDBindDnSSLLdapAuthenticationHandlerTests;
 import org.apereo.cas.authentication.ActiveDirectoryUnboundIDTypeADAuthenticationHandlerTests;
 import org.apereo.cas.authentication.AuthenticatedLdapAuthenticationHandlerTests;
@@ -24,6 +25,7 @@ import org.junit.runner.RunWith;
     ActiveDirectoryUnboundIDTypeADAuthenticationHandlerTests.class,
     ActiveDirectoryJndiUPNLdapAuthenticationHandlerTests.class,
     ActiveDirectoryJndiSamAccountNameLdapAuthenticationHandlerTests.class,
+    ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests.class,
     AuthenticatedLdapAuthenticationHandlerTests.class,
     PersonDirectoryPrincipalResolverLdaptiveTests.class,
     DirectLdapAuthenticationHandlerTests.class,

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryJndiSamAccountNameLdapAuthenticationHandlerTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryJndiSamAccountNameLdapAuthenticationHandlerTests.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.TestPropertySource;
  *  - This configuration doesn't retrieve any attributes as part of the authentication.
  *  - If the pool passivator is {@code CLOSE}, and the both success and failure tests run, the failure test will
  *      fail with wrong exception type. If multiple success tests are added, every other test will fail.
- *  - No SSL or startTls due to JDK-8217606 which currently impacts {@link JndiProvider}
  * @author Hal Deadman
  * @since 6.1.0
  */
@@ -23,7 +22,7 @@ import org.springframework.test.context.TestPropertySource;
     "cas.authn.ldap[0].type=AD",
     "cas.authn.ldap[0].ldapUrl=" + BaseActiveDirectoryLdapAuthenticationHandlerTests.AD_LDAP_URL,
     "cas.authn.ldap[0].useSsl=false",
-    "cas.authn.ldap[0].useStartTls=false",
+    "cas.authn.ldap[0].useStartTls=true",
     "cas.authn.ldap[0].subtreeSearch=true",
     "cas.authn.ldap[0].baseDn=cn=Users,dc=cas,dc=example,dc=org",
     "cas.authn.ldap[0].dnFormat=CAS\\\\%s",
@@ -35,6 +34,7 @@ import org.springframework.test.context.TestPropertySource;
     "cas.authn.ldap[0].providerClass=org.ldaptive.provider.jndi.JndiProvider",
     "cas.authn.ldap[0].trustStore=" + BaseActiveDirectoryLdapAuthenticationHandlerTests.AD_TRUST_STORE,
     "cas.authn.ldap[0].trustStoreType=JKS",
+    "cas.authn.ldap[0].trustStorePassword=changeit",
     "cas.authn.ldap[0].hostnameVerifier=DEFAULT"
 })
 @EnabledIfContinuousIntegration

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryJndiUPNLdapAuthenticationHandlerTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryJndiUPNLdapAuthenticationHandlerTests.java
@@ -11,8 +11,9 @@ import org.springframework.test.context.TestPropertySource;
  * The userPrincipalName attribute is the format UPN_PREFIX@UPN_SUFFIX where UPN_PREFIX is the "long" username
  * and UPN_SUFFIX is a domain in the Active Directory forest or a domain listed in upnSuffixes attribute.
  * UPN_PREFIX does not have to be unique but it is unique when combined with UPN_SUFFIX.
- * The {@link UnboundIDProvider} would fail this due to its DN validation.
- * This test currently uses no SSL or startTls due to bug JDK-8217606, turn on startTls once it is fixed.
+ * Issues:
+ *  - This configuration doesn't retrieve any attributes as part of the authentication.
+ *  - The {@link UnboundIDProvider} would fail this due to its DN validation.
  * @author Hal Deadman
  * @since 6.1.0
  */
@@ -20,7 +21,7 @@ import org.springframework.test.context.TestPropertySource;
     "cas.authn.ldap[0].type=AD",
     "cas.authn.ldap[0].ldapUrl=" + BaseActiveDirectoryLdapAuthenticationHandlerTests.AD_LDAP_URL,
     "cas.authn.ldap[0].useSsl=false",
-    "cas.authn.ldap[0].useStartTls=false",
+    "cas.authn.ldap[0].useStartTls=true",
     "cas.authn.ldap[0].subtreeSearch=true",
     "cas.authn.ldap[0].baseDn=cn=Users,dc=cas,dc=example,dc=org",
     "cas.authn.ldap[0].dnFormat=%s",
@@ -31,6 +32,7 @@ import org.springframework.test.context.TestPropertySource;
     "cas.authn.ldap[0].providerClass=org.ldaptive.provider.jndi.JndiProvider",
     "cas.authn.ldap[0].trustStore=" + BaseActiveDirectoryLdapAuthenticationHandlerTests.AD_TRUST_STORE,
     "cas.authn.ldap[0].trustStoreType=JKS",
+    "cas.authn.ldap[0].trustStorePassword=changeit",
     "cas.authn.ldap[0].hostnameVerifier=ANY"
 })
 @EnabledIfContinuousIntegration

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests.java
@@ -59,7 +59,7 @@ public class ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests extends
             val credential = new UsernamePasswordCredential(getUsername(), getSuccessPassword());
             val result = h.authenticate(credential);
             assertTrue(result.getWarnings() != null && result.getWarnings().size() > 0);
-            assertNotNull(result.getWarnings().stream().anyMatch(messageDescriptor -> messageDescriptor.getCode().equals("password.expiration.warning")));
+            assertTrue(result.getWarnings().stream().anyMatch(messageDescriptor -> messageDescriptor.getCode().equals("password.expiration.warning")));
             assertNotNull(result.getPrincipal());
             assertEquals(credential.getUsername(), result.getPrincipal().getId());
             val attributes = result.getPrincipal().getAttributes();

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests.java
@@ -1,0 +1,72 @@
+package org.apereo.cas.authentication;
+
+import org.apereo.cas.authentication.credential.UsernamePasswordCredential;
+import org.apereo.cas.util.junit.EnabledIfContinuousIntegration;
+
+import lombok.val;
+import org.jooq.lambda.Unchecked;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for {@link LdapAuthenticationHandler}.
+ * This test demonstrates password policy for AD by using user which soon to expire password.
+ * @author Hal Deadman
+ * @since 6.1.0
+ */
+@TestPropertySource(properties = {
+    "cas.authn.ldap[0].type=AUTHENTICATED",
+    "cas.authn.ldap[0].bindDn=Administrator@cas.example.org",
+    "cas.authn.ldap[0].bindCredential=" + BaseActiveDirectoryLdapAuthenticationHandlerTests.AD_ADMIN_PASSWORD,
+    "cas.authn.ldap[0].ldapUrl=" + BaseActiveDirectoryLdapAuthenticationHandlerTests.AD_LDAP_URL,
+    "cas.authn.ldap[0].useSsl=false",
+    "cas.authn.ldap[0].useStartTls=true",
+    "cas.authn.ldap[0].subtreeSearch=true",
+    "cas.authn.ldap[0].baseDn=dc=cas,dc=example,dc=org",
+    "cas.authn.ldap[0].followReferrals=false",
+    "cas.authn.ldap[0].principalAttributeList=sAMAccountName,cn",
+    "cas.authn.ldap[0].enhanceWithEntryResolver=true",
+    "cas.authn.ldap[0].searchFilter=(sAMAccountName={user})",
+    "cas.authn.ldap[0].minPoolSize=0",
+    "cas.authn.ldap[0].providerClass=org.ldaptive.provider.jndi.JndiProvider",
+    "cas.authn.ldap[0].trustStore=" + BaseActiveDirectoryLdapAuthenticationHandlerTests.AD_TRUST_STORE,
+    "cas.authn.ldap[0].trustStoreType=JKS",
+    "cas.authn.ldap[0].trustStorePassword=changeit",
+    "cas.authn.ldap[0].hostnameVerifier=DEFAULT",
+    "cas.authn.ldap[0].passwordPolicy.type=AD",
+    "cas.authn.ldap[0].passwordPolicy.enabled=true"
+})
+@EnabledIfContinuousIntegration
+public class ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests extends BaseActiveDirectoryLdapAuthenticationHandlerTests {
+
+    @Override
+    protected String getUsername() {
+        return "expirestomorrow";
+    }
+
+    @Test
+    public void verifyAuthenticateWarnings() {
+        assertNotEquals(handler.size(), 0);
+
+        this.handler.forEach(Unchecked.consumer(h -> {
+            val credential = new UsernamePasswordCredential(getUsername(), getSuccessPassword());
+            val result = h.authenticate(credential);
+            assertTrue(result.getWarnings() != null && result.getWarnings().size() > 0);
+            assertNotNull(result.getWarnings().stream().anyMatch(messageDescriptor -> messageDescriptor.getCode().equals("password.expiration.warning")));
+            assertNotNull(result.getPrincipal());
+            assertEquals(credential.getUsername(), result.getPrincipal().getId());
+            val attributes = result.getPrincipal().getAttributes();
+            Arrays.stream(getPrincipalAttributes()).forEach(s -> assertTrue(attributes.containsKey(s)));
+        }));
+    }
+
+}
+
+


### PR DESCRIPTION
This is adds a test for AD to validate that warnings for upcoming password expiration are returned with Active Directory. 