### PR TITLE
removed unnecessary synchronized method

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/attribute/DefaultAttributeDefinitionStore.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/attribute/DefaultAttributeDefinitionStore.java
@@ -15,7 +15,6 @@ import lombok.SneakyThrows;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.DisposableBean;
@@ -80,7 +79,7 @@ public class DefaultAttributeDefinitionStore implements AttributeDefinitionStore
 
     private void loadAttributeDefinitionsFromInputStream(final Resource resource) throws IOException {
         LOGGER.trace("Loading attribute definitions from [{}]", resource);
-        val json = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
+        val json = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         LOGGER.trace("Loaded attribute definitions [{}] from [{}]", json, resource);
         val map = MAPPER.readValue(json, new TypeReference<Map<String, AttributeDefinition>>() {
         });

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolver.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/PersonDirectoryPrincipalResolver.java
@@ -93,9 +93,9 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
 
     /**
      * Map to store objects to synchronize on for retrieval of attributes one at a time per user.
-     * Needs to be ConcurrentHashMap because it is added to and removed from in two different methods
-     * synchronized on different objects.
+     * Needs to be ConcurrentHashMap because it is updated in multiple threads.
      */
+    @ToString.Exclude
     protected Map<String, PersonAttributeRetriever> retrieverMap = new ConcurrentHashMap<>();
 
     public PersonDirectoryPrincipalResolver() {
@@ -266,7 +266,7 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
     }
 
     /**
-     * Retrieve person attributes map.
+     * Retrieve person attributes map synchronizing on a specific user.
      *
      * @param principalId the principal id
      * @param credential  the credential whose id we have extracted. This is passed so that implementations
@@ -274,22 +274,10 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
      * @return the map
      */
     protected Map<String, List<Object>> retrievePersonAttributes(final String principalId, final Credential credential) {
-        val retriever = getPersonAttributeRetriever(principalId, credential);
-        return retriever.retrievePersonAttributes();
-    }
-
-    /**
-     * This method is synchronized on this singleton but doesn't do anything expensive.
-     *
-     * The object returned from this method is specific to a user and it allows attribute retrieval to be synchronized
-     * on a user (so the same attributes are not retrieved multiple times for the same user and attribute cache can be employed.
-     * @param principalId User principal id
-     * @param credential User credentials
-     * @return PersonAttributeRetriever for given principal id
-     */
-    @Synchronized
-    protected PersonAttributeRetriever getPersonAttributeRetriever(final String principalId, final Credential credential) {
-        return retrieverMap.computeIfAbsent(principalId, s -> new PersonAttributeRetriever(principalId, credential));
+        val retriever = retrieverMap.computeIfAbsent(principalId, s -> new PersonAttributeRetriever(principalId, credential));
+        Map<String, List<Object>> personAttributes = retriever.retrievePersonAttributes();
+        retrieverMap.remove(principalId);
+        return personAttributes;
     }
 
     /**
@@ -336,9 +324,7 @@ public class PersonDirectoryPrincipalResolver implements PrincipalResolver {
 
         @Synchronized
         protected Map<String, List<Object>> retrievePersonAttributes() {
-            Map<String, List<Object>> attributes = CoreAuthenticationUtils.retrieveAttributesFromAttributeRepository(attributeRepository, principalId, activeAttributeRepositoryIdentifiers);
-            retrieverMap.remove(principalId);
-            return attributes;
+            return CoreAuthenticationUtils.retrieveAttributesFromAttributeRepository(attributeRepository, principalId, activeAttributeRepositoryIdentifiers);
         }
     }
 


### PR DESCRIPTION
This is a minor cleanup you suggested, although if you think we should get rid of the PersonAttributeRetriever altogether, let me know. 