### PR TITLE
remove ehcache monitor enabled property that doesn't exist in config

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ehcache/Ehcache3Properties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ehcache/Ehcache3Properties.java
@@ -30,31 +30,15 @@ public class Ehcache3Properties implements Serializable {
     private boolean enabled = true;
 
     /**
-     * The name of the cache manager instance.
-     */
-    @RequiredProperty
-    private String cacheManagerName = "ticketRegistryCacheManager";
-
-    /**
      * Builder that sets the maximum objects to be held in memory (0 = no limit).
      */
     private int maxElementsInMemory = 10_000;
-
-    /**
-     * Size of disk cache.
-     */
-    private String maxSizeOnDisk = "200MB";
 
     /**
      * Per cache size of disk cache.
      */
     private String perCacheSizeOnDisk = "20MB";
 
-    /**
-     * Size of off heap cache.
-     */
-    private String maxSizeOffHeap = "100MB";
-    
     /**
      * Sets whether elements are eternal.
      * If eternal, timeouts are ignored and the element is never expired. False by default.

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -4484,9 +4484,7 @@ To learn more about this topic, [please review this guide](../ticketing/Ehcache-
 ```properties
 # cas.ticket.registry.ehcache3.enabled=true
 # cas.ticket.registry.ehcache3.maxElementsInMemory=10000
-# cas.ticket.registry.ehcache3.maxSizeOnDisk=200MB
 # cas.ticket.registry.ehcache3.perCacheSizeOnDisk=20MB
-# cas.ticket.registry.ehcache3.maxSizeOffHeap=100MB
 # cas.ticket.registry.ehcache3.eternal=false
 # cas.ticket.registry.ehcache3.enableStatistics=true
 # cas.ticket.registry.ehcache3.enableManagement=true

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -4493,7 +4493,7 @@ To learn more about this topic, [please review this guide](../ticketing/Ehcache-
 # cas.ticket.registry.ehcache3.resourcePoolName=cas-ticket-pool
 # cas.ticket.registry.ehcache3.resourcePoolSize=15MB
 # cas.ticket.registry.ehcache3.rootDirectory=/tmp/cas/ehcache3
-# cas.ticket.registry.ehcache3.clusterConnectTimeout=150
+# cas.ticket.registry.ehcache3.clusterConnectionTimeout=150
 # cas.ticket.registry.ehcache3.clusterReadWriteTimeout=5
 # cas.ticket.registry.ehcache3.clusteredCacheConsistency=STRONG
 ```                                              

--- a/support/cas-server-support-ehcache-monitor/src/main/java/org/apereo/cas/monitor/config/EhCacheMonitorConfiguration.java
+++ b/support/cas-server-support-ehcache-monitor/src/main/java/org/apereo/cas/monitor/config/EhCacheMonitorConfiguration.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +21,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(value = "ehcacheMonitorConfiguration", proxyBeanMethods = false)
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnProperty(prefix = "cas.ticket.registry.ehcache.monitor", name = "enabled", havingValue = "true", matchIfMissing = true)
 @Deprecated
 public class EhCacheMonitorConfiguration {
 


### PR DESCRIPTION
This bean is already conditional on ehcacheHealthIndicator being enabled so it isn't needed (and doesn't work due to no property at cas.ticket.registry.ehcache.monitor.enabled
