### PR TITLE
Update to Spring Boot 2.2.6.RELEASE

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,8 +37,8 @@ targetCompatibility=11
 # in order to fully override component versions that are provided by Spring Boot.
 ##################################################################################
 
-lombokVersion=1.18.10
-aspectjVersion=1.9.4
+lombokVersion=1.18.12
+aspectjVersion=1.9.5
 errorProneVersion=2.3.2
 errorproneJavacVersion=9+181-r4173-1
 junitVersion=5.5.2
@@ -94,19 +94,19 @@ sentryRavenVersion=8.0.3
 # Spring versions
 ###############################
 
-springBootVersion=2.2.0.RELEASE
+springBootVersion=2.2.6.RELEASE
 springBootAdminVersion=2.2.0
 
-springRetryVersion=1.2.4.RELEASE
+springRetryVersion=1.2.5.RELEASE
 
-springIntegrationVersion=5.2.0.RELEASE
+springIntegrationVersion=5.2.5.RELEASE
 
 springWebflowVersion=2.5.1.RELEASE
 
-springDataCommonsVersion=2.2.0.RELEASE
-springDataMongoDbVersion=2.2.0.RELEASE
+springDataCommonsVersion=2.2.6.RELEASE
+springDataMongoDbVersion=2.2.6.RELEASE
 
-springSecurityVersion=5.2.0.RELEASE
+springSecurityVersion=5.2.2.RELEASE
 springSecurityRsaVersion=1.0.8.RELEASE
 springShellVersion=2.0.1.RELEASE
 

--- a/gradle/overrides.gradle
+++ b/gradle/overrides.gradle
@@ -7,36 +7,36 @@
   overlays could use and pull this file and have their 
   dependencies match that of CAS. 
  */
-ext["hibernateVersion"] = "5.4.9.Final"
-ext["hazelcastVersion"] = "3.12.4"
-ext["infinispanVersion"] = "9.4.16.Final"
+ext["hibernateVersion"] = "5.4.12.Final"
+ext["hazelcastVersion"] = "3.12.6"
+ext["infinispanVersion"] = "9.4.18.Final"
 
-ext["springVersion"] = "5.2.0.RELEASE"
-ext["springSessionVersion"] = "2.2.0.RELEASE"
-ext["springSessionMongoVersion"] = "2.2.1.RELEASE"
+ext["springVersion"] = "5.2.5.RELEASE"
+ext["springSessionVersion"] = "2.2.2.RELEASE"
+ext["springSessionMongoVersion"] = "2.2.3.RELEASE"
 
 ext["springBootTomcatVersion"] = "9.0.33"
 
-ext["jacksonVersion"] = "2.10.0.pr2"
-ext["jacksonCoreVersion"] = "2.10.0"
+ext["jacksonVersion"] = "2.10.3"
+ext["jacksonCoreVersion"] = "2.10.3"
 ext["thymeleafVersion"] = "3.0.11.RELEASE"
 ext["thymeleafDialectVersion"] = "2.4.1"
 ext["hsqlVersion"] = "2.5.0"
-ext["httpCoreVersion"] = "4.4.12"
-ext["hikariVersion"] = "3.4.1"
+ext["httpCoreVersion"] = "4.4.13"
+ext["hikariVersion"] = "3.4.2"
 ext["groovyVersion"] = "3.0.0-rc-1"
 ext["log4jVersion"] = "2.12.1"
 ext["commonsBeansVersion"] = "1.9.4"
 ext["logbackVersion"] = "1.3.0-alpha5"
-ext["caffeinVersion"] = "2.8.0"
-ext["couchbaseVersion"] = "2.7.4"
+ext["caffeinVersion"] = "2.8.1"
+ext["couchbaseVersion"] = "2.7.13"
 
-ext["mysqlVersion"] = "8.0.18"
-ext["postgresqlVersion"] = "42.2.8"
+ext["mysqlVersion"] = "8.0.19"
+ext["postgresqlVersion"] = "42.2.11"
 ext["mariaDbVersion"] = "2.5.1"
 ext["jtdsVersion"] = "1.3.1"
 ext["mssqlServerVersion"] = "7.2.1.jre11"
-ext["mongoDriverVersion"] = "3.11.0"
+ext["mongoDriverVersion"] = "3.11.2"
 ext["oracleJdbcVersion"] = "19.3.0.0"
 
 ext["couchbase-client.version"] = ext["couchbaseVersion"]


### PR DESCRIPTION
This updates CAS 6.1 from using Spring Boot 2.2.0 to 2.2.6 and also some transitive dependencies like Spring Framework and Spring Data.