### PR TITLE
Oauth 2 introspection expires at fix

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20IntrospectionEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20IntrospectionEndpointController.java
@@ -197,8 +197,8 @@ public class OAuth20IntrospectionEndpointController extends BaseOAuth20Controlle
             val subject = authentication.getPrincipal().getId();
             introspect.setSub(subject);
             introspect.setUniqueSecurityName(subject);
-            introspect.setExp(ticket.getExpirationPolicy().getTimeToLive());
             introspect.setIat(ticket.getCreationTime().toInstant().getEpochSecond());
+            introspect.setExp(introspect.getIat() + ticket.getExpirationPolicy().getTimeToLive());
 
             val methods = authentication.getAttributes().get(AuthenticationManager.AUTHENTICATION_METHOD_ATTRIBUTE);
             val realmNames = CollectionUtils.toCollection(methods)

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/controllers/OidcIntrospectionEndpointControllerTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/controllers/OidcIntrospectionEndpointControllerTests.java
@@ -15,6 +15,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -45,6 +46,7 @@ public class OidcIntrospectionEndpointControllerTests extends AbstractOidcTests 
         request.addParameter(OAuth20Constants.TOKEN, accessToken.getId());
         val result = oidcIntrospectionEndpointController.handleRequest(request, response);
         assertNotNull(result.getBody());
+        assertTrue(Instant.ofEpochSecond(result.getBody().getExp()).isAfter(Instant.ofEpochSecond(result.getBody().getIat())));
         assertTrue(result.getBody().isActive());
         assertEquals(accessToken.getScopes(), Set.of(result.getBody().getScope().split(" ")));
     }


### PR DESCRIPTION
A valid introspection response body "exp" value should be "Integer timestamp, measured in the number of seconds since January 1 1970 UTC, indicating when this token will expire". 

Before it was just the expiration policy's time to live value. 

https://tools.ietf.org/html/rfc7662#section-2.2

This problem affects OAuth 2.0 and OIDC protocols. 

Limitation: Trying to use Apereo CAS introspection request with Spring Security 5 resource server throws an "IllegalArgumentException: expiresAt must be after issuedAt" exception in the resource server when introspecting the token.  This might affect other resource servers that also perform these check for fields "iat" and "exp".
