### PR TITLE
Eliminate snakeyaml conflict

### DIFF
--- a/support/cas-server-support-okta-authentication/build.gradle
+++ b/support/cas-server-support-okta-authentication/build.gradle
@@ -1,4 +1,8 @@
 description = 'Apereo CAS Okta Authentication'
+configurations.all {
+    exclude(group: "org.yaml", module: "snakeyaml")
+}
+
 dependencies {
     api project(":api:cas-server-core-api")
 


### PR DESCRIPTION
Okta impl library brings snakeyaml 1.17 which conflicts with already available 1.25 and application fails to start. This behavior exhibits itself when compiling cas.war and running with `java -jar` It will also sometimes fail when deploying into Tomcat, but it is not deterministic and depends on the random order of Tomcat class loader. This was tested locally and is the only way to eliminate this transitive dependency.