### PR TITLE
ME - customParam of clientId switched from set to add 

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
@@ -93,7 +93,7 @@ public class DelegatedClientWebflowManager {
         if (client instanceof OidcClient) {
             val oidcClient = (OidcClient) client;
             val config = oidcClient.getConfiguration();
-            config.setCustomParams(CollectionUtils.wrap(PARAMETER_CLIENT_ID, ticketId));
+            config.addCustomParam(DelegatedClientWebflowManager.PARAMETER_CLIENT_ID, ticketId);
             config.setWithState(true);
             config.setStateGenerator(new StaticOrRandomStateGenerator(ticketId));
         }


### PR DESCRIPTION
Basically changed the clientid parameter customParam change from set to add.

Without this, customParams set via cas.properties (such as:
cas.authn.pac4j.oidc[0].azure.customParams.msafed=0) seem to be getting clobbered and aren't being honored.

Have tested briefly in my environment and seems to have no ill effect on delegated auth and allows me to set various customParams. 


<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
