### PR TITLE
Fix JDBC Groovy Password Encoder

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/GroovyPasswordEncoder.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/GroovyPasswordEncoder.java
@@ -33,6 +33,12 @@ public class GroovyPasswordEncoder extends AbstractPasswordEncoder implements Di
     }
 
     @Override
+    public boolean matches(final CharSequence rawPassword, final String encodedPassword) {
+        val args = new Object[]{rawPassword, encodedPassword, LOGGER, ApplicationContextProvider.getApplicationContext()};
+        return watchableScript.execute("matches", Boolean.class, args);
+    }
+
+    @Override
     public void destroy() {
         this.watchableScript.close();
     }

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/support/password/GroovyPasswordEncoderTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/support/password/GroovyPasswordEncoderTests.java
@@ -19,7 +19,6 @@ public class GroovyPasswordEncoderTests {
     @Test
     public void verifyOperation() {
         val enc = new GroovyPasswordEncoder(new ClassPathResource("GroovyPasswordEncoder.groovy"));
-        val encoded = enc.encode("helloworld");
-        assertTrue(enc.matches("helloworld", encoded));
+        assertTrue(enc.matches("helloworld", "6adfb183a4a2c94a2f92dab5ade762a47889a5a1"));
     }
 }

--- a/core/cas-server-core-authentication-api/src/test/resources/GroovyPasswordEncoder.groovy
+++ b/core/cas-server-core-authentication-api/src/test/resources/GroovyPasswordEncoder.groovy
@@ -1,9 +1,42 @@
+import java.util.*
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+
 def byte[] run(final Object... args) {
     def rawPassword = args[0]
     def generatedSalt = args[1]
     def logger = args[2]
     def casApplicationContext = args[3]
 
-    logger.debug("Encoding password...")
-    return rawPassword.toString().toUpperCase().getBytes("UTF-8")
+    if (rawPassword == null) {
+        return null;
+    }
+
+    try {
+        encoded = encode(rawPassword.toString());
+        logger.debug("Encoded password via [GroovyPasswordEncoder] and character-encoding [UTF-8] is [{}]", encoded);
+        return encoded;
+    } catch (final Exception e) {
+        logger.error(e.getMessage(), e);
+    }
+    return null;
+}
+
+def String encode(String rawPassword) {
+    pswBytes = rawPassword.getBytes("UTF-8");
+    return Hex.encodeHexString(DigestUtils.getDigest("SHA-1").digest(pswBytes));
+}
+
+def Boolean matches(final Object... args) {
+    def rawPassword = args[0]
+    def encodedPassword = args[1]
+    def logger = args[2]
+    def casApplicationContext = args[3]
+
+    encodedRawPassword = StringUtils.isNotBlank(rawPassword) ? encode(rawPassword.toString()) : null;
+    matched = StringUtils.equals(encodedRawPassword, encodedPassword);
+    logger.debug("Provided password does{}match the encoded password", BooleanUtils.toString(matched, StringUtils.EMPTY, " not "));
+    return matched;
 }

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -186,6 +186,15 @@ def byte[] run(final Object... args) {
     logger.debug("Encoding password...")
     return ...
 }
+
+def Boolean matches(final Object... args) {
+    def rawPassword = args[0]
+    def encodedPassword = args[1]
+    def logger = args[2]
+    def casApplicationContext = args[3]
+
+   logger.debug("Does match or not ?");
+   return ...
 ```
 
 ## Authentication Principal Transformation


### PR DESCRIPTION
# Details

Hello,

Today, when you try to use the JDBC Groovy Password Encoder [referenced here](https://apereo.github.io/cas/6.1.x/configuration/Configuration-Properties-Common.html#password-encoding), the authentication will fail due to the matches method from spring security which is never overrided.

The Groovy Password Encoder will successfully produce a hash according to the scheme you've defined in the Groovy script, but the matches method will be false because it is the one from spring which cannot work with a custom scheme:

```
@Override
public boolean matches(CharSequence rawPassword, String encodedPassword) {
	byte[] digested = Hex.decode(encodedPassword);
	byte[] salt = subArray(digested, 0, this.saltGenerator.getKeyLength());
	return matches(digested, encodeAndConcatenate(rawPassword, salt));
}
```

This pull request adds the missing matches method inside the Groovy Password Encoder class and also the capability to define the matches method inside the groovy script:

```
def Boolean matches(final Object... args) {
    def rawPassword = args[0]
    def encodedPassword = args[1]
    def logger = args[2]
    def casApplicationContext = args[3]
   logger.debug("Does match or not ?");
   return ...
```

Let me know if you need any further information.

Regards,
Julien