### PR TITLE
OIDC Discovery : code_challenge_methods_supported support

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oidc/OidcProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oidc/OidcProperties.java
@@ -176,6 +176,11 @@ public class OidcProperties implements Serializable {
         Stream.of("client_secret_basic", "client_secret_post", "client_secret_jwt", "private_key_jwt").collect(Collectors.toList());
 
     /**
+     * List of PKCE code challenge methods supported.
+     */
+    private List<String> codeChallengeMethodsSupported = Stream.of("plain", "S256").collect(Collectors.toList());
+
+    /**
      * OIDC webfinger protocol settings.
      */
     @NestedConfigurationProperty

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3408,6 +3408,7 @@ Allow CAS to become an OpenID Connect provider (OP). To learn more about this to
 # cas.authn.oidc.claimTypesSupported=normal
 # cas.authn.oidc.grantTypesSupported=authorization_code,password,client_credentials,refresh_token
 # cas.authn.oidc.tokenEndpointAuthMethodsSupported=client_secret_basic,client_secret_post,private_key_jwt,client_secret_jwt
+# cas.authn.oidc.codeChallengeMethodsSupported=plain,S256
 
 # cas.authn.oidc.idTokenSigningAlgValuesSupported=none,RS256,RS384,RS512,PS256,PS384,PS512,ES256,ES384,ES512,HS256,HS384,HS512
 # cas.authn.oidc.idTokenEncryptionAlgValuesSupported=RSA1_5,RSA-OAEP,RSA-OAEP-256,A128KW,A192KW,A256KW,\

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettings.java
@@ -65,6 +65,9 @@ public class OidcServerDiscoverySettings {
     @JsonProperty("token_endpoint_auth_methods_supported")
     private List<String> tokenEndpointAuthMethodsSupported;
 
+    @JsonProperty("code_challenge_methods_supported")
+    private List<String> codeChallengeMethodsSupported;
+
     @JsonProperty("claims_parameter_supported")
     private boolean claimsParameterSupported = true;
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettingsFactory.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/OidcServerDiscoverySettingsFactory.java
@@ -37,7 +37,8 @@ public class OidcServerDiscoverySettingsFactory implements FactoryBean<OidcServe
         discoveryProperties.setUserInfoSigningAlgValuesSupported(oidc.getUserInfoSigningAlgValuesSupported());
         discoveryProperties.setUserInfoEncryptionAlgValuesSupported(oidc.getUserInfoEncryptionAlgValuesSupported());
         discoveryProperties.setUserInfoEncryptionEncodingValuesSupported(oidc.getUserInfoEncryptionEncodingValuesSupported());
-        
+        discoveryProperties.setCodeChallengeMethodsSupported(oidc.getCodeChallengeMethodsSupported());
+
         return discoveryProperties;
     }
 


### PR DESCRIPTION
Hello Misagh,

The OIDC discovery endpoint from CAS doesn't currently support the [code_challenge_methods_supported](https://tools.ietf.org/html/rfc8414#section-2) parameter.

This pull request adds support for this metadata parameter in the discovery endpoint.

Regards,
Julien