### PR TITLE
Address various concurrency issues

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolver.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolver.java
@@ -90,6 +90,11 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
      */
     protected final Set<String> activeAttributeRepositoryIdentifiers;
 
+    /**
+     * Map to store objects to synchronize on for retrieval of attributes one at a time per user.
+     */
+    protected Map<String, PersonAttributeRetriever> retrieverMap = new HashMap<>();
+
     public PersonDirectoryPrincipalResolver() {
         this(new StubPersonAttributeDao(new HashMap<>(0)), PrincipalFactoryUtils.newPrincipalFactory(), false,
             String::trim, null,
@@ -265,9 +270,28 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
      *                    can extract useful bits of authN info such as attributes into the principal.
      * @return the map
      */
-    @Synchronized
     protected Map<String, List<Object>> retrievePersonAttributes(final String principalId, final Credential credential) {
-        return CoreAuthenticationUtils.retrieveAttributesFromAttributeRepository(this.attributeRepository, principalId, activeAttributeRepositoryIdentifiers);
+        val retriever = getPersonAttributeRetriever(principalId, credential);
+        return retriever.retrievePersonAttributes();
+    }
+
+    /**
+     * This method is synchronized on this singleton but doesn't do anything expensive.
+     *
+     * The object returned from this method is specific to a user and it allows attribute retrieval to be synchronized
+     * on a user (so the same attributes are not retrieved multiple times for the same user and attribute cache can be employed.
+     * @param principalId User principal id
+     * @param credential User credentials
+     * @return PersonAttributeRetriever for given principal id
+     */
+    @Synchronized
+    protected PersonAttributeRetriever getPersonAttributeRetriever(final String principalId, final Credential credential) {
+        var retriever = retrieverMap.get(principalId);
+        if (retriever == null) {
+            retriever = new PersonAttributeRetriever(principalId, credential);
+            retrieverMap.put(principalId, retriever);
+        }
+        return retriever;
     }
 
     /**
@@ -298,6 +322,26 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
         }
         LOGGER.debug("Extracted principal id [{}]", id);
         return id;
+    }
+
+    /**
+     * This object allows for synchronization of attribute retrieval for a particular user.
+     */
+    @RequiredArgsConstructor
+    @Getter
+    @Setter
+    public class PersonAttributeRetriever {
+
+        private final String principalId;
+
+        private final Credential credential;
+
+        @Synchronized
+        protected Map<String, List<Object>> retrievePersonAttributes() {
+            Map<String, List<Object>> attributes = CoreAuthenticationUtils.retrieveAttributesFromAttributeRepository(attributeRepository, principalId, activeAttributeRepositoryIdentifiers);
+            retrieverMap.remove(principalId);
+            return attributes;
+        }
     }
 
 }

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ChainingAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ChainingAttributeReleasePolicy.java
@@ -44,7 +44,6 @@ public class ChainingAttributeReleasePolicy implements RegisteredServiceAttribut
 
     @Override
     public RegisteredServiceConsentPolicy getConsentPolicy() {
-        AnnotationAwareOrderComparator.sortIfNecessary(policies);
         val chainingConsentPolicy = new ChainingRegisteredServiceConsentPolicy();
         val newConsentPolicies = policies
             .stream()
@@ -57,7 +56,6 @@ public class ChainingAttributeReleasePolicy implements RegisteredServiceAttribut
 
     @Override
     public Map<String, List<Object>> getAttributes(final Principal p, final Service selectedService, final RegisteredService service) {
-        AnnotationAwareOrderComparator.sortIfNecessary(policies);
 
         val merger = CoreAuthenticationUtils.getAttributeMerger(mergingPolicy);
         val attributes = new HashMap<String, List<Object>>();
@@ -72,8 +70,6 @@ public class ChainingAttributeReleasePolicy implements RegisteredServiceAttribut
 
     @Override
     public Map<String, List<Object>> getConsentableAttributes(final Principal principal, final Service selectedService, final RegisteredService service) {
-        AnnotationAwareOrderComparator.sortIfNecessary(policies);
-
         val merger = CoreAuthenticationUtils.getAttributeMerger(mergingPolicy);
         val attributes = new HashMap<String, List<Object>>();
         policies.forEach(policy -> {
@@ -86,7 +82,7 @@ public class ChainingAttributeReleasePolicy implements RegisteredServiceAttribut
     }
 
     /**
-     * Add policy.
+     * Add policy. Call finalizePolicies when done if adding more than one policy.
      *
      * @param policy the policy
      */
@@ -95,12 +91,20 @@ public class ChainingAttributeReleasePolicy implements RegisteredServiceAttribut
     }
 
     /**
-     * Add policies.
+     * Add all policies at once and then sort them.
      *
      * @param policies the policies
      */
     public void addPolicies(final RegisteredServiceAttributeReleasePolicy... policies) {
         this.policies.addAll(Arrays.stream(policies).collect(Collectors.toList()));
+        finalizePolicies();
+    }
+
+    /**
+     * Call after done adding policies.
+     */
+    public void finalizePolicies() {
+        AnnotationAwareOrderComparator.sortIfNecessary(policies);
     }
 
     /**

--- a/support/cas-server-support-git-service-registry/src/main/java/org/apereo/cas/services/GitServiceRegistry.java
+++ b/support/cas-server-support-git-service-registry/src/main/java/org/apereo/cas/services/GitServiceRegistry.java
@@ -38,7 +38,7 @@ public class GitServiceRegistry extends AbstractServiceRegistry {
     private static final Pattern PATTERN_ACCEPTED_REPOSITORY_FILES = RegexUtils.createPattern(".+\\.("
         + String.join("|", FILE_EXTENSIONS) + ')', Pattern.CASE_INSENSITIVE);
 
-    private final Collection<RegisteredService> registeredServices = new ArrayList<>(0);
+    private Collection<RegisteredService> registeredServices = new ArrayList<>(0);
 
     private final GitRepository gitRepository;
     private final Collection<StringSerializer<RegisteredService>> registeredServiceSerializers;
@@ -111,15 +111,14 @@ public class GitServiceRegistry extends AbstractServiceRegistry {
         }
 
         val objects = this.gitRepository.getObjectsInRepository(new PathRegexPatternTreeFilter(PATTERN_ACCEPTED_REPOSITORY_FILES));
-        registeredServices.clear();
-        registeredServices.addAll(objects
+        registeredServices = objects
             .stream()
             .filter(Objects::nonNull)
             .map(this::parseGitObjectContentIntoRegisteredService)
             .flatMap(Collection::stream)
             .map(this::invokeServiceRegistryListenerPostLoad)
             .filter(Objects::nonNull)
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList());
         return registeredServices;
     }
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServiceRegistryListener.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServiceRegistryListener.java
@@ -41,7 +41,7 @@ public class OidcServiceRegistryListener implements ServiceRegistryListener {
         val attributeReleasePolicy = registeredService.getAttributeReleasePolicy();
         policyToAdd.setConsentPolicy(attributeReleasePolicy.getConsentPolicy());
         policyToAdd.setPrincipalAttributesRepository(attributeReleasePolicy.getPrincipalAttributesRepository());
-        chain.getPolicies().add(policyToAdd);
+        chain.addPolicy(policyToAdd);
     }
 
     @Override
@@ -113,6 +113,7 @@ public class OidcServiceRegistryListener implements ServiceRegistryListener {
                 + "No claims/attributes will be released to [{}]", oidcService.getServiceId());
             oidcService.setAttributeReleasePolicy(new DenyAllAttributeReleasePolicy());
         } else {
+            policyChain.finalizePolicies();
             oidcService.setAttributeReleasePolicy(policyChain);
         }
 


### PR DESCRIPTION
The change to ChainingAttributeReleasePolicy and OidcServiceRegistryListener seeks to avoid ConcurrentModificationException observed during service ticket validation in policies.foreach loop (something modifying policies, presumably the sorting). 

Change to GitServiceRegistry seeks to avoid clearing instance variable collection used by findServiceById method. Instead collection is replaced when loaded or reloaded. This problem wasn't observed but seemed like it could happen. While the load method is Synchronized, the findServiceById method wasn't.

Change to PersonDirectoryPrincipalResolver seeks to remove Synchronize on method of singleton object which can cause many threads to block if retrieving attributes for any one user takes a significant amount of time. This attempts to synchronize on an object specific to a given user so if they auth to multiple services simultaneously the attributes will only be retrieved once and then subsequent calls should use cache. 