### PR TITLE
Fix default Mongo authn config

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mongo/MongoAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mongo/MongoAuthenticationProperties.java
@@ -7,6 +7,7 @@ import org.apereo.cas.configuration.support.RequiresModule;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -24,9 +25,9 @@ public class MongoAuthenticationProperties extends SingleCollectionMongoDbProper
     private static final long serialVersionUID = -7304734732383722585L;
 
     /**
-     * Attributes to fetch from Mongo.
+     * Attributes to fetch from Mongo (blank by default to force the pac4j legacy behavior).
      */
-    private String attributes;
+    private String attributes = StringUtils.EMPTY;
 
     /**
      * Attributes that holds the username.


### PR DESCRIPTION
Some times ago, we discuss an issue about the Mongo authentication defaults managed by pac4j. See: https://github.com/apereo/cas/pull/4404#issuecomment-549442367

This is the PR to fix the problem. I thought I could use "id,username,password" as the default `attributes` value but it's rejected by pac4j as these attributes are already retrieved. The empty string does the job.
