### PR TITLE
Fix event counting bug in DateTimeAuthenticationRequestRiskCalculator

### DIFF
--- a/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/DateTimeAuthenticationRequestRiskCalculator.java
+++ b/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/DateTimeAuthenticationRequestRiskCalculator.java
@@ -49,7 +49,9 @@ public class DateTimeAuthenticationRequestRiskCalculator extends BaseAuthenticat
                 val zdt = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);
                 return zdt.getHour();
             })
-            .filter(hour -> hour <= hoursFromNow && hour >= hoursBeforeNow)
+            .filter(hour ->
+                hoursBeforeNow <= hoursFromNow ? (hour >= hoursBeforeNow && hour <= hoursFromNow) : (hour >= hoursBeforeNow || hour <= hoursFromNow)
+            )
             .count();
 
         LOGGER.debug("Total authentication events found for [{}] in a [{}]h window: [{}]", timestamp, windowInHours, count);


### PR DESCRIPTION
When I was working in another pull request, I found that this unit test sometimes failed, which was supposed to be caused by the event counting bug in `DateTimeAuthenticationRequestRiskCalculator`
https://github.com/apereo/cas/blob/0701abd2a03c9fc41e44575785e61b54d321029f/support/cas-server-support-electrofence/src/test/java/org/apereo/cas/impl/calcs/DateTimeAuthenticationRequestRiskCalculatorTests.java#L30-L37

It seems like it doesn't take into account the possibility that `hoursFromNow` could be smaller than `hoursBeforeNow`.
https://github.com/apereo/cas/blob/0701abd2a03c9fc41e44575785e61b54d321029f/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/DateTimeAuthenticationRequestRiskCalculator.java#L44-L53

By the way, I think there is no need to add or modify unit tests yet.
