### PR TITLE
Jpa: Simple MFA configuration should change TransientSessionTicket to TransientSessionTicketImpl

### DIFF
--- a/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationTicketCatalogConfiguration.java
+++ b/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationTicketCatalogConfiguration.java
@@ -5,7 +5,7 @@ import org.apereo.cas.mfa.simple.CasSimpleMultifactorAuthenticationTicketFactory
 import org.apereo.cas.ticket.BaseTicketCatalogConfigurer;
 import org.apereo.cas.ticket.ExpirationPolicyBuilder;
 import org.apereo.cas.ticket.TicketCatalog;
-import org.apereo.cas.ticket.TransientSessionTicket;
+import org.apereo.cas.ticket.TransientSessionTicketImpl;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;

--- a/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationTicketCatalogConfiguration.java
+++ b/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationTicketCatalogConfiguration.java
@@ -34,7 +34,7 @@ public class CasSimpleMultifactorAuthenticationTicketCatalogConfiguration extend
     public void configureTicketCatalog(final TicketCatalog plan) {
         LOGGER.debug("Registering core WS security token ticket definitions...");
         val definition = buildTicketDefinition(plan, CasSimpleMultifactorAuthenticationTicketFactory.PREFIX,
-            TransientSessionTicket.class, Ordered.HIGHEST_PRECEDENCE);
+            TransientSessionTicketImpl.class, Ordered.HIGHEST_PRECEDENCE);
         val properties = definition.getProperties();
         properties.setStorageName("casSimpleMultifactorAuthenticationTicketsCache");
         val timeToLive = casSimpleMultifactorAuthenticationTicketExpirationPolicy.getObject().buildTicketExpirationPolicy().getTimeToLive();


### PR DESCRIPTION
I'm getting an exception when using the JpaTicketRegistry related to the DefaultTicketRegistryCleaner.  Shouldn't the ticket definition use the Entity class, not the interface?  The rest of the ticket definitions in my ticketCatalog do this.

From debug, ticketCatalog.ticketMetadataMap:
```
"TGT" -> {DefaultTicketDefinition@20866} "DefaultTicketDefinition(implementationClass=class org.apereo.cas.ticket.TicketGrantingTicketImpl, prefix=TGT, properties=DefaultTicketDefinitionProperties(cascade=true, storageName=null, storageTimeout=0, storagePassword=null), order=2147483647)"
"ST" -> {DefaultTicketDefinition@20306} "DefaultTicketDefinition(implementationClass=class org.apereo.cas.ticket.ServiceTicketImpl, prefix=ST, properties=DefaultTicketDefinitionProperties(cascade=false, storageName=null, storageTimeout=0, storagePassword=null), order=-2147483648)"
"PT" -> {DefaultTicketDefinition@19981} "DefaultTicketDefinition(implementationClass=class org.apereo.cas.ticket.ProxyTicketImpl, prefix=PT, properties=DefaultTicketDefinitionProperties(cascade=false, storageName=null, storageTimeout=0, storagePassword=null), order=-2147483648)"
"TST" -> {DefaultTicketDefinition@20870} "DefaultTicketDefinition(implementationClass=class org.apereo.cas.ticket.TransientSessionTicketImpl, prefix=TST, properties=DefaultTicketDefinitionProperties(cascade=false, storageName=null, storageTimeout=0, storagePassword=null), order=2147483647)"
"PGT" -> {DefaultTicketDefinition@20872} "DefaultTicketDefinition(implementationClass=class org.apereo.cas.ticket.ProxyGrantingTicketImpl, prefix=PGT, properties=DefaultTicketDefinitionProperties(cascade=true, storageName=null, storageTimeout=0, storagePassword=null), order=2147483647)"
"CASMFA" -> {DefaultTicketDefinition@20128} "DefaultTicketDefinition(implementationClass=interface org.apereo.cas.ticket.TransientSessionTicket, prefix=CASMFA, properties=DefaultTicketDefinitionProperties(cascade=false, storageName=casSimpleMultifactorAuthenticationTicketsCache, storageTimeout=30, storagePassword=null), order=-2147483648)"

Exception
2019-12-02 13:35:41,831 ERROR [org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner] - <org.hibernate.hql.internal.ast.QuerySyntaxException: TransientSessionTicket is not mapped [SELECT t FROM TransientSessionTicket t]>
java.lang.IllegalArgumentException: org.hibernate.hql.internal.ast.QuerySyntaxException: TransientSessionTicket is not mapped [SELECT t FROM TransientSessionTicket t]
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:138) ~[hibernate-core-5.4.7.Final.jar!/:5.4.7.Final]
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:181) ~[hibernate-core-5.4.7.Final.jar!/:5.4.7.Final]
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:188) ~[hibernate-core-5.4.7.Final.jar!/:5.4.7.Final]
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:718) ~[hibernate-core-5.4.7.Final.jar!/:5.4.7.Final]
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:809) ~[hibernate-core-5.4.7.Final.jar!/:5.4.7.Final]
	at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:109) ~[hibernate-core-5.4.7.Final.jar!/:5.4.7.Final]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.orm.jpa.SharedEntityManagerCreator$SharedEntityManagerInvocationHandler.invoke(SharedEntityManagerCreator.java:314) ~[spring-orm-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at com.sun.proxy.$Proxy229.createQuery(Unknown Source) ~[?:?]
	at org.apereo.cas.ticket.registry.JpaTicketRegistry.lambda$getTicketsStream$2(JpaTicketRegistry.java:159) ~[cas-server-support-jpa-ticket-registry-6.1.0.jar!/:6.1.0]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.IntPipeline.reduce(IntPipeline.java:491) ~[?:?]
	at java.util.stream.IntPipeline.sum(IntPipeline.java:449) ~[?:?]
	at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner.cleanInternal(DefaultTicketRegistryCleaner.java:65) ~[cas-server-core-tickets-api-6.1.0.jar!/:6.1.0]
	at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner.clean(DefaultTicketRegistryCleaner.java:45) ~[cas-server-core-tickets-api-6.1.0.jar!/:6.1.0]
	at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner$$FastClassBySpringCGLIB$$29f046b2.invoke(<generated>) ~[cas-server-core-tickets-api-6.1.0.jar!/:6.1.0]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:769) ~[spring-aop-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:747) ~[spring-aop-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:353) ~[spring-tx-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:99) ~[spring-tx-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:747) ~[spring-aop-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:689) ~[spring-aop-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner$$EnhancerBySpringCGLIB$$6c482f4a.clean(<generated>) ~[cas-server-core-tickets-api-6.1.0.jar!/:6.1.0]
	at org.apereo.cas.config.CasCoreTicketsSchedulingConfiguration$TicketRegistryCleanerScheduler.run(CasCoreTicketsSchedulingConfiguration.java:91) ~[cas-server-core-tickets-6.1.0.jar!/:6.1.0]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[spring-context-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-5.2.0.RELEASE.jar!/:5.2.0.RELEASE]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset$$$capture(FutureTask.java:305) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

