### PR TITLE
Give warning to mandatory MongoDB attributes properties 6.1.x

### DIFF
--- a/docs/cas-server-documentation/installation/MongoDb-Authentication.md
+++ b/docs/cas-server-documentation/installation/MongoDb-Authentication.md
@@ -30,3 +30,5 @@ Accounts are expected to be found as such in collections:
 	"last_name": "smith"
 }
 ```
+
+<div class="alert alert-warning"><p>The `attributes` properties is required for MongoDb Authentication, error will occur if `attributes` properties is unset or blank</p></div>


### PR DESCRIPTION

See discussion: https://groups.google.com/a/apereo.org/forum/#!topic/cas-user/_aOhb33YZXo

--------------
Since defining `attributes` is necessary for pac4j to work when using MongoDB Authentication, the `attributes` properties is necessary here.

However, this behavior of requiring `attributes` is different from other authentication methods (e.g.JDBC), so I proposed to add an warning here for clarity sake. See if agree.

Would port back to master once this is merged.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
