### PR TITLE
Fix SmsSender detection

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/io/CommunicationsManager.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/io/CommunicationsManager.java
@@ -30,7 +30,7 @@ public class CommunicationsManager {
     }
 
     public boolean isSmsSenderDefined() {
-        return this.smsSender != null;
+        return this.smsSender != null && this.smsSender.canSend();
     }
 
     /**

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/io/SmsSender.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/io/SmsSender.java
@@ -19,14 +19,4 @@ public interface SmsSender {
     default boolean send(final String from, final String to, final String message) {
         return false;
     }
-
-    /**
-     * No op sms sender.
-     *
-     * @return the sms sender
-     */
-    static SmsSender noOp() {
-        return new SmsSender() {
-        };
-    }
 }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/io/SmsSender.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/io/SmsSender.java
@@ -19,4 +19,28 @@ public interface SmsSender {
     default boolean send(final String from, final String to, final String message) {
         return false;
     }
+
+    /**
+     * Whether it can send an SMS.
+     *
+     * @return whether it can send an SMS
+     */
+    default boolean canSend() {
+        return true;
+    }
+
+    /**
+     * No op sms sender.
+     *
+     * @return the sms sender
+     */
+    static SmsSender noOp() {
+        return new SmsSender() {
+
+            @Override
+            public boolean canSend() {
+                return false;
+            }
+        };
+    }
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
@@ -112,7 +112,7 @@ public class CasCoreUtilConfiguration implements InitializingBean {
         if (StringUtils.isNotBlank(rest.getUrl())) {
             return new RestfulSmsSender(rest);
         }
-        return SmsSender.noOp();
+        return null;
     }
 
     /**

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
@@ -112,7 +112,7 @@ public class CasCoreUtilConfiguration implements InitializingBean {
         if (StringUtils.isNotBlank(rest.getUrl())) {
             return new RestfulSmsSender(rest);
         }
-        return null;
+        return SmsSender.noOp();
     }
 
     /**


### PR DESCRIPTION
The detection of the `SmsSender` setup is incorrect.

We instantiate a `SmsSender.noOp()` although we test if `this.smsSender` is `null`. Thus, the `SmsSender` is always considered to be properly defined even if it is not.

This PR fixes this problem.
