### PR TITLE
Fix cas.authn.throttle.appCode property falsy renamed

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -32,17 +32,6 @@
       }
     },
     {
-      "name": "cas.authn.throttle.appcode",
-      "type": "java.lang.String",
-      "description": "Throttling application code to record.",
-      "defaultValue": "CAS",
-      "deprecation": {
-        "replacement": "cas.authn.throttle.app-code",
-        "reason": "Property is renamed to account for new property naming rules",
-        "level": "error"
-      }
-    },
-    {
       "name": "cas.authn.x509.principal-sn-radix",
       "type": "java.lang.Integer",
       "description": "X509 principal extraction config.",


### PR DESCRIPTION
# Details

Hello Misagh,

When you're using the authentication throttling feature [referenced here](https://apereo.github.io/cas/6.1.x/installation/Configuring-Authentication-Throttling.html), the configuration properties are the folowing: 

```
# cas.authn.throttle.usernameParameter=username
# cas.authn.throttle.appCode=CAS

# cas.authn.throttle.failure.threshold=100
# cas.authn.throttle.failure.code=AUTHENTICATION_FAILED
# cas.authn.throttle.failure.rangeSeconds=60
``` 

But when you're starting CAS with this configuration, you will have the following warning message: 

```
WARN [org.springframework.boot.context.properties.migrator.PropertiesMigrationListener] - <
The use of configuration keys that have been renamed was found in the environment:

Property source 'bootstrapProperties':
	Key: cas.authn.throttle.appcode
		Replacement: cas.authn.throttle.app-code

Property source 'migrate-bootstrapProperties':
	Key: cas.authn.throttle.appcode
		Replacement: cas.authn.throttle.app-code


Each configuration key has been temporarily mapped to its replacement for your convenience. To silence this warning, please update your configuration to use the new keys.
```

The cas.authn.throttle.app-code property does not exist and the code and documentation are referring to the appCode key.

This pull request remove appcode from the migrate-bootstrapProperties.

Unless i missed something ?

Regards,
Julien