### PR TITLE
WIP: properly deregister JDBC driver at shutdown

### DIFF
--- a/style/checkstyle-suppressions.xml
+++ b/style/checkstyle-suppressions.xml
@@ -33,6 +33,4 @@
     <suppress checks="\w+" files="(\.(crt|crl|class|keystore))|rebel.xml"/>
     <suppress checks="." files="com[\\/]duosecurity[\\/]duoweb[\\/]"/>
     <suppress checks="." files="org[\\/]apereo[\\/]cas[\\/]authentication[\\/]soap[\\/]"/>
-    <suppress checks="FinalParameters" files="webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java"/>
-    <suppress checks="FinalLocalVariable" files="webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java"/>
 </suppressions>

--- a/style/checkstyle-suppressions.xml
+++ b/style/checkstyle-suppressions.xml
@@ -33,4 +33,6 @@
     <suppress checks="\w+" files="(\.(crt|crl|class|keystore))|rebel.xml"/>
     <suppress checks="." files="com[\\/]duosecurity[\\/]duoweb[\\/]"/>
     <suppress checks="." files="org[\\/]apereo[\\/]cas[\\/]authentication[\\/]soap[\\/]"/>
+    <suppress checks="FinalParameters" files="webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java"/>
+    <suppress checks="FinalLocalVariable" files="webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java"/>
 </suppressions>

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java
@@ -1,19 +1,24 @@
 package org.apereo.cas.web;
 
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-
-@Configuration
+/**
+ * This is {@link CasServletContextListenerConfigurationBean} that properly
+ * deregisters JDBC drivers.
+ *
+ * @author leeyc0
+ * @since 6.2.0
+ */
+@Configuration("casServletContextListenerConfigurationBean")
 @Slf4j
 public class CasServletContextListenerConfigurationBean {
     @Bean
@@ -31,26 +36,24 @@ public class CasServletContextListenerConfigurationBean {
 
         @Override
         public final void contextDestroyed(ServletContextEvent sce) {
-            // ... First close any background tasks which may be using the DB ...
-            // ... Then close any DB connection pools ...
+            /* ... First close any background tasks which may be using the DB ...
+               ... Then close any DB connection pools ...
 
-            // Now deregister JDBC drivers in this context's ClassLoader:
-            // Get the webapp's ClassLoader
+               Now deregister JDBC drivers in this context's ClassLoader:
+               Get the webapp's ClassLoader */
             val cl = Thread.currentThread().getContextClassLoader();
-            // Loop through all drivers
             val drivers = DriverManager.getDrivers();
             while (drivers.hasMoreElements()) {
                 val driver = drivers.nextElement();
                 if (driver.getClass().getClassLoader() == cl) {
-                    // This driver was registered by the webapp's ClassLoader, so deregister it:
+                    /* This driver was registered by the webapp's ClassLoader, so deregister it: */
                     try {
                         LOGGER.debug("Deregistering JDBC driver {}", driver);
                         DriverManager.deregisterDriver(driver);
-                    } catch (SQLException ex) {
+                    } catch (final SQLException ex) {
                         LOGGER.debug("Error deregistering JDBC driver {}", ex);
                     }
                 } else {
-                    // driver was not registered by the webapp's ClassLoader and may be in use elsewhere
                     LOGGER.debug("Not deregistering JDBC driver {} as it does not belong to this webapp's ClassLoader", driver);
                 }
             }

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java
@@ -30,12 +30,12 @@ public class CasServletContextListenerConfigurationBean {
 
     private static class CasServletContextListener implements ServletContextListener {
         @Override
-        public void contextInitialized(ServletContextEvent sce) {
+        public void contextInitialized(final ServletContextEvent sce) {
             LOGGER.debug("Registered CasServletContextListener");
         }
 
         @Override
-        public final void contextDestroyed(ServletContextEvent sce) {
+        public final void contextDestroyed(final ServletContextEvent sce) {
             /* ... First close any background tasks which may be using the DB ...
                ... Then close any DB connection pools ...
 

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasServletContextListenerConfigurationBean.java
@@ -1,0 +1,59 @@
+package org.apereo.cas.web;
+
+import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+@Configuration
+@Slf4j
+public class CasServletContextListenerConfigurationBean {
+    @Bean
+    ServletListenerRegistrationBean<ServletContextListener> servletListener() {
+        val srb = new ServletListenerRegistrationBean<ServletContextListener>();
+        srb.setListener(new CasServletContextListener());
+        return srb;
+    }
+
+    private static class CasServletContextListener implements ServletContextListener {
+        @Override
+        public void contextInitialized(ServletContextEvent sce) {
+            LOGGER.debug("Registered CasServletContextListener");
+        }
+
+        @Override
+        public final void contextDestroyed(ServletContextEvent sce) {
+            // ... First close any background tasks which may be using the DB ...
+            // ... Then close any DB connection pools ...
+
+            // Now deregister JDBC drivers in this context's ClassLoader:
+            // Get the webapp's ClassLoader
+            val cl = Thread.currentThread().getContextClassLoader();
+            // Loop through all drivers
+            val drivers = DriverManager.getDrivers();
+            while (drivers.hasMoreElements()) {
+                val driver = drivers.nextElement();
+                if (driver.getClass().getClassLoader() == cl) {
+                    // This driver was registered by the webapp's ClassLoader, so deregister it:
+                    try {
+                        LOGGER.debug("Deregistering JDBC driver {}", driver);
+                        DriverManager.deregisterDriver(driver);
+                    } catch (SQLException ex) {
+                        LOGGER.debug("Error deregistering JDBC driver {}", ex);
+                    }
+                } else {
+                    // driver was not registered by the webapp's ClassLoader and may be in use elsewhere
+                    LOGGER.debug("Not deregistering JDBC driver {} as it does not belong to this webapp's ClassLoader", driver);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
We should deregister JDBC drivers at shutdown instead of relying tomcat to forcefully deregister it. (This feature may not exist in other servlet servers.)

Tomcat throws this message
`SEVERE: A web application registered the JDBC driver [XXXXX] but failed to unregister it when the web application was stopped. To prevent a memory leak, the JDBC Driver has been forcibly unregistered.`
when a JDBC driver deregisters forcefully.

Note that the logging in contextDestroyed is not working as intended, presumably logger is uninitialized before contextDestroyed is called. I added System.out.println to test and confirmed contextDestroyed is working.

Ref: spring-projects/spring-boot#2612