### PR TITLE
fix css so password policy requirement hide() will work

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pwdupdateform.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pwdupdateform.html
@@ -88,7 +88,7 @@
                 </div>
             </div>
             <div class="cas-field my-3 text-danger" id="password-strength-notes">
-                <div id="password-policy-violation-msg" class="banner banner-danger p-2 mb-2  d-flex align-items-center" role="alert" style="display: none;">
+                <div id="password-policy-violation-msg" class="banner banner-danger p-2" role="alert" style="display: none;">
                     <span class="mdi mdi-alert" aria-hidden="true"></span>&nbsp;
                     <strong th:text="#{screen.pm.password.policyViolation}">Password does not match the password policy
                         requirement.</strong>


### PR DESCRIPTION
The ```screen.pm.password.policyViolation``` message was always displaying and calling "hide()" on it wasn't working. I think the ```d-flex``` class might have been making it stay visible at all times but this changes the styles to match the ```screen.pm.password.confirmMismatch``` message right below it. 
