### PR TITLE
fix DefaultTicketCatalog

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketCatalog.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketCatalog.java
@@ -43,7 +43,7 @@ public class DefaultTicketCatalog implements TicketCatalog {
     @Override
     public TicketDefinition find(final Ticket ticket) {
         LOGGER.trace("Locating ticket definition for ticket [{}]", ticket);
-        return find(ticket.getPrefix());
+        return find(ticket.getId());
     }
 
     @Override

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -262,9 +262,9 @@ public abstract class BaseTicketRegistryTests {
         val tickets = new ArrayList<Ticket>();
 
         for (var i = 0; i < TICKETS_IN_REGISTRY; i++) {
-            val ticketGrantingTicket = new TicketGrantingTicketImpl(ticketGrantingTicketId + i,
+            val ticketGrantingTicket = new TicketGrantingTicketImpl(ticketGrantingTicketId + "-" + i,
                 CoreAuthenticationTestUtils.getAuthentication(), NeverExpiresExpirationPolicy.INSTANCE);
-            val st = ticketGrantingTicket.grantServiceTicket("ST" + i,
+            val st = ticketGrantingTicket.grantServiceTicket("ST-" + i,
                 RegisteredServiceTestUtils.getService(),
                 NeverExpiresExpirationPolicy.INSTANCE, false, true);
             tickets.add(ticketGrantingTicket);
@@ -292,9 +292,9 @@ public abstract class BaseTicketRegistryTests {
         for (int i = 0; i < TICKETS_IN_REGISTRY; i++) {
             val a = CoreAuthenticationTestUtils.getAuthentication();
             val s = RegisteredServiceTestUtils.getService();
-            val ticketGrantingTicket = new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX + i,
+            val ticketGrantingTicket = new TicketGrantingTicketImpl(TicketGrantingTicket.PREFIX + "-" + i,
                 a, NeverExpiresExpirationPolicy.INSTANCE);
-            val st = ticketGrantingTicket.grantServiceTicket("ST" + i,
+            val st = ticketGrantingTicket.grantServiceTicket("ST-" + i,
                 s,
                 NeverExpiresExpirationPolicy.INSTANCE, false, true);
             tgts.add(ticketGrantingTicket);

--- a/support/cas-server-support-ehcache-monitor/src/test/java/org/apereo/cas/monitor/EhCacheHealthIndicatorTests.java
+++ b/support/cas-server-support-ehcache-monitor/src/test/java/org/apereo/cas/monitor/EhCacheHealthIndicatorTests.java
@@ -65,7 +65,7 @@ public class EhCacheHealthIndicatorTests {
          * above 10% free WARN threshold
          */
         IntStream.range(0, 95)
-            .forEach(i -> this.ticketRegistry.addTicket(new MockServiceTicket("T" + i, RegisteredServiceTestUtils.getService(),
+            .forEach(i -> this.ticketRegistry.addTicket(new MockServiceTicket("ST-" + i, RegisteredServiceTestUtils.getService(),
                 new MockTicketGrantingTicket("test"))));
 
         status = monitor.health();
@@ -76,7 +76,7 @@ public class EhCacheHealthIndicatorTests {
          * which should report WARN status
          */
         IntStream.range(95, 110).forEach(i -> {
-            val st = new MockServiceTicket("T" + i, RegisteredServiceTestUtils.getService(),
+            val st = new MockServiceTicket("ST-" + i, RegisteredServiceTestUtils.getService(),
                 new MockTicketGrantingTicket("test"));
             this.ticketRegistry.addTicket(st);
         });


### PR DESCRIPTION
When using the simple MFA + the Hazelcast tickets registry, I noticed it didn't work because there was an issue with the `DefaultTicketCatalog`.

Here is the fix.
