### PR TITLE
PKCE with client_secret_basic

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/Authenticators.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/Authenticators.java
@@ -28,7 +28,11 @@ public interface Authenticators {
      */
     String CAS_OAUTH_CLIENT_USER_FORM = "userForm";
     /**
-     * OAuth authn for PKCE.
+     * OAuth authn for PKCE with clientid and secret.
      */
-    String CAS_OAUTH_CLIENT_PROOF_KEY_CODE_EXCHANGE_AUTHN = "pkceAuthn";
+    String CAS_OAUTH_CLIENT_DIRECT_FORM_PROOF_KEY_CODE_EXCHANGE_AUTHN = "pkceFormAuthn";
+    /**
+     * OAuth authn for PKCE with basic authn
+     */
+    String CAS_OAUTH_CLIENT_BASIC_PROOF_KEY_CODE_EXCHANGE_AUTHN = "pkceBasicAuthn";
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/Authenticators.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/Authenticators.java
@@ -32,7 +32,7 @@ public interface Authenticators {
      */
     String CAS_OAUTH_CLIENT_DIRECT_FORM_PROOF_KEY_CODE_EXCHANGE_AUTHN = "pkceFormAuthn";
     /**
-     * OAuth authn for PKCE with basic authn
+     * OAuth authn for PKCE with basic authn.
      */
     String CAS_OAUTH_CLIENT_BASIC_PROOF_KEY_CODE_EXCHANGE_AUTHN = "pkceBasicAuthn";
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticator.java
@@ -49,15 +49,14 @@ public class OAuth20ProofKeyCodeExchangeAuthenticator extends OAuth20ClientIdCli
     @Override
     protected void validateCredentials(final UsernamePasswordCredentials credentials,
                                        final OAuthRegisteredService registeredService, final WebContext context) {
-        val clientSecret = context.getRequestParameter(OAuth20Constants.CLIENT_SECRET)
-                .map(String::valueOf)
-                .orElse(StringUtils.EMPTY);
+        val clientSecret = OAuth20Utils.getClientIdAndClientSecret(context).getRight();
 
         if (!OAuth20Utils.checkClientSecret(registeredService, clientSecret, getRegisteredServiceCipherExecutor())) {
             throw new CredentialsException("Client Credentials provided is not valid for registered service: " + registeredService.getName());
         }
 
-        val codeVerifier = credentials.getPassword();
+        val codeVerifier = context.getRequestParameter(OAuth20Constants.CODE_VERIFIER)
+            .map(String::valueOf).orElse(StringUtils.EMPTY);
         val code = context.getRequestParameter(OAuth20Constants.CODE)
             .map(String::valueOf).orElse(StringUtils.EMPTY);
 

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -267,11 +267,15 @@ public class CasOAuth20Configuration {
         directFormClient.setPasswordParameter(OAuth20Constants.CLIENT_SECRET);
         directFormClient.init();
 
-        val pkceAuthnClient = new DirectFormClient(oAuthProofKeyCodeExchangeAuthenticator());
-        pkceAuthnClient.setName(Authenticators.CAS_OAUTH_CLIENT_PROOF_KEY_CODE_EXCHANGE_AUTHN);
-        pkceAuthnClient.setUsernameParameter(OAuth20Constants.CLIENT_ID);
-        pkceAuthnClient.setPasswordParameter(OAuth20Constants.CODE_VERIFIER);
-        pkceAuthnClient.init();
+        val pkceAuthnFormClient = new DirectFormClient(oAuthProofKeyCodeExchangeAuthenticator());
+        pkceAuthnFormClient.setName(Authenticators.CAS_OAUTH_CLIENT_DIRECT_FORM_PROOF_KEY_CODE_EXCHANGE_AUTHN);
+        pkceAuthnFormClient.setUsernameParameter(OAuth20Constants.CLIENT_ID);
+        pkceAuthnFormClient.setPasswordParameter(OAuth20Constants.CODE_VERIFIER);
+        pkceAuthnFormClient.init();
+
+        val pkceBasicAuthClient = new DirectBasicAuthClient(oAuthProofKeyCodeExchangeAuthenticator());
+        pkceBasicAuthClient.setName(Authenticators.CAS_OAUTH_CLIENT_BASIC_PROOF_KEY_CODE_EXCHANGE_AUTHN);
+        pkceBasicAuthClient.init();
 
         val userFormClient = new DirectFormClient(oAuthUserAuthenticator());
         userFormClient.setName(Authenticators.CAS_OAUTH_CLIENT_USER_FORM);
@@ -294,7 +298,8 @@ public class CasOAuth20Configuration {
 
         clientList.add(oauthCasClient);
         clientList.add(basicAuthClient);
-        clientList.add(pkceAuthnClient);
+        clientList.add(pkceAuthnFormClient);
+        clientList.add(pkceBasicAuthClient);
         clientList.add(directFormClient);
         clientList.add(userFormClient);
         clientList.add(accessTokenClient);

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticatorTests.java
@@ -44,7 +44,25 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
     }
 
     @Test
-    public void verifyAuthenticationPlain() {
+    public void verifyAuthenticationPlainWithoutSecret() {
+        val credentials = new UsernamePasswordCredentials("clientWithoutSecret", "ABCD123");
+        val request = new MockHttpServletRequest();
+        ticketRegistry.addTicket(new OAuth20DefaultCode("CODE-1234567890", RegisteredServiceTestUtils.getService(), RegisteredServiceTestUtils.getAuthentication(),
+            new HardTimeoutExpirationPolicy(10),
+            new MockTicketGrantingTicket("casuser"),
+            new ArrayList<>(), "ABCD123",
+            "plain", "clientid12345", new HashMap<>()));
+        request.addParameter(OAuth20Constants.CLIENT_ID, "clientWithoutSecret");
+        request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
+        request.addParameter(OAuth20Constants.CODE, "CODE-1234567890");
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        authenticator.validate(credentials, ctx);
+        assertNotNull(credentials.getUserProfile());
+        assertEquals("clientWithoutSecret", credentials.getUserProfile().getId());
+    }
+
+    @Test
+    public void verifyAuthenticationPlainWithSecretTransmittedByFormAuthn() {
         val credentials = new UsernamePasswordCredentials("client", "ABCD123");
         val request = new MockHttpServletRequest();
         ticketRegistry.addTicket(new OAuth20DefaultCode("CODE-1234567890", RegisteredServiceTestUtils.getService(), RegisteredServiceTestUtils.getAuthentication(),
@@ -63,7 +81,45 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
     }
 
     @Test
-    public void verifyAuthenticationHashed() {
+    public void verifyAuthenticationPlainWithSecretTransmittedByBasicAuthn() {
+        val credentials = new UsernamePasswordCredentials("client", "secret");
+        val request = new MockHttpServletRequest();
+        ticketRegistry.addTicket(new OAuth20DefaultCode("CODE-1234567890", RegisteredServiceTestUtils.getService(), RegisteredServiceTestUtils.getAuthentication(),
+            new HardTimeoutExpirationPolicy(10),
+            new MockTicketGrantingTicket("casuser"),
+            new ArrayList<>(), "ABCD123",
+            "plain", "clientid12345", new HashMap<>()));
+        request.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:secret")));
+        request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
+        request.addParameter(OAuth20Constants.CODE, "CODE-1234567890");
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        authenticator.validate(credentials, ctx);
+        assertNotNull(credentials.getUserProfile());
+        assertEquals("client", credentials.getUserProfile().getId());
+    }
+
+    @Test
+    public void verifyAuthenticationHashedWithoutSecret() {
+        val hash = EncodingUtils.encodeUrlSafeBase64(DigestUtils.rawDigestSha256("ABCD123"));
+        val credentials = new UsernamePasswordCredentials("clientWithoutSecret", "ABCD123");
+        val request = new MockHttpServletRequest();
+        val ticket = new OAuth20DefaultCode("CODE-1234567890",
+            RegisteredServiceTestUtils.getService(), RegisteredServiceTestUtils.getAuthentication(),
+            new HardTimeoutExpirationPolicy(10),
+            new MockTicketGrantingTicket("casuser"),
+            new ArrayList<>(), hash, "s256", "clientid12345", new HashMap<>());
+        ticketRegistry.addTicket(ticket);
+        request.addParameter(OAuth20Constants.CLIENT_ID, "clientWithoutSecret");
+        request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
+        request.addParameter(OAuth20Constants.CODE, ticket.getId());
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        authenticator.validate(credentials, ctx);
+        assertNotNull(credentials.getUserProfile());
+        assertEquals("clientWithoutSecret", credentials.getUserProfile().getId());
+    }
+
+    @Test
+    public void verifyAuthenticationHashedWithSecretTransmittedByFormAuthn() {
         val hash = EncodingUtils.encodeUrlSafeBase64(DigestUtils.rawDigestSha256("ABCD123"));
         val credentials = new UsernamePasswordCredentials("client", "ABCD123");
         val request = new MockHttpServletRequest();
@@ -76,6 +132,26 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
         request.addParameter(OAuth20Constants.CLIENT_ID, "client");
         request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
         request.addParameter(OAuth20Constants.CLIENT_SECRET, "secret");
+        request.addParameter(OAuth20Constants.CODE, ticket.getId());
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        authenticator.validate(credentials, ctx);
+        assertNotNull(credentials.getUserProfile());
+        assertEquals("client", credentials.getUserProfile().getId());
+    }
+
+    @Test
+    public void verifyAuthenticationHashedWithSecretTransmittedByBasicFormAuthn() {
+        val hash = EncodingUtils.encodeUrlSafeBase64(DigestUtils.rawDigestSha256("ABCD123"));
+        val credentials = new UsernamePasswordCredentials("client", "ABCD123");
+        val request = new MockHttpServletRequest();
+        val ticket = new OAuth20DefaultCode("CODE-1234567890",
+            RegisteredServiceTestUtils.getService(), RegisteredServiceTestUtils.getAuthentication(),
+            new HardTimeoutExpirationPolicy(10),
+            new MockTicketGrantingTicket("casuser"),
+            new ArrayList<>(), hash, "s256", "clientid12345", new HashMap<>());
+        ticketRegistry.addTicket(ticket);request.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:secret")));
+        request.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:secret")));
+        request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
         request.addParameter(OAuth20Constants.CODE, ticket.getId());
         val ctx = new JEEContext(request, new MockHttpServletResponse());
         authenticator.validate(credentials, ctx);

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticatorTests.java
@@ -52,6 +52,7 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
             new MockTicketGrantingTicket("casuser"),
             new ArrayList<>(), "ABCD123",
             "plain", "clientid12345", new HashMap<>()));
+        request.addParameter(OAuth20Constants.CLIENT_ID, "client");
         request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
         request.addParameter(OAuth20Constants.CLIENT_SECRET, "secret");
         request.addParameter(OAuth20Constants.CODE, "CODE-1234567890");
@@ -63,8 +64,8 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
 
     @Test
     public void verifyAuthenticationHashed() {
-        val hash = EncodingUtils.encodeUrlSafeBase64(DigestUtils.rawDigestSha256("ABCD1234"));
-        val credentials = new UsernamePasswordCredentials("client", "ABCD1234");
+        val hash = EncodingUtils.encodeUrlSafeBase64(DigestUtils.rawDigestSha256("ABCD123"));
+        val credentials = new UsernamePasswordCredentials("client", "ABCD123");
         val request = new MockHttpServletRequest();
         val ticket = new OAuth20DefaultCode("CODE-1234567890",
             RegisteredServiceTestUtils.getService(), RegisteredServiceTestUtils.getAuthentication(),
@@ -72,6 +73,7 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
             new MockTicketGrantingTicket("casuser"),
             new ArrayList<>(), hash, "s256", "clientid12345", new HashMap<>());
         ticketRegistry.addTicket(ticket);
+        request.addParameter(OAuth20Constants.CLIENT_ID, "client");
         request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
         request.addParameter(OAuth20Constants.CLIENT_SECRET, "secret");
         request.addParameter(OAuth20Constants.CODE, ticket.getId());
@@ -83,7 +85,7 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
 
     @Test
     public void verifyAuthenticationNotHashedCorrectly() {
-        val credentials = new UsernamePasswordCredentials("client", "ABCD1234");
+        val credentials = new UsernamePasswordCredentials("client", "ABCD123");
         val request = new MockHttpServletRequest();
         val ticket = new OAuth20DefaultCode("CODE-1234567890",
             RegisteredServiceTestUtils.getService(), RegisteredServiceTestUtils.getAuthentication(),
@@ -92,6 +94,7 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
             new ArrayList<>(),
             "something-else", "s256", "clientid12345", new HashMap<>());
         ticketRegistry.addTicket(ticket);
+        request.addParameter(OAuth20Constants.CLIENT_ID, "client");
         request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
         request.addParameter(OAuth20Constants.CLIENT_SECRET, "secret");
         request.addParameter(OAuth20Constants.CODE, ticket.getId());

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ProofKeyCodeExchangeAuthenticatorTests.java
@@ -149,7 +149,8 @@ public class OAuth20ProofKeyCodeExchangeAuthenticatorTests extends BaseOAuth20Au
             new HardTimeoutExpirationPolicy(10),
             new MockTicketGrantingTicket("casuser"),
             new ArrayList<>(), hash, "s256", "clientid12345", new HashMap<>());
-        ticketRegistry.addTicket(ticket);request.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:secret")));
+        ticketRegistry.addTicket(ticket);
+        request.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:secret")));
         request.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:secret")));
         request.addParameter(OAuth20Constants.CODE_VERIFIER, "ABCD123");
         request.addParameter(OAuth20Constants.CODE, ticket.getId());


### PR DESCRIPTION
# Details

Hello,

Today the PKCE authentication with a client_secret only works with the client_secret_post authenticator and not with the client_secret_basic authenticator.

This pull request adds support for PKCE with a client_secret submitted with the client_secret_basic authentication.

Let me know if you need any further information.

Regards,
Julien
