### PR TITLE
Make LDAP PM conditonal on property

### DIFF
--- a/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/config/LdapPasswordManagementConfiguration.java
+++ b/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/config/LdapPasswordManagementConfiguration.java
@@ -9,6 +9,7 @@ import org.apereo.cas.util.crypto.CipherExecutor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +22,7 @@ import org.springframework.context.annotation.Configuration;
  * @since 5.2.0
  */
 @Configuration(value = "ldapPasswordManagementConfiguration", proxyBeanMethods = false)
+@ConditionalOnProperty(prefix = "cas.authn.pm.ldap", name = "ldapUrl")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class LdapPasswordManagementConfiguration {
     @Autowired


### PR DESCRIPTION
While adding the `cas-server-support-pm-ldap` dependency is a required step to add LDAP PM support, it should not be enough and the `cas.authn.pm.ldap.ldpUrl` property (at least) should be defined.