### PR TITLE
Upgrade ldaptive to v2.0.0-RC3

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -71,7 +71,7 @@ public abstract class AbstractLdapProperties implements Serializable {
     /**
      * Whether to use a pooled connection factory in components.
      */
-    private boolean disablePooling = false;
+    private boolean disablePooling;
 
     /**
      * Minimum LDAP connection pool size.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -69,6 +69,11 @@ public abstract class AbstractLdapProperties implements Serializable {
     private String trustStoreType;
 
     /**
+     * Whether to use a pooled connection factory in components.
+     */
+    private boolean disablePooling = false;
+
+    /**
      * Minimum LDAP connection pool size.
      * Size the pool should be initialized to and pruned to
      */
@@ -291,10 +296,6 @@ public abstract class AbstractLdapProperties implements Serializable {
          * No passivator.
          */
         NONE,
-        /**
-         * Close passivator.
-         */
-        CLOSE,
         /**
          * Bind passivator.
          */

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -1161,6 +1161,7 @@ The following  options apply  to features that integrate with an LDAP server (i.
 #${configurationKey}.keystore=
 #${configurationKey}.keystorePassword=
 #${configurationKey}.keystoreType=JKS|JCEKS|PKCS12
+#${configurationKey}.disablePooling=false
 #${configurationKey}.minPoolSize=3
 #${configurationKey}.maxPoolSize=10
 #${configurationKey}.validateOnCheckout=true

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -1151,7 +1151,7 @@ The following  options apply  to features that integrate with an LDAP server (i.
 #${configurationKey}.bindDn=cn=Directory Manager,dc=example,dc=org
 #${configurationKey}.bindCredential=Password
 
-#${configurationKey}.poolPassivator=NONE|CLOSE|BIND
+#${configurationKey}.poolPassivator=NONE|BIND
 #${configurationKey}.connectionStrategy=
 #${configurationKey}.connectTimeout=PT5S
 #${configurationKey}.trustCertificates=
@@ -1199,7 +1199,6 @@ The following options can be used to passivate objects when they are checked bac
 | Type                    | Description
 |-------------------------|----------------------------------------------------------------------------------------------------
 | `NONE`                  | No passivation takes place.
-| `CLOSE`                 | Passivates a connection by attempting to close it.
 | `BIND`                  | The default behavior which passivates a connection by performing a bind operation on it. This option requires the availability of bind credentials when establishing connections to LDAP.
 
 #### Why Passivators?

--- a/gradle.properties
+++ b/gradle.properties
@@ -237,7 +237,7 @@ userInfoVersion=1.1.0
 retrofit1Version=1.9.0
 gsonVersion=2.8.6
 
-ldaptiveVersion=2.0.0-RC2
+ldaptiveVersion=2.0.0-RC3
 unboundidVersion=4.0.14
 
 jcifsVersion=1.3.17

--- a/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-ldap/src/main/java/org/apereo/cas/aup/LdapAcceptableUsagePolicyRepository.java
@@ -55,7 +55,7 @@ public class LdapAcceptableUsagePolicyRepository extends AbstractPrincipalAttrib
         val filter = LdapUtils.newLdaptiveSearchFilter(ldap.getSearchFilter(),
             LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME,
             CollectionUtils.wrap(id));
-        val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
+        val connectionFactory = LdapUtils.newLdaptiveConnectionFactory(ldap);
         val response = LdapUtils.executeSearchOperation(connectionFactory, ldap.getBaseDn(), filter, ldap.getPageSize());
         if (LdapUtils.containsResultEntry(response)) {
             return Optional.of(Pair.of(connectionFactory, response));

--- a/support/cas-server-support-consent-ldap/src/main/java/org/apereo/cas/config/CasConsentLdapConfiguration.java
+++ b/support/cas-server-support-consent-ldap/src/main/java/org/apereo/cas/config/CasConsentLdapConfiguration.java
@@ -27,7 +27,7 @@ public class CasConsentLdapConfiguration {
     @Bean
     public ConsentRepository consentRepository() {
         val ldap = casProperties.getConsent().getLdap();
-        val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
+        val connectionFactory = LdapUtils.newLdaptiveConnectionFactory(ldap);
         return new LdapConsentRepository(connectionFactory, ldap);
     }
 }

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -67,9 +67,7 @@ import org.ldaptive.handler.MergeAttributeEntryHandler;
 import org.ldaptive.handler.RecursiveResultHandler;
 import org.ldaptive.handler.SearchResultHandler;
 import org.ldaptive.pool.BindConnectionPassivator;
-import org.ldaptive.pool.CloseConnectionPassivator;
 import org.ldaptive.pool.IdlePruneStrategy;
-import org.ldaptive.pool.OpenConnectionActivator;
 import org.ldaptive.referral.FollowSearchReferralHandler;
 import org.ldaptive.sasl.Mechanism;
 import org.ldaptive.sasl.QualityOfProtection;
@@ -630,7 +628,7 @@ public class LdapUtils {
         if (StringUtils.isBlank(l.getSearchFilter())) {
             throw new IllegalArgumentException("User filter cannot be empty/blank for authenticated/anonymous authentication");
         }
-        val connectionFactoryForSearch = newLdaptivePooledConnectionFactory(l);
+        val connectionFactoryForSearch = newLdaptiveConnectionFactory(l);
         val resolver = new SearchDnResolver();
         resolver.setBaseDn(l.getBaseDn());
         resolver.setSubtreeSearch(l.isSubtreeSearch());
@@ -647,11 +645,11 @@ public class LdapUtils {
         }
 
         val auth = StringUtils.isBlank(l.getPrincipalAttributePassword())
-            ? new Authenticator(resolver, getPooledBindAuthenticationHandler(newLdaptivePooledConnectionFactory(l)))
-            : new Authenticator(resolver, getPooledCompareAuthenticationHandler(l, newLdaptivePooledConnectionFactory(l)));
+            ? new Authenticator(resolver, getBindAuthenticationHandler(newLdaptiveConnectionFactory(l)))
+            : new Authenticator(resolver, getCompareAuthenticationHandler(l, newLdaptiveConnectionFactory(l)));
 
         if (l.isEnhanceWithEntryResolver()) {
-            auth.setEntryResolver(newLdaptiveSearchEntryResolver(l, newLdaptivePooledConnectionFactory(l)));
+            auth.setEntryResolver(newLdaptiveSearchEntryResolver(l, newLdaptiveConnectionFactory(l)));
         }
         return auth;
     }
@@ -672,22 +670,22 @@ public class LdapUtils {
 
     private static Authenticator getAuthenticatorViaDnFormat(final AbstractLdapAuthenticationProperties l) {
         val resolver = new FormatDnResolver(l.getDnFormat());
-        val authenticator = new Authenticator(resolver, getPooledBindAuthenticationHandler(newLdaptivePooledConnectionFactory(l)));
+        val authenticator = new Authenticator(resolver, getBindAuthenticationHandler(newLdaptiveConnectionFactory(l)));
 
         if (l.isEnhanceWithEntryResolver()) {
-            authenticator.setEntryResolver(newLdaptiveSearchEntryResolver(l, newLdaptivePooledConnectionFactory(l)));
+            authenticator.setEntryResolver(newLdaptiveSearchEntryResolver(l, newLdaptiveConnectionFactory(l)));
         }
         return authenticator;
     }
 
-    private static SimpleBindAuthenticationHandler getPooledBindAuthenticationHandler(final PooledConnectionFactory factory) {
+    private static SimpleBindAuthenticationHandler getBindAuthenticationHandler(final ConnectionFactory factory) {
         val handler = new SimpleBindAuthenticationHandler(factory);
         handler.setAuthenticationControls(new PasswordPolicyControl());
         return handler;
     }
 
-    private static CompareAuthenticationHandler getPooledCompareAuthenticationHandler(final AbstractLdapAuthenticationProperties l,
-                                                                                      final PooledConnectionFactory factory) {
+    private static CompareAuthenticationHandler getCompareAuthenticationHandler(final AbstractLdapAuthenticationProperties l,
+                                                                                final ConnectionFactory factory) {
         val handler = new CompareAuthenticationHandler(factory);
         handler.setPasswordAttribute(l.getPrincipalAttributePassword());
         return handler;
@@ -752,11 +750,6 @@ public class LdapUtils {
             val pass =
                 AbstractLdapProperties.LdapConnectionPoolPassivator.valueOf(l.getPoolPassivator().toUpperCase());
             switch (pass) {
-                case CLOSE:
-                    pooledCf.setPassivator(new CloseConnectionPassivator());
-                    pooledCf.setActivator(new OpenConnectionActivator());
-                    LOGGER.debug("Created [{}] passivator for [{}]", l.getPoolPassivator(), l.getLdapUrl());
-                    break;
                 case BIND:
                     if (StringUtils.isNotBlank(l.getBindDn()) && StringUtils.isNoneBlank(l.getBindCredential())) {
                         val bindRequest = new SimpleBindRequest(l.getBindDn(), l.getBindCredential());
@@ -914,13 +907,23 @@ public class LdapUtils {
         return sc;
     }
 
+  /**
+   * Returns a pooled connection factory or default connection factory based on {@link AbstractLdapProperties#isDisablePooling()}.
+   *
+   * @param l ldap properties
+   * @return the connection factory
+   */
+    public static ConnectionFactory newLdaptiveConnectionFactory(final AbstractLdapProperties l) {
+      return l.isDisablePooling() ? newLdaptiveDefaultConnectionFactory(l) : newLdaptivePooledConnectionFactory(l);
+    }
+
     /**
-     * New connection factory connection factory.
+     * New default connection factory.
      *
      * @param l the l
      * @return the connection factory
      */
-    public static DefaultConnectionFactory newLdaptiveConnectionFactory(final AbstractLdapProperties l) {
+    private static DefaultConnectionFactory newLdaptiveDefaultConnectionFactory(final AbstractLdapProperties l) {
         LOGGER.debug("Creating LDAP connection factory for [{}]", l.getLdapUrl());
         val cc = newLdaptiveConnectionConfig(l);
         val bindCf = new DefaultConnectionFactory(cc);
@@ -936,7 +939,7 @@ public class LdapUtils {
      * @return the entry resolver
      */
     public static EntryResolver newLdaptiveSearchEntryResolver(final AbstractLdapAuthenticationProperties l,
-                                                               final PooledConnectionFactory factory) {
+                                                               final ConnectionFactory factory) {
         if (StringUtils.isBlank(l.getBaseDn())) {
             throw new IllegalArgumentException("To create a search entry resolver, base dn cannot be empty/blank ");
         }

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -914,7 +914,7 @@ public class LdapUtils {
    * @return the connection factory
    */
     public static ConnectionFactory newLdaptiveConnectionFactory(final AbstractLdapProperties l) {
-      return l.isDisablePooling() ? newLdaptiveDefaultConnectionFactory(l) : newLdaptivePooledConnectionFactory(l);
+        return l.isDisablePooling() ? newLdaptiveDefaultConnectionFactory(l) : newLdaptivePooledConnectionFactory(l);
     }
 
     /**

--- a/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/config/LdapServiceRegistryConfiguration.java
+++ b/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/config/LdapServiceRegistryConfiguration.java
@@ -55,7 +55,7 @@ public class LdapServiceRegistryConfiguration {
     @RefreshScope
     public ServiceRegistry ldapServiceRegistry() {
         val ldap = casProperties.getServiceRegistry().getLdap();
-        val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
+        val connectionFactory = LdapUtils.newLdaptiveConnectionFactory(ldap);
         return new LdapServiceRegistry(connectionFactory, ldap.getBaseDn(), ldapServiceRegistryMapper(),
             ldap, applicationContext, serviceRegistryListeners.getObject());
     }

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapPasswordSynchronizationAuthenticationPostProcessor.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapPasswordSynchronizationAuthenticationPostProcessor.java
@@ -29,7 +29,7 @@ public class LdapPasswordSynchronizationAuthenticationPostProcessor implements A
 
     public LdapPasswordSynchronizationAuthenticationPostProcessor(final AbstractLdapSearchProperties properties) {
         this.ldapProperties = properties;
-        this.searchFactory = LdapUtils.newLdaptivePooledConnectionFactory(properties);
+        this.searchFactory = LdapUtils.newLdaptiveConnectionFactory(properties);
     }
 
     @Override

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/AllLdapTestsSuite.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/AllLdapTestsSuite.java
@@ -1,7 +1,7 @@
 package org.apereo.cas;
 
-import org.apereo.cas.authentication.ActiveDirectoryJndiSamAccountNameLdapAuthenticationHandlerTests;
-import org.apereo.cas.authentication.ActiveDirectoryJndiUPNLdapAuthenticationHandlerTests;
+import org.apereo.cas.authentication.ActiveDirectorySamAccountNameLdapAuthenticationHandlerTests;
+import org.apereo.cas.authentication.ActiveDirectoryUPNLdapAuthenticationHandlerTests;
 import org.apereo.cas.authentication.ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests;
 import org.apereo.cas.authentication.AuthenticatedLdapAuthenticationHandlerTests;
 import org.apereo.cas.authentication.DirectLdapAuthenticationHandlerTests;
@@ -19,8 +19,8 @@ import org.junit.runner.RunWith;
  * @since 4.1.0
  */
 @SelectClasses({
-    ActiveDirectoryJndiUPNLdapAuthenticationHandlerTests.class,
-    ActiveDirectoryJndiSamAccountNameLdapAuthenticationHandlerTests.class,
+    ActiveDirectoryUPNLdapAuthenticationHandlerTests.class,
+    ActiveDirectorySamAccountNameLdapAuthenticationHandlerTests.class,
     ActiveDirectoryLdapAuthenticationHandlerPasswordPolicyTests.class,
     AuthenticatedLdapAuthenticationHandlerTests.class,
     PersonDirectoryPrincipalResolverLdaptiveTests.class,

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectorySamAccountNameLdapAuthenticationHandlerTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectorySamAccountNameLdapAuthenticationHandlerTests.java
@@ -5,14 +5,10 @@ import org.springframework.test.context.TestPropertySource;
 
 /**
  * Unit test for {@link LdapAuthenticationHandler}.
- * This test demonstrates using the AD type with the {@link JndiProvider}.
- * Using the Ldaptive {@link UnboundIDProvider} would fail because the name doesn't validate as a DN.
+ * This test demonstrates using the AD type.
  * Login name is {@code sAMAccountName} (aka "short" windows login name), bind as DOMAIN\USERNAME.
- * This allows for a dnFormat that the UnboundID provider would not allow since it is not a valid DN.
  * Issues:
  *  - This configuration doesn't retrieve any attributes as part of the authentication.
- *  - If the pool passivator is {@code CLOSE}, and the both success and failure tests run, the failure test will
- *      fail with wrong exception type. If multiple success tests are added, every other test will fail.
  * @author Hal Deadman
  * @since 6.1.0
  */
@@ -34,7 +30,7 @@ import org.springframework.test.context.TestPropertySource;
     "cas.authn.ldap[0].hostnameVerifier=DEFAULT"
 })
 @EnabledIfContinuousIntegration
-public class ActiveDirectoryJndiSamAccountNameLdapAuthenticationHandlerTests extends BaseActiveDirectoryLdapAuthenticationHandlerTests {
+public class ActiveDirectorySamAccountNameLdapAuthenticationHandlerTests extends BaseActiveDirectoryLdapAuthenticationHandlerTests {
 
     /**
      * This dnFormat can authenticate but it isn't bringing back any attributes.

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryUPNLdapAuthenticationHandlerTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/ActiveDirectoryUPNLdapAuthenticationHandlerTests.java
@@ -5,13 +5,12 @@ import org.springframework.test.context.TestPropertySource;
 
 /**
  * Unit test for {@link LdapAuthenticationHandler}.
- * This test uses the {@link JndiProvider} and type AD where the user logs in with the userPrincipalName attribute.
+ * This test uses the type AD where the user logs in with the userPrincipalName attribute.
  * The userPrincipalName attribute is the format UPN_PREFIX@UPN_SUFFIX where UPN_PREFIX is the "long" username
  * and UPN_SUFFIX is a domain in the Active Directory forest or a domain listed in upnSuffixes attribute.
  * UPN_PREFIX does not have to be unique but it is unique when combined with UPN_SUFFIX.
  * Issues:
  *  - This configuration doesn't retrieve any attributes as part of the authentication.
- *  - The {@link UnboundIDProvider} would fail this due to its DN validation.
  * @author Hal Deadman
  * @since 6.1.0
  */
@@ -32,7 +31,7 @@ import org.springframework.test.context.TestPropertySource;
     "cas.authn.ldap[0].hostnameVerifier=ANY"
 })
 @EnabledIfContinuousIntegration
-public class ActiveDirectoryJndiUPNLdapAuthenticationHandlerTests extends BaseActiveDirectoryLdapAuthenticationHandlerTests {
+public class ActiveDirectoryUPNLdapAuthenticationHandlerTests extends BaseActiveDirectoryLdapAuthenticationHandlerTests {
 
     /**
      * This dnFormat can authenticate but it isn't bringing back any attributes.

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
@@ -269,7 +269,7 @@ public class CasPersonDirectoryConfiguration {
                 val ldapDao = new LdaptivePersonAttributeDao();
                 FunctionUtils.doIfNotNull(ldap.getId(), ldapDao::setId);
                 LOGGER.debug("Configured LDAP attribute source for [{}] and baseDn [{}]", ldap.getLdapUrl(), ldap.getBaseDn());
-                ldapDao.setConnectionFactory(LdapUtils.newLdaptivePooledConnectionFactory(ldap));
+                ldapDao.setConnectionFactory(LdapUtils.newLdaptiveConnectionFactory(ldap));
                 ldapDao.setBaseDN(ldap.getBaseDn());
 
                 LOGGER.debug("LDAP attributes are fetched from [{}] via filter [{}]", ldap.getLdapUrl(), ldap.getSearchFilter());

--- a/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/pm/LdapPasswordManagementService.java
+++ b/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/pm/LdapPasswordManagementService.java
@@ -75,7 +75,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
                     LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME,
                     CollectionUtils.wrap(username));
                 LOGGER.debug("Constructed LDAP filter [{}] to locate security questions", filter);
-                val ldapConnectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
+                val ldapConnectionFactory = LdapUtils.newLdaptiveConnectionFactory(ldap);
                 val response = LdapUtils.executeSearchOperation(ldapConnectionFactory, ldap.getBaseDn(), filter, ldap.getPageSize());
                 LOGGER.debug("LDAP response for security questions [{}]", response);
 
@@ -120,7 +120,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
                         LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME,
                         CollectionUtils.wrap(username));
                     LOGGER.debug("Constructed LDAP filter [{}] to locate account", filter);
-                    val ldapConnectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
+                    val ldapConnectionFactory = LdapUtils.newLdaptiveConnectionFactory(ldap);
                     val response = LdapUtils.executeSearchOperation(ldapConnectionFactory, ldap.getBaseDn(), filter, ldap.getPageSize());
                     LOGGER.debug("LDAP response is [{}]", response);
 
@@ -168,7 +168,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
                         LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME,
                         CollectionUtils.wrap(c.getId()));
                     LOGGER.debug("Constructed LDAP filter [{}] to update account password", filter);
-                    val ldapConnectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
+                    val ldapConnectionFactory = LdapUtils.newLdaptiveConnectionFactory(ldap);
                     val response = LdapUtils.executeSearchOperation(ldapConnectionFactory, ldap.getBaseDn(), filter, ldap.getPageSize());
                     LOGGER.debug("LDAP response to update password is [{}]", response);
 

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/config/SpnegoWebflowActionsConfiguration.java
@@ -96,7 +96,7 @@ public class SpnegoWebflowActionsConfiguration {
     @RefreshScope
     public Action ldapSpnegoClientAction() {
         val spnegoProperties = casProperties.getAuthn().getSpnego();
-        val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(spnegoProperties.getLdap());
+        val connectionFactory = LdapUtils.newLdaptiveConnectionFactory(spnegoProperties.getLdap());
         val filter = LdapUtils.newLdaptiveSearchFilter(spnegoProperties.getLdap().getSearchFilter());
 
         val searchRequest = LdapUtils.newLdaptiveSearchRequest(spnegoProperties.getLdap().getBaseDn(), filter);

--- a/support/cas-server-support-surrogate-authentication-ldap/src/main/java/org/apereo/cas/config/SurrogateLdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-surrogate-authentication-ldap/src/main/java/org/apereo/cas/config/SurrogateLdapAuthenticationConfiguration.java
@@ -40,7 +40,7 @@ public class SurrogateLdapAuthenticationConfiguration {
         val su = casProperties.getAuthn().getSurrogate();
         LOGGER.debug("Using LDAP [{}] with baseDn [{}] to locate surrogate accounts",
             su.getLdap().getLdapUrl(), su.getLdap().getBaseDn());
-        val factory = LdapUtils.newLdaptivePooledConnectionFactory(su.getLdap());
+        val factory = LdapUtils.newLdaptiveConnectionFactory(su.getLdap());
         return new SurrogateLdapAuthenticationService(factory, su.getLdap(), servicesManager.getObject());
     }
 }

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/authentication/MonitorEndpointLdapAuthenticationProvider.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/authentication/MonitorEndpointLdapAuthenticationProvider.java
@@ -125,7 +125,7 @@ public class MonitorEndpointLdapAuthenticationProvider implements Authentication
     @SuppressWarnings("java:S2095")
     private AuthorizationGenerator buildAuthorizationGenerator() {
         val ldapAuthz = this.ldapProperties.getLdapAuthz();
-        val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(this.ldapProperties);
+        val connectionFactory = LdapUtils.newLdaptiveConnectionFactory(this.ldapProperties);
 
         if (isGroupBasedAuthorization()) {
             LOGGER.debug("Handling LDAP authorization based on groups");


### PR DESCRIPTION
Remove the OpenActivator and ClosePassivator in favor of a disablePooling flag.
LdapUtils#newLdaptiveConnectionFactory inspects this flag and produces an appropriate connection factory.
Renamed classes containing 'Jndi' in the name, provider doesn't exist anymore.
