### PR TITLE
[bugfix] Prevent infinite 302 when embedded jetty and behind LB

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/application.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/application.properties
@@ -11,7 +11,7 @@ server.ssl.enabled=true
 server.port=8443
 server.servlet.context-path=/cas
 server.max-http-header-size=2097152
-server.forward-headers-strategy=NONE
+server.forward-headers-strategy=NATIVE
 server.connection-timeout=PT20S
 server.error.include-stacktrace=ALWAYS
 


### PR DESCRIPTION
We upgraded our embedded jetty CAS installation to 6.1.5 and when we deployed the service behind a load balancer we would see 302 responses for all calls that passed through the load balancer. After debugging we found that the `X-Forwarded-Proto: https` header being passed by our LB was triggering the 302.

To fix the issue we added `server.forward-headers-strategy=NATIVE` to our `application.properties`. This PR is meant to match the prior config that had `server.use-forward-headers=true`.

See https://github.com/apereo/cas/commit/fc9e7653aeb0cbb4b309bfab75712453e57db61e#diff-4b4050db4930afc20ddc6fda1aae1c13L14 for original change that introduced the problem.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
