### PR TITLE
Remove JWT generation in JWT authentication

### DIFF
--- a/support/cas-server-support-token-authentication/build.gradle
+++ b/support/cas-server-support-token-authentication/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation project(":core:cas-server-core-services-api")
     
     implementation project(":support:cas-server-support-pac4j-authentication")
-    implementation project(":support:cas-server-support-token-core")
     implementation project(":support:cas-server-support-token-core-api")
     implementation project(":support:cas-server-support-pac4j-core")
     

--- a/support/cas-server-support-token-webflow/build.gradle
+++ b/support/cas-server-support-token-webflow/build.gradle
@@ -13,8 +13,7 @@ dependencies {
     implementation project(":core:cas-server-core-configuration-api")
     implementation project(":core:cas-server-core-authentication-api")
     implementation project(":core:cas-server-core-authentication-attributes")
-    
-    implementation project(":support:cas-server-support-token-core")
+
     implementation project(":support:cas-server-support-token-core-api")
     implementation project(":support:cas-server-support-token-authentication")
 


### PR DESCRIPTION
I may be missing the point but I don't understand why the `cas-server-support-token-core` dependency is used for the JWT authentication (`cas-server-support-token-webflow` and `cas-server-support-authentication` dependencies). We don't need the JWT generation mechanism, do we?

Waiting for approval to back port to the 6.1.x branch.
