### PR TITLE
update createStateBinderConfiguration to allow for non-required parameters

### DIFF
--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
@@ -611,8 +611,19 @@ public abstract class AbstractCasWebflowConfigurer implements CasWebflowConfigur
      * @return the binder configuration
      */
     public BinderConfiguration createStateBinderConfiguration(final List<String> properties) {
+        return createStateBinderConfiguration(properties, true);
+    }
+
+    /**
+     * Create state model bindings.
+     *
+     * @param properties the properties
+     * @param required   are properties required
+     * @return the binder configuration
+     */
+    public BinderConfiguration createStateBinderConfiguration(final List<String> properties, final boolean required) {
         val binder = new BinderConfiguration();
-        properties.forEach(p -> binder.addBinding(new BinderConfiguration.Binding(p, null, true)));
+        properties.forEach(p -> binder.addBinding(new BinderConfiguration.Binding(p, null, required)));
         return binder;
     }
 

--- a/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/web/flow/AbstractMultifactorTrustedDeviceWebflowConfigurer.java
+++ b/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/web/flow/AbstractMultifactorTrustedDeviceWebflowConfigurer.java
@@ -117,7 +117,7 @@ public abstract class AbstractMultifactorTrustedDeviceWebflowConfigurer extends 
         val fields = Arrays.stream(MultifactorAuthenticationTrustBean.class.getDeclaredFields())
             .map(Field::getName)
             .collect(Collectors.toList());
-        val binder = createStateBinderConfiguration(fields);
+        val binder = createStateBinderConfiguration(fields, false);
         val viewRegister = createViewState(flow, CasWebflowConstants.STATE_ID_REGISTER_DEVICE, "casMfaRegisterDeviceView", binder);
         val transition = createTransitionForState(viewRegister, CasWebflowConstants.TRANSITION_ID_SUBMIT,
             CasWebflowConstants.STATE_ID_REGISTER_TRUSTED_DEVICE);


### PR DESCRIPTION
The MFA trusted device webflow is configured in `MultifactorAuthenticationSetTrustAction` to discard submissions of the trusted device registration form with empty inputs, which allows for setting up a "Skip" button that submits the form with no data. This is a useful technique to allow users to avoid registering a device that they happen to be using as trusted. However, recent changes to the way the `MultifactorAuthenticationTrustBean` is bound to the submission, namely through `createStateBinderConfiguration` on `AbstractCasWebflowConfigurer`, have created a situation where a submission with empty inputs errors out before arriving at the aforementioned action.

To work around this, I've overloaded `createStateBinderConfiguration` to accept a `required` parameter while still preserving the original method signature and behavior, and updated the call to it in the trusted device webflow configurer to specify the parameters are not required.