### PR TITLE
Trusted mfa couchdb fix

### DIFF
--- a/support/cas-server-support-trusted-mfa-couchdb/src/main/java/org/apereo/cas/config/CouchDbMultifactorAuthenticationTrustConfiguration.java
+++ b/support/cas-server-support-trusted-mfa-couchdb/src/main/java/org/apereo/cas/config/CouchDbMultifactorAuthenticationTrustConfiguration.java
@@ -55,8 +55,10 @@ public class CouchDbMultifactorAuthenticationTrustConfiguration {
     @RefreshScope
     public MultifactorAuthenticationTrustRecordCouchDbRepository couchDbTrustRecordRepository(
         @Qualifier("mfaTrustCouchDbFactory") final CouchDbConnectorFactory mfaTrustCouchDbFactory) {
-        return new MultifactorAuthenticationTrustRecordCouchDbRepository(mfaTrustCouchDbFactory.getCouchDbConnector(),
+        val repository = new MultifactorAuthenticationTrustRecordCouchDbRepository(mfaTrustCouchDbFactory.getCouchDbConnector(),
             casProperties.getAuthn().getMfa().getTrusted().getCouchDb().isCreateIfNotExists());
+        repository.initStandardDesignDocument();
+        return repository;
     }
 
     @ConditionalOnMissingBean(name = "couchDbMfaTrustEngine")

--- a/support/cas-server-support-trusted-mfa-couchdb/src/main/java/org/apereo/cas/config/CouchDbMultifactorAuthenticationTrustConfiguration.java
+++ b/support/cas-server-support-trusted-mfa-couchdb/src/main/java/org/apereo/cas/config/CouchDbMultifactorAuthenticationTrustConfiguration.java
@@ -8,6 +8,7 @@ import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustS
 import org.apereo.cas.trusted.authentication.storage.CouchDbMultifactorAuthenticationTrustStorage;
 import org.apereo.cas.util.crypto.CipherExecutor;
 
+import lombok.val;
 import org.ektorp.impl.ObjectMapperFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Trusted MFA storage in CouchDB is broken, evidently since the design document is not created. To fix this, I updated CouchDbMultifactorAuthenticationTrustConfiguration.java to call `initStandardDesignDocument` on the repository object before returning it.

It appears that CouchDbMultifactorAuthenticationTrustStorageTests.java calls `initStandardDesignDocument` on the repository, leading to the impression that this works as intended.