### PR TITLE
Fix openid and oauth doc

### DIFF
--- a/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
+++ b/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
@@ -45,7 +45,7 @@ After enabling OAuth support, the following endpoints will be available:
 | `/oauth2.0/profile`       | Get the authenticated user profile in JSON via `access_token` parameter.    | `GET`
 | `/oauth2.0/introspect`    | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OAuth2 service `client_id` and `client_secret` associated as username and password.  | `POST`
 | `/oauth2.0/device`        | Approve device user codes via the [device flow protocol](https://tools.ietf.org/html/draft-denniss-oauth-device-flow). | `POST`
-| `/oauth2.0/revoke`            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.
+| `/oauth2.0/revoke`            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OAuth2 service `client_id` and `client_secret` associated as username and password.
 
 ## Response/Grant Types
 

--- a/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
+++ b/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
@@ -43,9 +43,9 @@ After enabling OAuth support, the following endpoints will be available:
 | `/oauth2.0/authorize`     | Authorize the user and start the CAS authentication flow.                   | `GET`
 | `/oauth2.0/accessToken`,`/oauth2.0/token`      | Get an access token in plain-text or JSON              | `POST`
 | `/oauth2.0/profile`       | Get the authenticated user profile in JSON via `access_token` parameter.    | `GET`
-| `/oauth2.0/introspect`    | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662).  | `POST`
+| `/oauth2.0/introspect`    | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.  | `POST`
 | `/oauth2.0/device`        | Approve device user codes via the [device flow protocol](https://tools.ietf.org/html/draft-denniss-oauth-device-flow). | `POST`
-| `/oauth2.0/revoke`            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens.
+| `/oauth2.0/revoke`            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.
 
 ## Response/Grant Types
 

--- a/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
+++ b/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
@@ -43,7 +43,7 @@ After enabling OAuth support, the following endpoints will be available:
 | `/oauth2.0/authorize`     | Authorize the user and start the CAS authentication flow.                   | `GET`
 | `/oauth2.0/accessToken`,`/oauth2.0/token`      | Get an access token in plain-text or JSON              | `POST`
 | `/oauth2.0/profile`       | Get the authenticated user profile in JSON via `access_token` parameter.    | `GET`
-| `/oauth2.0/introspect`    | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.  | `POST`
+| `/oauth2.0/introspect`    | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OAuth2 service `client_id` and `client_secret` associated as username and password.  | `POST`
 | `/oauth2.0/device`        | Approve device user codes via the [device flow protocol](https://tools.ietf.org/html/draft-denniss-oauth-device-flow). | `POST`
 | `/oauth2.0/revoke`            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.
 

--- a/docs/cas-server-documentation/installation/OIDC-Authentication.md
+++ b/docs/cas-server-documentation/installation/OIDC-Authentication.md
@@ -43,9 +43,9 @@ The current implementation provides support for:
 | `/oidc/jwks`                              | Contains the server’s public signing keys, which clients may use to verify the digital signatures of access tokens and ID tokens issued by CAS.
 | `/oidc/authorize`                         | Authorization requests are handled here.
 | `/oidc/profile`                           | User profile requests are handled here.
-| `/oidc/introspect`                        | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.
+| `/oidc/introspect`                        | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OIDC service client_id and client_secret associated as username and password.
 | `/oidc/accessToken`, `/oidc/token`        | Produces authorized access tokens.
-| `/oidc/revoke`                            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.
+| `/oidc/revoke`                            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OIDC service client_id and client_secret associated as username and password.
 | `/oidc/register`                          | Register clients via the [dynamic client registration](https://tools.ietf.org/html/draft-ietf-oauth-dyn-reg-management-01) protocol.
 
 ## Register Clients

--- a/docs/cas-server-documentation/installation/OIDC-Authentication.md
+++ b/docs/cas-server-documentation/installation/OIDC-Authentication.md
@@ -43,7 +43,7 @@ The current implementation provides support for:
 | `/oidc/jwks`                              | Contains the server’s public signing keys, which clients may use to verify the digital signatures of access tokens and ID tokens issued by CAS.
 | `/oidc/authorize`                         | Authorization requests are handled here.
 | `/oidc/profile`                           | User profile requests are handled here.
-| `/oidc/introspect`                        | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OIDC service client_id and client_secret associated as username and password.
+| `/oidc/introspect`                        | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OIDC service `client_id` and `client_secret` associated as username and password.
 | `/oidc/accessToken`, `/oidc/token`        | Produces authorized access tokens.
 | `/oidc/revoke`                            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OIDC service client_id and client_secret associated as username and password.
 | `/oidc/register`                          | Register clients via the [dynamic client registration](https://tools.ietf.org/html/draft-ietf-oauth-dyn-reg-management-01) protocol.

--- a/docs/cas-server-documentation/installation/OIDC-Authentication.md
+++ b/docs/cas-server-documentation/installation/OIDC-Authentication.md
@@ -45,7 +45,7 @@ The current implementation provides support for:
 | `/oidc/profile`                           | User profile requests are handled here.
 | `/oidc/introspect`                        | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OIDC service `client_id` and `client_secret` associated as username and password.
 | `/oidc/accessToken`, `/oidc/token`        | Produces authorized access tokens.
-| `/oidc/revoke`                            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OIDC service client_id and client_secret associated as username and password.
+| `/oidc/revoke`                            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OIDC service `client_id` and `client_secret` associated as username and password.
 | `/oidc/register`                          | Register clients via the [dynamic client registration](https://tools.ietf.org/html/draft-ietf-oauth-dyn-reg-management-01) protocol.
 
 ## Register Clients

--- a/docs/cas-server-documentation/installation/OIDC-Authentication.md
+++ b/docs/cas-server-documentation/installation/OIDC-Authentication.md
@@ -43,9 +43,9 @@ The current implementation provides support for:
 | `/oidc/jwks`                              | Contains the server’s public signing keys, which clients may use to verify the digital signatures of access tokens and ID tokens issued by CAS.
 | `/oidc/authorize`                         | Authorization requests are handled here.
 | `/oidc/profile`                           | User profile requests are handled here.
-| `/oidc/introspect`                        | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662).
+| `/oidc/introspect`                        | Query CAS to detect the status of a given access token via [introspection](https://tools.ietf.org/html/rfc7662). This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.
 | `/oidc/accessToken`, `/oidc/token`        | Produces authorized access tokens.
-| `/oidc/revoke`                            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens.
+| `/oidc/revoke`                            | [Revoke](https://tools.ietf.org/html/rfc7009) access or refresh tokens. This endpoint expects HTTP basic authentication with OAuth2 service client_id and client_secret associated as username and password.
 | `/oidc/register`                          | Register clients via the [dynamic client registration](https://tools.ietf.org/html/draft-ietf-oauth-dyn-reg-management-01) protocol.
 
 ## Register Clients


### PR DESCRIPTION
Update HTTP basic auth requirement for introspect and revoke endpoint. I have to read the source code directly to figure the authentication required.