### PR TITLE
Fix the DistributedJ2ESessionStore when a TGT expires

### DIFF
--- a/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/integration/pac4j/DistributedJ2ESessionStore.java
+++ b/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/integration/pac4j/DistributedJ2ESessionStore.java
@@ -121,7 +121,9 @@ public class DistributedJ2ESessionStore implements SessionStore<JEEContext>, Log
     public void handle(final TicketGrantingTicket ticketGrantingTicket) {
         val request = HttpRequestUtils.getHttpServletRequestFromRequestAttributes();
         val response = HttpRequestUtils.getHttpServletResponseFromRequestAttributes();
-        destroySession(new JEEContext(request, response, this));
+        if (request != null && response != null) {
+            destroySession(new JEEContext(request, response, this));
+        }
     }
 
     @Override


### PR DESCRIPTION
I get the following error from the `DefaultTicketRegistryCleaner` when the TGT expires and when I use the `DistributedJ2ESessionStore`:

```java
2020-01-06 10:04:52,519 DEBUG [org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner] - <Cleaning up expired ticket-granting ticket [TGT-1-*****pIWKKdU-castest]>
2020-01-06 10:04:52,519 INFO [org.apereo.cas.logout.DefaultLogoutManager] - <Performing logout operations for [TGT-1-*****pIWKKdU-castest]>
2020-01-06 10:04:52,520 ERROR [org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner] - <request cannot be null>
org.pac4j.core.exception.TechnicalException: request cannot be null
	at org.pac4j.core.util.CommonHelper.assertTrue(CommonHelper.java:107) ~[pac4j-core-4.0.0-RC2.jar!/:?]
	at org.pac4j.core.util.CommonHelper.assertNotNull(CommonHelper.java:139) ~[pac4j-core-4.0.0-RC2.jar!/:?]
	at org.pac4j.core.context.JEEContext.<init>(JEEContext.java:45) ~[pac4j-core-4.0.0-RC2.jar!/:?]
	at org.apereo.cas.integration.pac4j.DistributedJ2ESessionStore.handle(DistributedJ2ESessionStore.java:124) ~[cas-server-support-pac4j-api-6.1.3.jar!/:6.1.3]
	at org.apereo.cas.logout.DefaultLogoutManager.lambda$performLogout$0(DefaultLogoutManager.java:45) ~[cas-server-core-logout-api-6.1.3.jar!/:6.1.3]
	at java.util.ArrayList.forEach(ArrayList.java:1540) ~[?:?]
	at org.apereo.cas.logout.DefaultLogoutManager.performLogout(DefaultLogoutManager.java:43) ~[cas-server-core-logout-api-6.1.3.jar!/:6.1.3]
```

This PR fixes the issue.
