### PR TITLE
Show friendly names for consent attributes instead of SAML URNs

### DIFF
--- a/support/cas-server-support-consent-core/build.gradle
+++ b/support/cas-server-support-consent-core/build.gradle
@@ -4,6 +4,8 @@ dependencies {
     api project(":api:cas-server-core-api-services")
 
     implementation project(":support:cas-server-support-consent-api")
+    implementation project(":support:cas-server-support-saml-idp-core")
+    implementation project(":support:cas-server-support-saml-idp-web")
     implementation project(":core:cas-server-core-web-api")
     implementation project(":core:cas-server-core-configuration-api")
     implementation project(":core:cas-server-core-authentication-api")

--- a/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/config/CasConsentCoreConfiguration.java
+++ b/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/config/CasConsentCoreConfiguration.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.config;
 
 import org.apereo.cas.audit.AuditTrailRecordResolutionPlanConfigurer;
+import org.apereo.cas.authentication.attribute.AttributeDefinitionStore;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.consent.AttributeConsentReportEndpoint;
 import org.apereo.cas.consent.AttributeReleaseConsentCipherExecutor;
@@ -51,11 +52,15 @@ public class CasConsentCoreConfiguration {
     @Qualifier("returnValueResourceResolver")
     private ObjectProvider<AuditResourceResolver> returnValueResourceResolver;
 
+    @Autowired
+    @Qualifier("attributeDefinitionStore")
+    private ObjectProvider<AttributeDefinitionStore> attributeDefinitionStore;
+
     @ConditionalOnMissingBean(name = "consentEngine")
     @Bean
     @RefreshScope
     public ConsentEngine consentEngine() {
-        return new DefaultConsentEngine(consentRepository(), consentDecisionBuilder());
+        return new DefaultConsentEngine(consentRepository(), consentDecisionBuilder(), casProperties.getAuthn().getSamlIdp(), attributeDefinitionStore.getObject());
     }
 
     @ConditionalOnMissingBean(name = "consentCipherExecutor")


### PR DESCRIPTION
This PR changes the way consent attributes are shown  for SAML based authentication. Consent attribute names for SAML authentications are no longer shown as URN, but as friendly name, which can be configured via `attribute-defns.json`.