### PR TITLE
Use PrincipalAttributeRepository defined in OidcRegisteredService 

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServiceRegistryListener.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServiceRegistryListener.java
@@ -38,8 +38,9 @@ public class OidcServiceRegistryListener implements ServiceRegistryListener {
                                                   final String givenScope,
                                                   final OidcRegisteredService registeredService) {
         LOGGER.debug("Mapped [{}] to attribute release policy [{}]", givenScope, policyToAdd.getClass().getSimpleName());
-        val consentPolicy = registeredService.getAttributeReleasePolicy().getConsentPolicy();
-        policyToAdd.setConsentPolicy(consentPolicy);
+        val attributeReleasePolicy = registeredService.getAttributeReleasePolicy();
+        policyToAdd.setConsentPolicy(attributeReleasePolicy.getConsentPolicy());
+        policyToAdd.setPrincipalAttributesRepository(attributeReleasePolicy.getPrincipalAttributesRepository());
         chain.getPolicies().add(policyToAdd);
     }
 


### PR DESCRIPTION
This PR ensures that when Scopes for OIDC requests are resolved they will use the PrincipalAttributeRepository that has been defined in the AttributeReleasePolicy from the registered service for the request.

