### PR TITLE
properly clean up resources at application shutdown

### DIFF
--- a/support/cas-server-support-jdbc-drivers/src/main/java/org/apereo/cas/JdbcServletContextListener.java
+++ b/support/cas-server-support-jdbc-drivers/src/main/java/org/apereo/cas/JdbcServletContextListener.java
@@ -1,0 +1,53 @@
+package org.apereo.cas;
+
+import lombok.val;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+/**
+ * This is {@link JdbcServletContextListener} that properly
+ * deregisters JDBC drivers.
+ *
+ * Ref: https://github.com/apereo/cas/pull/4812
+ * Note that Slf4j does not work in contextDestroyed.
+ * We need to stick to old-school logging method.
+ *
+ * @author leeyc0
+ * @since 6.2.0
+ */
+@WebListener
+public class JdbcServletContextListener implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(final ServletContextEvent sce) {
+    }
+
+    /*
+     * Deregister JDBC drivers in this context's ClassLoader
+     */
+    @Override
+    public final void contextDestroyed(final ServletContextEvent sce) {
+        val logger = Logger.getLogger("org.apereo.cas");
+        logger.fine("Unregistering JdbcServletContextListener");
+
+        val cl = Thread.currentThread().getContextClassLoader();
+        val drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            val driver = drivers.nextElement();
+            if (driver.getClass().getClassLoader() == cl) {
+                try {
+                    DriverManager.deregisterDriver(driver);
+                } catch (final SQLException ex) {
+                    logger.warning("Error deregistering JDBC driver " + ex);
+                }
+            } else {
+                logger.fine("Not deregistering JDBC driver as it does not belong to this webapp's ClassLoader: " + driver);
+            }
+        }
+    }
+}

--- a/support/cas-server-support-jdbc-drivers/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-jdbc-drivers/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -1,0 +1,16 @@
+package org.apereo.cas;
+
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.runner.RunWith;
+
+/**
+ * This is {@link AllTestsSuite}.
+ *
+ * @author leeyc0
+ * @since 6.2.0
+ */
+@SelectClasses(JdbcServletContextListenerTests.class)
+@RunWith(JUnitPlatform.class)
+public class AllTestsSuite {
+}

--- a/support/cas-server-support-jdbc-drivers/src/test/java/org/apereo/cas/JdbcServletContextListenerTests.java
+++ b/support/cas-server-support-jdbc-drivers/src/test/java/org/apereo/cas/JdbcServletContextListenerTests.java
@@ -1,0 +1,42 @@
+package org.apereo.cas;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.sql.DriverManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link JdbcServletContextListenerTest}.
+ *
+ * @author leeyc0
+ * @since 6.2.0
+ */
+@Tag("JDBC")
+public class JdbcServletContextListenerTests {
+
+    private final JdbcServletContextListener listener = new JdbcServletContextListener();
+
+    @Test
+    public void verifyContextInitialized() throws Exception {
+        listener.contextInitialized(null);
+        assertFalse(DriverManager.getDrivers().hasMoreElements());
+    }
+
+    @Test
+    public void verifyContextDestroyed() throws Exception {
+        /* registers all drivers */
+        Class.forName("org.hsqldb.jdbc.JDBCDriver");
+        Class.forName("org.postgresql.Driver");
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Class.forName("org.mariadb.jdbc.Driver");
+        Class.forName("net.sourceforge.jtds.jdbc.Driver");
+        Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        Class.forName("oracle.jdbc.driver.OracleDriver");
+        Class.forName("org.h2.Driver");
+
+        listener.contextDestroyed(null);
+        assertFalse(DriverManager.getDrivers().hasMoreElements());
+    }
+}


### PR DESCRIPTION
PR #4803 rewritten. This should really work now. I realized I can simply use `@WebListener` annoation to add ServletContextListener.

We should unregister JDBC drivers at shutdown instead of relying tomcat to forcefully deregister it. (This feature may not exist in other servlet servers.)

Tomcat throws this message
`SEVERE: A web application registered the JDBC driver [XXXXX] but failed to unregister it when the web application was stopped. To prevent a memory leak, the JDBC Driver has been forcibly unregistered.`
when a JDBC driver deregisters forcefully.

Also, for unknown reason quartz thread shut down is asynchronous and I have to put 5 sec wait to wait these threads to shut down