### PR TITLE
Delegated auth: Delegated client identifier cannot be located

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/config/DelegatedAuthenticationWebflowConfiguration.java
@@ -214,7 +214,6 @@ public class DelegatedAuthenticationWebflowConfiguration {
         return new Saml2ClientMetadataController(builtClients.getObject(), configBean.getObject());
     }
 
-    @ConditionalOnMissingBean(name = "delegatedClientNavigationController")
     @Bean
     public DelegatedClientNavigationController delegatedClientNavigationController() {
         return new DelegatedClientNavigationController(builtClients.getObject(),


### PR DESCRIPTION
Error when using pac4j authentication delegation after
login submission when the authentication flow goes back
from delegated authentication to authentication server.

The authentication server generates the following error:

```
ERROR [org.apereo.cas.web.DelegatedClientWebflowManager] - <Delegated client identifier cannot be located in the authentication request [https://mycasserver.com/cas/login?client_name=PERSONAS&ticket=ST-2827--XXX
```

This is due because DelegatedClientNavigationController uses
a JEESessionStore (DelegatedClientNavigationController
is used before redirecting to delegated server) while
DelegatedClientAuthenticationAction uses DistributedJ2ESessionStore
(DelegatedClientAuthenticationAction is used when cas server is handling
the redirect back from delegated server).

DelegatedClientNavigationController save some data [1] in JEESessionStore,
while DelegatedClientAuthenticationAction tries to get the data [2]
in DistributedJ2ESessionStore (hence a different session).

This issue is because DelegatedClientNavigationController bean is not
created by DelegatedAuthenticationWebflowConfiguration.

[1] see DelegatedClientWebflowManager.store
[2] see DelegatedClientWebflowManager.getDelegatedClientId

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
