### PR TITLE
Fix UnmodifiableComponentException during SAML2 SLO

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SLOSamlPostProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SLOSamlPostProfileHandlerController.java
@@ -33,7 +33,7 @@ public class SLOSamlPostProfileHandlerController extends AbstractSamlSLOProfileH
     @PostMapping(path = SamlIdPConstants.ENDPOINT_SAML2_SLO_PROFILE_POST)
     protected void handleSaml2ProfileSLOPostRequest(final HttpServletResponse response,
                                                     final HttpServletRequest request) throws Exception {
-        val decoder = getSamlProfileHandlerConfigurationContext().getSamlMessageDecoders().get(HttpMethod.POST);
+        val decoder = getSamlProfileHandlerConfigurationContext().getSamlMessageDecoders().getInstance(HttpMethod.POST);
         handleSloProfileRequest(response, request, decoder);
     }
 }


### PR DESCRIPTION
As stated, fixes UnmodifiableComponentException during *any* subsequent SAML2 SLO attempt. Without this fix, the first logout/SLO attempt succeeds, but the second and any other SLO attempts will fail since BaseHttpServletRequestXMLMessageDecoder is already initialized and trips the `ComponentSupport.ifInitializedThrowUnmodifiabledComponentException` check.