### PR TITLE
Update json in documentation for CachingPrincipalAttributesRepository.

### DIFF
--- a/docs/cas-server-documentation/integration/Attribute-Release-Caching.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Caching.md
@@ -60,11 +60,8 @@ Sample configuration follows:
     "@class" : "org.apereo.cas.services.ReturnAllowedAttributeReleasePolicy",
     "principalAttributesRepository" : {
       "@class" : "org.apereo.cas.authentication.principal.cache.CachingPrincipalAttributesRepository",
-      "duration" : {
-        "@class" : "javax.cache.expiry.Duration",
-        "timeUnit" : [ "java.util.concurrent.TimeUnit", "HOURS" ],
-        "expiration" : 2
-      },
+      "timeUnit" : "HOURS",
+      "expiration" : 2,
       "mergingStrategy" : "NONE"
     }
   }
@@ -97,11 +94,8 @@ For example:
     "@class" : "org.apereo.cas.services.ReturnAllowedAttributeReleasePolicy",
     "principalAttributesRepository" : {
       "@class" : "org.apereo.cas.authentication.principal.cache.CachingPrincipalAttributesRepository",
-      "duration" : {
-        "@class" : "javax.cache.expiry.Duration",
-        "timeUnit" : [ "java.util.concurrent.TimeUnit", "HOURS" ],
-        "expiration" : 2
-      },
+      "timeUnit" : "HOURS",
+      "expiration" : 2,
       "mergingStrategy" : "MULTIVALUED"
     }
   }
@@ -128,11 +122,8 @@ For example:
     "@class" : "org.apereo.cas.services.ReturnAllowedAttributeReleasePolicy",
     "principalAttributesRepository" : {
       "@class" : "org.apereo.cas.authentication.principal.cache.CachingPrincipalAttributesRepository",
-      "duration" : {
-        "@class" : "javax.cache.expiry.Duration",
-        "timeUnit" : [ "java.util.concurrent.TimeUnit", "HOURS" ],
-        "expiration" : 2
-      },
+      "timeUnit" : "HOURS",
+      "expiration" : 2,
       "mergingStrategy" : "ADD"
     }
   }
@@ -160,11 +151,8 @@ For example:
     "@class" : "org.apereo.cas.services.ReturnAllowedAttributeReleasePolicy",
     "principalAttributesRepository" : {
       "@class" : "org.apereo.cas.authentication.principal.cache.CachingPrincipalAttributesRepository",
-      "duration" : {
-        "@class" : "javax.cache.expiry.Duration",
-        "timeUnit" : [ "java.util.concurrent.TimeUnit", "HOURS" ],
-        "expiration" : 2
-      },
+      "timeUnit" : "HOURS",
+      "expiration" : 2,
       "mergingStrategy" : "REPLACE"
     }
   }
@@ -188,11 +176,8 @@ again to fetch attributes and cache them for `30` minutes.
     "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy",
     "principalAttributesRepository" : {
         "@class" : "org.apereo.cas.authentication.principal.cache.CachingPrincipalAttributesRepository",
-        "duration" : {
-          "@class" : "javax.cache.expiry.Duration",
-          "timeUnit" : [ "java.util.concurrent.TimeUnit", "MINUTES" ],
-          "expiration" : 30
-        },
+        "timeUnit" : "MINUTES",
+        "expiration" : 30,
         "ignoreResolvedAttributes": true,
         "attributeRepositoryIds": ["java.util.HashSet", [ "MyJsonRepository" ]],
         "mergingStrategy" : "MULTIVALUED"

--- a/docs/cas-server-documentation/services/JSON-Service-Management.md
+++ b/docs/cas-server-documentation/services/JSON-Service-Management.md
@@ -149,11 +149,8 @@ An example legacy JSON file is listed below for reference:
     "@class" : "org.jasig.cas.services.ReturnAllowedAttributeReleasePolicy",
     "principalAttributesRepository" : {
       "@class" : "org.jasig.cas.authentication.principal.cache.CachingPrincipalAttributesRepository",
-      "duration" : {
-        "@class" : "javax.cache.expiry.Duration",
-        "timeUnit" : [ "java.util.concurrent.TimeUnit", "HOURS" ],
-        "expiration" : 2
-      },
+      "timeUnit" : "HOURS",
+      "expiration" : 2,
       "mergingStrategy" : "NONE"
     },
     "authorizedToReleaseCredentialPassword" : false,


### PR DESCRIPTION
The currently documented syntax results in this warning:

2020-02-06 08:44:14,142 WARN
[org.apereo.cas.services.util.JasigRegisteredServiceDeserializationProblemHandler]
 - <CAS has converted legacy JSON property [duration] for type
 [org.apereo.cas.authentication.principal.cache.CachingPrincipalAttributesRepository].
 It parsed 'expiration' value [120] with time unit of [MINUTES].
 It is STRONGLY recommended that you review the configuration and upgrade from the legacy syntax.
