### PR TITLE
OAuth2 PKCE code_challenge must be a SHA2 digest

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DigestUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DigestUtils.java
@@ -144,7 +144,7 @@ public class DigestUtils {
      */
     public static byte[] rawDigestSha256(final String data) {
         try {
-            return rawDigest(MessageDigestAlgorithms.SHA3_256, data.getBytes(StandardCharsets.UTF_8));
+            return rawDigest(MessageDigestAlgorithms.SHA_256, data.getBytes(StandardCharsets.UTF_8));
         } catch (final Exception cause) {
             throw new SecurityException(cause);
         }


### PR DESCRIPTION
OAuth2 PKCE `code_challenge` must be a SHA2 digest (not a SHA3).

https://tools.ietf.org/html/rfc7636#section-2
https://tools.ietf.org/html/rfc7636#section-4.2