### PR TITLE
Enable transaction on deleteTicket

### DIFF
--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
@@ -192,6 +192,18 @@ public class JpaTicketRegistry extends AbstractTicketRegistry {
         return countToLong(query.getSingleResult());
     }
 
+    /**
+     * Delete a ticket by its identifier.
+     * Simple call to the super method to force a transaction to be started in case of a direct call.
+     *
+     * @param ticketId the ticket identifier
+     * @return the number of tickets deleted including children.
+     */
+    @Override
+    public int deleteTicket(final String ticketId) {
+        return super.deleteTicket(ticketId);
+    }
+
     @Override
     public boolean deleteSingleTicket(final String ticketIdToDelete) {
         val encTicketId = encodeTicketId(ticketIdToDelete);


### PR DESCRIPTION
I have a special use case where I chain a JWT authentication and a SAML IdP-initiated call.

This leads to a "transaction error":

```java
ERROR [org.apereo.cas.web.flow.login.CreateTicketGrantingTicketAction] - <Executing an update/delete query>
javax.persistence.TransactionRequiredException: Executing an update/delete query
	at org.hibernate.internal.AbstractSharedSessionContract.checkTransactionNeededForUpdateOperation(AbstractSharedSessionContract.java:409) ~[hibernate-core-5.4.9.Final.jar:5.4.9.Final]
	at org.hibernate.query.internal.AbstractProducedQuery.executeUpdate(AbstractProducedQuery.java:1601) ~[hibernate-core-5.4.9.Final.jar:5.4.9.Final]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.orm.jpa.SharedEntityManagerCreator$DeferredQueryInvocationHandler.invoke(SharedEntityManagerCreator.java:409) ~[spring-orm-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at com.sun.proxy.$Proxy282.executeUpdate(Unknown Source) ~[?:?]
	at org.apereo.cas.ticket.registry.JpaTicketRegistry.deleteSingleTicket(JpaTicketRegistry.java:215) ~[classes/:6.1.5]
	at org.apereo.cas.ticket.registry.AbstractTicketRegistry.lambda$deleteChildren$1(AbstractTicketRegistry.java:173) ~[cas-server-core-tickets-api-6.1.5.jar:6.1.5]
	at java.util.HashMap$KeySet.forEach(HashMap.java:928) ~[?:?]
	at org.apereo.cas.ticket.registry.AbstractTicketRegistry.deleteChildren(AbstractTicketRegistry.java:172) ~[cas-server-core-tickets-api-6.1.5.jar:6.1.5]
	at org.apereo.cas.ticket.registry.AbstractTicketRegistry.deleteTicket(AbstractTicketRegistry.java:112) ~[cas-server-core-tickets-api-6.1.5.jar:6.1.5]
	at org.apereo.cas.ticket.registry.AbstractTicketRegistry.deleteTicket(AbstractTicketRegistry.java:103) ~[cas-server-core-tickets-api-6.1.5.jar:6.1.5]
	at org.apereo.cas.ticket.registry.AbstractTicketRegistry$$FastClassBySpringCGLIB$$d3c67a11.invoke(<generated>) ~[cas-server-core-tickets-api-6.1.5.jar:6.1.5]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:685) ~[spring-aop-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.apereo.cas.ticket.registry.JpaTicketRegistry$$EnhancerBySpringCGLIB$$d1db7cba.deleteTicket(<generated>) ~[classes/:6.1.5]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:279) ~[spring-core-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:499) ~[spring-cloud-context-2.2.0.RC1.jar:2.2.0.RC1]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:212) ~[spring-aop-5.2.0.RELEASE.jar:5.2.0.RELEASE]
	at com.sun.proxy.$Proxy160.deleteTicket(Unknown Source) ~[?:?]
	at org.apereo.cas.web.flow.login.CreateTicketGrantingTicketAction.createOrUpdateTicketGrantingTicket(CreateTicketGrantingTicketAction.java:159) ~[cas-server-support-actions-6.1.5.jar:6.1.5]
	at org.apereo.cas.web.flow.login.CreateTicketGrantingTicketAction.doExecute(CreateTicketGrantingTicketAction.java:108) ~[cas-server-support-actions-6.1.5.jar:6.1.5]
	at org.springframework.webflow.action.AbstractAction.execute(AbstractAction.java:188) ~[spring-webflow-2.5.1.RELEASE.jar:2.5.1.RELEASE]
...
```

In that specific use case, the `deleteTicket` method is called from the `CreateTicketGrantingTicketAction` component and no transaction has been started.

In several similar use cases, the fix has been to add a `@Transactional` on several components, but I don't like this solution. The `@Transaction` should not leak outside the `JpaTicketRegistry`, this is why I propose this alternative.
