### PR TITLE
Limit stack traces

### DIFF
--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/DefaultCasDelegatingWebflowEventResolver.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/DefaultCasDelegatingWebflowEventResolver.java
@@ -83,7 +83,8 @@ public class DefaultCasDelegatingWebflowEventResolver extends AbstractCasWebflow
         } catch (final Exception e) {
             var event = returnAuthenticationExceptionEventIfNeeded(e);
             if (event == null) {
-                LOGGER.warn(e.getMessage(), e);
+                LOGGER.warn("{}: {}", e.getClass(), e.getMessage());
+                LOGGER.debug(e.getMessage(), e);
                 event = newEvent(CasWebflowConstants.TRANSITION_ID_ERROR, e);
             }
             val response = WebUtils.getHttpServletResponseFromExternalWebflowContext(context);
@@ -163,13 +164,15 @@ public class DefaultCasDelegatingWebflowEventResolver extends AbstractCasWebflow
 
     private Event returnAuthenticationExceptionEventIfNeeded(final Exception e) {
         if (e instanceof AuthenticationException || e instanceof AbstractTicketException) {
-            LOGGER.warn(e.getMessage(), e);
+            LOGGER.warn("{}: {}", e.getClass(), e.getMessage());
+            LOGGER.debug(e.getMessage(), e);
             return newEvent(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, e);
         }
 
         if (e.getCause() instanceof AuthenticationException || e.getCause() instanceof AbstractTicketException) {
             val ex = e.getCause();
-            LOGGER.warn(ex.getMessage(), ex);
+            LOGGER.warn("{}: {}", ex.getClass(), ex.getMessage());
+            LOGGER.debug(ex.getMessage(), ex);
             return newEvent(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, ex);
         }
         return null;


### PR DESCRIPTION
The `DefaultCasDelegatingWebflowEventResolver` generates full stack traces at the WARN level which pollutes the logs with no real value.
For an authentication failed, there is already a log from the `PolicyBasedAuthenticationManager` for example:

```
2019-12-03 08:54:45,004 ERROR [org.apereo.cas.authentication.PolicyBasedAuthenticationManager] - <Authentication has failed. Credentials may be incorrect or CAS cannot find authentication handler that supports [UsernamePasswordCredential(username=non, source=null, customFields={})] of type [UsernamePasswordCredential]. Examine the configuration to ensure a method of authentication is defined and analyze CAS logs at DEBUG level to trace the authentication event.>
2019-12-03 08:54:45,011 WARN [org.apereo.cas.web.flow.resolver.impl.DefaultCasDelegatingWebflowEventResolver] - <1 errors, 0 successes>
org.apereo.cas.authentication.AuthenticationException: 1 errors, 0 successes
	at org.apereo.cas.authentication.PolicyBasedAuthenticationManager.evaluateFinalAuthentication(PolicyBasedAuthenticationManager.java:350) ~[cas-server-core-authentication-api-6.2.0-SNAPSHOT.jar:6.2.0-SNAPSHOT]
	at org.apereo.cas.authentication.PolicyBasedAuthenticationManager.authenticateInternal(PolicyBasedAuthenticationManager.java:328) ~[cas-server-core-authentication-api-6.2.0-SNAPSHOT.jar:6.2.0-SNAPSHOT]
	at org.apereo.cas.authentication.PolicyBasedAuthenticationManager.authenticate(PolicyBasedAuthenticationManager.java:136) ~[cas-server-core-authentication-api-6.2.0-SNAPSHOT.jar:6.2.0-SNAPSHOT]
...
```

So my proposal is to keep that kind of stack traces at the DEBUG level and be less verbose at the WARN level.
