### PR TITLE
Fix the authentication delegation to a CAS server

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
@@ -50,6 +50,7 @@ public class DelegatedClientWebflowManager {
      */
     public static final String PARAMETER_CLIENT_ID = "delegatedclientid";
     private static final String OAUTH10_CLIENT_ID_SESSION_KEY = "OAUTH10_CLIENT_ID";
+    private static final String CAS_CLIENT_ID_SESSION_KEY = "CAS_CLIENT_ID";
 
     private final TicketRegistry ticketRegistry;
     private final TicketFactory ticketFactory;
@@ -97,9 +98,7 @@ public class DelegatedClientWebflowManager {
             config.setStateGenerator(new StaticOrRandomStateGenerator(ticketId));
         }
         if (client instanceof CasClient) {
-            val casClient = (CasClient) client;
-            val config = casClient.getConfiguration();
-            config.addCustomParam(DelegatedClientWebflowManager.PARAMETER_CLIENT_ID, ticketId);
+            webContext.getSessionStore().set(webContext, CAS_CLIENT_ID_SESSION_KEY, ticket.getId());
         }
         if (client instanceof OAuth10Client) {
             sessionStore.set(webContext, OAUTH10_CLIENT_ID_SESSION_KEY, ticket.getId());
@@ -216,10 +215,16 @@ public class DelegatedClientWebflowManager {
                 clientId = webContext.getRequestParameter(OAuth20Configuration.STATE_REQUEST_PARAMETER);
             }
             if (client instanceof OAuth10Client) {
-                LOGGER.debug("Client identifier could not be found as part of request parameters. Looking at state for the OAuth1 client");
+                LOGGER.debug("Client identifier could not be found as part of request parameters. Looking at the session store for the OAuth1 client");
                 val sessionStore = webContext.getSessionStore();
                 clientId = sessionStore.get(webContext, OAUTH10_CLIENT_ID_SESSION_KEY);
                 sessionStore.set(webContext, OAUTH10_CLIENT_ID_SESSION_KEY, null);
+            }
+            if (client instanceof CasClient) {
+                LOGGER.debug("Client identifier could not be found as part of request parameters. Looking at the session store for the CAS client");
+                val sessionStore = webContext.getSessionStore();
+                clientId = sessionStore.get(webContext, CAS_CLIENT_ID_SESSION_KEY);
+                sessionStore.set(webContext, CAS_CLIENT_ID_SESSION_KEY, null);
             }
         }
         LOGGER.debug("Located delegated client identifier for this request as [{}]", clientId);

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
@@ -98,7 +98,7 @@ public class DelegatedClientWebflowManager {
             config.setStateGenerator(new StaticOrRandomStateGenerator(ticketId));
         }
         if (client instanceof CasClient) {
-            webContext.getSessionStore().set(webContext, CAS_CLIENT_ID_SESSION_KEY, ticket.getId());
+            sessionStore.set(webContext, CAS_CLIENT_ID_SESSION_KEY, ticket.getId());
         }
         if (client instanceof OAuth10Client) {
             sessionStore.set(webContext, OAUTH10_CLIENT_ID_SESSION_KEY, ticket.getId());


### PR DESCRIPTION
The authentication delegation to a CAS server has a big issue. It seems to work, but it doesn't. You generally see that under a certain workload, but it can be reproduced fairly easily.
The TST is saved into the `customParams` of the `configuration` of the `CasClient` which is a problem because it's a singleton so the TST used at the time of the ticket validation (`CasAuthenticator`) can be the one of another authentication delegation.
This PR fixes the issue by using the session instead.

It can be tested easily with this project: https://github.com/casinthecloud/cas-pac4j-oauth-demo (master branch). It's the version 6.2.0-RC1, but all CAS versions have the same code and issue.
- Call the login page (http://localhost:8080/cas/login) and start the authentication delegation to a CAS server by clicking on the "CAS" button.
- Do the same in another browser and finish the login process: it works
- Return to the first browser and finish the login process: it doesn't work.
