### PR TITLE
Fix a typo about sample back channel SLO message.

### DIFF
--- a/development/installation/Logout-Single-Signout.md
+++ b/development/installation/Logout-Single-Signout.md
@@ -66,11 +66,10 @@ A sample back channel SLO message:
 ```xml
 <samlp:LogoutRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     ID="[RANDOM ID]"
     Version="2.0"
     IssueInstant="[CURRENT DATE/TIME]">
-    <saml:NameID>@NOT_USED@</saml:NameID>
+    <saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@NOT_USED@</saml:NameID>
     <samlp:SessionIndex>[SESSION IDENTIFIER]</samlp:SessionIndex>
 </samlp:LogoutRequest>
 ```


### PR DESCRIPTION
The document's format is not the same as the actual output, so one of them is wrong.
