### PR TITLE
Fix missing "warn" transition for spnego weblflow with "renew" query param

### DIFF
--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpengoWebflowConfigurer.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/SpengoWebflowConfigurer.java
@@ -64,6 +64,7 @@ public class SpengoWebflowConfigurer extends AbstractCasWebflowConfigurer {
         val transitions = spnego.getTransitionSet();
         transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_SUCCESS, CasWebflowConstants.STATE_ID_CREATE_TICKET_GRANTING_TICKET));
         transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_ERROR, CasWebflowConstants.STATE_ID_VIEW_LOGIN_FORM));
+        transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_WARN, CasWebflowConstants.TRANSITION_ID_WARN));
         transitions.add(createTransition(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE, CasWebflowConstants.STATE_ID_VIEW_LOGIN_FORM));
         spnego.getExitActionList().add(createEvaluateAction(CasWebflowConstants.ACTION_ID_CLEAR_WEBFLOW_CREDENTIALS));
         return spnego;


### PR DESCRIPTION
…param

When requesting sso session renew with spnego enabled, eg. `https://mycasdomain/cas/login?service=https://myotherservice&renew=true`, authentication process fails on missing transition for "warn".
User receives error screen instead of being redirected to requested service, because ST was succesfully created.

From application logs:
```
ERROR [org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/cas].[dispatcherServlet]] - <Servlet.service() for servlet [dispatcherServlet] in context with path [/cas] threw exception [Request processing failed; nested exception is org.springframework.webflow.engine.NoMatchingTransitionException: No transition was matched on the event(s) signaled by the [1] action(s) that executed in this action state 'spnego' of flow 'login'; transitions must be defined to handle action result outcomes -- possible flow configuration error? Note: the eventIds signaled were: 'array<String>['warn']', while the supported set of transitional criteria for this action state is 'array<TransitionCriteria>[success, error, authenticationFailure]'] with root cause>
  org.springframework.webflow.engine.NoMatchingTransitionException: No transition was matched on the event(s) signaled by the [1] action(s) that executed in this action state 'spnego' of flow 'login'; transitions must be defined to handle action result outcomes -- possible flow configuration error? Note: the eventIds signaled were: 'array<String>['warn']', while the supported set of transitional criteria for this action state is 'array<TransitionCriteria>[success, error, authenticationFailure]'
```
