### PR TITLE
backport health actuator fixes

### DIFF
--- a/ci/tests/webapp/validate-embedded-webapp.sh
+++ b/ci/tests/webapp/validate-embedded-webapp.sh
@@ -6,6 +6,64 @@ gradleBuildOptions="--build-cache --configure-on-demand --no-daemon "
 
 webAppServerType="$1"
 
+createConfig() {
+  configDir=$1
+  echo "Creating config in ${configDir}"
+  mkdir -p ${configDir}
+  cat > ${configDir}/cas.properties <<EOF
+management.endpoints.web.exposure.include=health,info,env,loggers
+management.endpoint.health.enabled=true
+management.endpoint.info.enabled=true
+cas.monitor.endpoints.endpoint.defaults.access[0]=IP_ADDRESS
+cas.monitor.endpoints.endpoint.defaults.requiredIpAddresses[0]=127\\\\.0\\\\.0\\\\.1|0:0:0:0:0:0:0:1
+management.endpoint.health.show-details=always
+spring.cloud.discovery.client.composite-indicator.enabled=false
+management.health.defaults.enabled=false
+management.health.ping.enabled=true
+management.health.diskSpace.enabled=true
+management.endpoint.env.enabled=true
+management.endpoint.loggers.enabled=true
+# memoryHealthIndicator requires cas-server-core-monitor which is not present by default
+management.health.memoryHealthIndicator.enabled=true
+EOF
+cat ${configDir}/cas.properties
+}
+
+dumpOutput() {
+  local msg=$1
+  local outputfile=$2
+  echo "Output Start [${msg}]"
+  if [[ -f "${outputfile}" ]]; then
+    cat ${outputfile}
+  else
+    echo "File [${outputfile}] not found."
+  fi
+  echo -e "\nOutput End [${msg}]"
+}
+
+testUrl() {
+  local uri=$1
+  local requiredcontent=$2
+  echo "Testing https://localhost:8443/cas$uri"
+  local output="/tmp/testoutput"
+  rc=`curl --silent -k --connect-timeout 60 -o ${output} -w "%{http_code}" https://localhost:8443/cas$uri`
+  if [ "$rc" == 200 ]; then
+    grep --count ${requiredcontent} ${output}
+    if [[ $? -eq 0 ]] ; then
+      echo "Test of URI ${uri} contained required content"
+      return 0
+    else
+      echo "Test of URI ${uri} failed, it did not contain required content: ${requiredcontent}"
+      dumpOutput ${uri} ${output}
+      return 2
+    fi
+  else
+    echo "Test of URI ${uri} resulted in status code RC=$rc"
+    dumpOutput ${uri} ${output}
+    return 1
+  fi
+}
+
 echo -e "***********************************************"
 echo -e "Gradle build started at `date` for web application server ${webAppServerType}"
 echo -e "***********************************************"
@@ -54,22 +112,45 @@ else
           -keystore "${keystore}" -dname "${dname}" -ext SAN="${subjectAltName}"
 
         echo "Launching CAS web application ${webAppServerType} server..."
-        java -jar webapp/cas-server-webapp-"${webAppServerType}"/build/libs/cas.war \
-          --server.ssl.key-store="${keystore}" &> /dev/null &
+        configDir="/tmp/config"
+        casOutput="/tmp/logs/cas.log"
+        [ ! -d /tmp/logs ] && mkdir /tmp/logs
+        createConfig ${configDir}
+
+        cmd="java -jar webapp/cas-server-webapp-${webAppServerType}/build/libs/cas.war \\
+          --server.ssl.key-store=${keystore} --cas.standalone.configurationDirectory=${configDir}"
+        exec $cmd > ${casOutput} 2>&1 &
         pid=$!
         echo "Launched CAS with pid ${pid}. Waiting for CAS server to come online..."
         sleep 60
-        cmd=`curl -k --connect-timeout 60 -s -o /dev/null -I -w "%{http_code}" https://localhost:8443/cas/login`
+        echo "Testing status of server with pid ${pid}."
+        testUrl "/login" "Username"
+        retValLogin=$?
+        testUrl "/actuator/health" "UP"
+        retValHealth=$?
+        testUrl "/actuator/health/ping" "{\"status\":\"UP\"}"
+        retValPing=$?
+        testUrl "/actuator/info" "java"
+        retValInfo=$?
+        testUrl "/actuator/loggers" "FATAL"
+        retValLoggers=$?
+        testUrl "/actuator/env" "systemProperties"
+        retValEnv=$?
+        [[ ${retValLogin} -eq 0 ]] && \
+        [[ ${retValHealth} -eq 0 ]] && \
+        [[ ${retValPing} -eq 0 ]] && \
+        [[ ${retValInfo} -eq 0 ]] && \
+        [[ ${retValLoggers} -eq 0 ]] && \
+        [[ ${retValEnv} -eq 0 ]]
+        retVal=$?
+        if [[ ${retVal} -ne 0 ]]; then
+          dumpOutput cas.log ${casOutput}
+        fi
         kill -9 "${pid}"
         [ -f "${keystore}" ] && rm "${keystore}"
-        echo "CAS server is responding with HTTP status code ${cmd}."
-        if [ "$cmd" == 200 ]; then
-          echo "CAS server with ${webAppServerType} is successfully up and running."
-          exit 0
-        else
-          echo "CAS server with ${webAppServerType} failed to start successfully."
-          exit 1
-        fi
+        [ -d "${configDir}" ] && rm -rf "${configDir}"
+        [ -f "${casOutput}" ] && rm "${casOutput}"
+        exit $retVal
     else
         echo "Gradle build did NOT finish successfully."
         exit $retVal

--- a/webapp/cas-server-webapp-resources/src/main/resources/application.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/application.properties
@@ -99,9 +99,14 @@ spring.security.user.name=casuser
 # Define a CAS-specific "WARN" status code and its order
 management.health.status.order=WARN,DOWN,OUT_OF_SERVICE,UNKNOWN,UP
 
-# Define health indicator behavior
+# Define health indicator behavior (requires cas-server-core-monitor)
 management.health.memoryHealthIndicator.enabled=true
+# Define a default that doesn't require module /cas/actuator/health/ping serves as status
+management.health.ping.enabled=true
+
+# turn off health indicators by default
 management.health.defaults.enabled=false
+spring.cloud.discovery.client.composite-indicator.enabled=false
 
 ##
 # CAS Web Application Session Configuration


### PR DESCRIPTION
Turn off spring.cloud.discovery.client.composite-indicator by default
test more urls in embedded webapp test

Not critical to back port these b/c the properties can be set by the user, but finding the property to turn off spring.cloud.discovery.client.composite-indicator is a little tough, unless you are using spring cloud discovery and they you probably know where it is. There is an issue open regarding the health actuator erroring out with 404 if no health monitors are enabled but might as well enable do ping check in the meantime so it does something it if  the health endpoint is enabled.

