### PR TITLE
Backport: Refresh & revoke requests support for public clients.

### DIFF
--- a/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20RefreshToken.java
+++ b/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20RefreshToken.java
@@ -15,4 +15,10 @@ public interface OAuth20RefreshToken extends OAuth20Token {
      * The prefix for refresh tokens.
      */
     String PREFIX = "RT";
+
+    /**
+     * Client id for whom this access token was issued.
+     * @return client id.
+     */
+    String getClientId();
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/Authenticators.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/Authenticators.java
@@ -20,6 +20,14 @@ public interface Authenticators {
      */
     String CAS_OAUTH_CLIENT_ACCESS_TOKEN_AUTHN = "clientAccessTokenAuth";
     /**
+     * OAuth authn for refresh token with client_id and secret.
+     */
+    String CAS_OAUTH_CLIENT_FORM_REFRESH_TOKEN_AUTHN = "clientRefreshTokenFormAuth";
+    /**
+     * OAuth authn for refresh token with basic authn.
+     */
+    String CAS_OAUTH_CLIENT_BASIC_REFRESH_TOKEN_AUTHN = "clientRefreshTokenBasicAuth";
+    /**
      * OAuth authn for client id and secret.
      */
     String CAS_OAUTH_CLIENT_DIRECT_FORM = "clientForm";

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
@@ -111,6 +111,10 @@ public class OAuth20ClientIdClientSecretAuthenticator implements Authenticator<U
             LOGGER.debug("Skipping Client credential authentication to use password authentication");
             return false;
         }
+        if (grantType.isPresent() && OAuth20Utils.isGrantType(grantType.get(), OAuth20GrantTypes.REFRESH_TOKEN)) {
+            LOGGER.debug("Skipping Client credential authentication to use refresh_token authentication");
+            return false;
+        }
 
         val code = context.getRequestParameter(OAuth20Constants.CODE);
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20RefreshTokenAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20RefreshTokenAuthenticator.java
@@ -1,0 +1,70 @@
+package org.apereo.cas.support.oauth.authenticator;
+
+import org.apereo.cas.audit.AuditableExecution;
+import org.apereo.cas.authentication.principal.ServiceFactory;
+import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.support.oauth.OAuth20Constants;
+import org.apereo.cas.support.oauth.OAuth20GrantTypes;
+import org.apereo.cas.support.oauth.services.OAuthRegisteredService;
+import org.apereo.cas.support.oauth.util.OAuth20Utils;
+import org.apereo.cas.ticket.refreshtoken.OAuth20RefreshToken;
+import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.util.crypto.CipherExecutor;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.exception.CredentialsException;
+
+import java.io.Serializable;
+
+/**
+ * This is {@link OAuth20RefreshTokenAuthenticator}.
+ *
+ * @author Julien Huon
+ * @since 6.1.6
+ */
+@Slf4j
+public class OAuth20RefreshTokenAuthenticator extends OAuth20ClientIdClientSecretAuthenticator {
+
+    public OAuth20RefreshTokenAuthenticator(final ServicesManager servicesManager,
+                                            final ServiceFactory webApplicationServiceFactory,
+                                            final AuditableExecution registeredServiceAccessStrategyEnforcer,
+                                            final TicketRegistry ticketRegistry,
+                                            final CipherExecutor<Serializable, String> registeredServiceCipherExecutor) {
+        super(servicesManager, webApplicationServiceFactory, registeredServiceAccessStrategyEnforcer, registeredServiceCipherExecutor, ticketRegistry);
+    }
+
+    @Override
+    protected boolean canAuthenticate(final WebContext context) {
+        val grantType = context.getRequestParameter(OAuth20Constants.GRANT_TYPE);
+
+        if (grantType.isPresent() && OAuth20Utils.isGrantType(grantType.get(), OAuth20GrantTypes.REFRESH_TOKEN)) {
+            return context.getRequestParameter(OAuth20Constants.REFRESH_TOKEN).isPresent();
+        }
+        return false;
+    }
+
+    @Override
+    protected void validateCredentials(final UsernamePasswordCredentials credentials,
+                                       final OAuthRegisteredService registeredService, final WebContext context) {
+        val clientId = OAuth20Utils.getClientIdAndClientSecret(context).getLeft();
+        val clientSecret = OAuth20Utils.getClientIdAndClientSecret(context).getRight();
+
+        if (!OAuth20Utils.checkClientSecret(registeredService, clientSecret, getRegisteredServiceCipherExecutor())) {
+            throw new CredentialsException("Client Credentials provided is not valid for registered service: " + registeredService.getName());
+        }
+
+        val token = context.getRequestParameter(OAuth20Constants.REFRESH_TOKEN)
+            .map(String::valueOf).orElse(StringUtils.EMPTY);
+        LOGGER.trace("Received refresh token [{}] for authentication", token);
+
+        val refreshToken = getTicketRegistry().getTicket(token, OAuth20RefreshToken.class);
+        if (refreshToken == null || refreshToken.isExpired() || !StringUtils.equals(refreshToken.getClientId(), clientId)) {
+            LOGGER.error("Provided refresh token [{}] is either not found in the ticket registry or has expired or not related with the client provided");
+            throw new CredentialsException("Invalid token: " + token);
+        }
+    }
+}

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/OAuth20DefaultTokenGenerator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/OAuth20DefaultTokenGenerator.java
@@ -272,7 +272,7 @@ public class OAuth20DefaultTokenGenerator implements OAuth20TokenGenerator {
             responseHolder.getAuthentication(),
             responseHolder.getTicketGrantingTicket(),
             responseHolder.getScopes(),
-            responseHolder.getClientId(),
+            responseHolder.getRegisteredService().getClientId(),
             responseHolder.getClaims());
         LOGGER.debug("Adding refresh token [{}] to the registry", refreshToken);
         addTicketToRegistry(refreshToken, responseHolder.getTicketGrantingTicket());

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -19,6 +19,7 @@ import org.apereo.cas.support.oauth.authenticator.OAuth20AccessTokenAuthenticato
 import org.apereo.cas.support.oauth.authenticator.OAuth20CasAuthenticationBuilder;
 import org.apereo.cas.support.oauth.authenticator.OAuth20ClientIdClientSecretAuthenticator;
 import org.apereo.cas.support.oauth.authenticator.OAuth20ProofKeyCodeExchangeAuthenticator;
+import org.apereo.cas.support.oauth.authenticator.OAuth20RefreshTokenAuthenticator;
 import org.apereo.cas.support.oauth.authenticator.OAuth20UsernamePasswordAuthenticator;
 import org.apereo.cas.support.oauth.authenticator.OAuthAuthenticationClientProvider;
 import org.apereo.cas.support.oauth.profile.CasServerApiBasedTicketValidator;
@@ -273,6 +274,17 @@ public class CasOAuth20Configuration {
         pkceBasicAuthClient.setName(Authenticators.CAS_OAUTH_CLIENT_BASIC_PROOF_KEY_CODE_EXCHANGE_AUTHN);
         pkceBasicAuthClient.init();
 
+        val refreshTokenAuthenticator = oAuthRefreshTokenAuthenticator();
+        val refreshTokenFormClient = new DirectFormClient(refreshTokenAuthenticator);
+        refreshTokenFormClient.setName(Authenticators.CAS_OAUTH_CLIENT_FORM_REFRESH_TOKEN_AUTHN);
+        refreshTokenFormClient.setUsernameParameter(OAuth20Constants.CLIENT_ID);
+        refreshTokenFormClient.setPasswordParameter(OAuth20Constants.REFRESH_TOKEN);
+        refreshTokenFormClient.init();
+
+        val refreshTokenBasicAuthClient = new DirectBasicAuthClient(refreshTokenAuthenticator);
+        refreshTokenBasicAuthClient.setName(Authenticators.CAS_OAUTH_CLIENT_BASIC_REFRESH_TOKEN_AUTHN);
+        refreshTokenBasicAuthClient.init();
+
         val userFormClient = new DirectFormClient(oAuthUserAuthenticator());
         userFormClient.setName(Authenticators.CAS_OAUTH_CLIENT_USER_FORM);
         userFormClient.init();
@@ -296,6 +308,8 @@ public class CasOAuth20Configuration {
         clientList.add(basicAuthClient);
         clientList.add(pkceAuthnFormClient);
         clientList.add(pkceBasicAuthClient);
+        clientList.add(refreshTokenFormClient);
+        clientList.add(refreshTokenBasicAuthClient);
         clientList.add(directFormClient);
         clientList.add(userFormClient);
         clientList.add(accessTokenClient);
@@ -328,6 +342,17 @@ public class CasOAuth20Configuration {
     @Bean
     public Authenticator<UsernamePasswordCredentials> oAuthProofKeyCodeExchangeAuthenticator() {
         return new OAuth20ProofKeyCodeExchangeAuthenticator(this.servicesManager.getObject(),
+            webApplicationServiceFactory.getObject(),
+            registeredServiceAccessStrategyEnforcer.getObject(),
+            ticketRegistry.getObject(),
+            oauthRegisteredServiceCipherExecutor());
+    }
+
+    @ConditionalOnMissingBean(name = "oAuthRefreshTokenAuthenticator")
+    @Bean
+    @RefreshScope
+    public Authenticator<UsernamePasswordCredentials> oAuthRefreshTokenAuthenticator() {
+        return new OAuth20RefreshTokenAuthenticator(this.servicesManager.getObject(),
             webApplicationServiceFactory.getObject(),
             registeredServiceAccessStrategyEnforcer.getObject(),
             ticketRegistry.getObject(),

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
@@ -3,6 +3,7 @@ package org.apereo.cas;
 import org.apereo.cas.support.oauth.authenticator.OAuth20AccessTokenAuthenticatorTests;
 import org.apereo.cas.support.oauth.authenticator.OAuth20ClientIdClientSecretAuthenticatorTests;
 import org.apereo.cas.support.oauth.authenticator.OAuth20ProofKeyCodeExchangeAuthenticatorTests;
+import org.apereo.cas.support.oauth.authenticator.OAuth20RefreshTokenAuthenticatorTests;
 import org.apereo.cas.support.oauth.authenticator.OAuth20UsernamePasswordAuthenticatorTests;
 import org.apereo.cas.support.oauth.services.OAuth20RegisteredServiceCipherExecutorTests;
 import org.apereo.cas.support.oauth.services.OAuth20WebApplicationServiceTests;
@@ -65,6 +66,7 @@ import org.junit.runner.RunWith;
     OAuth20AccessTokenAuthenticatorTests.class,
     OAuth20ClientIdClientSecretAuthenticatorTests.class,
     OAuth20ProofKeyCodeExchangeAuthenticatorTests.class,
+    OAuth20RefreshTokenAuthenticatorTests.class,
     OAuth20DefaultUserProfileViewRendererFlatTests.class,
     OAuth20DefaultUserProfileViewRendererNestedTests.class,
     OAuth20AccessTokenGrantRequestAuditResourceResolverTests.class,

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20RefreshTokenAuthenticatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20RefreshTokenAuthenticatorTests.java
@@ -1,0 +1,155 @@
+package org.apereo.cas.support.oauth.authenticator;
+
+import org.apereo.cas.services.RegisteredServiceAccessStrategyAuditableEnforcer;
+import org.apereo.cas.support.oauth.OAuth20Constants;
+import org.apereo.cas.support.oauth.services.OAuth20RegisteredServiceCipherExecutor;
+import org.apereo.cas.util.EncodingUtils;
+
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.pac4j.core.context.JEEContext;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.exception.CredentialsException;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link OAuth20RefreshTokenAuthenticator}.
+ *
+ * @author Julien Huon
+ * @since 6.1.6
+ */
+@Tag("OAuth")
+public class OAuth20RefreshTokenAuthenticatorTests extends BaseOAuth20AuthenticatorTests {
+    protected OAuth20RefreshTokenAuthenticator authenticator;
+
+    @BeforeEach
+    public void init() {
+        authenticator = new OAuth20RefreshTokenAuthenticator(servicesManager, serviceFactory,
+            new RegisteredServiceAccessStrategyAuditableEnforcer(), ticketRegistry,
+            new OAuth20RegisteredServiceCipherExecutor());
+    }
+
+    @Test
+    public void verifyAuthenticationWithClientWithoutSecret() {
+        val refreshToken = getRefreshToken(serviceWithoutSecret);
+        ticketRegistry.addTicket(refreshToken);
+
+        val credentials = new UsernamePasswordCredentials("clientWithoutSecret", refreshToken.getId());
+        val request = new MockHttpServletRequest();
+        request.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        request.addParameter(OAuth20Constants.CLIENT_ID, "clientWithoutSecret");
+        request.addParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
+        request.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example2.org");
+
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        authenticator.validate(credentials, ctx);
+        assertNotNull(credentials.getUserProfile());
+        assertEquals("clientWithoutSecret", credentials.getUserProfile().getId());
+
+
+        val badClientIdCredentials = new UsernamePasswordCredentials("clientWithoutSecret", refreshToken.getId());
+        val badClientIdRequest = new MockHttpServletRequest();
+        badClientIdRequest.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        badClientIdRequest.addParameter(OAuth20Constants.CLIENT_ID, "client");
+        badClientIdRequest.addParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
+        badClientIdRequest.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val badClientIdCtx = new JEEContext(badClientIdRequest, new MockHttpServletResponse());
+        assertThrows(CredentialsException.class, () -> authenticator.validate(badClientIdCredentials, badClientIdCtx));
+
+
+        val badRefreshTokenCredentials = new UsernamePasswordCredentials("clientWithoutSecret", "badRefreshToken");
+        val badRefreshTokenRequest = new MockHttpServletRequest();
+        badRefreshTokenRequest.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.CLIENT_ID, "clientWithoutSecret");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.REFRESH_TOKEN, "badRefreshToken");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val badRefreshTokenCtx = new JEEContext(badRefreshTokenRequest, new MockHttpServletResponse());
+        assertThrows(CredentialsException.class, () -> authenticator.validate(badRefreshTokenCredentials, badRefreshTokenCtx));
+    }
+
+    @Test
+    public void verifyAuthenticationWithClientWithSecretTransmittedByFormAuthn() {
+        val refreshToken = getRefreshToken(service);
+        ticketRegistry.addTicket(refreshToken);
+
+        val credentials = new UsernamePasswordCredentials("client", "secret");
+        val request = new MockHttpServletRequest();
+        request.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        request.addParameter(OAuth20Constants.CLIENT_ID, "client");
+        request.addParameter(OAuth20Constants.CLIENT_SECRET, "secret");
+        request.addParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
+        request.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        authenticator.validate(credentials, ctx);
+        assertNotNull(credentials.getUserProfile());
+        assertEquals("client", credentials.getUserProfile().getId());
+
+        val badSecretCredentials = new UsernamePasswordCredentials("client", "badsecret");
+        val badSecretRequest = new MockHttpServletRequest();
+        badSecretRequest.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        badSecretRequest.addParameter(OAuth20Constants.CLIENT_ID, "client");
+        badSecretRequest.addParameter(OAuth20Constants.CLIENT_SECRET, "badsecret");
+        badSecretRequest.addParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
+        badSecretRequest.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val badSecretCtx = new JEEContext(badSecretRequest, new MockHttpServletResponse());
+        assertThrows(CredentialsException.class, () -> authenticator.validate(badSecretCredentials, badSecretCtx));
+
+        val badRefreshTokenCredentials = new UsernamePasswordCredentials("client", "badRefreshToken");
+        val badRefreshTokenRequest = new MockHttpServletRequest();
+        badRefreshTokenRequest.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.CLIENT_ID, "client");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.CLIENT_SECRET, "secret");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.REFRESH_TOKEN, "badRefreshToken");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val badRefreshTokenCtx = new JEEContext(badRefreshTokenRequest, new MockHttpServletResponse());
+        assertThrows(CredentialsException.class, () -> authenticator.validate(badRefreshTokenCredentials, badRefreshTokenCtx));
+    }
+
+    @Test
+    public void verifyAuthenticationWithClientWithSecretTransmittedByBasicAuthn() {
+        val refreshToken = getRefreshToken(service);
+        ticketRegistry.addTicket(refreshToken);
+
+        val credentials = new UsernamePasswordCredentials("client", "secret");
+        val request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:secret")));
+        request.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        request.addParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
+        request.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        authenticator.validate(credentials, ctx);
+        assertNotNull(credentials.getUserProfile());
+        assertEquals("client", credentials.getUserProfile().getId());
+
+        val badSecretCredentials = new UsernamePasswordCredentials("client", "badsecret");
+        val badSecretRequest = new MockHttpServletRequest();
+        badSecretRequest.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:badRefreshToken")));
+        badSecretRequest.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        badSecretRequest.addParameter(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
+        badSecretRequest.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val badSecretCtx = new JEEContext(badSecretRequest, new MockHttpServletResponse());
+        assertThrows(CredentialsException.class, () -> authenticator.validate(badSecretCredentials, badSecretCtx));
+
+        val badRefreshTokenCredentials = new UsernamePasswordCredentials("client", "badRefreshToken");
+        val badRefreshTokenRequest = new MockHttpServletRequest();
+        badSecretRequest.addHeader("Authorization", "Basic " + new String(EncodingUtils.encodeBase64("client:badRefreshToken")));
+        badRefreshTokenRequest.addParameter(OAuth20Constants.GRANT_TYPE, "refresh_token");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.REFRESH_TOKEN, "badRefreshToken");
+        badRefreshTokenRequest.addParameter(OAuth20Constants.REDIRECT_URI, "https://www.example.org");
+
+        val badRefreshTokenCtx = new JEEContext(badRefreshTokenRequest, new MockHttpServletResponse());
+        assertThrows(CredentialsException.class, () -> authenticator.validate(badRefreshTokenCredentials, badRefreshTokenCtx));
+    }
+}


### PR DESCRIPTION
Hello Misagh,

CAS doesn't let [OAuth 2.0 public clients](https://tools.ietf.org/html/rfc6749#section-2.1) to renew or revoke their tokens because they don't have any client_secret.

According to the OAuth 2.0 specification, the authentication for a renew request is mandatory for the confidential clients only:

> If the client type is confidential or
   the client was issued client credentials (or assigned other
   authentication requirements), the client MUST authenticate with the
   authorization server as described in Section 3.2.1.
https://tools.ietf.org/html/rfc6749#section-6

Same thing for the revocation:

> The authorization server first validates the client credentials (in
   case of a confidential client) and then verifies whether the token
   was issued to the client making the revocation request.
https://tools.ietf.org/html/rfc7009#section-2.1

I also found out that CAS doesn't verifies whether the token was issued to the client making the revocation request.

This PR fixes these 3 issues.

Regards,
Julien