### PR TITLE
Allow SAML logout messages to be signed

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/saml/Pac4jSamlClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/saml/Pac4jSamlClientProperties.java
@@ -130,6 +130,11 @@ public class Pac4jSamlClientProperties extends Pac4jBaseClientProperties {
     private boolean wantsAssertionsSigned;
 
     /**
+     * Whether logout requests and responses should be signed.
+     */
+    private boolean signLogoutRequests;
+
+    /**
      * AttributeConsumingServiceIndex attribute of AuthnRequest element.
      * The given index points out a specific AttributeConsumingService structure, declared into the
      * Service Provider (SP)'s metadata, to be used to specify all the attributes that the Service Provider

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3043,6 +3043,7 @@ prefixes for the `keystorePath` or `identityProviderMetadataPath` property).
 # cas.authn.pac4j.saml[0].passive=false
 
 # cas.authn.pac4j.saml[0].wantsAssertionsSigned=
+# cas.authn.pac4j.saml[0].signLogoutRequests=
 # cas.authn.pac4j.saml[0].signServiceProviderMetadata=false
 # cas.authn.pac4j.saml[0].principalIdAttribute=eduPersonPrincipalName
 # cas.authn.pac4j.saml[0].useNameQualifier=true

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
@@ -430,6 +430,7 @@ public class DelegatedClientFactory {
                     cfg.setAttributeAsId(saml.getPrincipalIdAttribute());
                 }
                 cfg.setWantsAssertionsSigned(saml.isWantsAssertionsSigned());
+                cfg.setSpLogoutRequestSigned(saml.isSignLogoutRequests());
                 cfg.setLogoutHandler(casServerSpecificLogoutHandler);
                 cfg.setUseNameQualifier(saml.isUseNameQualifier());
                 cfg.setAttributeConsumingServiceIndex(saml.getAttributeConsumingServiceIndex());


### PR DESCRIPTION
This effectively makes org.pac4j.saml.config.SAML2Configuration#spLogoutRequestSigned configurable.

forward port of #4458 