### PR TITLE
fix MFA trusted device login /cas service access denied

### DIFF
--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/RegisteredServiceAccessStrategyAuditableEnforcer.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/RegisteredServiceAccessStrategyAuditableEnforcer.java
@@ -107,7 +107,6 @@ public class RegisteredServiceAccessStrategyAuditableEnforcer extends BaseAudita
         }
 
         val result = AuditableExecutionResult.builder().build();
-        result.setException(new UnauthorizedServiceException(UnauthorizedServiceException.CODE_UNAUTHZ_SERVICE, "Service unauthorized"));
         return result;
     }
 }

--- a/core/cas-server-core-services-api/src/test/java/org/apereo/cas/services/util/RegisteredServiceAccessStrategyAuditableEnforcerTests.java
+++ b/core/cas-server-core-services-api/src/test/java/org/apereo/cas/services/util/RegisteredServiceAccessStrategyAuditableEnforcerTests.java
@@ -238,8 +238,8 @@ public class RegisteredServiceAccessStrategyAuditableEnforcerTests {
     public void verifyExceptionNotThrown() {
         val context = AuditableContext.builder().build();
         val result = new RegisteredServiceAccessStrategyAuditableEnforcer().execute(context);
-        assertTrue(result.isExecutionFailure());
-        assertTrue(result.getException().isPresent());
+        assertFalse(result.isExecutionFailure());
+        assertFalse(result.getException().isPresent());
     }
 
     private static RegexRegisteredService createRegisteredService(final boolean enabled) {

--- a/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/DefaultMultifactorAuthenticationTrustedDeviceBypassEvaluator.java
+++ b/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/DefaultMultifactorAuthenticationTrustedDeviceBypassEvaluator.java
@@ -5,6 +5,9 @@ import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.services.RegexRegisteredService;
+
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +37,9 @@ public class DefaultMultifactorAuthenticationTrustedDeviceBypassEvaluator implem
         val accessResult = this.registeredServiceAccessStrategyEnforcer.execute(audit);
         accessResult.throwExceptionIfNeeded();
 
-        val mfaPolicy = registeredService.getMultifactorPolicy();
+        val mfaPolicy = Optional.ofNullable(registeredService)
+                                .orElse(new RegexRegisteredService())
+                                .getMultifactorPolicy();
         return mfaPolicy != null && mfaPolicy.isBypassTrustedDeviceEnabled();
     }
 }


### PR DESCRIPTION
CAS configuration: MFA trust device enabled

Error case: user login to https://<cas>/cas directly without redirection from any server, after entering username/password, user receives "Unauthorized Service" error instead of presenting MFA (or bypass if the device is trusted). This is inconvenient for testing, which testers normally logins https://<cas>/cas directly.

Cause: RegisteredServiceAccessStrategyAuditableEnforcer.java throws CODE_UNAUTHZ_SERVICE if registeredService is null (which is the case if user logins to https://<cas>/cas directly). This PR corrects this problem by not throwing CODE_UNAUTHZ_SERVICE if registeredService is null.

I am not sure if there is any security implications in this fix, because I am not sure if there is any other cases that registeredService is null.