### PR TITLE
Extend the length of the JDBC audit columns

### DIFF
--- a/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/entity/AuditTrailEntity.java
+++ b/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/entity/AuditTrailEntity.java
@@ -32,7 +32,7 @@ public class AuditTrailEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id = -1;
 
-    @Column(name = "AUD_USER")
+    @Column(name = "AUD_USER", length = 2048)
     private String user;
 
     @Column(name = "AUD_CLIENT_IP")
@@ -41,10 +41,10 @@ public class AuditTrailEntity {
     @Column(name = "AUD_SERVER_IP")
     private String serverIp;
 
-    @Column(name = "AUD_RESOURCE")
+    @Column(name = "AUD_RESOURCE", length = 2048)
     private String resource;
 
-    @Column(name = "AUD_ACTION")
+    @Column(name = "AUD_ACTION", length = 2048)
     private String action;
 
     @Column(name = "APPLIC_CD")


### PR DESCRIPTION
When I use the JDBC audit ( `cas-server-support-audit-jdbc`) and the `cas.audit.includeValidationAssertion: true` property, I have SQL errors as the resource column (`AUD_RESOURCE`) is too small (255 characters).

I propose to increase the size of this column to 2048. As the user (`AUD_USER`) and the action (`AUD_ACTION`) columns are also linked by the trimming mechanism ( `cas.audit.jdbc.columnLength` property), I propose to increase them as well.
