### PR TITLE
Fix for MDQ Metadata Resolve

### DIFF
--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceCacheKey.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceCacheKey.java
@@ -43,7 +43,7 @@ public class SamlRegisteredServiceCacheKey implements Serializable {
      * @return the string
      */
     public static String buildRegisteredServiceCacheKey(final SamlRegisteredService service) {
-        val key = service.getMetadataLocation();
+        val key = service.getServiceId();
         LOGGER.trace("Determined cache key for service [{}] as [{}]", service.getName(), key);
         val hashedKey = DigestUtils.sha512(key);
         LOGGER.trace("Hashed service cache key as [{}]", hashedKey);

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
@@ -224,7 +224,9 @@ public class UrlResourceMetadataResolver extends BaseSamlRegisteredServiceMetada
     public boolean supports(final SamlRegisteredService service) {
         try {
             val metadataLocation = getMetadataLocationForService(service, new CriteriaSet());
-            return StringUtils.isNotBlank(metadataLocation) && StringUtils.startsWith(metadataLocation, "http");
+            return StringUtils.isNotBlank(metadataLocation)
+                    && StringUtils.startsWith(metadataLocation, "http")
+                    && !StringUtils.endsWith(metadataLocation, "{0}");
         } catch (final Exception e) {
             LOGGER.trace(e.getMessage(), e);
         }

--- a/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolverTests.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestPropertySource(properties = "cas.authn.samlIdp.metadata.location=file:/tmp")
 public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
     public static final String METADATA_URL = "https://raw.githubusercontent.com/apereo/cas/master/support/cas-server-support-saml-idp/src/test/resources/metadata/testshib-providers.xml";
+    public static final String MDQ_URL = "https://mdq.incommon.org/entities/{0}";
 
     @Test
     public void verifyResolverSupports() {
@@ -33,6 +34,8 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
         service.setMetadataLocation(METADATA_URL);
         assertTrue(resolver.supports(service));
         service.setMetadataLocation("classpath:sample-sp.xml");
+        assertFalse(resolver.supports(service));
+        service.setMetadataLocation(MDQ_URL);
         assertFalse(resolver.supports(service));
     }
 


### PR DESCRIPTION
PR stops UrlMetadataResolver from being included in supported resolvers when metadata location is an MDQ server.

Change SamlRegisteredCacheKey to be based on Entity Id of SPs instead of metadata location.  When using MDQ, all entities use the same location and is no longer a unique key.