### PR TITLE
OIDC - Allow client basic auth to be used in password grant flow

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20UsernamePasswordAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20UsernamePasswordAuthenticator.java
@@ -13,11 +13,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.authenticator.Authenticator;
-import org.pac4j.core.credentials.extractor.BasicAuthExtractor;
 import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.profile.CommonProfile;
 
@@ -42,7 +40,7 @@ public class OAuth20UsernamePasswordAuthenticator implements Authenticator<Usern
     public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws CredentialsException {
         val casCredential = new UsernamePasswordCredential(credentials.getUsername(), credentials.getPassword());
         try {
-            val clientIdAndSecret = getClientIdAndClientSecret(context);
+            val clientIdAndSecret = OAuth20Utils.getClientIdAndClientSecret(context);
             if (clientIdAndSecret == null || StringUtils.isBlank(clientIdAndSecret.getKey())) {
                 throw new CredentialsException("No client credentials could be identified in this request");
             }
@@ -81,25 +79,5 @@ public class OAuth20UsernamePasswordAuthenticator implements Authenticator<Usern
         } catch (final Exception e) {
             throw new CredentialsException("Cannot login user using CAS internal authentication", e);
         }
-    }
-
-    /**
-     * Gets client id and client secret.
-     *
-     * @param context the context
-     * @return the client id and client secret
-     */
-    protected Pair<String, String> getClientIdAndClientSecret(final WebContext context) {
-        val extractor = new BasicAuthExtractor();
-        val upcResult = extractor.extract(context);
-        if (upcResult.isPresent()) {
-            val upc = upcResult.get();
-            return Pair.of(upc.getUsername(), upc.getPassword());
-        }
-        val clientId = context.getRequestParameter(OAuth20Constants.CLIENT_ID)
-            .map(String::valueOf).orElse(StringUtils.EMPTY);
-        val clientSecret = context.getRequestParameter(OAuth20Constants.CLIENT_SECRET)
-            .map(String::valueOf).orElse(StringUtils.EMPTY);
-        return Pair.of(clientId, clientSecret);
     }
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
@@ -25,6 +25,8 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.pac4j.core.context.JEEContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.extractor.BasicAuthExtractor;
 import org.pac4j.core.profile.CommonProfile;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.ModelAndView;
@@ -486,5 +488,25 @@ public class OAuth20Utils {
     public static Set<String> parseUserInfoRequestClaims(final JEEContext context) throws Exception {
         val requestedClaims = parseRequestClaims(context);
         return requestedClaims.getOrDefault("userinfo", new HashMap<>(0)).keySet();
+    }
+
+    /**
+     * Gets client id and client secret.
+     *
+     * @param context the context
+     * @return the client id and client secret
+     */
+    public static Pair<String, String> getClientIdAndClientSecret(final WebContext context) {
+        val extractor = new BasicAuthExtractor();
+        val upcResult = extractor.extract(context);
+        if (upcResult.isPresent()) {
+            val upc = upcResult.get();
+            return Pair.of(upc.getUsername(), upc.getPassword());
+        }
+        val clientId = context.getRequestParameter(OAuth20Constants.CLIENT_ID)
+                .map(String::valueOf).orElse(StringUtils.EMPTY);
+        val clientSecret = context.getRequestParameter(OAuth20Constants.CLIENT_SECRET)
+                .map(String::valueOf).orElse(StringUtils.EMPTY);
+        return Pair.of(clientId, clientSecret);
     }
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20PasswordGrantTypeTokenRequestValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20PasswordGrantTypeTokenRequestValidator.java
@@ -1,11 +1,9 @@
 package org.apereo.cas.support.oauth.validator.token;
 
 import org.apereo.cas.audit.AuditableContext;
-import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.OAuth20GrantTypes;
 import org.apereo.cas.support.oauth.util.OAuth20Utils;
 import org.apereo.cas.support.oauth.web.endpoints.OAuth20ConfigurationContext;
-import org.apereo.cas.util.HttpRequestUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20PasswordGrantTypeTokenRequestValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20PasswordGrantTypeTokenRequestValidator.java
@@ -35,11 +35,12 @@ public class OAuth20PasswordGrantTypeTokenRequestValidator extends BaseOAuth20To
     protected boolean validateInternal(final JEEContext context, final String grantType,
                                        final ProfileManager manager, final UserProfile uProfile) {
 
-        val request = context.getNativeRequest();
-        if (!HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_ID)) {
+        val clientIdAndSecret = OAuth20Utils.getClientIdAndClientSecret(context);
+
+        if (clientIdAndSecret == null || StringUtils.isBlank(clientIdAndSecret.getKey())) {
             return false;
         }
-        val clientId = context.getRequestParameter(OAuth20Constants.CLIENT_ID).map(String::valueOf).orElse(StringUtils.EMPTY);
+        val clientId = clientIdAndSecret.getKey();
         LOGGER.debug("Received grant type [{}] with client id [{}]", grantType, clientId);
         val registeredService = OAuth20Utils.getRegisteredOAuthServiceByClientId(getConfigurationContext().getServicesManager(), clientId);
         val service = getConfigurationContext().getWebApplicationServiceServiceFactory().createService(registeredService.getServiceId());

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenPasswordGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenPasswordGrantRequestExtractor.java
@@ -32,14 +32,15 @@ public class AccessTokenPasswordGrantRequestExtractor extends BaseAccessTokenGra
 
     @Override
     public AccessTokenRequestDataHolder extract(final HttpServletRequest request, final HttpServletResponse response) {
-        val clientId = request.getParameter(OAuth20Constants.CLIENT_ID);
+        val context = new JEEContext(request, response, getOAuthConfigurationContext().getSessionStore());
+        val clientId = OAuth20Utils.getClientIdAndClientSecret(context).getKey();
         val scopes = OAuth20Utils.parseRequestScopes(request);
         LOGGER.debug("Locating OAuth registered service by client id [{}]", clientId);
 
         val registeredService = OAuth20Utils.getRegisteredOAuthServiceByClientId(getOAuthConfigurationContext().getServicesManager(), clientId);
         LOGGER.debug("Located OAuth registered service [{}]", registeredService);
 
-        val context = new JEEContext(request, response, getOAuthConfigurationContext().getSessionStore());
+
         val manager = new ProfileManager<CommonProfile>(context, context.getSessionStore());
         val profile = manager.get(true);
         if (profile.isEmpty()) {


### PR DESCRIPTION
As per the OIDC Client implementors guide clients should use Basic Auth to send client credentials. It points to Section 2.1.3 of the OAuth 2.0 specification which states that

The client identifier is encoded using the
"application/x-www-form-urlencoded" encoding algorithm per
Appendix B, and the encoded value is used as the username; the client
password is encoded using the same algorithm and used as the
password.

The Authentication part works as expected as this supports using Authentication Header
https://github.com/apereo/cas/blob/master/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20UsernamePasswordAuthenticator.java#L45

But due to additional validation in `OAuth20PasswordGrantTypeTokenRequestValidator`
https://github.com/apereo/cas/blob/master/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20PasswordGrantTypeTokenRequestValidator.java#L39

and looking for client_id in request param in  `AccessTokenPasswordGrantRequestExtractor` https://github.com/apereo/cas/blob/master/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenPasswordGrantRequestExtractor.java#L35

request fails with error.

Fixed this by using same approach as used in Authenticator to fetch client_id (and secret).

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [x] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [x] Any possible limitations, side effects, etc - None
- [x] Reference any other pull requests that might be related - None
