### PR TITLE
improve ticket expiration policies - throttled timeout

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/ThrottledUseAndTimeoutExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/ThrottledUseAndTimeoutExpirationPolicy.java
@@ -12,8 +12,8 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
+import java.time.Clock;
 import java.time.Duration;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 /**
@@ -44,6 +44,8 @@ public class ThrottledUseAndTimeoutExpirationPolicy extends AbstractCasExpiratio
 
     private long timeInBetweenUsesInSeconds;
 
+    private Clock clock = Clock.systemUTC();
+
     @JsonCreator
     public ThrottledUseAndTimeoutExpirationPolicy(@JsonProperty("timeToLive") final long timeToKillInSeconds, @JsonProperty("timeToIdle") final long timeInBetweenUsesInSeconds) {
         this.timeToKillInSeconds = timeToKillInSeconds;
@@ -54,7 +56,7 @@ public class ThrottledUseAndTimeoutExpirationPolicy extends AbstractCasExpiratio
     public boolean isExpired(final TicketState ticketState) {
         LOGGER.trace("Checking validity of ticket [{}]", ticketState);
         val lastTimeUsed = ticketState.getLastTimeUsed();
-        val currentTime = ZonedDateTime.now(ZoneOffset.UTC);
+        val currentTime = ZonedDateTime.now(clock);
 
         LOGGER.trace("Current time is [{}]. Ticket last used time is [{}]", currentTime, lastTimeUsed);
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/ThrottledUseAndTimeoutExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/ThrottledUseAndTimeoutExpirationPolicy.java
@@ -12,6 +12,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
+import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
@@ -57,11 +58,9 @@ public class ThrottledUseAndTimeoutExpirationPolicy extends AbstractCasExpiratio
 
         LOGGER.trace("Current time is [{}]. Ticket last used time is [{}]", currentTime, lastTimeUsed);
 
-        val currentTimeSeconds = currentTime.toEpochSecond();
-        val lastTimeUsedInSeconds = lastTimeUsed.toEpochSecond();
+        val margin = Duration.between(lastTimeUsed, currentTime).toSeconds();
 
-        val margin = currentTimeSeconds - lastTimeUsedInSeconds;
-        LOGGER.trace("Current time in seconds is [{}]. Ticket last used time in seconds is [{}]", currentTimeSeconds, lastTimeUsedInSeconds);
+        LOGGER.trace("The duration in seconds between current time and last used time is [{}]", margin);
 
         if (ticketState.getCountOfUses() == 0 && margin < this.timeToKillInSeconds) {
             LOGGER.debug("Valid [{}]: Usage count is zero and number of seconds since ticket usage time [{}] is less than [{}]",

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/expiration/ThrottledUseAndTimeoutExpirationPolicyTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/expiration/ThrottledUseAndTimeoutExpirationPolicyTests.java
@@ -69,8 +69,8 @@ public class ThrottledUseAndTimeoutExpirationPolicyTests {
     public void verifyThrottleNotTriggeredWithinOneSecond() {
         this.ticket.grantServiceTicket("test", RegisteredServiceTestUtils.getService(), this.expirationPolicy, false,
                 true);
-        TicketState state = (TicketState)this.ticket;
-        Clock clock = Clock.fixed(state.getLastTimeUsed().toInstant().plusMillis(999), ZoneId.of("UTC"));
+        val state = (TicketState) this.ticket;
+        val clock = Clock.fixed(state.getLastTimeUsed().toInstant().plusMillis(999), ZoneId.of("UTC"));
         expirationPolicy.setClock(clock);
         assertFalse(this.ticket.isExpired());
     }
@@ -79,8 +79,8 @@ public class ThrottledUseAndTimeoutExpirationPolicyTests {
     public void verifyNotWaitingEnoughTime() {
         this.ticket.grantServiceTicket("test", RegisteredServiceTestUtils.getService(), this.expirationPolicy, false,
             true);
-        TicketState state = (TicketState)this.ticket;
-        Clock clock = Clock.fixed(state.getLastTimeUsed().toInstant().plusSeconds(1), ZoneId.of("UTC"));
+        val state = (TicketState) this.ticket;
+        val clock = Clock.fixed(state.getLastTimeUsed().toInstant().plusSeconds(1), ZoneId.of("UTC"));
         expirationPolicy.setClock(clock);
         assertTrue(this.ticket.isExpired());
     }


### PR DESCRIPTION
After enabling TGT's throttling policy in our test environment, the SERVICE_TICKET_VALIDATE_FAILED event occurs frequently on the server. The configuration we used for this policy is below.
```
cas.ticket.tgt.throttledTimeout.timeToKillInSeconds=28800
cas.ticket.tgt.throttledTimeout.timeInBetweenUsesInSeconds=1
```

After trawling through the logs, the reason is that the ST was removed from the cache (redis) due to the TGT expiration.
```
2020-04-15 13:28:15,897 DEBUG [org.apereo.cas.services.RegisteredServiceAccessStrategyUtils] - Current authentication via ticket [TGT-717-********************************************************ZDJyFo0PCWYxxxxx-xxxxx-02] allows service [http://oa.example.org/login] to participate in the existing SSO session 
2020-04-15 13:28:15,898 TRACE [org.apereo.cas.AbstractCentralAuthenticationService] - TGT is not proxied by another service 
2020-04-15 13:28:15,898 DEBUG [org.apereo.cas.ticket.factory.DefaultServiceTicketFactory] - Looking up service ticket id generator for [org.apereo.cas.authentication.principal.SimpleWebApplicationServiceImpl] 
2020-04-15 13:28:15,898 DEBUG [org.apereo.cas.ticket.factory.DefaultServiceTicketFactory] - Attempting to encode service ticket [ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02] 
2020-04-15 13:28:15,899 DEBUG [org.apereo.cas.ticket.factory.DefaultServiceTicketFactory] - Encoded service ticket id [ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02] 
2020-04-15 13:28:15,899 DEBUG [org.apereo.cas.ticket.registry.RedisTicketRegistry] - Updating ticket [TGT-717-********************************************************ZDJyFo0PCWYxxxxx-xxxxx-02] 
2020-04-15 13:28:15,899 TRACE [org.apereo.cas.ticket.registry.AbstractTicketRegistry] - Ticket encryption is not enabled. Falling back to default behavior 
2020-04-15 13:28:15,900 DEBUG [org.apereo.cas.ticket.registry.RedisTicketRegistry] - Adding ticket [ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02] 
2020-04-15 13:28:15,901 TRACE [org.apereo.cas.ticket.registry.AbstractTicketRegistry] - Ticket encryption is not enabled. Falling back to default behavior 
2020-04-15 13:28:15,901 INFO [org.apereo.cas.DefaultCentralAuthenticationService] - Granted ticket [ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02] for service [http://oa.example.org/login] and principal [someone] 
2020-04-15 13:28:15,902 DEBUG [org.apereo.cas.AbstractCentralAuthenticationService] - Publishing [CasServiceTicketGrantedEvent(ticketGrantingTicket=TGT-717-********************************************************ZDJyFo0PCWYxxxxx-xxxxx-02, serviceTicket=ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02)] 
2020-04-15 13:28:15,902 TRACE [org.apereo.cas.web.CasWebApplicationContext] - Publishing event in org.apereo.cas.web.CasWebApplicationContext@587e5365: CasServiceTicketGrantedEvent(ticketGrantingTicket=TGT-717-********************************************************ZDJyFo0PCWYxxxxx-xxxxx-02, serviceTicket=ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02) 
2020-04-15 13:28:15,902 TRACE [org.apereo.cas.audit.spi.ThreadLocalPrincipalResolver] - Resolving principal at audit point [execution(ServiceTicket org.apereo.cas.DefaultCentralAuthenticationService.grantServiceTicket(String,Service,AuthenticationResult))] 
2020-04-15 13:28:15,902 INFO [org.apereo.inspektr.audit.support.Slf4jLoggingAuditTrailManager] - Audit trail record BEGIN
=============================================================
WHO: someone
WHAT: ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02 for http://oa.example.org/login
ACTION: SERVICE_TICKET_CREATED
APPLICATION: CAS
WHEN: Wed Apr 15 13:28:15 CST 2020
CLIENT IP ADDRESS: 10.162.65.117
SERVER IP ADDRESS: 127.0.0.1
=============================================================

/*
* irrelevant entries deleted
*/

2020-04-15 13:28:16,206 TRACE [org.apereo.cas.ticket.support.ThrottledUseAndTimeoutExpirationPolicy] - Checking validity of ticket [TGT-717-********************************************************ZDJyFo0PCWYxxxxx-xxxxx-02] 
2020-04-15 13:28:16,206 TRACE [org.apereo.cas.ticket.support.ThrottledUseAndTimeoutExpirationPolicy] - Current time is [2020-04-15T05:28:16.206Z]. Ticket last used time is [2020-04-15T05:28:15.899Z] 
2020-04-15 13:28:16,206 TRACE [org.apereo.cas.ticket.support.ThrottledUseAndTimeoutExpirationPolicy] - Current time in seconds is [1586928496]. Ticket last used time in seconds is [1586928495] 
2020-04-15 13:28:16,206 WARN [org.apereo.cas.ticket.support.ThrottledUseAndTimeoutExpirationPolicy] - Expired [TGT-717-********************************************************ZDJyFo0PCWYxxxxx-xxxxx-02]: number of seconds since ticket usage time [1] is less than or equal to time in between uses in seconds [1] 
2020-04-15 13:28:16,207 DEBUG [org.apereo.cas.ticket.registry.RedisTicketRegistry] - Ticket [ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02] has expired and is now removed from the cache 
2020-04-15 13:28:16,207 WARN [org.apereo.cas.DefaultCentralAuthenticationService] - Service ticket [ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02] does not exist. 
2020-04-15 13:28:16,207 TRACE [org.apereo.cas.audit.spi.ThreadLocalPrincipalResolver] - Resolving principal at audit point [execution(Assertion org.apereo.cas.DefaultCentralAuthenticationService.validateServiceTicket(String,Service))] with thrown exception [RootCasException(code=INVALID_TICKET)] 
2020-04-15 13:28:16,207 INFO [org.apereo.inspektr.audit.support.Slf4jLoggingAuditTrailManager] - Audit trail record BEGIN
=============================================================
WHO: audit:unknown
WHAT: ST-1070--kFNUImJI9Q8fyHu1jwhxBrmjyUxxxxx-xxxxx-02 for http://oa.example.org/login
ACTION: SERVICE_TICKET_VALIDATE_FAILED
APPLICATION: CAS
WHEN: Wed Apr 15 13:28:16 CST 2020
CLIENT IP ADDRESS: 10.154.91.107
SERVER IP ADDRESS: 127.0.0.1
=============================================================
```

As you can see from the logs,  the time interval between granting(2020-04-15T05:28:15.899Z) and validating(2020-04-15T05:28:16.206Z) the ST is less than 1 second, which should be a normal thing, why would it be throttled and marked as expired? So I created this pull request.

In the pull request, throttling policy will not be triggered if the time interval doesn’t exceed 1 second, instead of having to be in the same epoch second.

This may not be perfect, but i think it works a little better than before. 

Maybe we should import another DateTime property of the ticket to improve throttling policy in the future.
