### PR TITLE
limit use of mavenLocal() per gradle best practices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ defaultTasks "clean", "build"
 
 buildscript {
     repositories {
-        mavenLocal()
         jcenter()
         maven {
             url "https://maven.eveoh.nl/content/repositories/releases"
@@ -178,7 +177,12 @@ allprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal{
+            content {
+                includeModuleByRegex "org\\.apereo", "person-directory.*"
+                includeGroupByRegex "$mavenLocalGroupInclude"
+            }
+        }
         mavenCentral()
         jcenter()
         maven {
@@ -237,7 +241,12 @@ subprojects {
     ext.libraries = rootProject.ext.libraries
 
     repositories {
-        mavenLocal()
+        mavenLocal{
+            content {
+                includeModuleByRegex "org\\.apereo", "person-directory.*"
+                includeGroupByRegex "$mavenLocalGroupInclude"
+            }
+        }
         mavenCentral()
         maven {
             url "https://build.shibboleth.net/nexus/content/repositories/releases"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,9 @@ sonatypeRepositoryUrl=https://oss.sonatype.org/service/local/staging/deploy/mave
 sonatypeSnapshotsRepositoryUrl=https://oss.sonatype.org/content/repositories/snapshots/
 sonatypeReleasesRepositoryUrl=https://oss.sonatype.org/content/repositories/releases
 
+# override this in .gradle/gradle.properties if you want to pull some modules from mavenLocal() repository
+mavenLocalGroupInclude=org\\.example
+
 ###############################################################################################
 # Localized gradle settings to ensure modules can be loaded/configured as quickly as possible.
 ################################################################################################


### PR DESCRIPTION
See [the case for mavenLocal()](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:case-for-maven-local) which is really a case for not using mavenLocal() or using it with a repository filter and that is what this PR does. This PR configures mavenLocal to use person-directory from the local repo since that is a related maven project that someone working on CAS might be also working on. This also allows someone to define a group regular expression that someone might use to include other maven dependencies that they are working on and want to pull from mavenLocal. Someone could define a wildcard that included all groups if they really wanted to use mavenLocal() despite the drawbacks. This doesn't use mavenLocal() at all for ```buildscript``` repositories.