### PR TITLE
update jradius dependency to use version from maven central (#4507)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,8 @@
   },
   "ignoreDeps": [
     "com.github.coova:jradius",
+    "net.jradius:jradius-core",
+    "net.jradius:jradius-dictionary",
     "com.mebigfatguy.fb-contrib:fb-contrib"
   ],
   "packageRules": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -241,7 +241,7 @@ unboundidScim2Version=2.3.2
 unboundidScim1Version=1.8.22
 jerseyVersion=2.29.1
 
-jradiusVersion=jradius-1.1.5
+jradiusVersion=1.1.5
 
 httpclientVersion=4.5.10
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1542,7 +1542,7 @@ ext.libraries = [
             force = true
         },
         jradius                 : [
-                dependencies.create("com.github.coova:jradius:$jradiusVersion") {
+                dependencies.create("net.jradius:jradius-core:$jradiusVersion") {
                     exclude(group: "commons-logging", module: "commons-logging")
                     exclude(group: "log4j", module: "log4j")
                     exclude(group: "org.slf4j", module: "slf4j-api")
@@ -1557,6 +1557,9 @@ ext.libraries = [
                     exclude(group: "commons-lang", module: "commons-lang")
                     exclude(group: "net.sf.ehcache", module: "ehcache-core")
                     force = true
+                },
+                dependencies.create("net.jradius:jradius-dictionary:1.1.5") {
+                    exclude(group: "net.jradius", module: "jradius-core")
                 },
                 dependencies.create("gnu.getopt:java-getopt:1.0.13") {
                     force = true


### PR DESCRIPTION
* use jradius dependencies from maven central

The jar referenced in mvnrepository.com for com.github.coova:jradius is 22 bytes.

* exclude jradius from renovate under new group name

(cherry picked from commit 4463954c96c3e32d503d8c448fabd00861c9e253)

