### PR TITLE
Fix possible NPE

### DIFF
--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceAccessStrategy.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/DefaultRegisteredServiceAccessStrategy.java
@@ -166,7 +166,7 @@ public class DefaultRegisteredServiceAccessStrategy implements RegisteredService
 
     @Override
     public boolean doPrincipalAttributesAllowServiceAccess(final String principal, final Map<String, Object> principalAttributes) {
-        if (this.rejectedAttributes.isEmpty() && this.requiredAttributes.isEmpty()) {
+        if ((this.rejectedAttributes == null || this.rejectedAttributes.isEmpty()) && (this.requiredAttributes == null || this.requiredAttributes.isEmpty())) {
             LOGGER.trace("Skipping access strategy policy, since no attributes rules are defined");
             return true;
         }
@@ -273,7 +273,7 @@ public class DefaultRegisteredServiceAccessStrategy implements RegisteredService
         }
         return difference.stream().anyMatch(key -> requiredAttributeFound(key, principalAttributes, requiredAttributes));
     }
-    
+
     private boolean requiredAttributeFound(final String attributeName,
                                            final Map<String, Object> principalAttributes,
                                            final Map<String, Set<String>> requiredAttributes) {


### PR DESCRIPTION
Check if requiredAttributes and rejectedAttributes are null before using them.

Fixes NPE which arises for services that are added through service management webapp.
When using json service registry to add services, there is no NPE.

### Steps to reproduce

1. Use service management webapp to add a service with all the default values (Add only serviceId and serviceName and click save).
2. Access this service
3. Authenticate to CAS
4. The following NPE is thrown:

>[info] 2019-11-16 10:19:01,187 INFO [org.apereo.inspektr.audit.support.Slf4jLoggingAuditTrailManager] - <Audit trail record BEGIN
[info] =============================================================             
[info] WHO: 0000000000000000000003                                               
[info] WHAT: Supplied credentials: [UsernamePasswordCredential(username=auser, source=null, customFields={})]
[info] ACTION: AUTHENTICATION_SUCCESS                                            
[info] APPLICATION: CAS                                                          
[info] WHEN: Sat Nov 16 10:19:01 EET 2019                                        
[info] CLIENT IP ADDRESS: 10.247.1.1                                             
[info] SERVER IP ADDRESS: 10.247.1.13                                            
[info] =============================================================             
[info] >                                                                         
[info] 2019-11-16 10:19:01,189 INFO [org.apereo.inspektr.audit.support.Slf4jLoggingAuditTrailManager] - <Audit trail record BEGIN
[info] =============================================================             
[info] WHO: 0000000000000000000003                                               
[info] WHAT: java.lang.NullPointerException                                      
[info] ACTION: SERVICE_ACCESS_ENFORCEMENT                                        
[info] APPLICATION: CAS                                                          
[info] WHEN: Sat Nov 16 10:19:01 EET 2019                                        
[info] CLIENT IP ADDRESS: 10.247.1.1                                             
[info] SERVER IP ADDRESS: 10.247.1.13                                            
[info] =============================================================             
[info] >                                                                         
[info] 2019-11-16 10:19:01,197 WARN [org.apereo.cas.web.flow.resolver.impl.DefaultCasDelegatingWebflowEventResolver] - <null>
[info] java.lang.NullPointerException: null                                      
[info]    at org.apereo.cas.services.DefaultRegisteredServiceAccessStrategy.doPrincipalAttributesAllowServiceAccess(DefaultRegisteredServiceAccessStrategy.java:169) ~[cas-server-core-services-api-6.1.2-SNAPSHOT.jar:6.1.2-SNAPSHOT]                           
[info]    at org.apereo.cas.services.RegisteredServiceAccessStrategyUtils.ensurePrincipalAccessIsAllowedForService(RegisteredServiceAccessStrategyUtils.java:99) ~[cas-server-core-services-api-6.1.2-SNAPSHOT.jar:6.1.2-SNAPSHOT]                               
[info]    at org.apereo.cas.services.RegisteredServiceAccessStrategyUtils.ensurePrincipalAccessIsAllowedForService(RegisteredServiceAccessStrategyUtils.java:149) ~[cas-server-core-services-api-6.1.2-SNAPSHOT.jar:6.1.2-SNAPSHOT]                              
[info]    at org.apereo.cas.services.RegisteredServiceAccessStrategyAuditableEnforcer.execute(RegisteredServiceAccessStrategyAuditableEnforcer.java:70) ~[cas-server-core-services-api-6.1.2-SNAPSHOT.jar:6.1.2-SNAPSHOT]                                        
[info]    at org.apereo.cas.services.RegisteredServiceAccessStrategyAuditableEnforcer$$FastClassBySpringCGLIB$$b0989194.invoke(<generated>) ~[cas-server-core-services-api-6.1.2-SNAPSHOT.jar:6.1.2-SNAPSHOT]