### PR TITLE
Remave Async from TGT creation event

### DIFF
--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasEventListener.java
@@ -58,7 +58,6 @@ public class DefaultCasEventListener {
      * @param event the event
      */
     @EventListener
-    @Async
     public void handleCasTicketGrantingTicketCreatedEvent(final CasTicketGrantingTicketCreatedEvent event) {
         if (this.casEventRepository != null) {
             val dto = prepareCasEvent(event);


### PR DESCRIPTION
If TGT creation event is async, geoLocation and agent information is lost when handling/storing event.

A side effect of this, is a NPE in UserAgentAuthenticationRequestRiskCalculator when calculating score.