### PR TITLE
log warning when cookie is invalidated

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/InvalidCookieException.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/InvalidCookieException.java
@@ -1,0 +1,16 @@
+package org.apereo.cas.web.support;
+
+/**
+ * This exception is thrown when there are problems found with cookies.
+ * @author Hal Deadman
+ * @since 6.2.0
+ */
+public class InvalidCookieException extends RuntimeException {
+    public InvalidCookieException(final String message) {
+        super(message);
+    }
+
+    public InvalidCookieException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
@@ -163,6 +163,12 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator implements 
             return Optional.ofNullable(cookie)
                 .map(ck -> this.casCookieValueManager.obtainCookieValue(ck, request))
                 .orElse(null);
+        } catch (final IllegalStateException e) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.warn(e.getMessage(), e);
+            } else {
+                LOGGER.warn(e.getMessage());
+            }
         } catch (final Exception e) {
             LOGGER.debug(e.getMessage(), e);
         }

--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
@@ -170,7 +170,7 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator implements 
                 LOGGER.warn(e.getMessage());
             }
         } catch (final Exception e) {
-            LOGGER.debug(e.getMessage(), e);
+            LOGGER.warn(e.getMessage(), e);
         }
         return null;
     }

--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
@@ -4,6 +4,7 @@ import org.apereo.cas.authentication.RememberMeCredential;
 import org.apereo.cas.web.cookie.CasCookieBuilder;
 import org.apereo.cas.web.cookie.CookieGenerationContext;
 import org.apereo.cas.web.cookie.CookieValueManager;
+import org.apereo.cas.web.support.InvalidCookieException;
 import org.apereo.cas.web.support.WebUtils;
 import org.apereo.cas.web.support.mgmr.NoOpCookieValueManager;
 
@@ -163,7 +164,7 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator implements 
             return Optional.ofNullable(cookie)
                 .map(ck -> this.casCookieValueManager.obtainCookieValue(ck, request))
                 .orElse(null);
-        } catch (final IllegalStateException e) {
+        } catch (final InvalidCookieException e) {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.warn(e.getMessage(), e);
             } else {

--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/mgmr/DefaultCasCookieValueManager.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/mgmr/DefaultCasCookieValueManager.java
@@ -3,6 +3,7 @@ package org.apereo.cas.web.support.mgmr;
 import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
 import org.apereo.cas.util.HttpRequestUtils;
 import org.apereo.cas.util.crypto.CipherExecutor;
+import org.apereo.cas.web.support.InvalidCookieException;
 
 import com.google.common.base.Splitter;
 import lombok.extern.slf4j.Slf4j;
@@ -65,24 +66,24 @@ public class DefaultCasCookieValueManager extends EncryptedCookieValueManager {
         }
 
         if (cookieParts.size() != COOKIE_FIELDS_LENGTH) {
-            throw new IllegalStateException("Invalid cookie. Required fields are missing");
+            throw new InvalidCookieException("Invalid cookie. Required fields are missing");
         }
         val remoteAddr = cookieParts.get(1);
         val userAgent = cookieParts.get(2);
 
         if (Stream.of(value, remoteAddr, userAgent).anyMatch(StringUtils::isBlank)) {
-            throw new IllegalStateException("Invalid cookie. Required fields are empty");
+            throw new InvalidCookieException("Invalid cookie. Required fields are empty");
         }
 
         val clientInfo = ClientInfoHolder.getClientInfo();
         if (!remoteAddr.equals(clientInfo.getClientIpAddress())) {
-            throw new IllegalStateException("Invalid cookie. Required remote address "
+            throw new InvalidCookieException("Invalid cookie. Required remote address "
                 + remoteAddr + " does not match " + clientInfo.getClientIpAddress());
         }
 
         val agent = HttpRequestUtils.getHttpServletRequestUserAgent(request);
         if (!userAgent.equals(agent)) {
-            throw new IllegalStateException("Invalid cookie. Required user-agent " + userAgent + " does not match " + agent);
+            throw new InvalidCookieException("Invalid cookie. Required user-agent " + userAgent + " does not match " + agent);
         }
         return value;
     }

--- a/core/cas-server-core-cookie-api/src/test/java/org/apereo/cas/web/support/DefaultCasCookieValueManagerTests.java
+++ b/core/cas-server-core-cookie-api/src/test/java/org/apereo/cas/web/support/DefaultCasCookieValueManagerTests.java
@@ -79,28 +79,28 @@ public class DefaultCasCookieValueManagerTests {
     public void verifyBadValue() {
         val props = new TicketGrantingCookieProperties();
         val mgr = new DefaultCasCookieValueManager(CipherExecutor.noOp(), props);
-        assertThrows(IllegalStateException.class, () -> mgr.obtainCookieValue("something", new MockHttpServletRequest()));
+        assertThrows(InvalidCookieException.class, () -> mgr.obtainCookieValue("something", new MockHttpServletRequest()));
     }
 
     @Test
     public void verifyBadCookie() {
         val props = new TicketGrantingCookieProperties();
         val mgr = new DefaultCasCookieValueManager(CipherExecutor.noOp(), props);
-        assertThrows(IllegalStateException.class, () -> mgr.obtainCookieValue("something@1@", new MockHttpServletRequest()));
+        assertThrows(InvalidCookieException.class, () -> mgr.obtainCookieValue("something@1@", new MockHttpServletRequest()));
     }
 
     @Test
     public void verifyBadIp() {
         val props = new TicketGrantingCookieProperties();
         val mgr = new DefaultCasCookieValueManager(CipherExecutor.noOp(), props);
-        assertThrows(IllegalStateException.class, () -> mgr.obtainCookieValue("something@1@agent", new MockHttpServletRequest()));
+        assertThrows(InvalidCookieException.class, () -> mgr.obtainCookieValue("something@1@agent", new MockHttpServletRequest()));
     }
 
     @Test
     public void verifyBadAgent() {
         val props = new TicketGrantingCookieProperties();
         val mgr = new DefaultCasCookieValueManager(CipherExecutor.noOp(), props);
-        assertThrows(IllegalStateException.class, () -> mgr.obtainCookieValue("something@"
+        assertThrows(InvalidCookieException.class, () -> mgr.obtainCookieValue("something@"
             + ClientInfoHolder.getClientInfo().getClientIpAddress() + "@agent", new MockHttpServletRequest()));
     }
 }


### PR DESCRIPTION
I was seeing the CAS TGC cookie get deleted by CAS and it wasn't clear why. I believe it was due to CAS cookies being `pinToSession=true` (which guards against client ip changes) but the "client" ip was changing due to a faulty load balancer setup. 

I suspect my problem has to do with me setting up CAS behind AWS ALB and then a Kubernetes nginx ingress controller and the ingress controller isn't configured to respect the headers set by ALB (the `use-forwarded-headers` setting) and it is either not setting its own headers or the traffic is being round-robin'ed to nginx on more than one node in the kubernetes cluster and so the X-Forwarded-For header is changing. 

I can fix my setup but hopefully this extra logging will help someone catch on to the reason any cookies are being deleted sooner than otherwise. If the WARN errors show up too often, maybe different exceptions can be thrown for common harmless causes of the IllegalStateException and in the meantime someone can always adjust log level to ERROR to suppress the WARN. Since pinToSession is trying to guard against session theft, logging suspected cases of that at a higher level shouldn't hurt. 

The catch block for `Exception` is changed to log at WARN because that would be an unexpected error that should probably be investigated and fixed, or caught and logged specifically. 
