### PR TITLE
Fix OIDC logout

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/logout/LogoutProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/logout/LogoutProperties.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.configuration.model.core.logout;
 
+import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import lombok.Getter;
@@ -25,7 +26,7 @@ public class LogoutProperties implements Serializable {
      * is indicated and extracted by a parameter name of your choosing here. If none specified,
      * the default will be used as {@code service}.
      */
-    private String redirectParameter;
+    private String redirectParameter = CasProtocolConstants.PARAMETER_SERVICE;
 
     /**
      * Whether CAS should be allowed to redirect to an alternative location after logout.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/logout/LogoutProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/logout/LogoutProperties.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.configuration.model.core.logout;
 
-import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import lombok.Getter;
@@ -26,7 +25,7 @@ public class LogoutProperties implements Serializable {
      * is indicated and extracted by a parameter name of your choosing here. If none specified,
      * the default will be used as {@code service}.
      */
-    private String redirectParameter = CasProtocolConstants.PARAMETER_SERVICE;
+    private String redirectParameter = "service";
 
     /**
      * Whether CAS should be allowed to redirect to an alternative location after logout.

--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/logout/LogoutAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/logout/LogoutAction.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.web.flow.logout;
 
-import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.model.core.logout.LogoutProperties;
@@ -52,7 +51,7 @@ public class LogoutAction extends AbstractLogoutAction {
             () -> Boolean.FALSE)
             .get();
 
-        val paramName = StringUtils.defaultIfEmpty(logoutProperties.getRedirectParameter(), CasProtocolConstants.PARAMETER_SERVICE);
+        val paramName = logoutProperties.getRedirectParameter();
         LOGGER.trace("Using parameter name [{}] to detect destination service, if any", paramName);
         val service = request.getParameter(paramName);
         LOGGER.trace("Located target service [{}] for redirection after logout", service);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/logout/OidcLogoutEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/logout/OidcLogoutEndpointController.java
@@ -79,7 +79,7 @@ public class OidcLogoutEndpointController extends BaseOAuth20Controller {
             if (urls.isEmpty()) {
                 return getLogoutRedirectView(state, null);
             }
-            return getLogoutRedirectView(state, urls.toArray()[0].toString());
+            return getLogoutRedirectView(state, urls.iterator().next().getUrl());
         }
 
         return getLogoutRedirectView(state, null);
@@ -91,7 +91,7 @@ public class OidcLogoutEndpointController extends BaseOAuth20Controller {
             builder.queryParam(getOAuthConfigurationContext().getCasProperties().getLogout().getRedirectParameter(), redirectUrl);
         }
         if (StringUtils.isNotBlank(state)) {
-            builder.queryParam(OAuth20Constants.STATE, redirectUrl);
+            builder.queryParam(OAuth20Constants.STATE, state);
         }
         val logoutUrl = builder.build().toUriString();
         return new RedirectView(logoutUrl);

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/OidcTestsSuite.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/OidcTestsSuite.java
@@ -30,6 +30,7 @@ import org.apereo.cas.oidc.util.OidcAuthorizationRequestSupportTests;
 import org.apereo.cas.oidc.web.OidcAccessTokenResponseGeneratorTests;
 import org.apereo.cas.oidc.web.controllers.OidcIntrospectionEndpointControllerTests;
 import org.apereo.cas.oidc.web.controllers.OidcWellKnownEndpointControllerTests;
+import org.apereo.cas.oidc.web.controllers.logout.OidcLogoutEndpointControllerTests;
 import org.apereo.cas.oidc.web.flow.OidcAuthenticationContextWebflowEventResolverTests;
 import org.apereo.cas.oidc.web.flow.OidcRegisteredServiceUIActionTests;
 
@@ -66,6 +67,7 @@ import org.junit.runner.RunWith;
     OidcUserProfileViewRendererFlatTests.class,
     OidcAccessTokenResponseGeneratorTests.class,
     OidcIntrospectionEndpointControllerTests.class,
+    OidcLogoutEndpointControllerTests.class,
     OidcRestfulWebFingerUserInfoRepositoryTests.class,
     OidcAddressScopeAttributeReleasePolicyTests.class,
     OidcCustomScopeAttributeReleasePolicyTests.class,

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
@@ -36,6 +36,7 @@ import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettings;
 import org.apereo.cas.oidc.jwks.OidcJsonWebKeystoreGeneratorService;
 import org.apereo.cas.services.OidcRegisteredService;
 import org.apereo.cas.services.RegisteredServiceCipherExecutor;
+import org.apereo.cas.services.RegisteredServiceLogoutType;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServiceRegistryListener;
 import org.apereo.cas.services.ServicesManager;
@@ -252,6 +253,8 @@ public abstract class AbstractOidcTests {
         svc.setInformationUrl("info");
         svc.setPrivacyUrl("privacy");
         svc.setJwks("classpath:keystore.jwks");
+        svc.setLogoutUrl("https://oauth.example.org/logout,https://logout");
+        svc.setLogoutType(RegisteredServiceLogoutType.BACK_CHANNEL);
         svc.setScopes(CollectionUtils.wrapSet(OidcConstants.StandardScopes.EMAIL.getScope(),
             OidcConstants.StandardScopes.PROFILE.getScope()));
         return svc;

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/controllers/OidcLogoutEndpointControllerTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/controllers/OidcLogoutEndpointControllerTests.java
@@ -1,0 +1,122 @@
+package org.apereo.cas.oidc.web.controllers.logout;
+
+import org.apereo.cas.oidc.AbstractOidcTests;
+
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.view.RedirectView;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link OidcLogoutEndpointControllerTests}.
+ *
+ * @author Julien Huon
+ * @since 6.1.0
+ */
+@Tag("OIDC")
+public class OidcLogoutEndpointControllerTests extends AbstractOidcTests {
+    @Autowired
+    @Qualifier("oidcLogoutEndpointController")
+    protected OidcLogoutEndpointController oidcLogoutEndpointController;
+
+    @Test
+    public void verifyOidcLogoutWithoutParams() {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        val result = oidcLogoutEndpointController.handleRequestInternal(StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY, request, response);
+        assertTrue(result instanceof RedirectView);
+
+        val redirectView = (RedirectView) result;
+        val redirectUrl = redirectView.getUrl();
+        assertEquals("https://cas.example.org:8443/cas/logout", redirectUrl);
+    }
+
+    @Test
+    public void verifyOidcLogoutWithStateParam() {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        val result = oidcLogoutEndpointController.handleRequestInternal(StringUtils.EMPTY, "abcd1234", StringUtils.EMPTY, request, response);
+        assertTrue(result instanceof RedirectView);
+
+        val redirectView = (RedirectView) result;
+        val redirectUrl = redirectView.getUrl();
+        assertEquals("https://cas.example.org:8443/cas/logout?state=abcd1234", redirectUrl);
+    }
+
+    @Test
+    public void verifyOidcLogoutWithIdTokenParam() {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        val claims = getClaims();
+        val oidcRegisteredService = getOidcRegisteredService(true, false);
+        val idToken = oidcTokenSigningAndEncryptionService.encode(oidcRegisteredService, claims);
+
+        val result = oidcLogoutEndpointController.handleRequestInternal(StringUtils.EMPTY, StringUtils.EMPTY, idToken, request, response);
+        assertTrue(result instanceof RedirectView);
+
+        val redirectView = (RedirectView) result;
+        val redirectUrl = redirectView.getUrl();
+        assertEquals("https://cas.example.org:8443/cas/logout?service=https://oauth.example.org/logout", redirectUrl);
+    }
+
+    @Test
+    public void verifyOidcLogoutWithIdTokenAndStateParams() {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        val claims = getClaims();
+        val oidcRegisteredService = getOidcRegisteredService(true, false);
+        val idToken = oidcTokenSigningAndEncryptionService.encode(oidcRegisteredService, claims);
+
+        val result = oidcLogoutEndpointController.handleRequestInternal(StringUtils.EMPTY, "abcd1234", idToken, request, response);
+        assertTrue(result instanceof RedirectView);
+
+        val redirectView = (RedirectView) result;
+        val redirectUrl = redirectView.getUrl();
+        assertEquals("https://cas.example.org:8443/cas/logout?service=https://oauth.example.org/logout&state=abcd1234", redirectUrl);
+    }
+
+    @Test
+    public void verifyOidcLogoutWithIdTokenAndValidPostLogoutRedirectUrlParams() {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        val claims = getClaims();
+        val oidcRegisteredService = getOidcRegisteredService(true, false);
+        val idToken = oidcTokenSigningAndEncryptionService.encode(oidcRegisteredService, claims);
+
+        val result = oidcLogoutEndpointController.handleRequestInternal("https://logout", "abcd1234", idToken, request, response);
+        assertTrue(result instanceof RedirectView);
+
+        val redirectView = (RedirectView) result;
+        val redirectUrl = redirectView.getUrl();
+        assertEquals("https://cas.example.org:8443/cas/logout?service=https://logout&state=abcd1234", redirectUrl);
+    }
+
+    @Test
+    public void verifyOidcLogoutWithIdTokenAndInvalidPostLogoutRedirectUrlParams() {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        val claims = getClaims();
+        val oidcRegisteredService = getOidcRegisteredService(true, false);
+        val idToken = oidcTokenSigningAndEncryptionService.encode(oidcRegisteredService, claims);
+
+        val result = oidcLogoutEndpointController.handleRequestInternal("https://invalidlogouturl", "abcd1234", idToken, request, response);
+        assertTrue(result instanceof RedirectView);
+
+        val redirectView = (RedirectView) result;
+        val redirectUrl = redirectView.getUrl();
+        assertEquals("https://cas.example.org:8443/cas/logout?service=https://oauth.example.org/logout&state=abcd1234", redirectUrl);
+    }
+}


### PR DESCRIPTION
Hello Misagh,

The OIDC RP-initiated logout [describe here](https://openid.net/specs/openid-connect-session-1_0.html#RPLogout) seems broken in CAS if you're using any of the specified parameters.

This pull request fixes the oidc logout and adds unit tests to avoid any future problem. the following bugs are fixed:

### State Parameter
The state parameter is never returned:

```
> GET /cas/oidc/logout?state=fefefe HTTP/1.1
< Location: http://cas.example.org:8080/cas/logout?state
```

### RedirectParameter is not defaulted to service
If you're not setting the following property in your cas.properties:

```
cas.logout.redirectParameter=service
```

When you're sending a valid id token, the following error will appears:

```
2020-02-21 11:53:16,056 DEBUG [org.apereo.cas.logout.slo.DefaultSingleLogoutServiceLogoutUrlBuilder] - <Logout request will be sent to [http://logout,http://pouet] for service [AbstractWebApplicationService(id=svod, originalUrl=svod, artifactId=null, principal=null, source=null, loggedOutAlready=false, format=XML, attributes={})]>
2020-02-21 11:53:16,071 DEBUG [org.apereo.cas.web.FlowExecutionExceptionResolver] - <Ignoring the received exception [java.lang.IllegalArgumentException: Name must not be null] due to a type mismatch with handler [org.apereo.cas.oidc.web.controllers.logout.OidcLogoutEndpointController#handleRequestInternal(String, String, String, HttpServletRequest, HttpServletResponse)]>
2020-02-21 11:53:16,073 DEBUG [org.apereo.cas.web.FlowExecutionExceptionResolver] - <Ignoring the received exception [java.lang.IllegalArgumentException: Name must not be null] due to a type mismatch with handler [org.apereo.cas.oidc.web.controllers.logout.OidcLogoutEndpointController#handleRequestInternal(String, String, String, HttpServletRequest, HttpServletResponse)]>
2020-02-21 11:53:16,076 ERROR [org.springframework.boot.web.servlet.support.ErrorPageFilter] - <Forwarding to error page from request [/oidc/logout] due to exception [Name must not be null]>

```

And you will never be redirected.


### The redirect url is not correctly formatted when you're not using post_logout_redirect_uri

If you're sending a request with an id_token but without post_logout_redirect_uri, cas will redirect you to an invalid url:

```
> GET /cas/oidc/logout?id_token_hint=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InBvdWV0In0.eyJqdGkiOiJUR1QtMS1rZFZmOGMyU1BsZmJCMFFURU9LNllaNWMxVVpKNDJIUGpFbW10UnluSTFNMFBkaXpaa2hLYXFYaWNmay1HNjdOLW9nLWEwZmYwYTAxYzVhYiIsImlzcyI6Imh0dHA6Ly9jYXMuZXhhbXBsZS5vcmc6ODA4MC9jYXMvb2lkYyIsImF1ZCI6InN2b2QiLCJleHAiOjE1ODIzMTYxNTMsImlhdCI6MTU4MjI4NzM1MywibmJmIjoxNTgyMjg3MDUzLCJzdWIiOiJwb3VldCIsImNsaWVudF9pZCI6InN2b2QiLCJhdXRoX3RpbWUiOjE1ODIyODczNDUsInN0YXRlIjoiRTRIM0NJOUM5elQ5T0ZBeDd5dU9FZyIsIm5vbmNlIjoiIiwiYXRfaGFzaCI6Ii01ZXF6V1JLWTZYZ0g5Zm9PQTFXWUEiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJwb3VldCJ9.1_0Kdo6h_Pw73Z5aN0OOnt1sVLXPX1AMwy4Er2o1ZB-wtX6Ua3uOSFsFsSQKUMf6jRsi0JwfdB44ICiVvKfVQQ&state=fefefe HTTP/1.1

< Location: http://cas.example.org:8080/cas/logout?service=org.apereo.cas.logout.slo.SingleLogoutUrl@b123286f&state=org.apereo.cas.logout.slo.SingleLogoutUrl@b123286f
```

Notice the state parameter value.

Regards,
Julien


