### PR TITLE
Hazelcast Monitor: Fixes integer overflow when calculating free heap percentage

### DIFF
--- a/support/cas-server-support-hazelcast-monitor/src/main/java/org/apereo/cas/monitor/HazelcastHealthIndicator.java
+++ b/support/cas-server-support-hazelcast-monitor/src/main/java/org/apereo/cas/monitor/HazelcastHealthIndicator.java
@@ -86,7 +86,7 @@ public class HazelcastHealthIndicator extends AbstractCacheHealthIndicator {
 
         @Override
         public long getPercentFree() {
-            return (int) this.memoryStats.getFreeHeap() * PERCENTAGE_VALUE / this.memoryStats.getCommittedHeap();
+            return this.memoryStats.getFreeHeap() * PERCENTAGE_VALUE / this.memoryStats.getCommittedHeap();
         }
 
         @Override

--- a/support/cas-server-support-hazelcast-monitor/src/test/java/org/apereo/cas/monitor/HazelcastHealthIndicatorTests.java
+++ b/support/cas-server-support-hazelcast-monitor/src/test/java/org/apereo/cas/monitor/HazelcastHealthIndicatorTests.java
@@ -23,6 +23,7 @@ import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguratio
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.apereo.cas.monitor.config.HazelcastMonitorConfiguration;
 
+import com.hazelcast.memory.MemoryStats;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * This is {@link HazelcastHealthIndicatorTests}.
@@ -94,5 +96,15 @@ public class HazelcastHealthIndicatorTests {
             }
         });
         assertNotNull(hazelcastHealthIndicator.toString());
+    }
+
+    @Test
+    public void verifyFreeHeapPercentageCalculation() {
+        val memoryStats = mock(MemoryStats.class);
+        when(memoryStats.getFreeHeap()).thenReturn(125_555_248L);
+        when(memoryStats.getCommittedHeap()).thenReturn(251_658_240L);
+        val statistics = new HazelcastHealthIndicator.HazelcastStatistics(null, 1, memoryStats);
+
+        assertEquals(49, statistics.getPercentFree());
     }
 }


### PR DESCRIPTION
…cast monitor

Signed-off-by: Marek Chodor <marek.chodor@grupawp.pl>

Casting free heap value (*100) to integer made it overflow and report wrong values.

eg.

```
jshell> (long)((int) 125555248L * 100 / 251658240L)
$1 ==> -1

jshell> (int) 125555248L * 100
$3 ==> -329377088

jshell> (long)( 125555248L * 100 / 251658240L)
$4 ==> 49
```
