### PR TITLE
Updating Json Authentication Documentation Example to make it work

### DIFF
--- a/docs/cas-server-documentation/installation/Whitelist-Authentication.md
+++ b/docs/cas-server-documentation/installation/Whitelist-Authentication.md
@@ -42,8 +42,8 @@ The password file may also be specified as a JSON resource instead which allows 
     "password" : "Mellon",
     "attributes" : {
       "@class" : "java.util.LinkedHashMap",
-      "firstName" : ["Apereo"],
-      "lastName" : ["CAS"]
+      "firstName" : [ "java.util.List", ["Apereo"]],
+      "lastName" : [ "java.util.List", ["CAS"]]
     },
     "status" : "OK",
     "expirationDate" : "2050-01-01"


### PR DESCRIPTION
## Brief description of changes applied

The previous json example don't work, but this modified one would work

## Problem encountered

I have tried the original example 
```
...
"firstName" : ["Apereo"],
...
```
and exception like this one `ERROR [org.apereo.cas.authentication.PolicyBasedAuthenticationManager] - <[JsonResourceAuthenticationHandler]: [com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'CAS' as a subtype of [collection type; class java.util.List, contains [simple type, class java.lang.Object]]: no such class found` is thrown .

## Fix

After some tinkering with the json file, I found that the following syntax would work
```
"firstName" : [ "java.util.List", ["Apereo"]],
```
Adding this would make this example work as expected.

## Any documentation on how to configure, test
I can demonstrate the example of this behavior using overlay if it is deem necessary, thanks.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
