### PR TITLE
oauth2 pkce code_challenge_method should be optional

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticator.java
@@ -68,7 +68,7 @@ public class OAuth20ProofKeyCodeExchangeAuthenticator extends OAuth20ClientIdCli
             throw new CredentialsException("Invalid token: " + code);
         }
 
-        val method = StringUtils.defaultString(token.getCodeChallengeMethod(), "plain");
+        val method = StringUtils.defaultIfEmpty(token.getCodeChallengeMethod(), "plain");
         val hash = calculateCodeVerifierHash(method, codeVerifier);
         if (!hash.equalsIgnoreCase(token.getCodeChallenge())) {
             LOGGER.error("Code verifier [{}] does not match the challenge [{}]", hash, token.getCodeChallenge());


### PR DESCRIPTION
In `rfc7636` **Proof Key for Code Exchange by OAuth Public Clients**, the `code_challenge_method` is OPTIONAL (https://tools.ietf.org/html/rfc7636#section-4.3)

When I test PKCE in CAS wihtout `code_challenge_method` parameter (`/oauth2.0/authorize` endpoint), it ends with an error during `code_verifier` verification (`/oauth2.0/accessToken` endpoint) :

```
org.pac4j.core.exception.CredentialsException: Code verification method is unrecognized: 
	at org.apereo.cas.support.oauth.authenticator.OAuth20ProofKeyCodeExchangeAuthenticator.calculateCodeVerifierHash(OAuth20ProofKeyCodeExchangeAuthenticator.java:85) ~[cas-server-support-oauth-core-api-6.1.2.jar!/:6.1.2]
	at org.apereo.cas.support.oauth.authenticator.OAuth20ProofKeyCodeExchangeAuthenticator.validateCredentials(OAuth20ProofKeyCodeExchangeAuthenticator.java:69) ~[cas-server-support-oauth-core-api-6.1.2.jar!/:6.1.2]
	at org.apereo.cas.support.oauth.authenticator.OAuth20ClientIdClientSecretAuthenticator.validate(OAuth20ClientIdClientSecretAuthenticator.java:68) ~[cas-server-support-oauth-core-api-6.1.2.jar!/:6.1.2]
```
The root cause is  `codeChallengeMethod` default value is an empty string when no `code_challenge_method` parameter is sent to `/oauth2.0/authorize` endpoint.