### PR TITLE
Backport: Add client_secret_basic authentication support for refresh token request

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidator.java
@@ -35,8 +35,9 @@ public class OAuth20RefreshTokenGrantTypeTokenRequestValidator extends BaseOAuth
     protected boolean validateInternal(final JEEContext context, final String grantType,
                                        final ProfileManager manager, final UserProfile uProfile) {
         val request = context.getNativeRequest();
+        val clientId = OAuth20Utils.getClientIdAndClientSecret(context).getLeft();
         if (!HttpRequestUtils.doesParameterExist(request, OAuth20Constants.REFRESH_TOKEN)
-            || !HttpRequestUtils.doesParameterExist(request, OAuth20Constants.CLIENT_ID)) {
+            || clientId.isEmpty()) {
             return false;
         }
 
@@ -55,7 +56,6 @@ public class OAuth20RefreshTokenGrantTypeTokenRequestValidator extends BaseOAuth
             return false;
         }
 
-        val clientId = request.getParameter(OAuth20Constants.CLIENT_ID);
         LOGGER.debug("Received grant type [{}] with client id [{}]", grantType, clientId);
         val registeredService = OAuth20Utils.getRegisteredOAuthServiceByClientId(
             getConfigurationContext().getServicesManager(), clientId);

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenRefreshTokenGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenRefreshTokenGrantRequestExtractor.java
@@ -11,6 +11,7 @@ import org.apereo.cas.ticket.OAuth20UnauthorizedScopeRequestException;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.pac4j.core.context.JEEContext;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -39,7 +40,8 @@ public class AccessTokenRefreshTokenGrantRequestExtractor extends AccessTokenAut
     protected AccessTokenRequestDataHolder extractInternal(final HttpServletRequest request,
                                                            final HttpServletResponse response,
                                                            final AccessTokenRequestDataHolder.AccessTokenRequestDataHolderBuilder builder) {
-        val registeredService = getOAuthRegisteredServiceBy(request);
+        val context = new JEEContext(request, response, getOAuthConfigurationContext().getSessionStore());
+        val registeredService = getOAuthRegisteredServiceBy(context);
         if (registeredService == null) {
             throw new UnauthorizedServiceException("Unable to locate service in registry ");
         }
@@ -63,16 +65,16 @@ public class AccessTokenRefreshTokenGrantRequestExtractor extends AccessTokenAut
     }
 
     @Override
-    protected OAuthRegisteredService getOAuthRegisteredServiceBy(final HttpServletRequest request) {
-        val clientId = getRegisteredServiceIdentifierFromRequest(request);
+    protected OAuthRegisteredService getOAuthRegisteredServiceBy(final JEEContext context) {
+        val clientId = getRegisteredServiceIdentifierFromRequest(context);
         val registeredService = OAuth20Utils.getRegisteredOAuthServiceByClientId(getOAuthConfigurationContext().getServicesManager(), clientId);
         LOGGER.debug("Located registered service [{}]", registeredService);
         return registeredService;
     }
 
     @Override
-    protected String getRegisteredServiceIdentifierFromRequest(final HttpServletRequest request) {
-        return request.getParameter(OAuth20Constants.CLIENT_ID);
+    protected String getRegisteredServiceIdentifierFromRequest(final JEEContext context) {
+        return OAuth20Utils.getClientIdAndClientSecret(context).getLeft();
     }
 
     /**

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/validator/token/OAuth20RefreshTokenGrantTypeTokenRequestValidatorTests.java
@@ -11,6 +11,7 @@ import org.apereo.cas.support.oauth.web.endpoints.OAuth20ConfigurationContext;
 import org.apereo.cas.ticket.refreshtoken.OAuth20RefreshToken;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.util.CollectionUtils;
+import org.apereo.cas.util.EncodingUtils;
 
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
@@ -88,7 +89,7 @@ public class OAuth20RefreshTokenGrantTypeTokenRequestValidatorTests {
     }
 
     @Test
-    public void verifyOperation() {
+    public void verifyOperationClientSecretPost() {
         val request = new MockHttpServletRequest();
 
         val profile = new CommonProfile();
@@ -117,6 +118,42 @@ public class OAuth20RefreshTokenGrantTypeTokenRequestValidatorTests {
         session.setAttribute(Pac4jConstants.USER_PROFILES, profile);
         request.setParameter(OAuth20Constants.CLIENT_ID, RequestValidatorTestUtils.PROMISCUOUS_CLIENT_ID);
         request.setParameter(OAuth20Constants.CLIENT_SECRET, RequestValidatorTestUtils.SHARED_SECRET);
+        request.setParameter(OAuth20Constants.REFRESH_TOKEN, PROMISCUOUS_SERVICE_TICKET);
+        assertTrue(this.validator.validate(new JEEContext(request, response)));
+    }
+
+    @Test
+    public void verifyOperationClientSecretBasic() {
+        val request = new MockHttpServletRequest();
+
+        val profile = new CommonProfile();
+        profile.setClientName(Authenticators.CAS_OAUTH_CLIENT_BASIC_AUTHN);
+        profile.setId(RequestValidatorTestUtils.SUPPORTING_CLIENT_ID);
+        val session = request.getSession(true);
+        assertNotNull(session);
+        session.setAttribute(Pac4jConstants.USER_PROFILES, profile);
+
+        val response = new MockHttpServletResponse();
+        request.addHeader("Authorization",
+                          "Basic " + EncodingUtils.encodeBase64(RequestValidatorTestUtils.SUPPORTING_CLIENT_ID + ":" + RequestValidatorTestUtils.SHARED_SECRET));
+        request.setParameter(OAuth20Constants.GRANT_TYPE, OAuth20GrantTypes.REFRESH_TOKEN.getType());
+        request.setParameter(OAuth20Constants.REFRESH_TOKEN, SUPPORTING_SERVICE_TICKET);
+
+        assertTrue(this.validator.validate(new JEEContext(request, response)));
+
+        profile.setId(RequestValidatorTestUtils.NON_SUPPORTING_CLIENT_ID);
+        session.setAttribute(Pac4jConstants.USER_PROFILES, profile);
+        request.removeHeader("Authorization");
+        request.addHeader("Authorization",
+                          "Basic " + EncodingUtils.encodeBase64(RequestValidatorTestUtils.NON_SUPPORTING_CLIENT_ID + ":" + RequestValidatorTestUtils.SHARED_SECRET));
+        request.setParameter(OAuth20Constants.REFRESH_TOKEN, NON_SUPPORTING_SERVICE_TICKET);
+        assertFalse(this.validator.validate(new JEEContext(request, response)));
+
+        profile.setId(RequestValidatorTestUtils.PROMISCUOUS_CLIENT_ID);
+        session.setAttribute(Pac4jConstants.USER_PROFILES, profile);
+        request.removeHeader("Authorization");
+        request.addHeader("Authorization",
+                          "Basic " + EncodingUtils.encodeBase64(RequestValidatorTestUtils.PROMISCUOUS_CLIENT_ID + ":" + RequestValidatorTestUtils.SHARED_SECRET));
         request.setParameter(OAuth20Constants.REFRESH_TOKEN, PROMISCUOUS_SERVICE_TICKET);
         assertTrue(this.validator.validate(new JEEContext(request, response)));
     }


### PR DESCRIPTION
Hello Misagh,

The refresh token request in CAS is not working with client_secret_basic authentication. The following error appears:

```
2020-03-03 13:37:58,486 ERROR [org.apereo.cas.util.HttpRequestUtils] - <Missing request parameter: [client_id]>
```

[According to the OAuth 2.0 specification](https://tools.ietf.org/html/rfc6749#section-2.3): The authorization server MUST support the HTTP Basic authentication scheme for authenticating clients that were issued a client password and alternatively, the authorization server MAY support including the client credentials in the request-body using the following parameters: client_id & client_secret.

This pull request fixes the problem and adds client_secret_basic authentication support for the refresh token requests.

Let me know if you need any further information.

Regards,
Julien
