### PR TITLE
Google Authenticator: do not store the OTP used to register MFA

### DIFF
--- a/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/credential/GoogleAuthenticatorAccount.java
+++ b/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/credential/GoogleAuthenticatorAccount.java
@@ -35,6 +35,7 @@ public class GoogleAuthenticatorAccount extends OneTimeTokenAccount {
                                       @JsonProperty("secretKey") final String secretKey,
                                       @JsonProperty("validationCode") final int validationCode,
                                       @JsonProperty("scratchCodes") final List<Integer> scratchCodes) {
-        super(username, secretKey, validationCode, scratchCodes);
+        // Do not store the validation code that creates the account
+        super(username, secretKey, 0, scratchCodes);
     }
 }


### PR DESCRIPTION
It is unnecessary (actually very bad) to store the OTP used to register MFA