### PR TITLE
Upgrade cryptacular to v1.2.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -287,7 +287,7 @@ bouncyCastleVersion=1.64
 shibbolethUtilJavaSupportVersion=7.5.1
 jdomVersion=1.1
 
-cryptacularVersion=1.2.3
+cryptacularVersion=1.2.4
 
 grouperVersion=2.5.1
 


### PR DESCRIPTION
Fix for CVE-2020-7226.

@serac 
