### PR TITLE
Changing generated SAML service eval order to LOWEST

### DIFF
--- a/support/cas-server-support-saml-sp-integrations/src/main/java/org/apereo/cas/util/SamlSPUtils.java
+++ b/support/cas-server-support-saml-sp-integrations/src/main/java/org/apereo/cas/util/SamlSPUtils.java
@@ -43,7 +43,7 @@ public class SamlSPUtils {
 
     /**
      * New saml service provider registration.
-     *
+     * Precedence of services is lowest so generated service can be overridden by non-generated version.
      * @param sp       the properties
      * @param resolver the resolver
      * @return the saml registered service
@@ -59,7 +59,7 @@ public class SamlSPUtils {
         val service = new SamlRegisteredService();
         service.setName(sp.getName());
         service.setDescription(sp.getDescription());
-        service.setEvaluationOrder(Ordered.HIGHEST_PRECEDENCE);
+        service.setEvaluationOrder(Ordered.LOWEST_PRECEDENCE);
         service.setMetadataLocation(sp.getMetadata());
         val attributesToRelease = new ArrayList<String>(sp.getAttributes());
         if (StringUtils.isNotBlank(sp.getNameIdAttribute())) {


### PR DESCRIPTION
A generated service should not override non-generated service. Occasionally a SAML service will get generated and it overrides my custom SAML service (which for whatever reason wasn't found when the server started). Eventually the correct service definition arrives but its eval order can't override HIGHEST_PRIORITY. I actually set this to HIGHEST in previous commit but it was MIN_VALUE before that so I was just keeping the behavior the same. 
