### PR TITLE
backport x509 additional x509subjectUPN attribute to 6.1.x branch

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -2312,7 +2312,7 @@ For the ```CN_EDIPI```,```SUBJECT_ALT_NAME```, and ```RFC822_EMAIL``` principal 
 you may specify the following property in order to have a different attribute from the certificate used as the principal.  
 If no alternative attribute is specified then the principal will be null and CAS will fail auth or use a different authenticator.
 ```properties
-# cas.authn.x509.alternatePrincipalAttribute=subjectDn|sigAlgOid|subjectX500Principal|x509Rfc822Email
+# cas.authn.x509.alternatePrincipalAttribute=subjectDn|sigAlgOid|subjectX500Principal|x509Rfc822Email|x509subjectUPN
 ```
 
 ### CRL Fetching / Revocation
@@ -2397,10 +2397,10 @@ To fetch CRLs, the following options are available:
 # cas.authn.x509.subjectAltName.alternatePrincipalAttribute=[sigAlgOid|subjectDn|subjectX500Principal|x509Rfc822Email]
 
 # CN_EDIPI 
-# cas.authn.x509.cnEdipi.alternatePrincipalAttribute=[sigAlgOid|subjectDn|subjectX500Principal|x509Rfc822Email]
+# cas.authn.x509.cnEdipi.alternatePrincipalAttribute=[sigAlgOid|subjectDn|subjectX500Principal|x509Rfc822Email|x509subjectUPN]
 
 # RFC822_EMAIL 
-# cas.authn.x509.rfc822Email.alternatePrincipalAttribute=[sigAlgOid|subjectDn|subjectX500Principal]
+# cas.authn.x509.rfc822Email.alternatePrincipalAttribute=[sigAlgOid|subjectDn|subjectX500Principal|x509subjectUPN]
 ```
 
 ### X509 Certificate Extraction

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
@@ -141,7 +141,17 @@ public abstract class AbstractX509PrincipalResolver extends PersonDirectoryPrinc
                     attributes.put("x509Rfc822Email", CollectionUtils.wrapList(rfc822Email));
                 }
             } catch (final CertificateParsingException e) {
-                LOGGER.warn("Error parsing subject alternative names to get rfc822 email [{}]", e.getMessage());
+                LOGGER.warn("Error parsing subject alternative names to get rfc822 email [{}]",
+                    e.getMessage(), LOGGER.isDebugEnabled() ? e : null);
+            }
+            try {
+                val x509subjectUPN = X509UPNExtractorUtils.extractUPNString(certificate);
+                if (x509subjectUPN != null) {
+                    attributes.put("x509subjectUPN", CollectionUtils.wrapList(x509subjectUPN));
+                }
+            } catch (final CertificateParsingException e) {
+                LOGGER.warn("Error parsing subject alternative names to get User Principal Name as an attribute [{}]",
+                    e.getMessage(), LOGGER.isDebugEnabled() ? e : null);
             }
         }
         return attributes;

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
@@ -141,8 +141,10 @@ public abstract class AbstractX509PrincipalResolver extends PersonDirectoryPrinc
                     attributes.put("x509Rfc822Email", CollectionUtils.wrapList(rfc822Email));
                 }
             } catch (final CertificateParsingException e) {
-                LOGGER.warn("Error parsing subject alternative names to get rfc822 email [{}]",
-                    e.getMessage(), LOGGER.isDebugEnabled() ? e : null);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.warn("Error parsing subject alternative names to get rfc822 email", e);
+                }
+                LOGGER.warn("Error parsing subject alternative names to get rfc822 email [{}]", e.getMessage());
             }
             try {
                 val x509subjectUPN = X509UPNExtractorUtils.extractUPNString(certificate);
@@ -150,8 +152,11 @@ public abstract class AbstractX509PrincipalResolver extends PersonDirectoryPrinc
                     attributes.put("x509subjectUPN", CollectionUtils.wrapList(x509subjectUPN));
                 }
             } catch (final CertificateParsingException e) {
-                LOGGER.warn("Error parsing subject alternative names to get User Principal Name as an attribute [{}]",
-                    e.getMessage(), LOGGER.isDebugEnabled() ? e : null);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.warn("Error parsing subject alternative names to get User Principal Name as an attribute", e);
+                } else {
+                    LOGGER.warn("Error parsing subject alternative names to get User Principal Name as an attribute [{}]", e.getMessage());
+                }
             }
         }
         return attributes;

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolver.java
@@ -1,45 +1,29 @@
 package org.apereo.cas.adaptors.x509.authentication.principal;
 
 import org.apereo.cas.authentication.principal.PrincipalFactory;
-import org.apereo.cas.util.function.FunctionUtils;
 
-import com.google.common.base.Predicates;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.apereo.services.persondir.IPersonAttributeDao;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1OctetString;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.ASN1String;
-import org.bouncycastle.asn1.ASN1TaggedObject;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.Set;
 
 /**
- * Credential to principal resolver that extracts Subject Alternative Name UPN extension
- * from the provided certificate if available as a resolved principal id.
+ * Extracts Subject Alternative Name UPN extension from the provided certificate if available as a resolved principal id.
  *
  * @author Dmitriy Kopylenko
+ * @author Hal Deadman
  * @since 4.1.0
  */
 @Slf4j
 @ToString(callSuper = true)
 @NoArgsConstructor
 public class X509SubjectAlternativeNameUPNPrincipalResolver extends AbstractX509PrincipalResolver {
-
-    /**
-     * ObjectID for upn altName for windows smart card logon.
-     */
-    public static final String UPN_OBJECTID = "1.3.6.1.4.1.311.20.2.3";
 
     public X509SubjectAlternativeNameUPNPrincipalResolver(final IPersonAttributeDao attributeRepository,
                                                           final PrincipalFactory principalFactory, final boolean returnNullIfNoAttributes,
@@ -53,98 +37,15 @@ public class X509SubjectAlternativeNameUPNPrincipalResolver extends AbstractX509
             resolveAttributes, activeAttributeRepositoryIdentifiers);
     }
 
-    /**
-     * Get UPN String.
-     *
-     * @param seq ASN1Sequence abstraction representing subject alternative name.
-     *            First element is the object identifier, second is the object itself.
-     * @return UPN string or null
-     */
-    private static String getUPNStringFromSequence(final ASN1Sequence seq) {
-        if (seq == null) {
-            return null;
-        }
-        val id = ASN1ObjectIdentifier.getInstance(seq.getObjectAt(0));
-        if (id != null && UPN_OBJECTID.equals(id.getId())) {
-            val obj = (ASN1TaggedObject) seq.getObjectAt(1);
-            val primitiveObj = obj.getObject();
-
-            val func = FunctionUtils.doIf(Predicates.instanceOf(ASN1TaggedObject.class),
-                () -> ASN1TaggedObject.getInstance(primitiveObj).getObject(),
-                () -> primitiveObj);
-            val prim = func.apply(primitiveObj);
-
-            if (prim instanceof ASN1OctetString) {
-                return new String(((ASN1OctetString) prim).getOctets(), StandardCharsets.UTF_8);
-            }
-            if (prim instanceof ASN1String) {
-                return ((ASN1String) prim).getString();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Get alt name seq.
-     *
-     * @param sanItem subject alternative name value encoded as a two elements List with elem(0) representing object id and elem(1)
-     *                representing object (subject alternative name) itself.
-     * @return ASN1Sequence abstraction representing subject alternative name or null if the passed in
-     * List doesn't contain at least two elements.
-     * as expected to be returned by implementation of {@code X509Certificate.html#getSubjectAlternativeNames}
-     * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/security/cert/X509Certificate.html#getSubjectAlternativeNames()">
-     * X509Certificate#getSubjectAlternativeNames</a>
-     */
-    private static ASN1Sequence getAltnameSequence(final List sanItem) {
-        //Should not be the case, but still, a extra "safety" check
-        if (sanItem.size() < 2) {
-            LOGGER.error("Subject Alternative Name List does not contain at least two required elements. Returning null principal id...");
-        }
-        val itemType = (Integer) sanItem.get(0);
-        if (itemType == 0) {
-            val altName = (byte[]) sanItem.get(1);
-            return getAltnameSequence(altName);
-        }
-        return null;
-    }
-
-    /**
-     * Get alt name seq.
-     *
-     * @param sanValue subject alternative name value encoded as byte[]
-     * @return ASN1Sequence abstraction representing subject alternative name
-     * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/security/cert/X509Certificate.html#getSubjectAlternativeNames()">
-     * X509Certificate#getSubjectAlternativeNames</a>
-     */
-    private static ASN1Sequence getAltnameSequence(final byte[] sanValue) {
-        try (val bInput = new ByteArrayInputStream(sanValue);
-             val input = new ASN1InputStream(bInput)) {
-            return ASN1Sequence.getInstance(input.readObject());
-        } catch (final IOException e) {
-            LOGGER.error("An error has occurred while reading the subject alternative name value", e);
-        }
-        return null;
-    }
-
     @Override
     protected String resolvePrincipalInternal(final X509Certificate certificate) {
         LOGGER.debug("Resolving principal from Subject Alternative Name UPN for [{}]", certificate);
         try {
-            val subjectAltNames = certificate.getSubjectAlternativeNames();
-            if (subjectAltNames != null) {
-                for (val sanItem : subjectAltNames) {
-                    val seq = getAltnameSequence(sanItem);
-                    val upnString = getUPNStringFromSequence(seq);
-                    if (upnString != null) {
-                        return upnString;
-                    }
-                }
-            }
+            val upnString = X509UPNExtractorUtils.extractUPNString(certificate);
+            return StringUtils.isNotBlank(upnString) ? upnString : getAlternatePrincipal(certificate);
         } catch (final CertificateParsingException e) {
             LOGGER.error("Error is encountered while trying to retrieve subject alternative names collection from certificate", e);
             return getAlternatePrincipal(certificate);
         }
-
-        return getAlternatePrincipal(certificate);
     }
 }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509UPNExtractorUtils.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509UPNExtractorUtils.java
@@ -1,0 +1,150 @@
+package org.apereo.cas.adaptors.x509.authentication.principal;
+
+import org.apereo.cas.util.function.FunctionUtils;
+
+import com.google.common.base.Predicates;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.asn1.ASN1TaggedObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * Credential to principal resolver that extracts Subject Alternative Name UPN extension
+ * from the provided certificate if available as a resolved principal id.
+ *
+ * @author Dmitriy Kopylenko
+ * @author Hal Deadman
+ * @since 4.1.0
+ */
+@Slf4j
+@UtilityClass
+public class X509UPNExtractorUtils {
+
+    /**
+     * ObjectID for upn altName for windows smart card logon.
+     */
+    private static final String UPN_OBJECTID = "1.3.6.1.4.1.311.20.2.3";
+
+    /**
+     * Integer representing the type of the subject alt name known as OtherName or ANY.
+     */
+    private static final int SAN_TYPE_OTHER = 0;
+
+
+    /**
+     * Get UPN String.
+     *
+     * @param seq ASN1Sequence abstraction representing subject alternative name.
+     *            First element is the object identifier, second is the object itself.
+     * @return UPN string or null
+     */
+    private String getUPNStringFromSequence(final ASN1Sequence seq) {
+        if (seq == null) {
+            return null;
+        }
+        val id = ASN1ObjectIdentifier.getInstance(seq.getObjectAt(0));
+        if (id != null && UPN_OBJECTID.equals(id.getId())) {
+            val obj = (ASN1TaggedObject) seq.getObjectAt(1);
+            val primitiveObj = obj.getObject();
+
+            val func = FunctionUtils.doIf(Predicates.instanceOf(ASN1TaggedObject.class),
+                () -> ASN1TaggedObject.getInstance(primitiveObj).getObject(),
+                () -> primitiveObj);
+            val prim = func.apply(primitiveObj);
+
+            if (prim instanceof ASN1OctetString) {
+                return new String(((ASN1OctetString) prim).getOctets(), StandardCharsets.UTF_8);
+            }
+            if (prim instanceof ASN1String) {
+                return ((ASN1String) prim).getString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the alt name sequence if it is of type OtherName, otherwise return null.
+     *
+     * @param sanItem subject alternative name value encoded as a two elements List with elem(0) representing object id and elem(1)
+     *                representing object (subject alternative name) itself.
+     * @return ASN1Sequence abstraction representing subject alternative name or null if the passed in
+     * List doesn't contain at least two elements and the type of the element is not the type OtherName.
+     * as expected to be returned by implementation of {@code X509Certificate.html#getSubjectAlternativeNames}
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/cert/X509Certificate.html#getSubjectAlternativeNames()">
+     * X509Certificate#getSubjectAlternativeNames</a>
+     */
+    private ASN1Sequence getOtherNameTypeSAN(final List<?> sanItem) {
+        //Should not be the case, but still, a extra "safety" check
+        if (sanItem.size() < 2) {
+            LOGGER.error("Subject Alternative Name List does not contain at least two required elements. Returning null principal id...");
+            return null;
+        }
+        val itemType = (Integer) sanItem.get(0);
+        if (itemType == SAN_TYPE_OTHER) {
+            val altName = (byte[]) sanItem.get(1);
+            return getAltnameSequence(altName);
+        }
+        return null;
+    }
+
+    /**
+     * Get alt name seq.
+     *
+     * @param sanValue subject alternative name value encoded as byte[]
+     * @return ASN1Sequence abstraction representing subject alternative name
+     * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/cert/X509Certificate.html#getSubjectAlternativeNames()">
+     * X509Certificate#getSubjectAlternativeNames</a>
+     */
+    private ASN1Sequence getAltnameSequence(final byte[] sanValue) {
+        try (val bInput = new ByteArrayInputStream(sanValue);
+             val input = new ASN1InputStream(bInput)) {
+            return ASN1Sequence.getInstance(input.readObject());
+        } catch (final IOException e) {
+            LOGGER.error("An error has occurred while reading the subject alternative name value: {}", e.getMessage(), e);
+        }
+        return null;
+    }
+
+    /**
+     * Return the first {@code X509UPNExtractorUtils.UPN_OBJECTID} found in the subject alternative names (SAN) extension field of the certificate.
+     * @param certificate X509 certificate
+     * @return User principal name, or null if no SAN found matching UPN type.
+     * @throws CertificateParsingException if Java retrieval of subject alt names fails.
+     */
+    public String extractUPNString(final X509Certificate certificate) throws CertificateParsingException {
+        val subjectAltNames = certificate.getSubjectAlternativeNames();
+        if (subjectAltNames != null) {
+            for (val sanItem : subjectAltNames) {
+                if (LOGGER.isTraceEnabled()) {
+                    if (sanItem.size() == 2) {
+                        val name = sanItem.get(1);
+                        LOGGER.trace("Found subject alt name of type [{}] with value [{}]",
+                            sanItem.get(0), name instanceof String ? name : name instanceof byte[] ? getAltnameSequence((byte[]) name) : name);
+                    } else {
+                        LOGGER.trace("SAN item of unexpected size found: [{}]", sanItem);
+                    }
+                }
+                val seq = getOtherNameTypeSAN(sanItem);
+                val upnString = getUPNStringFromSequence(seq);
+                if (upnString != null) {
+                    LOGGER.debug("Found user principal name in certificate: [{}]", upnString);
+                    return upnString;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
@@ -37,28 +38,32 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests {
             arguments(
                 "/x509-san-upn-resolver.crt",
                 "test@somecompany.com",
-                null
+                null,
+                "x509Rfc822Email"
             ),
 
             /* test with alternate parameter and cert with RFC822 Email Address */
             arguments(
                 "/x509-san-upn-resolver.crt",
                 "test@somecompany.com",
-                "subjectDn"
+                "subjectDn",
+                "x509subjectUPN"
             ),
 
             /* test with alternate parameter and cert without RFC822 Email Address */
             arguments(
                 "/user-valid.crt",
                 "CN=Alice, OU=CAS, O=Jasig, L=Westminster, ST=Colorado, C=US",
-                "subjectDn"
+                "subjectDn",
+                null
             ),
 
             /* test with bad alternate parameter and cert without RFC822 Email Address */
             arguments(
                 "/user-valid.crt",
                 null,
-                "badAttribute"
+                "badAttribute",
+                null
             )
         );
     }
@@ -67,7 +72,8 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests {
     @MethodSource("getTestParameters")
     public void verifyResolvePrincipalInternal(final String certPath,
                                                final String expectedResult,
-                                               final String alternatePrincipalAttribute) throws FileNotFoundException, CertificateException {
+                                               final String alternatePrincipalAttribute,
+                                               final String requiredAttribute) throws FileNotFoundException, CertificateException {
         val resolver = new X509SubjectAlternativeNameRFC822EmailPrincipalResolver();
         resolver.setAlternatePrincipalAttribute(alternatePrincipalAttribute);
         val certificate = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
@@ -82,6 +88,9 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests {
         if (expectedResult != null) {
             assertNotNull(principal);
             assertFalse(principal.getAttributes().isEmpty());
+            if (requiredAttribute != null) {
+                assertTrue(principal.getAttributes().keySet().contains(requiredAttribute));
+            }
         } else {
             assertNull(principal);
         }

--- a/support/cas-server-support-x509-core/src/test/resources/log4j2.xml
+++ b/support/cas-server-support-x509-core/src/test/resources/log4j2.xml
@@ -6,8 +6,9 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="org.apereo" level="off" />
-        <Root level="off">
+        <Logger name="org.apereo.cas.adaptors.x509.authentication.principal.X509UPNExtractorUtils" level="debug" />
+        <Logger name="org.apereo" level="error" />
+        <Root level="error">
             <AppenderRef ref="console"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
I would like to use this feature on 6.1.x. It isn't a bug fix but it addresses an oversight that left out a fairly important attribute. 