### PR TITLE
Open up a little the FileSystemSamlIdPMetadataGenerator

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/idp/metadata/generator/FileSystemSamlIdPMetadataGenerator.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/idp/metadata/generator/FileSystemSamlIdPMetadataGenerator.java
@@ -52,7 +52,7 @@ public class FileSystemSamlIdPMetadataGenerator extends BaseSamlIdPMetadataGener
     }
 
     @SneakyThrows
-    private void writeCertificateAndKey(final File certificate, final File key) {
+    protected void writeCertificateAndKey(final File certificate, final File key) {
         if (certificate.exists()) {
             FileUtils.forceDelete(certificate);
         }


### PR DESCRIPTION
By changing the `writeCertificateAndKey` method visibility (`private` ->  `protected`).