### PR TITLE
Docs: Change example expiration date so it don't fail by default

### DIFF
--- a/docs/cas-server-documentation/installation/Whitelist-Authentication.md
+++ b/docs/cas-server-documentation/installation/Whitelist-Authentication.md
@@ -46,7 +46,7 @@ The password file may also be specified as a JSON resource instead which allows 
       "lastName" : ["CAS"]
     },
     "status" : "OK",
-    "expirationDate" : "2018-01-19"
+    "expirationDate" : "2050-01-01"
   }
 }
 ```


### PR DESCRIPTION
When I tried to use the example above, it failed by default due to expiration date on `2018`.

I proposed to set the date to a time in the far future (e.g. `2050`) , so this example can work out of the box.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
