### PR TITLE
activate the jwt signing key and encryption key

### DIFF
--- a/support/cas-server-support-token-core/src/main/java/org/apereo/cas/token/cipher/TokenTicketCipherExecutor.java
+++ b/support/cas-server-support-token-core/src/main/java/org/apereo/cas/token/cipher/TokenTicketCipherExecutor.java
@@ -12,7 +12,7 @@ import org.apereo.cas.util.cipher.BaseStringCipherExecutor;
 @Slf4j
 public class TokenTicketCipherExecutor extends BaseStringCipherExecutor {
     public TokenTicketCipherExecutor() {
-        this(null, null, null, false, false);
+        this(null, null, null, true, true);
     }
 
     public TokenTicketCipherExecutor(final String secretKeyEncryption,


### PR DESCRIPTION
the constructor by default called by RegisteredServiceTokenTicketCipherExecutor class has false and false for encryptionEnabled and signingEnabled...

in order enabled, can you accept my PR ? please ?

because in the cas server logs we can see this :
---
2020-04-01 12:20:22,866 WARN [org.apereo.cas.util.cipher.BaseStringCipherExecutor] - <Encryption is not enabled for [Token/JWT Tickets]. The cipher [RegisteredServiceTokenTicketCipherExecutor] will only attempt to produce signed objects>
2020-04-01 12:20:22,866 WARN [org.apereo.cas.util.cipher.BaseStringCipherExecutor] - <Signing is not enabled for [Token/JWT Tickets]. The cipher [RegisteredServiceTokenTicketCipherExecutor] will attempt to produce plain objects>
---

it means that it is not enabled for encryptionEnabled and signingEnabled

Thanks a lot !

Sincerly,

Mathieu HETRU

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
