### PR TITLE
fix double logging of requests in access logs

### DIFF
--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/tomcat/CasTomcatServletWebServerFactoryCustomizer.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/tomcat/CasTomcatServletWebServerFactoryCustomizer.java
@@ -137,7 +137,6 @@ public class CasTomcatServletWebServerFactoryCustomizer extends ServletWebServer
             valve.setEnabled(true);
             valve.setRotatable(true);
             valve.setBuffered(true);
-            tomcat.addContextValves(valve);
             tomcat.addEngineValves(valve);
         }
     }


### PR DESCRIPTION
The access logging valve was being added to the engine and the context so requests were being logged twice. This logs at the engine level to get all requests regardless of context (e.g outside of /cas). 


