### PR TITLE
Groovy MFA Trigger: The first args parameter will be service instead of registeredService

### DIFF
--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/trigger/GroovyScriptMultifactorAuthenticationTrigger.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/trigger/GroovyScriptMultifactorAuthenticationTrigger.java
@@ -63,11 +63,17 @@ public class GroovyScriptMultifactorAuthenticationTrigger implements Multifactor
             LOGGER.debug("No authentication is available to determine event for principal");
             return Optional.empty();
         }
+        
         if (registeredService == null) {
             LOGGER.debug("No registered service is available to determine event for principal [{}]", authentication.getPrincipal());
             return Optional.empty();
         }
 
+        if (service == null) {
+            LOGGER.debug("No service is available to determine event for principal [{}]", authentication.getPrincipal());
+            return Optional.empty();
+        }
+        
         val providerMap = MultifactorAuthenticationUtils.getAvailableMultifactorAuthenticationProviders(ApplicationContextProvider.getApplicationContext());
         if (providerMap.isEmpty()) {
             LOGGER.error("No multifactor authentication providers are available in the application context");
@@ -75,7 +81,7 @@ public class GroovyScriptMultifactorAuthenticationTrigger implements Multifactor
         }
 
         try {
-            val args = new Object[]{registeredService, registeredService, authentication, httpServletRequest, LOGGER};
+            val args = new Object[]{service, registeredService, authentication, httpServletRequest, LOGGER};
             val provider = this.watchableScript.execute(args, String.class);
             LOGGER.debug("Groovy script run for [{}] returned the provider id [{}]", registeredService, provider);
             if (StringUtils.isBlank(provider)) {


### PR DESCRIPTION
as described here: https://apereo.github.io/cas/6.1.x/mfa/Configuring-Multifactor-Authentication-Triggers.html#groovy
        def service = args[0]
        def registeredService = args[1]
        def authentication = args[2]
        def httpRequest = args[3]
        def logger = args[4]