### PR TITLE
Fix typo of Rest Attribute `username.`  back to `username`.

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -1051,7 +1051,7 @@ Retrieve attributes from a REST endpoint. RESTful settings for this feature are 
 # cas.authn.attributeRepository.rest[0].caseInsensitive=false
 ```
 
-The authenticating user id is passed in form of a request parameter under `username.` The response is expected
+The authenticating user id is passed in form of a request parameter under `username`. The response is expected
 to be a JSON map as such:
 
 ```json


### PR DESCRIPTION
Just tested Rest Authentication Attribute, the request parameter should be:
**`username`.** 
Instead of:
**`username.`**

Changed the position of the full-stop. Thanks.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
