### PR TITLE
Find the right service in the RegisteredServiceAuthenticationHandlerResolver

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/RegisteredServiceAuthenticationHandlerResolver.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/RegisteredServiceAuthenticationHandlerResolver.java
@@ -2,6 +2,7 @@ package org.apereo.cas.authentication.handler;
 
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationHandlerResolver;
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationTransaction;
 import org.apereo.cas.authentication.handler.support.HttpBasedServiceCredentialsAuthenticationHandler;
 import org.apereo.cas.services.ServicesManager;
@@ -35,11 +36,16 @@ public class RegisteredServiceAuthenticationHandlerResolver implements Authentic
      */
     protected final ServicesManager servicesManager;
 
+    /**
+     * The service selection plan.
+     */
+    protected final AuthenticationServiceSelectionPlan authenticationServiceSelectionPlan;
+
     private int order;
 
     @Override
     public boolean supports(final Set<AuthenticationHandler> handlers, final AuthenticationTransaction transaction) {
-        val service = transaction.getService();
+        val service = authenticationServiceSelectionPlan.resolveService(transaction.getService());
         if (service != null) {
             val registeredService = this.servicesManager.findServiceBy(service);
             LOGGER.trace("Located registered service definition [{}] for this authentication transaction", registeredService);
@@ -54,7 +60,7 @@ public class RegisteredServiceAuthenticationHandlerResolver implements Authentic
 
     @Override
     public Set<AuthenticationHandler> resolve(final Set<AuthenticationHandler> candidateHandlers, final AuthenticationTransaction transaction) {
-        val service = transaction.getService();
+        val service = authenticationServiceSelectionPlan.resolveService(transaction.getService());
         val registeredService = this.servicesManager.findServiceBy(service);
 
         val requiredHandlers = registeredService.getRequiredHandlers();

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationSupportConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationSupportConfiguration.java
@@ -2,6 +2,7 @@ package org.apereo.cas.config;
 
 import org.apereo.cas.authentication.AuthenticationEventExecutionPlanConfigurer;
 import org.apereo.cas.authentication.AuthenticationHandlerResolver;
+import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.AuthenticationTransactionManager;
 import org.apereo.cas.authentication.DefaultAuthenticationSystemSupport;
@@ -51,6 +52,10 @@ public class CasCoreAuthenticationSupportConfiguration {
     @Qualifier("authenticationTransactionManager")
     private ObjectProvider<AuthenticationTransactionManager> authenticationTransactionManager;
 
+    @Autowired
+    @Qualifier("authenticationServiceSelectionPlan")
+    private ObjectProvider<AuthenticationServiceSelectionPlan> authenticationServiceSelectionPlan;
+
     @Bean
     public AuthenticationSystemSupport defaultAuthenticationSystemSupport() {
         return new DefaultAuthenticationSystemSupport(authenticationTransactionManager.getObject(),
@@ -61,7 +66,8 @@ public class CasCoreAuthenticationSupportConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = "registeredServiceAuthenticationHandlerResolver")
     public AuthenticationHandlerResolver registeredServiceAuthenticationHandlerResolver() {
-        val resolver = new RegisteredServiceAuthenticationHandlerResolver(servicesManager.getObject());
+        val resolver = new RegisteredServiceAuthenticationHandlerResolver(servicesManager.getObject(),
+                authenticationServiceSelectionPlan.getObject());
         resolver.setOrder(casProperties.getAuthn().getCore().getServiceAuthenticationResolution().getOrder());
         return resolver;
     }

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManagerTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/PolicyBasedAuthenticationManagerTests.java
@@ -214,7 +214,8 @@ public class PolicyBasedAuthenticationManagerTests {
     private static AuthenticationEventExecutionPlan getAuthenticationExecutionPlan(final Map<AuthenticationHandler, PrincipalResolver> map) {
         val plan = new DefaultAuthenticationEventExecutionPlan();
         plan.registerAuthenticationHandlerWithPrincipalResolver(map);
-        plan.registerAuthenticationHandlerResolver(new RegisteredServiceAuthenticationHandlerResolver(mockServicesManager()));
+        plan.registerAuthenticationHandlerResolver(new RegisteredServiceAuthenticationHandlerResolver(mockServicesManager(),
+                new DefaultAuthenticationServiceSelectionPlan(new DefaultAuthenticationServiceSelectionStrategy())));
         plan.registerAuthenticationHandlerResolver(new DefaultAuthenticationHandlerResolver());
         return plan;
     }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceAuthenticationHandlerResolverTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceAuthenticationHandlerResolverTests.java
@@ -2,6 +2,8 @@ package org.apereo.cas.services;
 
 import org.apereo.cas.authentication.AcceptUsersAuthenticationHandler;
 import org.apereo.cas.authentication.AuthenticationHandler;
+import org.apereo.cas.authentication.DefaultAuthenticationServiceSelectionPlan;
+import org.apereo.cas.authentication.DefaultAuthenticationServiceSelectionStrategy;
 import org.apereo.cas.authentication.DefaultAuthenticationTransaction;
 import org.apereo.cas.authentication.handler.DefaultAuthenticationHandlerResolver;
 import org.apereo.cas.authentication.handler.RegisteredServiceAuthenticationHandlerResolver;
@@ -59,7 +61,8 @@ public class RegisteredServiceAuthenticationHandlerResolverTests {
 
     @Test
     public void checkAuthenticationHandlerResolutionDefault() {
-        val resolver = new RegisteredServiceAuthenticationHandlerResolver(this.defaultServicesManager);
+        val resolver = new RegisteredServiceAuthenticationHandlerResolver(this.defaultServicesManager,
+                new DefaultAuthenticationServiceSelectionPlan(new DefaultAuthenticationServiceSelectionStrategy()));
         val transaction = DefaultAuthenticationTransaction.of(RegisteredServiceTestUtils.getService("serviceid1"),
             RegisteredServiceTestUtils.getCredentialsWithSameUsernameAndPassword("casuser"));
 


### PR DESCRIPTION
We should retrieve the right service in the `RegisteredServiceAuthenticationHandlerResolver` by using the `authenticationServiceSelectionPlan`.
Currently, if the CAS server acts as a SAML IdP, we try to find the authentication handlers related to the callback URL instead of the SAML service.
