### PR TITLE
Pac4j: Allow configuring the scope for delegated Github SSO

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jDelegatedAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jDelegatedAuthenticationProperties.java
@@ -283,6 +283,11 @@ public class Pac4jDelegatedAuthenticationProperties implements Serializable {
         public Github() {
             setClientName("Github");
         }
+
+        /**
+         * The requested scope from the provider.
+         */
+        private String scope;
     }
 
     @RequiresModule(name = "cas-server-support-pac4j-webflow")

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3527,6 +3527,16 @@ Provision and create established user profiles to identity stores.
 
 RESTful settings for this feature are available [here](Configuration-Properties-Common.html#restful-integrations) under the configuration key `cas.authn.pac4j.provisioning.rest`.
 
+### GitHub
+
+In addition to the [common block of settings](Configuration-Properties-Common.html#delegated-authentication-settings) , the following properties are additionally supported, when delegating authentication to GitHub:
+
+```properties
+# cas.authn.pac4j.github.scope=user|read:user|user:email|...
+```
+
+For a full list of possible scopes, please check https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
+
 ### Google
 
 In addition to the [common block of settings](Configuration-Properties-Common.html#delegated-authentication-settings) , the following properties are additionally supported, when delegating authentication to Google:

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3534,6 +3534,7 @@ In addition to the [common block of settings](Configuration-Properties-Common.ht
 ```properties
 # cas.authn.pac4j.github.scope=user|read:user|user:email|...
 ```
+The default scope is `user`, i.e. read/write access to the GitHub user account.
 
 For a full list of possible scopes, please check https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
 

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java
@@ -112,6 +112,9 @@ public class DelegatedClientFactory {
         if (github.isEnabled() && StringUtils.isNotBlank(github.getId()) && StringUtils.isNotBlank(github.getSecret())) {
             val client = new GitHubClient(github.getId(), github.getSecret());
             configureClient(client, github);
+            if (StringUtils.isNotBlank(github.getScope())) {
+                client.setScope(github.getScope());
+            }
             LOGGER.debug("Created client [{}] with identifier [{}]", client.getName(), client.getKey());
             properties.add(client);
         }


### PR DESCRIPTION
I noticed CAS configuration does not support customizing the provider of the Github SSO delegate but pac4j's client implementation does. I used the Google/Facebook client configuration as a blueprint to add the support.

What's missing:
1) No tests done, yet. I first have to understand how to get it running in my CAS overlay project.
2) I did not find any tests for providers like FB and Google. Or did I just miss them?
