### PR TITLE
TimeoutExpirationPolicy with JWT fails

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/TimeoutExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/TimeoutExpirationPolicy.java
@@ -71,12 +71,12 @@ public class TimeoutExpirationPolicy extends AbstractCasExpirationPolicy {
     @JsonIgnore
     @Override
     public Long getTimeToLive() {
-        return Long.MAX_VALUE;
+        return this.timeToKillInSeconds;
     }
 
     @Override
     public Long getTimeToIdle() {
-        return this.timeToKillInSeconds;
+        return Long.MAX_VALUE;
     }
 
 


### PR DESCRIPTION
Generate JWT ticket with timeout TGT policy fail with server error. I think it is because getters in TimeoutExpirationPolicy are swaped. `getTimeToLive()` should return provided value and `getTimeToIdle()` `Long.MAX_VALUE`. JwtTokenBuilder:47 always invoke  `ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(expirationPolicy.buildTicketExpirationPolicy().getTimeToLive())` so `Long.MAX_VALUE` is not valid option.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please remove this block and check off relevant items below.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targetted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
