### PR TITLE
fix some typos in configuration metadata JSON

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,13 +1,13 @@
 {
   "properties": [
     {
-      "name": "cas.session-seplication.session-cookie-name",
+      "name": "cas.session-replication.session-cookie-name",
       "type": "java.lang.String",
       "description": "Choose the name of the cookie for session replication.",
       "defaultValue": "DISSESSION",
       "deprecation": {
-        "replacement": "cas.session-seplication.cookie.name",
-        "reason": "Cooki settings are moved to a new cookie namespace under cas.session-seplication",
+        "replacement": "cas.session-replication.cookie.name",
+        "reason": "Cookie settings are moved to a new cookie namespace under cas.session-replication.",
         "level": "error"
       }
     },
@@ -54,8 +54,7 @@
     {
       "name": "cas.authn.saml-idp.scope",
       "type": "java.lang.String",
-      "description": "Definition of scope for CAS acting as a SAML IdP",
-      "deprecated": true,
+      "description": "Definition of scope for CAS acting as a SAML IdP.",
       "deprecation": {
         "replacement": "cas.server.scope",
         "reason": "Property is moved to cas.server.scope to be applied globally.",


### PR DESCRIPTION
Typos in additional-spring-configuration-metadata.json - seplication -> replication

Also remove "deprecated: true" from another entry because Intellij said it was bad and it appears out of place (i.e. deprecation block implies deprecated) so I assume it doesn't need to be there. 