### PR TITLE
OAuth: per-service expiration in expires_in

### DIFF
--- a/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/accesstoken/OAuth20AccessToken.java
+++ b/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/accesstoken/OAuth20AccessToken.java
@@ -29,4 +29,10 @@ public interface OAuth20AccessToken extends OAuth20Token {
      * @return the id token
      */
     String getIdToken();
+
+    /**
+     * Expiration time of the Access Token in seconds since the response was generated.
+     * @return access token expiration in seconds
+     */
+    long getExpiresIn();
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AccessTokenEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AccessTokenEndpointController.java
@@ -12,6 +12,7 @@ import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerat
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenRequestDataHolder;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20AccessTokenResponseResult;
 import org.apereo.cas.ticket.OAuth20UnauthorizedScopeRequestException;
+import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 
 import com.google.common.base.Supplier;
 import lombok.SneakyThrows;
@@ -126,12 +127,11 @@ public class OAuth20AccessTokenEndpointController extends BaseOAuth20Controller 
 
         val deviceRefreshInterval = Beans.newDuration(getOAuthConfigurationContext().getCasProperties()
             .getAuthn().getOauth().getDeviceToken().getRefreshInterval()).getSeconds();
-        val atPolicy = getOAuthConfigurationContext().getAccessTokenExpirationPolicy();
         val dtPolicy = getOAuthConfigurationContext().getDeviceTokenExpirationPolicy();
         val tokenResult = OAuth20AccessTokenResponseResult.builder()
             .registeredService(requestHolder.getRegisteredService())
             .service(requestHolder.getService())
-            .accessTokenTimeout(atPolicy.buildTicketExpirationPolicy().getTimeToLive())
+            .accessTokenTimeout(result.getAccessToken().map(OAuth20AccessToken::getExpiresIn).orElse(0L))
             .deviceRefreshInterval(deviceRefreshInterval)
             .deviceTokenTimeout(dtPolicy.buildTicketExpirationPolicy().getTimeToLive())
             .responseType(result.getResponseType().orElse(OAuth20ResponseTypes.NONE))

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20ConfigurationContext.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20ConfigurationContext.java
@@ -21,7 +21,6 @@ import org.apereo.cas.support.oauth.web.views.OAuth20CallbackAuthorizeViewResolv
 import org.apereo.cas.support.oauth.web.views.OAuth20UserProfileViewRenderer;
 import org.apereo.cas.ticket.ExpirationPolicyBuilder;
 import org.apereo.cas.ticket.OAuth20TokenSigningAndEncryptionService;
-import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessTokenFactory;
 import org.apereo.cas.ticket.code.OAuth20CodeFactory;
 import org.apereo.cas.ticket.device.OAuth20DeviceToken;
@@ -78,8 +77,6 @@ public class OAuth20ConfigurationContext {
     private final JwtBuilder accessTokenJwtBuilder;
 
     private final OAuth20AccessTokenResponseGenerator accessTokenResponseGenerator;
-
-    private final ExpirationPolicyBuilder<OAuth20AccessToken> accessTokenExpirationPolicy;
 
     private final Collection<OAuth20TokenRequestValidator> accessTokenGrantRequestValidators;
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20DefaultAccessTokenResponseGenerator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20DefaultAccessTokenResponseGenerator.java
@@ -127,10 +127,10 @@ public class OAuth20DefaultAccessTokenResponseGenerator implements OAuth20Access
         generatedToken.getAccessToken().ifPresent(t -> {
             model.put(OAuth20Constants.ACCESS_TOKEN, encodeAccessToken(t, result));
             model.put(OAuth20Constants.SCOPE, String.join(" ", t.getScopes()));
+            model.put(OAuth20Constants.EXPIRES_IN, t.getExpiresIn());
         });
         generatedToken.getRefreshToken().ifPresent(t -> model.put(OAuth20Constants.REFRESH_TOKEN, t.getId()));
         model.put(OAuth20Constants.TOKEN_TYPE, OAuth20Constants.TOKEN_TYPE_BEARER);
-        model.put(OAuth20Constants.EXPIRES_IN, result.getAccessTokenTimeout());
         return model;
     }
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20ClientCredentialsResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20ClientCredentialsResponseBuilder.java
@@ -6,8 +6,6 @@ import org.apereo.cas.support.oauth.OAuth20GrantTypes;
 import org.apereo.cas.support.oauth.util.OAuth20Utils;
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerator;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20AccessTokenResponseGenerator;
-import org.apereo.cas.ticket.ExpirationPolicyBuilder;
-import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -23,9 +21,8 @@ public class OAuth20ClientCredentialsResponseBuilder extends OAuth20ResourceOwne
 
     public OAuth20ClientCredentialsResponseBuilder(final OAuth20AccessTokenResponseGenerator accessTokenResponseGenerator,
                                                    final OAuth20TokenGenerator accessTokenGenerator,
-                                                   final ExpirationPolicyBuilder<OAuth20AccessToken> accessTokenExpirationPolicy,
                                                    final CasConfigurationProperties casProperties) {
-        super(accessTokenResponseGenerator, accessTokenGenerator, accessTokenExpirationPolicy, casProperties);
+        super(accessTokenResponseGenerator, accessTokenGenerator, casProperties);
     }
 
     @Override

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20ResourceOwnerCredentialsResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20ResourceOwnerCredentialsResponseBuilder.java
@@ -8,7 +8,6 @@ import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerat
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenRequestDataHolder;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20AccessTokenResponseGenerator;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20AccessTokenResponseResult;
-import org.apereo.cas.ticket.ExpirationPolicyBuilder;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 
 import lombok.RequiredArgsConstructor;
@@ -27,18 +26,16 @@ import org.springframework.web.servlet.ModelAndView;
 public class OAuth20ResourceOwnerCredentialsResponseBuilder implements OAuth20AuthorizationResponseBuilder {
     private final OAuth20AccessTokenResponseGenerator accessTokenResponseGenerator;
     private final OAuth20TokenGenerator accessTokenGenerator;
-    private final ExpirationPolicyBuilder<OAuth20AccessToken> accessTokenExpirationPolicy;
     private final CasConfigurationProperties casProperties;
 
     @Override
     public ModelAndView build(final JEEContext context, final String clientId,
                               final AccessTokenRequestDataHolder holder) {
         val accessTokenResult = accessTokenGenerator.generate(holder);
-        val expirationPolicy = accessTokenExpirationPolicy.buildTicketExpirationPolicy();
         val result = OAuth20AccessTokenResponseResult.builder()
             .registeredService(holder.getRegisteredService())
             .service(holder.getService())
-            .accessTokenTimeout(expirationPolicy.getTimeToLive())
+            .accessTokenTimeout(accessTokenResult.getAccessToken().map(OAuth20AccessToken::getExpiresIn).orElse(0L))
             .responseType(OAuth20Utils.getResponseType(context))
             .casProperties(casProperties)
             .generatedToken(accessTokenResult)

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilder.java
@@ -7,7 +7,6 @@ import org.apereo.cas.support.oauth.OAuth20ResponseTypes;
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerator;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenRequestDataHolder;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenEncoder;
-import org.apereo.cas.ticket.ExpirationPolicyBuilder;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 import org.apereo.cas.ticket.refreshtoken.OAuth20RefreshToken;
 import org.apereo.cas.token.JwtBuilder;
@@ -38,7 +37,6 @@ import java.util.List;
 @Getter
 public class OAuth20TokenAuthorizationResponseBuilder implements OAuth20AuthorizationResponseBuilder {
     private final OAuth20TokenGenerator accessTokenGenerator;
-    private final ExpirationPolicyBuilder<OAuth20AccessToken> accessTokenExpirationPolicy;
     private final ServicesManager servicesManager;
     private final JwtBuilder accessTokenJwtBuilder;
     private final CasConfigurationProperties casProperties;
@@ -95,8 +93,7 @@ public class OAuth20TokenAuthorizationResponseBuilder implements OAuth20Authoriz
             .build()
             .encode();
 
-        val expiration = accessTokenExpirationPolicy.buildTicketExpirationPolicy();
-        val timeToLive = expiration.getTimeToLive();
+        val expiresIn = accessToken.getExpiresIn();
         stringBuilder.append(OAuth20Constants.ACCESS_TOKEN)
             .append('=')
             .append(encodedAccessToken)
@@ -107,7 +104,7 @@ public class OAuth20TokenAuthorizationResponseBuilder implements OAuth20Authoriz
             .append('&')
             .append(OAuth20Constants.EXPIRES_IN)
             .append('=')
-            .append(timeToLive);
+            .append(expiresIn);
 
         if (refreshToken != null) {
             stringBuilder.append('&')
@@ -142,7 +139,7 @@ public class OAuth20TokenAuthorizationResponseBuilder implements OAuth20Authoriz
         if (refreshToken != null) {
             parameters.put(OAuth20Constants.REFRESH_TOKEN, refreshToken.getId());
         }
-        parameters.put(OAuth20Constants.EXPIRES_IN, timeToLive.toString());
+        parameters.put(OAuth20Constants.EXPIRES_IN, String.valueOf(expiresIn));
         parameters.put(OAuth20Constants.STATE, state);
         parameters.put(OAuth20Constants.NONCE, nonce);
         parameters.put(OAuth20Constants.CLIENT_ID, accessToken.getClientId());

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/OAuth20DefaultAccessToken.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/OAuth20DefaultAccessToken.java
@@ -65,4 +65,9 @@ public class OAuth20DefaultAccessToken extends OAuth20DefaultCode implements OAu
     public String getPrefix() {
         return OAuth20AccessToken.PREFIX;
     }
+
+    @Override
+    public long getExpiresIn() {
+        return getExpirationPolicy().getTimeToLive();
+    }
 }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -708,7 +708,7 @@ public class CasOAuth20Configuration {
     @RefreshScope
     public OAuth20AuthorizationResponseBuilder oauthResourceOwnerCredentialsResponseBuilder() {
         return new OAuth20ResourceOwnerCredentialsResponseBuilder(accessTokenResponseGenerator(), oauthTokenGenerator(),
-            accessTokenExpirationPolicy(), casProperties);
+            casProperties);
     }
 
     @ConditionalOnMissingBean(name = "oauthClientCredentialsResponseBuilder")
@@ -716,14 +716,14 @@ public class CasOAuth20Configuration {
     @RefreshScope
     public OAuth20AuthorizationResponseBuilder oauthClientCredentialsResponseBuilder() {
         return new OAuth20ClientCredentialsResponseBuilder(accessTokenResponseGenerator(),
-            oauthTokenGenerator(), accessTokenExpirationPolicy(), casProperties);
+            oauthTokenGenerator(), casProperties);
     }
 
     @ConditionalOnMissingBean(name = "oauthTokenResponseBuilder")
     @Bean
     @RefreshScope
     public OAuth20AuthorizationResponseBuilder oauthTokenResponseBuilder() {
-        return new OAuth20TokenAuthorizationResponseBuilder(oauthTokenGenerator(), accessTokenExpirationPolicy(),
+        return new OAuth20TokenAuthorizationResponseBuilder(oauthTokenGenerator(),
             servicesManager.getObject(), accessTokenJwtBuilder(), casProperties);
     }
 
@@ -899,7 +899,6 @@ public class CasOAuth20Configuration {
             .accessTokenGenerator(oauthTokenGenerator())
             .accessTokenJwtBuilder(accessTokenJwtBuilder())
             .accessTokenResponseGenerator(accessTokenResponseGenerator())
-            .accessTokenExpirationPolicy(accessTokenExpirationPolicy())
             .deviceTokenExpirationPolicy(deviceTokenExpirationPolicy())
             .accessTokenGrantRequestValidators(oauthTokenRequestValidators())
             .userProfileDataCreator(oAuth2UserProfileDataCreator())

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/AbstractOAuth20Tests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/AbstractOAuth20Tests.java
@@ -36,6 +36,7 @@ import org.apereo.cas.config.CasThrottlingConfiguration;
 import org.apereo.cas.config.CasThymeleafConfiguration;
 import org.apereo.cas.config.support.CasWebApplicationServiceFactoryConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.apereo.cas.mock.MockServiceTicket;
 import org.apereo.cas.mock.MockTicketGrantingTicket;
@@ -588,6 +589,11 @@ public abstract class AbstractOAuth20Tests {
             .generatedToken(generatedToken)
             .build();
         return accessTokenResponseGenerator.generate(mockRequest, mockResponse, result);
+    }
+
+    protected long getDefaultAccessTokenExpiration() {
+        return Beans.newDuration(casProperties.getAuthn().getOauth().getAccessToken().getMaxTimeToLiveInSeconds())
+                .getSeconds();
     }
 
     @TestConfiguration("OAuth20TestConfiguration")

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AccessTokenEndpointControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AccessTokenEndpointControllerTests.java
@@ -457,7 +457,7 @@ public class OAuth20AccessTokenEndpointControllerTests extends AbstractOAuth20Te
         requiresAuthenticationInterceptor.preHandle(mockRequest, approveResp, null);
         val mvApproved = controller.handleRequest(mockRequest, approveResp);
         assertTrue(mvApproved.getModel().containsKey(OAuth20Constants.ACCESS_TOKEN));
-        assertTrue(mvApproved.getModel().containsKey(OAuth20Constants.EXPIRES_IN));
+        assertEquals(getDefaultAccessTokenExpiration(), mvApproved.getModel().get(OAuth20Constants.EXPIRES_IN));
         assertTrue(mvApproved.getModel().containsKey(OAuth20Constants.TOKEN_TYPE));
     }
 

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilderTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilderTests.java
@@ -8,7 +8,6 @@ import org.apereo.cas.support.oauth.OAuth20GrantTypes;
 import org.apereo.cas.support.oauth.OAuth20ResponseTypes;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenRequestDataHolder;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
-import org.apereo.cas.ticket.accesstoken.OAuth20AccessTokenExpirationPolicyBuilder;
 
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -78,9 +77,7 @@ public class OAuth20TokenAuthorizationResponseBuilderTests extends AbstractOAuth
             .getAccessToken()
             .get();
 
-        val tokenExpirationPolicyBuilder = new OAuth20AccessTokenExpirationPolicyBuilder(casProperties);
         val tokenAuthorizationResponseBuilder = new OAuth20TokenAuthorizationResponseBuilder(oauthTokenGenerator,
-            tokenExpirationPolicyBuilder,
             servicesManager,
             accessTokenJwtBuilder,
             casProperties);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcImplicitIdTokenAndTokenAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcImplicitIdTokenAndTokenAuthorizationResponseBuilder.java
@@ -39,12 +39,11 @@ public class OidcImplicitIdTokenAndTokenAuthorizationResponseBuilder extends OAu
 
     public OidcImplicitIdTokenAndTokenAuthorizationResponseBuilder(final IdTokenGeneratorService idTokenGenerator,
                                                                    final OAuth20TokenGenerator accessTokenGenerator,
-                                                                   final ExpirationPolicyBuilder<OAuth20AccessToken> accessTokenExpirationPolicy,
                                                                    final ExpirationPolicyBuilder idTokenExpirationPolicy,
                                                                    final ServicesManager servicesManager,
                                                                    final JwtBuilder accessTokenJwtBuilder,
                                                                    final CasConfigurationProperties casProperties) {
-        super(accessTokenGenerator, accessTokenExpirationPolicy, servicesManager, accessTokenJwtBuilder, casProperties);
+        super(accessTokenGenerator, servicesManager, accessTokenJwtBuilder, casProperties);
         this.idTokenGenerator = idTokenGenerator;
         this.idTokenExpirationPolicy = idTokenExpirationPolicy;
     }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcImplicitIdTokenAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcImplicitIdTokenAuthorizationResponseBuilder.java
@@ -39,12 +39,11 @@ public class OidcImplicitIdTokenAuthorizationResponseBuilder extends OAuth20Toke
 
     public OidcImplicitIdTokenAuthorizationResponseBuilder(final IdTokenGeneratorService idTokenGenerator,
                                                            final OAuth20TokenGenerator accessTokenGenerator,
-                                                           final ExpirationPolicyBuilder<OAuth20AccessToken> accessTokenExpirationPolicy,
                                                            final ExpirationPolicyBuilder idTokenExpirationPolicy,
                                                            final ServicesManager servicesManager,
                                                            final JwtBuilder accessTokenJwtBuilder,
                                                            final CasConfigurationProperties casProperties) {
-        super(accessTokenGenerator, accessTokenExpirationPolicy, servicesManager, accessTokenJwtBuilder, casProperties);
+        super(accessTokenGenerator, servicesManager, accessTokenJwtBuilder, casProperties);
         this.idTokenGenerator = idTokenGenerator;
         this.idTokenExpirationPolicy = idTokenExpirationPolicy;
     }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -216,10 +216,6 @@ public class OidcConfiguration implements WebMvcConfigurer {
     private ObjectProvider<ServiceFactory<WebApplicationService>> webApplicationServiceFactory;
 
     @Autowired
-    @Qualifier("accessTokenExpirationPolicy")
-    private ObjectProvider<ExpirationPolicyBuilder> accessTokenExpirationPolicy;
-
-    @Autowired
     @Qualifier("deviceTokenExpirationPolicy")
     private ObjectProvider<ExpirationPolicyBuilder> deviceTokenExpirationPolicy;
 
@@ -695,14 +691,14 @@ public class OidcConfiguration implements WebMvcConfigurer {
     @Bean
     public OAuth20AuthorizationResponseBuilder oidcImplicitIdTokenCallbackUrlBuilder() {
         return new OidcImplicitIdTokenAuthorizationResponseBuilder(oidcIdTokenGenerator(), oauthTokenGenerator.getObject(),
-            accessTokenExpirationPolicy.getObject(), grantingTicketExpirationPolicy.getObject(),
+            grantingTicketExpirationPolicy.getObject(),
             servicesManager.getObject(), accessTokenJwtBuilder.getObject(), casProperties);
     }
 
     @Bean
     public OAuth20AuthorizationResponseBuilder oidcImplicitIdTokenAndTokenCallbackUrlBuilder() {
         return new OidcImplicitIdTokenAndTokenAuthorizationResponseBuilder(oidcIdTokenGenerator(), oauthTokenGenerator.getObject(),
-            accessTokenExpirationPolicy.getObject(), grantingTicketExpirationPolicy.getObject(),
+            grantingTicketExpirationPolicy.getObject(),
             servicesManager.getObject(), accessTokenJwtBuilder.getObject(), casProperties);
     }
 
@@ -839,7 +835,6 @@ public class OidcConfiguration implements WebMvcConfigurer {
             .profileScopeToAttributesFilter(profileScopeToAttributesFilter())
             .accessTokenGenerator(oauthTokenGenerator.getObject())
             .accessTokenResponseGenerator(oidcAccessTokenResponseGenerator())
-            .accessTokenExpirationPolicy(accessTokenExpirationPolicy.getObject())
             .deviceTokenExpirationPolicy(deviceTokenExpirationPolicy.getObject())
             .accessTokenGrantRequestValidators(oauthTokenRequestValidators.getObject())
             .accessTokenGrantAuditableRequestExtractor(accessTokenGrantAuditableRequestExtractor.getObject())


### PR DESCRIPTION
From OAuth specifications, expires_in from token
and authorization endpoints must be equal to
accessToken expiration.

Before this fix, expires_in was always set to
global oauth accessToken expiration and not
per-service expiration.