### PR TITLE
[docs] Update custom Authentication Interrupt documentation

### DIFF
--- a/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt.md
+++ b/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt.md
@@ -148,6 +148,7 @@ package org.apereo.cas.support.interrupt;
 @Configuration("myInterruptConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class MyInterruptConfiguration {
+    @Bean
     public InterruptInquirer interruptInquirer() {
       ...
     }

--- a/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt.md
+++ b/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt.md
@@ -148,9 +148,15 @@ package org.apereo.cas.support.interrupt;
 @Configuration("myInterruptConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class MyInterruptConfiguration {
-    @Bean
     public InterruptInquirer interruptInquirer() {
       ...
+    }
+
+    @Bean
+    public InterruptInquiryExecutionPlanConfigurer myInterruptInquiryExecutionPlanConfigurer() {
+        return plan -> {
+            plan.registerInterruptInquirer(interruptInquirer());
+        };
     }
 }
 ```


### PR DESCRIPTION
Current documentation for custom Authentication Interrupt is not working.
Declare @Bean for "InterruptInquirer" disable "InterruptInquiryExecutionPlan" bean.
If custom "InterruptInquirer" is not registered in "ExecutionPlanConfigurer" nothing happen.
