### PR TITLE
Fix oauth2 profile endpoint mediatype when HTTP verb is GET

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
@@ -72,7 +72,8 @@ public class OAuth20UserProfileEndpointController extends BaseOAuth20Controller 
      * @return the response entity
      * @throws Exception the exception
      */
-    @GetMapping(path = OAuth20Constants.BASE_OAUTH20_URL + '/' + OAuth20Constants.PROFILE_URL)
+    @GetMapping(path = OAuth20Constants.BASE_OAUTH20_URL + '/' + OAuth20Constants.PROFILE_URL,
+        produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> handleGetRequest(final HttpServletRequest request,
                                                    final HttpServletResponse response) throws Exception {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);


### PR DESCRIPTION
when `/oauth2.0/profile` endpoint is used with `POST` verb, the mime type response is correct : `application/json`

when `/oauth2.0/profile` endpoint is used with `GET` verb, the mime type response is wrong :` text/plain`