### PR TITLE
doc: TGT REST API returns 401 on incorrect credentials

### DIFF
--- a/docs/cas-server-documentation/protocol/REST-Protocol.md
+++ b/docs/cas-server-documentation/protocol/REST-Protocol.md
@@ -47,9 +47,7 @@ Location: http://www.whatever.com/cas/v1/tickets/{TGT id}
 
 ### Unsuccessful Response
 
-If incorrect credentials are sent, CAS will respond with a 401 Unauthorized.
-A 400 Bad Request error will be sent for missing parameters, etc. 
-If you send a media type it does not understand, it will send the 415 Unsupported Media Type.
+If incorrect credentials are sent, CAS will respond with a `401 Unauthorized`. A `400 Bad Request` error will be sent for missing parameters, etc. If you send a media type it does not understand, it will send the `415 Unsupported Media Type`.
 
 ### JWT Ticket Granting Tickets
 

--- a/docs/cas-server-documentation/protocol/REST-Protocol.md
+++ b/docs/cas-server-documentation/protocol/REST-Protocol.md
@@ -47,9 +47,9 @@ Location: http://www.whatever.com/cas/v1/tickets/{TGT id}
 
 ### Unsuccessful Response
 
-If incorrect credentials are sent, CAS will respond with a 400 Bad Request error
-(will also respond for missing parameters, etc.). If you send a media type
-it does not understand, it will send the 415 Unsupported Media Type.
+If incorrect credentials are sent, CAS will respond with a 401 Unauthorized.
+A 400 Bad Request error will be sent for missing parameters, etc. 
+If you send a media type it does not understand, it will send the 415 Unsupported Media Type.
 
 ### JWT Ticket Granting Tickets
 


### PR DESCRIPTION
Documentation of REST protocol erroneously says that "400 Bad Request" is returned if incorrect credentials are sent.
Instead, "401 Unauthorized" is returned in this case, which is much more logical.

See org.apereo.cas.support.rest.resources.TicketGrantingTicketResource
See org.apereo.cas.support.rest.resources.RestResourceUtils.createResponseEntityForAuthnFailure(...)

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
