### PR TITLE
Password Management Token & Server/Client IP Address check

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/PasswordManagementProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/PasswordManagementProperties.java
@@ -269,12 +269,12 @@ public class PasswordManagementProperties implements Serializable {
         /**
          * Whether the Password Management Token will contain the server IP Address.
          */
-        private boolean checkServerIpAddress = true;
+        private boolean includeServerIpAddress = true;
 
         /**
          * Whether the Password Management Token will contain the client IP Address.
          */
-        private boolean checkClientIpAddress = true;
+        private boolean includeClientIpAddress = true;
 
         /**
          * How long in minutes should the password expiration link remain valid.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/PasswordManagementProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/PasswordManagementProperties.java
@@ -267,6 +267,16 @@ public class PasswordManagementProperties implements Serializable {
         private boolean securityQuestionsEnabled = true;
 
         /**
+         * Whether the Password Management Token will contain the server IP Address.
+         */
+        private boolean checkServerIpAddress = true;
+
+        /**
+         * Whether the Password Management Token will contain the client IP Address.
+         */
+        private boolean checkClientIpAddress = true;
+
+        /**
          * How long in minutes should the password expiration link remain valid.
          */
         private long expirationMinutes = 1;

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -5090,8 +5090,8 @@ To learn more about this topic, [please review this guide](../installation/Passw
 # cas.authn.pm.reset.expirationMinutes=1
 # cas.authn.pm.reset.securityQuestionsEnabled=true
 # Whether the Password Management Token will contain the client or server IP Address.
-# cas.authn.pm.reset.checkServerIpAddress=true
-# cas.authn.pm.reset.checkClientIpAddress=true
+# cas.authn.pm.reset.includeServerIpAddress=true
+# cas.authn.pm.reset.includeClientIpAddress=true
 
 # Automatically log in after successful password change
 # cas.authn.pm.autoLogin=false

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -5089,6 +5089,9 @@ To learn more about this topic, [please review this guide](../installation/Passw
 
 # cas.authn.pm.reset.expirationMinutes=1
 # cas.authn.pm.reset.securityQuestionsEnabled=true
+# Whether the Password Management Token will contain the client or server IP Address.
+# cas.authn.pm.reset.checkServerIpAddress=true
+# cas.authn.pm.reset.checkClientIpAddress=true
 
 # Automatically log in after successful password change
 # cas.authn.pm.autoLogin=false

--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
@@ -59,6 +59,7 @@ public class BasePasswordManagementService implements PasswordManagementService 
         try {
             val json = this.cipherExecutor.decode(token);
             val claims = JwtClaims.parse(json);
+            val resetProperties = properties.getReset();
 
             if (!claims.getIssuer().equals(issuer)) {
                 LOGGER.error("Token issuer does not match CAS");
@@ -74,11 +75,11 @@ public class BasePasswordManagementService implements PasswordManagementService 
             }
 
             val holder = ClientInfoHolder.getClientInfo();
-            if (properties.getReset().isCheckServerIpAddress() && !claims.getStringClaimValue("origin").equals(holder.getServerIpAddress())) {
+            if (resetProperties.isIncludeServerIpAddress() && !claims.getStringClaimValue("origin").equals(holder.getServerIpAddress())) {
                 LOGGER.error("Token origin server IP address does not match CAS");
                 return null;
             }
-            if (properties.getReset().isCheckClientIpAddress() && !claims.getStringClaimValue("client").equals(holder.getClientIpAddress())) {
+            if (resetProperties.isIncludeClientIpAddress() && !claims.getStringClaimValue("client").equals(holder.getClientIpAddress())) {
                 LOGGER.error("Token client IP address does not match CAS");
                 return null;
             }
@@ -102,18 +103,19 @@ public class BasePasswordManagementService implements PasswordManagementService 
         try {
             val token = UUID.randomUUID().toString();
             val claims = new JwtClaims();
+            val resetProperties = properties.getReset();
             claims.setJwtId(token);
             claims.setIssuer(issuer);
             claims.setAudience(issuer);
-            claims.setExpirationTimeMinutesInTheFuture(properties.getReset().getExpirationMinutes());
+            claims.setExpirationTimeMinutesInTheFuture(resetProperties.getExpirationMinutes());
             claims.setIssuedAtToNow();
 
             val holder = ClientInfoHolder.getClientInfo();
             if (holder != null) {
-                if (properties.getReset().isCheckServerIpAddress()) {
+                if (resetProperties.isIncludeServerIpAddress()) {
                     claims.setStringClaim("origin", holder.getServerIpAddress());
                 }
-                if (properties.getReset().isCheckClientIpAddress()) {
+                if (resetProperties.isIncludeClientIpAddress()) {
                     claims.setStringClaim("client", holder.getClientIpAddress());
                 }
             }

--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
@@ -74,11 +74,11 @@ public class BasePasswordManagementService implements PasswordManagementService 
             }
 
             val holder = ClientInfoHolder.getClientInfo();
-            if (!claims.getStringClaimValue("origin").equals(holder.getServerIpAddress())) {
+            if (properties.getReset().isCheckServerIpAddress() && !claims.getStringClaimValue("origin").equals(holder.getServerIpAddress())) {
                 LOGGER.error("Token origin server IP address does not match CAS");
                 return null;
             }
-            if (!claims.getStringClaimValue("client").equals(holder.getClientIpAddress())) {
+            if (properties.getReset().isCheckClientIpAddress() && !claims.getStringClaimValue("client").equals(holder.getClientIpAddress())) {
                 LOGGER.error("Token client IP address does not match CAS");
                 return null;
             }
@@ -110,8 +110,12 @@ public class BasePasswordManagementService implements PasswordManagementService 
 
             val holder = ClientInfoHolder.getClientInfo();
             if (holder != null) {
-                claims.setStringClaim("origin", holder.getServerIpAddress());
-                claims.setStringClaim("client", holder.getClientIpAddress());
+                if (properties.getReset().isCheckServerIpAddress()) {
+                    claims.setStringClaim("origin", holder.getServerIpAddress());
+                }
+                if (properties.getReset().isCheckClientIpAddress()) {
+                    claims.setStringClaim("client", holder.getClientIpAddress());
+                }
             }
             claims.setSubject(to);
             LOGGER.debug("Creating password management token for [{}]", to);


### PR DESCRIPTION
 # Details

Hello Misagh

When you're using the reset password feature, a Token is generated and sent inside a hyperlink by email or SMS.

The Token contains the client IPaddress who requested the reset and the server IP adress who received it.

If the link is used by another client IP address or processed by another server IP address than the ones contains in the Token, the reset will fail.

Problem: When you're running cas inside a container orchestrator like Kubernetes :
 
* It could be difficult to stick a user to a specific container
* A container could have a very short life (less than the token TTL) because of horizontal autoscaling

This pull request adds the capability to disable the check of the server IP address. It also adds the capability to disable to check of the client IP address if needed.

Let me know if you need any further information.

Regards,
Julien
