### PR TITLE
Extract issuer dn from certificate as x509 attribute

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/x509/SubjectDnPrincipalResolverProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/x509/SubjectDnPrincipalResolverProperties.java
@@ -1,0 +1,69 @@
+package org.apereo.cas.configuration.model.support.x509;
+
+import org.apereo.cas.configuration.support.RequiresModule;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.security.auth.x500.X500Principal;
+import java.io.Serializable;
+
+/**
+ * This is {@link SubjectDnPrincipalResolverProperties}, properties for SUBJECT_DN principal resolver type.
+ * Allows choosing which method for retrieving subject DN is called.
+ * @author Hal Deadman
+ * @since 6.2
+ */
+@RequiresModule(name = "cas-server-support-x509-webflow")
+@Getter
+@Setter
+public class SubjectDnPrincipalResolverProperties implements Serializable {
+
+    private static final long serialVersionUID = -1833042842488884318L;
+
+    /**
+     * Format of subject DN to use.
+     */
+    private SubjectDnPrincipalResolverProperties.SubjectDnFormat format = SubjectDnPrincipalResolverProperties.SubjectDnFormat.DEFAULT;
+
+    /**
+     * The format of subject dn to be used.
+     */
+    public enum SubjectDnFormat {
+        /**
+         * Denigrated result of calling certificate.getSubjectDN() method.
+         * Javadocs designate this method as "denigrated" for not being portable and/or not being well defined.
+         * It is what has been used by CAS for a long time so it remains the default.
+         * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/cert/X509Certificate.html#getIssuerDN()">DENIGRATED</a>
+         */
+        DEFAULT,
+        /**
+         * RFC 1779 String format of Distinguished Names.
+         * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/security/auth/x500/X500Principal.html#getName()">RFC1779</a>
+         */
+        RFC1779,
+        /**
+         * RFC 2253 String format of Distinguished Names.
+         * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/security/auth/x500/X500Principal.html#getName()">RFC2253</a>
+         */
+        RFC2253,
+        /**
+         * Canonical String format of Distinguished Names.
+         * @see <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/security/auth/x500/X500Principal.html#getName()">CANONICAL</a>
+         */
+        CANONICAL
+    }
+
+    public String getSubjectDnFormat() {
+        switch (format) {
+            case RFC1779:
+                return X500Principal.RFC1779;
+            case RFC2253:
+                return X500Principal.RFC2253;
+            case CANONICAL:
+                return X500Principal.CANONICAL;
+            default:
+                return null;
+        }
+    }
+}

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/x509/X509Properties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/x509/X509Properties.java
@@ -271,6 +271,12 @@ public class X509Properties implements Serializable {
     }
 
     /**
+     * Principal resolver properties for SUBJECT_DN resolver type.
+     */
+    @NestedConfigurationProperty
+    private SubjectDnPrincipalResolverProperties subjectDn = new SubjectDnPrincipalResolverProperties();
+
+    /**
      * Principal resolver properties for CN_EDIPI resolver type.
      */
     @NestedConfigurationProperty

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -2495,7 +2495,15 @@ To fetch CRLs, the following options are available:
 
 # SUBJECT_DN
 # cas.authn.x509.subjectDn.format=[DEFAULT,RFC1779,RFC2253,CANONICAL]
+```
+| Type          | Description
+|---------------|----------------------------------------------------------------------
+| `DEFAULT`     | Calls certificate.getSubjectDN() method for backwards compatibility but that method is ["denigrated"](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/cert/X509Certificate.html#getIssuerDN()). 
+| `RFC1779`     | Calls [X500Principal.getName("RFC1779")](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/security/auth/x500/X500Principal.html#getName()) which emits a subject DN with the attribute keywords defined in RFC 1779 (CN, L, ST, O, OU, C, STREET). Any other attribute type is emitted as an OID.
+| `RFC2253`     | Calls [X500Principal.getName("RFC2253")](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/security/auth/x500/X500Principal.html#getName()) which emits a subject DN with the attribute keywords defined in RFC 2253 (CN, L, ST, O, OU, C, STREET, DC, UID). Any other attribute type is emitted as an OID.
+| `CANONICAL`   | Calls X500Principal.getName("CANONICAL" which emits a subject DN that starts with RFC 2253 and applies additional canonicalizations described in the [javadoc](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/security/auth/x500/X500Principal.html#getName()).
 
+```properties
 # SERIAL_NO_DN
 # cas.authn.x509.serialNoDn.serialNumberPrefix=SERIALNUMBER=
 # cas.authn.x509.serialNoDn.valueDelimiter=,

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -2493,6 +2493,9 @@ To fetch CRLs, the following options are available:
 # cas.authn.x509.refreshIntervalSeconds=3600
 # cas.authn.x509.maxPathLengthAllowUnspecified=false
 
+# SUBJECT_DN
+# cas.authn.x509.subjectDn.format=[DEFAULT,RFC1779,RFC2253,CANONICAL]
+
 # SERIAL_NO_DN
 # cas.authn.x509.serialNoDn.serialNumberPrefix=SERIALNUMBER=
 # cas.authn.x509.serialNoDn.valueDelimiter=,

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
@@ -135,6 +135,14 @@ public abstract class AbstractX509PrincipalResolver extends PersonDirectoryPrinc
             if (subjectPrincipal != null) {
                 attributes.put("subjectX500Principal", CollectionUtils.wrapList(subjectPrincipal.getName()));
             }
+            val issuerDn = certificate.getIssuerDN();
+            if (issuerDn != null) {
+                attributes.put("issuerDn", CollectionUtils.wrapList(issuerDn.getName()));
+            }
+            val issuerPrincipal = certificate.getIssuerX500Principal();
+            if (issuerPrincipal != null) {
+                attributes.put("issuerX500Principal", CollectionUtils.wrapList(issuerPrincipal.getName()));
+            }
             try {
                 val rfc822Email = getRFC822EmailAddress(certificate.getSubjectAlternativeNames());
                 if (rfc822Email != null) {

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectDNPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectDNPrincipalResolver.java
@@ -2,7 +2,7 @@ package org.apereo.cas.adaptors.x509.authentication.principal;
 
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.apereo.services.persondir.IPersonAttributeDao;
 
@@ -16,20 +16,26 @@ import java.util.Set;
  * @since 3.0.0
  */
 @ToString(callSuper = true)
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class X509SubjectDNPrincipalResolver extends AbstractX509PrincipalResolver {
+
+    private final String subjectDnFormat;
 
     public X509SubjectDNPrincipalResolver(final IPersonAttributeDao attributeRepository, final PrincipalFactory principalFactory,
                                           final boolean returnNullIfNoAttributes, final String principalAttributeName,
                                           final boolean useCurrentPrincipalId, final boolean resolveAttributes,
-                                          final Set<String> activeAttributeRepositoryIdentifiers) {
+                                          final Set<String> activeAttributeRepositoryIdentifiers,
+                                          final String subjectDnFormat) {
         super(attributeRepository, principalFactory, returnNullIfNoAttributes,
             principalAttributeName, useCurrentPrincipalId, resolveAttributes,
             activeAttributeRepositoryIdentifiers);
+        this.subjectDnFormat = subjectDnFormat;
     }
 
     @Override
     protected String resolvePrincipalInternal(final X509Certificate certificate) {
-        return certificate.getSubjectDN().getName();
+        return subjectDnFormat == null
+            ? certificate.getSubjectDN().getName()
+            : certificate.getSubjectX500Principal().getName(subjectDnFormat);
     }
 }

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectDNPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectDNPrincipalResolverTests.java
@@ -8,6 +8,7 @@ import org.apereo.cas.authentication.handler.support.SimpleTestUsernamePasswordA
 import lombok.val;
 import org.junit.jupiter.api.Test;
 
+import javax.security.auth.x500.X500Principal;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
 
@@ -21,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.*;
 public class X509SubjectDNPrincipalResolverTests {
     private static final CasX509Certificate VALID_CERTIFICATE = new CasX509Certificate(true);
 
-    private final X509SubjectDNPrincipalResolver resolver = new X509SubjectDNPrincipalResolver();
+    private final X509SubjectDNPrincipalResolver resolver = new X509SubjectDNPrincipalResolver(null);
+
+    private final X509SubjectDNPrincipalResolver resolverRFC2253 = new X509SubjectDNPrincipalResolver(X500Principal.RFC2253);
 
     @Test
     public void verifyResolvePrincipalInternal() {
@@ -31,6 +34,16 @@ public class X509SubjectDNPrincipalResolverTests {
             Optional.of(CoreAuthenticationTestUtils.getPrincipal()),
             Optional.of(new SimpleTestUsernamePasswordAuthenticationHandler())).getId());
     }
+
+    @Test
+    public void verifyResolvePrincipalInternalRFC2253() {
+        val c = new X509CertificateCredential(new X509Certificate[]{VALID_CERTIFICATE});
+        c.setCertificate(VALID_CERTIFICATE);
+        assertEquals(VALID_CERTIFICATE.getSubjectX500Principal().getName(X500Principal.RFC2253), this.resolverRFC2253.resolve(c,
+            Optional.of(CoreAuthenticationTestUtils.getPrincipal()),
+            Optional.of(new SimpleTestUsernamePasswordAuthenticationHandler())).getId());
+    }
+
 
     @Test
     public void verifySupport() {

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -227,6 +227,7 @@ public class X509AuthenticationConfiguration {
     @ConditionalOnMissingBean(name = "x509SubjectDNPrincipalResolver")
     public PrincipalResolver x509SubjectDNPrincipalResolver() {
         val x509 = casProperties.getAuthn().getX509();
+        val subjectDn = x509.getSubjectDn();
         val personDirectory = casProperties.getPersonDirectory();
         val principal = x509.getPrincipal();
         val principalAttribute = StringUtils.defaultIfBlank(principal.getPrincipalAttribute(), personDirectory.getPrincipalAttribute());
@@ -237,7 +238,8 @@ public class X509AuthenticationConfiguration {
             principalAttribute,
             principal.isUseExistingPrincipalId() || personDirectory.isUseExistingPrincipalId(),
             principal.isAttributeResolutionEnabled(),
-            org.springframework.util.StringUtils.commaDelimitedListToSet(principal.getActiveAttributeRepositoryIds()));
+            org.springframework.util.StringUtils.commaDelimitedListToSet(principal.getActiveAttributeRepositoryIds()),
+            subjectDn.getSubjectDnFormat());
     }
 
     @Bean


### PR DESCRIPTION
I have something I am working on where I will need to retrieve additional person attributes using a combination of the x509 subject DN and the issuer DN. I am thinking I will need to use a GroovyScriptAttributeReleasePolicy and that I will need the issuer DN extracted from the certificate as an additional attribute. This PR extracts the issuer DN, both using the "denigrated" getIssuerDN() method and the preferred getIssuerX500Principal().getName() method. 

This also allows specifying the subject DN format since the default format is listed as "denigrated" in javadocs. This doesn't change the default that CAS currently uses but it allows for other non-denigrated formats to be specified. 

