### PR TITLE
Fix AUP for ldap implementation

### DIFF
--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -69,7 +69,7 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
                     if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
                         LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
                         return AcceptableUsagePolicyStatus.accepted(principal);
-		                }
+            }
                 }
             }
         } catch (final Exception e) {

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -59,19 +59,19 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
             return AcceptableUsagePolicyStatus.accepted(principal);
         }    	
         try {
-        	    LOGGER.debug("AUP Attempt direct ldap call for [{}]", principal.getId());
-                String[] returnAttributes = {aupAttributeName};
-				Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory, ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()), ldapProperties.getPageSize(),null,returnAttributes);
-				for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext(); ) {
-				    LdapEntry element = iter.next();
-				    if ( !(element.getAttribute() == null) && element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
-				    	LOGGER.debug("Evaluating attribute value [{}] found for [{}]", element.getAttribute().getStringValue(), this.aupAttributeName);
-		                if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
-		                	LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
-		                	return AcceptableUsagePolicyStatus.accepted(principal);
+            LOGGER.debug("AUP Attempt direct ldap call for [{}]", principal.getId());
+            String[] returnAttributes = {aupAttributeName};
+			Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory, ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()), ldapProperties.getPageSize(),null,returnAttributes);
+            for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext();) {
+                LdapEntry element = iter.next();
+                if (!(element.getAttribute() == null) && element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
+                    LOGGER.debug("Evaluating attribute value [{}] found for [{}]", element.getAttribute().getStringValue(), this.aupAttributeName);
+		            if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
+		                LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
+		                return AcceptableUsagePolicyStatus.accepted(principal);
 		                }
 				    }
-				}
+            }
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
         }

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -61,16 +61,16 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
         try {
             LOGGER.debug("AUP Attempt direct ldap call for [{}]", principal.getId());
             String[] returnAttributes = {aupAttributeName};
-			Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory, ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()), ldapProperties.getPageSize(),null,returnAttributes);
+            Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory, ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()), ldapProperties.getPageSize(),null,returnAttributes);
             for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext();) {
                 LdapEntry element = iter.next();
                 if (!(element.getAttribute() == null) && element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
                     LOGGER.debug("Evaluating attribute value [{}] found for [{}]", element.getAttribute().getStringValue(), this.aupAttributeName);
-		            if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
-		                LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
-		                return AcceptableUsagePolicyStatus.accepted(principal);
+                    if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
+                        LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
+                        return AcceptableUsagePolicyStatus.accepted(principal);
 		                }
-				    }
+                }
             }
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -127,3 +127,4 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
         return false;
     }
 }
+

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -69,7 +69,7 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
                     if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
                         LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
                         return AcceptableUsagePolicyStatus.accepted(principal);
-            }
+                    }
                 }
             }
         } catch (final Exception e) {

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -60,7 +60,7 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
             val filter = new SearchFilter("cn=" + credential.getId());
             Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory, ldapProperties.getBaseDn(), filter, ldapProperties.getPageSize(), null, returnAttributes);
             for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext();) {
-                LdapEntry element = iter.next();
+                val element = iter.next();
                 if (!(element.getAttribute() == null) && element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
                     LOGGER.debug("Evaluating attribute value [{}] found for [{}]", element.getAttribute().getStringValue(), this.aupAttributeName);
                     if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -26,109 +26,107 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
- * This is {@link LdapAcceptableUsagePolicyRepository}. Examines the principal
- * attribute collection to determine if the policy has been accepted, and if
- * not, allows for a configurable way so that user's choice can later be
- * remembered and saved back into the LDAP instance.
+ * This is {@link LdapAcceptableUsagePolicyRepository}.
+ * Examines the principal attribute collection to determine if
+ * the policy has been accepted, and if not, allows for a configurable
+ * way so that user's choice can later be remembered and saved back into
+ * the LDAP instance.
  *
  * @author Misagh Moayyed
  * @since 4.2
  */
 @Slf4j
 public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttributeAcceptableUsagePolicyRepository {
-	private static final long serialVersionUID = 1600024683199961892L;
+    private static final long serialVersionUID = 1600024683199961892L;
 
-	private final transient ConnectionFactory connectionFactory;
-	private final AcceptableUsagePolicyProperties.Ldap ldapProperties;
+    private final transient ConnectionFactory connectionFactory;
+    private final AcceptableUsagePolicyProperties.Ldap ldapProperties;
 
-	public LdapAcceptableUsagePolicyRepository(final TicketRegistrySupport ticketRegistrySupport,
-			final String aupAttributeName, final ConnectionFactory connectionFactory,
-			final AcceptableUsagePolicyProperties.Ldap ldapProperties) {
-		super(ticketRegistrySupport, aupAttributeName);
-		this.connectionFactory = connectionFactory;
-		this.ldapProperties = ldapProperties;
-	}
-
-	@Override
-	public AcceptableUsagePolicyStatus verify(final RequestContext requestContext, final Credential credential) {
-		val principal = WebUtils.getAuthentication(requestContext).getPrincipal();
-		if (isUsagePolicyAcceptedBy(principal)) {
-			LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
-			return AcceptableUsagePolicyStatus.accepted(principal);
-		}
-		try {
-			LOGGER.debug("AUP Attempt direct ldap call for [{}]", principal.getId());
-			String[] returnAttributes = { aupAttributeName };
-			Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory,
-					ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()),
-					ldapProperties.getPageSize(), null, returnAttributes);
-			for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext();) {
-				LdapEntry element = iter.next();
-				if (!(element.getAttribute() == null)
-						&& element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
-					LOGGER.debug("Evaluating attribute value [{}] found for [{}]",
-							element.getAttribute().getStringValue(), this.aupAttributeName);
-					if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
-						LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
-						return AcceptableUsagePolicyStatus.accepted(principal);
-					}
+    public LdapAcceptableUsagePolicyRepository(final TicketRegistrySupport ticketRegistrySupport,
+        final String aupAttributeName,
+        final ConnectionFactory connectionFactory,
+        final AcceptableUsagePolicyProperties.Ldap ldapProperties) {
+        super(ticketRegistrySupport, aupAttributeName);
+        this.connectionFactory = connectionFactory;
+        this.ldapProperties = ldapProperties;
+    }
+    
+    @Override
+    public AcceptableUsagePolicyStatus verify(final RequestContext requestContext, final Credential credential) {
+    	val principal = WebUtils.getAuthentication(requestContext).getPrincipal();
+        if (isUsagePolicyAcceptedBy(principal)) {
+            LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
+            return AcceptableUsagePolicyStatus.accepted(principal);
+        }    	
+        try {
+        	    LOGGER.debug("AUP Attempt direct ldap call for [{}]", principal.getId());
+                String[] returnAttributes = {aupAttributeName};
+				Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory, ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()), ldapProperties.getPageSize(),null,returnAttributes);
+				for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext(); ) {
+				    LdapEntry element = iter.next();
+				    if ( !(element.getAttribute() == null) && element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
+				    	LOGGER.debug("Evaluating attribute value [{}] found for [{}]", element.getAttribute().getStringValue(), this.aupAttributeName);
+		                if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
+		                	LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
+		                	return AcceptableUsagePolicyStatus.accepted(principal);
+		                }
+				    }
 				}
-			}
-		} catch (final Exception e) {
-			LOGGER.error(e.getMessage(), e);
-		}
-		LOGGER.warn("Usage policy has not been accepted by [{}]", principal.getId());
-		return AcceptableUsagePolicyStatus.denied(principal);
-	}
+        } catch (final Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+        LOGGER.warn("Usage policy has not been accepted by [{}]", principal.getId());        
+        return AcceptableUsagePolicyStatus.denied(principal);
+    }    
 
-	@Override
-	public boolean submit(final RequestContext requestContext, final Credential credential) {
-		try {
-			val response = searchForId(credential.getId());
-			if (LdapUtils.containsResultEntry(response)) {
-				val currentDn = response.getResult().getEntry().getDn();
-				LOGGER.debug("Updating [{}]", currentDn);
-				val attributes = CollectionUtils.<String, Set<String>>wrap(this.aupAttributeName,
-						CollectionUtils.wrapSet(Boolean.TRUE.toString().toUpperCase()));
-				return LdapUtils.executeModifyOperation(currentDn, this.connectionFactory, attributes);
-			}
-		} catch (final Exception e) {
-			LOGGER.error(e.getMessage(), e);
-		}
-		return false;
-	}
+    @Override
+    public boolean submit(final RequestContext requestContext, final Credential credential) {
+        try {
+            val response = searchForId(credential.getId());
+            if (LdapUtils.containsResultEntry(response)) {
+                val currentDn = response.getResult().getEntry().getDn();
+                LOGGER.debug("Updating [{}]", currentDn);
+                val attributes = CollectionUtils.<String, Set<String>>wrap(this.aupAttributeName,
+                    CollectionUtils.wrapSet(Boolean.TRUE.toString().toUpperCase()));
+                return LdapUtils.executeModifyOperation(currentDn, this.connectionFactory, attributes);
+            }
+        } catch (final Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+        return false;
+    }
 
-	/**
-	 * Search for service by id.
-	 *
-	 * @param id the id
-	 * @return the response
-	 * @throws LdapException the ldap exception
-	 */
-	private Response<SearchResult> searchForId(final String id) throws LdapException {
-		val filter = LdapUtils.newLdaptiveSearchFilter(ldapProperties.getSearchFilter(),
-				LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME, CollectionUtils.wrap(id));
-		return LdapUtils.executeSearchOperation(this.connectionFactory, ldapProperties.getBaseDn(), filter,
-				ldapProperties.getPageSize());
-	}
+    /**
+     * Search for service by id.
+     *
+     * @param id the id
+     * @return the response
+     * @throws LdapException the ldap exception
+     */
+    private Response<SearchResult> searchForId(final String id) throws LdapException {
+        val filter = LdapUtils.newLdaptiveSearchFilter(ldapProperties.getSearchFilter(),
+            LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME,
+            CollectionUtils.wrap(id));
+        return LdapUtils.executeSearchOperation(this.connectionFactory, ldapProperties.getBaseDn(), filter, ldapProperties.getPageSize());
+    }
+    
+    /**
+     * Is usage policy accepted by user?
+     * Looks into the attributes collected by the principal to find {@link #aupAttributeName}.
+     * If the attribute contains {@code true}, then the policy is determined as accepted.
+     *
+     * @param principal the principal
+     * @return true if accepted, false otherwise.
+     */
+    protected boolean isUsagePolicyAcceptedBy(final Principal principal) {
+        val attributes = principal.getAttributes();
+        LOGGER.debug("Principal attributes found for [{}] are [{}]", principal.getId(), attributes);
 
-	/**
-	 * Is usage policy accepted by user? Looks into the attributes collected by the
-	 * principal to find {@link #aupAttributeName}. If the attribute contains
-	 * {@code true}, then the policy is determined as accepted.
-	 *
-	 * @param principal the principal
-	 * @return true if accepted, false otherwise.
-	 */
-	protected boolean isUsagePolicyAcceptedBy(final Principal principal) {
-		val attributes = principal.getAttributes();
-		LOGGER.debug("Principal attributes found for [{}] are [{}]", principal.getId(), attributes);
-
-		if (attributes != null && attributes.containsKey(this.aupAttributeName)) {
-			val value = CollectionUtils.toCollection(attributes.get(this.aupAttributeName));
-			LOGGER.debug("Evaluating attribute value [{}] found for [{}]", value, this.aupAttributeName);
-			return value.stream().anyMatch(v -> v.toString().equalsIgnoreCase(Boolean.TRUE.toString()));
-		}
-		return false;
-	}
+        if (attributes != null && attributes.containsKey(this.aupAttributeName)) {
+            val value = CollectionUtils.toCollection(attributes.get(this.aupAttributeName));
+            LOGGER.debug("Evaluating attribute value [{}] found for [{}]", value, this.aupAttributeName);
+            return value.stream().anyMatch(v -> v.toString().equalsIgnoreCase(Boolean.TRUE.toString()));
+        }
+        return false;
+    }    
 }

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -26,107 +26,109 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
- * This is {@link LdapAcceptableUsagePolicyRepository}.
- * Examines the principal attribute collection to determine if
- * the policy has been accepted, and if not, allows for a configurable
- * way so that user's choice can later be remembered and saved back into
- * the LDAP instance.
+ * This is {@link LdapAcceptableUsagePolicyRepository}. Examines the principal
+ * attribute collection to determine if the policy has been accepted, and if
+ * not, allows for a configurable way so that user's choice can later be
+ * remembered and saved back into the LDAP instance.
  *
  * @author Misagh Moayyed
  * @since 4.2
  */
 @Slf4j
 public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttributeAcceptableUsagePolicyRepository {
-    private static final long serialVersionUID = 1600024683199961892L;
+	private static final long serialVersionUID = 1600024683199961892L;
 
-    private final transient ConnectionFactory connectionFactory;
-    private final AcceptableUsagePolicyProperties.Ldap ldapProperties;
+	private final transient ConnectionFactory connectionFactory;
+	private final AcceptableUsagePolicyProperties.Ldap ldapProperties;
 
-    public LdapAcceptableUsagePolicyRepository(final TicketRegistrySupport ticketRegistrySupport,
-                                               final String aupAttributeName,
-                                               final ConnectionFactory connectionFactory,
-                                               final AcceptableUsagePolicyProperties.Ldap ldapProperties) {
-        super(ticketRegistrySupport, aupAttributeName);
-        this.connectionFactory = connectionFactory;
-        this.ldapProperties = ldapProperties;
-    }
-    
-    @Override
-    public AcceptableUsagePolicyStatus verify(final RequestContext requestContext, final Credential credential) {
-    	val principal = WebUtils.getAuthentication(requestContext).getPrincipal();
-        if (isUsagePolicyAcceptedBy(principal)) {
-            LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
-            return AcceptableUsagePolicyStatus.accepted(principal);
-        }    	
-        try {
-        	    LOGGER.debug("AUP Attempt direct ldap call for [{}]", principal.getId());
-                String[] returnAttributes = {aupAttributeName};
-				Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory, ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()), ldapProperties.getPageSize(),null,returnAttributes);
-				for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext(); ) {
-				    LdapEntry element = iter.next();
-				    if ( !(element.getAttribute() == null) && element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
-				    	LOGGER.debug("Evaluating attribute value [{}] found for [{}]", element.getAttribute().getStringValue(), this.aupAttributeName);
-		                if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
-		                	LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
-		                	return AcceptableUsagePolicyStatus.accepted(principal);
-		                }
-				    }
+	public LdapAcceptableUsagePolicyRepository(final TicketRegistrySupport ticketRegistrySupport,
+			final String aupAttributeName, final ConnectionFactory connectionFactory,
+			final AcceptableUsagePolicyProperties.Ldap ldapProperties) {
+		super(ticketRegistrySupport, aupAttributeName);
+		this.connectionFactory = connectionFactory;
+		this.ldapProperties = ldapProperties;
+	}
+
+	@Override
+	public AcceptableUsagePolicyStatus verify(final RequestContext requestContext, final Credential credential) {
+		val principal = WebUtils.getAuthentication(requestContext).getPrincipal();
+		if (isUsagePolicyAcceptedBy(principal)) {
+			LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
+			return AcceptableUsagePolicyStatus.accepted(principal);
+		}
+		try {
+			LOGGER.debug("AUP Attempt direct ldap call for [{}]", principal.getId());
+			String[] returnAttributes = { aupAttributeName };
+			Response<SearchResult> result = LdapUtils.executeSearchOperation(connectionFactory,
+					ldapProperties.getBaseDn(), new SearchFilter("cn=" + credential.getId()),
+					ldapProperties.getPageSize(), null, returnAttributes);
+			for (Iterator<LdapEntry> iter = result.getResult().getEntries().iterator(); iter.hasNext();) {
+				LdapEntry element = iter.next();
+				if (!(element.getAttribute() == null)
+						&& element.getAttribute().getName().equalsIgnoreCase(aupAttributeName)) {
+					LOGGER.debug("Evaluating attribute value [{}] found for [{}]",
+							element.getAttribute().getStringValue(), this.aupAttributeName);
+					if (element.getAttribute().getStringValue().toString().toUpperCase().equals("TRUE")) {
+						LOGGER.debug("Usage policy has been accepted by [{}]", principal.getId());
+						return AcceptableUsagePolicyStatus.accepted(principal);
+					}
 				}
-        } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
-        }
-        LOGGER.warn("Usage policy has not been accepted by [{}]", principal.getId());        
-        return AcceptableUsagePolicyStatus.denied(principal);
-    }    
+			}
+		} catch (final Exception e) {
+			LOGGER.error(e.getMessage(), e);
+		}
+		LOGGER.warn("Usage policy has not been accepted by [{}]", principal.getId());
+		return AcceptableUsagePolicyStatus.denied(principal);
+	}
 
-    @Override
-    public boolean submit(final RequestContext requestContext, final Credential credential) {
-        try {
-            val response = searchForId(credential.getId());
-            if (LdapUtils.containsResultEntry(response)) {
-                val currentDn = response.getResult().getEntry().getDn();
-                LOGGER.debug("Updating [{}]", currentDn);
-                val attributes = CollectionUtils.<String, Set<String>>wrap(this.aupAttributeName,
-                    CollectionUtils.wrapSet(Boolean.TRUE.toString().toUpperCase()));
-                return LdapUtils.executeModifyOperation(currentDn, this.connectionFactory, attributes);
-            }
-        } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
-        }
-        return false;
-    }
+	@Override
+	public boolean submit(final RequestContext requestContext, final Credential credential) {
+		try {
+			val response = searchForId(credential.getId());
+			if (LdapUtils.containsResultEntry(response)) {
+				val currentDn = response.getResult().getEntry().getDn();
+				LOGGER.debug("Updating [{}]", currentDn);
+				val attributes = CollectionUtils.<String, Set<String>>wrap(this.aupAttributeName,
+						CollectionUtils.wrapSet(Boolean.TRUE.toString().toUpperCase()));
+				return LdapUtils.executeModifyOperation(currentDn, this.connectionFactory, attributes);
+			}
+		} catch (final Exception e) {
+			LOGGER.error(e.getMessage(), e);
+		}
+		return false;
+	}
 
-    /**
-     * Search for service by id.
-     *
-     * @param id the id
-     * @return the response
-     * @throws LdapException the ldap exception
-     */
-    private Response<SearchResult> searchForId(final String id) throws LdapException {
-        val filter = LdapUtils.newLdaptiveSearchFilter(ldapProperties.getSearchFilter(),
-            LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME,
-            CollectionUtils.wrap(id));
-        return LdapUtils.executeSearchOperation(this.connectionFactory, ldapProperties.getBaseDn(), filter, ldapProperties.getPageSize());
-    }
-    
-    /**
-     * Is usage policy accepted by user?
-     * Looks into the attributes collected by the principal to find {@link #aupAttributeName}.
-     * If the attribute contains {@code true}, then the policy is determined as accepted.
-     *
-     * @param principal the principal
-     * @return true if accepted, false otherwise.
-     */
-    protected boolean isUsagePolicyAcceptedBy(final Principal principal) {
-        val attributes = principal.getAttributes();
-        LOGGER.debug("Principal attributes found for [{}] are [{}]", principal.getId(), attributes);
+	/**
+	 * Search for service by id.
+	 *
+	 * @param id the id
+	 * @return the response
+	 * @throws LdapException the ldap exception
+	 */
+	private Response<SearchResult> searchForId(final String id) throws LdapException {
+		val filter = LdapUtils.newLdaptiveSearchFilter(ldapProperties.getSearchFilter(),
+				LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME, CollectionUtils.wrap(id));
+		return LdapUtils.executeSearchOperation(this.connectionFactory, ldapProperties.getBaseDn(), filter,
+				ldapProperties.getPageSize());
+	}
 
-        if (attributes != null && attributes.containsKey(this.aupAttributeName)) {
-            val value = CollectionUtils.toCollection(attributes.get(this.aupAttributeName));
-            LOGGER.debug("Evaluating attribute value [{}] found for [{}]", value, this.aupAttributeName);
-            return value.stream().anyMatch(v -> v.toString().equalsIgnoreCase(Boolean.TRUE.toString()));
-        }
-        return false;
-    }    
+	/**
+	 * Is usage policy accepted by user? Looks into the attributes collected by the
+	 * principal to find {@link #aupAttributeName}. If the attribute contains
+	 * {@code true}, then the policy is determined as accepted.
+	 *
+	 * @param principal the principal
+	 * @return true if accepted, false otherwise.
+	 */
+	protected boolean isUsagePolicyAcceptedBy(final Principal principal) {
+		val attributes = principal.getAttributes();
+		LOGGER.debug("Principal attributes found for [{}] are [{}]", principal.getId(), attributes);
+
+		if (attributes != null && attributes.containsKey(this.aupAttributeName)) {
+			val value = CollectionUtils.toCollection(attributes.get(this.aupAttributeName));
+			LOGGER.debug("Evaluating attribute value [{}] found for [{}]", value, this.aupAttributeName);
+			return value.stream().anyMatch(v -> v.toString().equalsIgnoreCase(Boolean.TRUE.toString()));
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
Fix Acceptable Usage Policy feature for ldap implementation.

Issue :

When clicking on accept button nothing happens.

Why :

1 When using ldap cache for the attributes, the attributes are not read again from 
  ldap so the Aup attribute is not available in context so the accept usage policy keeps popping up.
2 When using Master ldap with replication.
  The Aup ldap will be on the master one. (for all the writes)
  The ldap used for attributes and auth is on the slaves.
  When clicking accept the accept usage policy keeps popping up
  because it takes time for the attribute to replicate to slave
  even with cache off. 
  
Solution : 

Override verify method and test whether the aup attribute is available in context(SSO session).

If so use this value to decide if aup was accepted.

If not available do a direct call to aup ldap to verify.

This direct routine will only activate probably on first login when cache is used 
( other logins will have the attribute available in context(SSO session) )
or 
when master slave ldap replication is used
( other logins will have the attribute available in context(SSO session) after replication ).
