### PR TITLE
Fix Invalid Character in Attribute Name Errors

### DIFF
--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/support/DefaultCasProtocolAttributeEncoder.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/support/DefaultCasProtocolAttributeEncoder.java
@@ -2,6 +2,7 @@ package org.apereo.cas.authentication.support;
 
 import org.apereo.cas.CasViewConstants;
 import org.apereo.cas.CipherExecutor;
+import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceCipherExecutor;
 import org.apereo.cas.services.ServicesManager;
@@ -67,7 +68,7 @@ public class DefaultCasProtocolAttributeEncoder extends AbstractProtocolAttribut
 
         val attrs = attributes.keySet().stream()
             .filter(getSanitizingAttributeNamePredicate())
-            .map(s -> Pair.of(EncodingUtils.hexEncode(s.getBytes(StandardCharsets.UTF_8)), attributes.get(s)))
+            .map(s -> Pair.of(ProtocolAttributeEncoder.encodeAttribute(s), attributes.get(s)))
             .collect(Collectors.toSet());
 
         if (!attrs.isEmpty()) {

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/attribute/SamlAttributeEncoder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/attribute/SamlAttributeEncoder.java
@@ -2,12 +2,10 @@ package org.apereo.cas.support.saml.web.idp.profile.builders.enc.attribute;
 
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.services.RegisteredService;
-import org.apereo.cas.util.EncodingUtils;
 
 import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -25,14 +23,9 @@ public class SamlAttributeEncoder implements ProtocolAttributeEncoder {
         val finalAttributes = Maps.<String, Object>newHashMapWithExpectedSize(attributes.size());
 
         attributes.forEach((k, v) -> {
-            val attributeName = EncodingUtils.hexDecode(k);
-            if (StringUtils.isNotBlank(attributeName)) {
-                LOGGER.debug("Decoded SAML attribute [{}] to [{}] with value(s) [{}]", k, attributeName, v);
-                finalAttributes.put(attributeName, v);
-            } else {
-                LOGGER.debug("Unable to decode SAML attribute [{}]; accepting it verbatim", k);
-                finalAttributes.put(k, v);
-            }
+            val attributeName = ProtocolAttributeEncoder.decodeAttribute(k);
+            LOGGER.debug("Decoded SAML attribute [{}] to [{}] with value(s) [{}]", k, attributeName, v);
+            finalAttributes.put(attributeName, v);
         });
         return finalAttributes;
     }


### PR DESCRIPTION
This fixes a regression in 6.0.x that throws a SAX error (specificall Element or attribute do not match QName production)  when using special characters in the mapped attribute release policy for the attribute name. This would/should occur for all protocols other than CAS due to the nature of the protocol bridge. This fix backports upstream changes in 6.1.x to 6.0.x to eliminate the errors and allow values containing : or & such as oid to be returned properly. 

Tested in 6.0.6-SNAPSHOT with both the SAML2 and CAS 3 protocols.