### PR TITLE
exclude pull-parser from dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,7 @@ subprojects {
         exclude(group: "org.slf4j", module: "slf4j-log4j12")
         exclude(group: "org.slf4j", module: "slf4j-simple")
         exclude(group: "org.apache.logging.log4j", module: "log4j-to-slf4j")
+        exclude(group: "pull-parser", module: "pull-parser")
     }
 
     /**


### PR DESCRIPTION
pull-parser conflicts with tomcat, tomcat refuses to load cas when pull-parser is included in war. I have to exclude pull-parser from the output war to make tomcat start.

This dependency is introduced by org.dom4j:dom4j:2.1.3 via :support:cas-server-support-jpa-hibernate
