### PR TITLE
Add autocommit to jpa properties

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/JpaBeans.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/JpaBeans.java
@@ -142,7 +142,8 @@ public class JpaBeans {
         properties.put(Environment.FORMAT_SQL, Boolean.TRUE);
         properties.put("hibernate.connection.useUnicode", Boolean.TRUE);
         properties.put("hibernate.connection.characterEncoding", StandardCharsets.UTF_8.name());
-        properties.put("hibernate.connection.charSet", StandardCharsets.UTF_8.name());
+        properties.put("hibernate.connection.charSet", StandardCharsets.UTF_8.name());        
+        properties.put("hibernate.connection.autocommit", jpaProperties.isAutocommit());
         if (StringUtils.isNotBlank(jpaProperties.getPhysicalNamingStrategyClassName())) {
             properties.put(Environment.PHYSICAL_NAMING_STRATEGY, jpaProperties.getPhysicalNamingStrategyClassName());
         }


### PR DESCRIPTION
autocommit properties is used in the newDataSource() method but not in newHibernateEntityManagerFactoryBean.
It creates issues with PostgresSQL where autocommit must be setted at false for large objects

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
