### PR TITLE
update signalfx dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -201,6 +201,7 @@ pac4jVersion=4.0.0-RC1
 
 statsdVersion=3.1.0
 micrometerVersion=1.3.0
+signalFxVersion=0.2.1
 
 amazonSdkVersion=1.11.651
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1779,6 +1779,7 @@ ext.libraries = [
                 },
                 dependencies.create("io.micrometer:micrometer-registry-wavefront:$micrometerVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
+                    exclude(group: "com.signalfx.public", module: "signalfx-java")
                     force = true
                 },
                 dependencies.create("io.micrometer:micrometer-registry-new-relic:$micrometerVersion") {
@@ -1787,6 +1788,9 @@ ext.libraries = [
                 },
                 dependencies.create("io.micrometer:micrometer-registry-cloudwatch:$micrometerVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
+                    force = true
+                },
+                dependencies.create("com.signalfx.public:signalfx-java:$signalFxVersion") {
                     force = true
                 }
         ],


### PR DESCRIPTION
Manage signalfx-java dependency to get latest version so old shaded jackson-databind doesn't get included in CAS.  