### PR TITLE
Add Elliptic Curve support for OIDC token signature

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcDefaultJsonWebKeystoreCacheLoader.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcDefaultJsonWebKeystoreCacheLoader.java
@@ -7,7 +7,7 @@ import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwk.JsonWebKeySet;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 import org.springframework.core.io.Resource;
 
 import java.nio.charset.StandardCharsets;
@@ -22,16 +22,16 @@ import java.util.Optional;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class OidcDefaultJsonWebKeystoreCacheLoader implements CacheLoader<String, Optional<RsaJsonWebKey>> {
+public class OidcDefaultJsonWebKeystoreCacheLoader implements CacheLoader<String, Optional<PublicJsonWebKey>> {
     private final Resource jwksFile;
 
-    private static RsaJsonWebKey getJsonSigningWebKeyFromJwks(final JsonWebKeySet jwks) {
+    private static PublicJsonWebKey getJsonSigningWebKeyFromJwks(final JsonWebKeySet jwks) {
         if (jwks.getJsonWebKeys().isEmpty()) {
             LOGGER.warn("No JSON web keys are available in the keystore");
             return null;
         }
 
-        val key = (RsaJsonWebKey) jwks.getJsonWebKeys().get(0);
+        val key = (PublicJsonWebKey) jwks.getJsonWebKeys().get(0);
         if (StringUtils.isBlank(key.getAlgorithm())) {
             LOGGER.debug("Located JSON web key [{}] has no algorithm defined", key);
         }
@@ -102,7 +102,7 @@ public class OidcDefaultJsonWebKeystoreCacheLoader implements CacheLoader<String
     }
 
     @Override
-    public Optional<RsaJsonWebKey> load(final String issuer) {
+    public Optional<PublicJsonWebKey> load(final String issuer) {
         val jwks = buildJsonWebKeySet();
         if (jwks.isEmpty() || jwks.get().getJsonWebKeys().isEmpty()) {
             return Optional.empty();

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeySetUtils.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeySetUtils.java
@@ -11,7 +11,7 @@ import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwk.JsonWebKeySet;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 
@@ -81,13 +81,13 @@ public class OidcJsonWebKeySetUtils {
      * @param jwks the jwks
      * @return the json web key from jwks
      */
-    public static RsaJsonWebKey getJsonWebKeyFromJsonWebKeySet(final JsonWebKeySet jwks) {
+    public static PublicJsonWebKey getJsonWebKeyFromJsonWebKeySet(final JsonWebKeySet jwks) {
         if (jwks.getJsonWebKeys().isEmpty()) {
             LOGGER.warn("No JSON web keys are available in the keystore");
             return null;
         }
 
-        val key = (RsaJsonWebKey) jwks.getJsonWebKeys().get(0);
+        val key = (PublicJsonWebKey) jwks.getJsonWebKeys().get(0);
         if (StringUtils.isBlank(key.getAlgorithm())) {
             LOGGER.warn("Located JSON web key [{}] has no algorithm defined", key);
         }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcServiceJsonWebKeystoreCacheExpirationPolicy.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcServiceJsonWebKeystoreCacheExpirationPolicy.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -22,26 +22,26 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class OidcServiceJsonWebKeystoreCacheExpirationPolicy implements Expiry<OAuthRegisteredService, Optional<RsaJsonWebKey>> {
+public class OidcServiceJsonWebKeystoreCacheExpirationPolicy implements Expiry<OAuthRegisteredService, Optional<PublicJsonWebKey>> {
     private final CasConfigurationProperties casProperties;
 
     @Override
     public long expireAfterCreate(final OAuthRegisteredService oidcRegisteredService,
-                                  final Optional<RsaJsonWebKey> rsaJsonWebKey,
+                                  final Optional<PublicJsonWebKey> rsaJsonWebKey,
                                   final long currentTime) {
         return getExpiration(oidcRegisteredService, currentTime);
     }
 
     @Override
     public long expireAfterUpdate(final OAuthRegisteredService oidcRegisteredService,
-                                  final Optional<RsaJsonWebKey> rsaJsonWebKey,
+                                  final Optional<PublicJsonWebKey> rsaJsonWebKey,
                                   final long currentTime, final long currentDuration) {
         return getExpiration(oidcRegisteredService, currentDuration);
     }
 
     @Override
     public long expireAfterRead(final OAuthRegisteredService oidcRegisteredService,
-                                final Optional<RsaJsonWebKey> rsaJsonWebKey,
+                                final Optional<PublicJsonWebKey> rsaJsonWebKey,
                                 final long currentTime,
                                 final long currentDuration) {
         return getExpiration(oidcRegisteredService, currentDuration);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcServiceJsonWebKeystoreCacheLoader.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcServiceJsonWebKeystoreCacheLoader.java
@@ -8,7 +8,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 
 import java.util.Optional;
 
@@ -20,10 +20,10 @@ import java.util.Optional;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class OidcServiceJsonWebKeystoreCacheLoader implements CacheLoader<OAuthRegisteredService, Optional<RsaJsonWebKey>> {
+public class OidcServiceJsonWebKeystoreCacheLoader implements CacheLoader<OAuthRegisteredService, Optional<PublicJsonWebKey>> {
 
     @Override
-    public Optional<RsaJsonWebKey> load(final @NonNull OAuthRegisteredService service) {
+    public Optional<PublicJsonWebKey> load(final @NonNull OAuthRegisteredService service) {
         if (service instanceof OidcRegisteredService) {
             val svc = (OidcRegisteredService) service;
             val jwks = OidcJsonWebKeySetUtils.getJsonWebKeySet(svc);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileSigningAndEncryptionService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileSigningAndEncryptionService.java
@@ -8,7 +8,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jws.AlgorithmIdentifiers;
 
 import java.util.Optional;
@@ -26,8 +26,8 @@ public class OidcUserProfileSigningAndEncryptionService extends BaseOidcJsonWebK
      */
     public static final String USER_INFO_RESPONSE_ENCRYPTION_ENCODING_DEFAULT = "A128CBC-HS256";
 
-    public OidcUserProfileSigningAndEncryptionService(final LoadingCache<String, Optional<RsaJsonWebKey>> defaultJsonWebKeystoreCache,
-                                                      final LoadingCache<OAuthRegisteredService, Optional<RsaJsonWebKey>> serviceJsonWebKeystoreCache,
+    public OidcUserProfileSigningAndEncryptionService(final LoadingCache<String, Optional<PublicJsonWebKey>> defaultJsonWebKeystoreCache,
+                                                      final LoadingCache<OAuthRegisteredService, Optional<PublicJsonWebKey>> serviceJsonWebKeystoreCache,
                                                       final String issuer) {
         super(defaultJsonWebKeystoreCache, serviceJsonWebKeystoreCache, issuer);
     }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/BaseOidcJsonWebKeyTokenSigningAndEncryptionService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/BaseOidcJsonWebKeyTokenSigningAndEncryptionService.java
@@ -12,7 +12,6 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.jose4j.jwk.PublicJsonWebKey;
-import org.jose4j.jwk.RsaJsonWebKey;
 import org.jose4j.jwt.JwtClaims;
 
 import java.util.Objects;
@@ -29,14 +28,14 @@ public abstract class BaseOidcJsonWebKeyTokenSigningAndEncryptionService extends
     /**
      * The default keystore for OIDC tokens.
      */
-    protected final LoadingCache<String, Optional<RsaJsonWebKey>> defaultJsonWebKeystoreCache;
+    protected final LoadingCache<String, Optional<PublicJsonWebKey>> defaultJsonWebKeystoreCache;
     /**
      * The service keystore for OIDC tokens.
      */
-    protected final LoadingCache<OAuthRegisteredService, Optional<RsaJsonWebKey>> serviceJsonWebKeystoreCache;
+    protected final LoadingCache<OAuthRegisteredService, Optional<PublicJsonWebKey>> serviceJsonWebKeystoreCache;
 
-    public BaseOidcJsonWebKeyTokenSigningAndEncryptionService(final LoadingCache<String, Optional<RsaJsonWebKey>> defaultJsonWebKeystoreCache,
-                                                              final LoadingCache<OAuthRegisteredService, Optional<RsaJsonWebKey>> serviceJsonWebKeystoreCache,
+    public BaseOidcJsonWebKeyTokenSigningAndEncryptionService(final LoadingCache<String, Optional<PublicJsonWebKey>> defaultJsonWebKeystoreCache,
+                                                              final LoadingCache<OAuthRegisteredService, Optional<PublicJsonWebKey>> serviceJsonWebKeystoreCache,
                                                               final String issuer) {
         super(issuer);
         this.defaultJsonWebKeystoreCache = defaultJsonWebKeystoreCache;

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenSigningAndEncryptionService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenSigningAndEncryptionService.java
@@ -7,7 +7,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jws.AlgorithmIdentifiers;
 
 import java.util.Optional;
@@ -21,8 +21,8 @@ import java.util.Optional;
 @Slf4j
 public class OidcIdTokenSigningAndEncryptionService extends BaseOidcJsonWebKeyTokenSigningAndEncryptionService {
 
-    public OidcIdTokenSigningAndEncryptionService(final LoadingCache<String, Optional<RsaJsonWebKey>> defaultJsonWebKeystoreCache,
-                                                  final LoadingCache<OAuthRegisteredService, Optional<RsaJsonWebKey>> serviceJsonWebKeystoreCache,
+    public OidcIdTokenSigningAndEncryptionService(final LoadingCache<String, Optional<PublicJsonWebKey>> defaultJsonWebKeystoreCache,
+                                                  final LoadingCache<OAuthRegisteredService, Optional<PublicJsonWebKey>> serviceJsonWebKeystoreCache,
                                                   final String issuer) {
         super(defaultJsonWebKeystoreCache, serviceJsonWebKeystoreCache, issuer);
     }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcRegisteredServiceJwtAccessTokenCipherExecutor.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcRegisteredServiceJwtAccessTokenCipherExecutor.java
@@ -16,7 +16,7 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers;
 import org.jose4j.jwk.JsonWebKey;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 
 import java.io.Serializable;
 import java.security.Key;
@@ -35,11 +35,11 @@ public class OidcRegisteredServiceJwtAccessTokenCipherExecutor extends OAuth20Re
     /**
      * The default keystore for OIDC tokens.
      */
-    protected final LoadingCache<String, Optional<RsaJsonWebKey>> defaultJsonWebKeystoreCache;
+    protected final LoadingCache<String, Optional<PublicJsonWebKey>> defaultJsonWebKeystoreCache;
     /**
      * The service keystore for OIDC tokens.
      */
-    protected final LoadingCache<OAuthRegisteredService, Optional<RsaJsonWebKey>> serviceJsonWebKeystoreCache;
+    protected final LoadingCache<OAuthRegisteredService, Optional<PublicJsonWebKey>> serviceJsonWebKeystoreCache;
 
     /**
      * OIDC issuer.

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -112,7 +112,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
@@ -576,7 +576,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public LoadingCache<OAuthRegisteredService, Optional<RsaJsonWebKey>> oidcServiceJsonWebKeystoreCache() {
+    public LoadingCache<OAuthRegisteredService, Optional<PublicJsonWebKey>> oidcServiceJsonWebKeystoreCache() {
         return Caffeine.newBuilder()
             .maximumSize(1)
             .expireAfter(new OidcServiceJsonWebKeystoreCacheExpirationPolicy(casProperties))
@@ -584,7 +584,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public LoadingCache<String, Optional<RsaJsonWebKey>> oidcDefaultJsonWebKeystoreCache() {
+    public LoadingCache<String, Optional<PublicJsonWebKey>> oidcDefaultJsonWebKeystoreCache() {
         val oidc = casProperties.getAuthn().getOidc();
         return Caffeine.newBuilder().maximumSize(1)
             .expireAfterWrite(oidc.getJwksCacheInMinutes(), TimeUnit.MINUTES)
@@ -597,7 +597,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public CacheLoader<OAuthRegisteredService, Optional<RsaJsonWebKey>> oidcServiceJsonWebKeystoreCacheLoader() {
+    public CacheLoader<OAuthRegisteredService, Optional<PublicJsonWebKey>> oidcServiceJsonWebKeystoreCacheLoader() {
         return new OidcServiceJsonWebKeystoreCacheLoader();
     }
 

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
@@ -67,7 +67,7 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwe.ContentEncryptionAlgorithmIdentifiers;
 import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers;
-import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.NumericDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -176,7 +176,7 @@ public abstract class AbstractOidcTests {
 
     @Autowired
     @Qualifier("oidcDefaultJsonWebKeystoreCache")
-    protected LoadingCache<String, Optional<RsaJsonWebKey>> oidcDefaultJsonWebKeystoreCache;
+    protected LoadingCache<String, Optional<PublicJsonWebKey>> oidcDefaultJsonWebKeystoreCache;
 
     @Autowired
     @Qualifier("oidcTokenSigningAndEncryptionService")
@@ -184,7 +184,7 @@ public abstract class AbstractOidcTests {
 
     @Autowired
     @Qualifier("oidcServiceJsonWebKeystoreCache")
-    protected LoadingCache<OAuthRegisteredService, Optional<RsaJsonWebKey>> oidcServiceJsonWebKeystoreCache;
+    protected LoadingCache<OAuthRegisteredService, Optional<PublicJsonWebKey>> oidcServiceJsonWebKeystoreCache;
 
     @Autowired
     @Qualifier("oidcJsonWebKeystoreGeneratorService")

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/authn/OidcPrivateKeyJwtAuthenticatorTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/authn/OidcPrivateKeyJwtAuthenticatorTests.java
@@ -53,7 +53,7 @@ public class OidcPrivateKeyJwtAuthenticatorTests extends AbstractOidcTests {
         val claims = getClaims(registeredService.getClientId(), registeredService.getClientId(),
             registeredService.getClientId(), audience);
         val webKey = oidcServiceJsonWebKeystoreCache.get(registeredService).get();
-        val jwt = EncodingUtils.signJwsRSASha512(webKey.getRsaPrivateKey(), claims.toJson().getBytes(StandardCharsets.UTF_8), Map.of());
+        val jwt = EncodingUtils.signJwsRSASha512(webKey.getPrivateKey(), claims.toJson().getBytes(StandardCharsets.UTF_8), Map.of());
         val credentials = new UsernamePasswordCredentials(OAuth20Constants.CLIENT_ASSERTION_TYPE_JWT_BEARER,
             new String(jwt, StandardCharsets.UTF_8));
 


### PR DESCRIPTION
Hello Misagh,

When you're generating a keystore.jwks file with a EC key like this one:

```
{
    "keys": [
        {
            "kty": "EC",
            "d": "RmIrX6aZ-5ttAFtFCz-K4INVFGdII2VPg-gOWMLYqr4",
            "use": "sig",
            "crv": "P-256",
            "kid": "pouet",
            "x": "5MuRs_uRY86eBblVqHKsHjin_VhBSX_Robg8E1GyfH8",
            "y": "v7FD3O-XVzF1R2QbR7d75XlDBtU22pR-u1WkSSAhlo0",
            "alg": "ES256"
        }
    ]
}
```

And configure your service to use it:

```
{
  "@class" : "org.apereo.cas.services.OidcRegisteredService",
  "clientId": "test",
  "serviceId" : "http://test",
  "name": "TEST",
  "id": 1000,
  "scopes" : [ "java.util.HashSet", 
    [ "profile", "email", "offline_access" ]
  ],
  "idTokenSigningAlg": "ES256",
  "userInfoSigningAlg": "ES256"
}
```

You'll have the following error when you'll try to get the id_token (or the signed userinfo):

```
2020-02-16 19:18:52,673 DEBUG [org.apereo.cas.oidc.jwks.OidcDefaultJsonWebKeystoreCacheLoader] - <class org.jose4j.jwk.EllipticCurveJsonWebKey cannot be cast to class org.jose4j.jwk.RsaJsonWebKey (org.jose4j.jwk.EllipticCurveJsonWebKey and org.jose4j.jwk.RsaJsonWebKey are in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @62f87c44)>
java.lang.ClassCastException: class org.jose4j.jwk.EllipticCurveJsonWebKey cannot be cast to class org.jose4j.jwk.RsaJsonWebKey (org.jose4j.jwk.EllipticCurveJsonWebKey and org.jose4j.jwk.RsaJsonWebKey are in unnamed module of loader org.apache.catalina.loader..
```

This pull request adds support for OIDC token signature with an EC key.

Regards,
Julien