### PR TITLE
Fix ldap connection pool shut down - phase 1

### DIFF
--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/AbstractPoolHealthIndicator.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/AbstractPoolHealthIndicator.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 
@@ -20,7 +21,7 @@ import java.util.concurrent.TimeoutException;
  */
 @Slf4j
 @RequiredArgsConstructor
-public abstract class AbstractPoolHealthIndicator extends AbstractHealthIndicator {
+public abstract class AbstractPoolHealthIndicator extends AbstractHealthIndicator implements DisposableBean {
 
     /**
      * Maximum amount of time in ms to wait while validating pool resources.
@@ -54,6 +55,15 @@ public abstract class AbstractPoolHealthIndicator extends AbstractHealthIndicato
             .withDetail("name", getClass().getSimpleName())
             .withDetail("activeCount", getActiveCount())
             .withDetail("idleCount", getIdleCount());
+    }
+
+    /**
+     * Shuts down the thread pool. Subclasses whose wish to override this method
+     * must call super.destroy().
+     */
+    @Override
+    public void destroy() {
+        executor.shutdown();
     }
 
     /**

--- a/core/cas-server-core-monitor/src/test/java/org/apereo/cas/monitor/PoolHealthIndicatorTests.java
+++ b/core/cas-server-core-monitor/src/test/java/org/apereo/cas/monitor/PoolHealthIndicatorTests.java
@@ -2,6 +2,8 @@ package org.apereo.cas.monitor;
 
 import lombok.val;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
@@ -20,7 +22,7 @@ public class PoolHealthIndicatorTests {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Test
-    public void verifyObserveOK() {
+    public void verifyObserveOK() throws Exception {
         val monitor = new AbstractPoolHealthIndicator(1000, executor) {
             @Override
             protected Health.Builder checkPool(final Health.Builder builder) {
@@ -36,13 +38,21 @@ public class PoolHealthIndicatorTests {
             protected int getActiveCount() {
                 return 2;
             }
+
         };
         val health = monitor.health();
         assertEquals(health.getStatus(), Status.UP);
+
+        assertAll(new Executable() {
+            @Override
+            public void execute() throws Exception {
+                ((DisposableBean) monitor).destroy();
+            }
+        });
     }
 
     @Test
-    public void verifyObserveDown() {
+    public void verifyObserveDown() throws Exception {
         val monitor = new AbstractPoolHealthIndicator(200, executor) {
             @Override
             protected Health.Builder checkPool(final Health.Builder builder) throws Exception {
@@ -62,10 +72,17 @@ public class PoolHealthIndicatorTests {
         };
         val health = monitor.health();
         assertEquals(Status.DOWN, health.getStatus());
+
+        assertAll(new Executable() {
+                @Override
+                public void execute() throws Exception {
+                    ((DisposableBean) monitor).destroy();
+                }
+        });
     }
 
     @Test
-    public void verifyObserveError() {
+    public void verifyObserveError() throws Exception {
         val monitor = new AbstractPoolHealthIndicator(500, executor) {
             @Override
             protected Health.Builder checkPool(final Health.Builder builder) {
@@ -84,5 +101,11 @@ public class PoolHealthIndicatorTests {
         };
         val health = monitor.health();
         assertEquals(health.getStatus(), Status.OUT_OF_SERVICE);
+        assertAll(new Executable() {
+                @Override
+                public void execute() throws Exception {
+                    ((DisposableBean) monitor).destroy();
+                }
+        });
     }
 }

--- a/support/cas-server-support-consent-ldap/src/main/java/org/apereo/cas/consent/LdapConsentRepository.java
+++ b/support/cas-server-support-consent-ldap/src/main/java/org/apereo/cas/consent/LdapConsentRepository.java
@@ -17,6 +17,7 @@ import org.ldaptive.ConnectionFactory;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
+import org.springframework.beans.factory.DisposableBean;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class LdapConsentRepository implements ConsentRepository {
+public class LdapConsentRepository implements ConsentRepository, DisposableBean {
     private static final long serialVersionUID = 8561763114482490L;
 
     private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
@@ -258,5 +259,10 @@ public class LdapConsentRepository implements ConsentRepository {
         }
         LOGGER.debug("Unable to read consent entries from LDAP via filter [{}]", filter);
         return new HashSet<>(0);
+    }
+
+    @Override
+    public void destroy() {
+        connectionFactory.close();
     }
 }

--- a/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/PooledLdapConnectionFactoryHealthIndicator.java
+++ b/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/PooledLdapConnectionFactoryHealthIndicator.java
@@ -35,6 +35,13 @@ public class PooledLdapConnectionFactoryHealthIndicator extends AbstractPoolHeal
         this.validator = validator;
     }
 
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        this.connectionFactory.close();
+    }
+
     @Override
     protected Health.Builder checkPool(final Health.Builder builder) throws Exception {
         if (this.connectionFactory != null && this.validator != null) {

--- a/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
+++ b/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
@@ -6,18 +6,24 @@ import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.monitor.PooledLdapConnectionFactoryHealthIndicator;
 import org.apereo.cas.util.LdapUtils;
 
+import lombok.SneakyThrows;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.ldaptive.ConnectionFactory;
 import org.ldaptive.SearchConnectionValidator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ListFactoryBean;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.CompositeHealthContributor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -36,9 +42,28 @@ public class LdapMonitorConfiguration {
     private CasConfigurationProperties casProperties;
 
     @Bean
+    public ListFactoryBean pooledLdapConnectionFactoryHealthIndicatorListFactoryBean() {
+        val list = new ListFactoryBean() {
+            @Override
+            protected void destroyInstance(final List list) {
+                list.forEach(connectionFactory -> {
+                    ((ConnectionFactory) connectionFactory).close();
+                });
+            }
+        };
+        list.setSourceList(new ArrayList());
+        return list;
+    }
+
+    @Bean
+    @SneakyThrows
+    @Autowired
+    @Qualifier("pooledLdapConnectionFactoryHealthIndicatorListFactoryBean")
     @ConditionalOnEnabledHealthIndicator("pooledLdapConnectionFactoryHealthIndicator")
-    public CompositeHealthContributor pooledLdapConnectionFactoryHealthIndicator() {
+    public CompositeHealthContributor pooledLdapConnectionFactoryHealthIndicator(
+            final ListFactoryBean pooledLdapConnectionFactoryHealthIndicatorListFactoryBean) {
         val ldaps = casProperties.getMonitor().getLdap();
+        val connectionFactoryList = pooledLdapConnectionFactoryHealthIndicatorListFactoryBean.getObject();
         val contributors = new LinkedHashMap<>(MAP_SIZE);
         ldaps.stream()
             .filter(LdapMonitorProperties::isEnabled)
@@ -46,6 +71,7 @@ public class LdapMonitorConfiguration {
                 val executor = Beans.newThreadPoolExecutorFactoryBean(ldap.getPool());
                 executor.afterPropertiesSet();
                 val connectionFactory = LdapUtils.newLdaptivePooledConnectionFactory(ldap);
+                connectionFactoryList.add(connectionFactory);
                 val healthIndicator = new PooledLdapConnectionFactoryHealthIndicator(Beans.newDuration(ldap.getMaxWait()).toMillis(),
                     connectionFactory, executor.getObject(), new SearchConnectionValidator());
                 val name = StringUtils.defaultIfBlank(ldap.getName(), UUID.randomUUID().toString());

--- a/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
+++ b/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
@@ -46,21 +46,21 @@ public class LdapMonitorConfiguration {
         val list = new ListFactoryBean() {
             @Override
             protected void destroyInstance(final List list) {
-                list.forEach(connectionFactory -> {
-                    ((ConnectionFactory) connectionFactory).close();
-                });
+                list.forEach(connectionFactory ->
+                    ((ConnectionFactory) connectionFactory).close()
+                );
             }
         };
-        list.setSourceList(new ArrayList());
+        list.setSourceList(new ArrayList<>());
         return list;
     }
 
     @Bean
     @SneakyThrows
     @Autowired
-    @Qualifier("pooledLdapConnectionFactoryHealthIndicatorListFactoryBean")
     @ConditionalOnEnabledHealthIndicator("pooledLdapConnectionFactoryHealthIndicator")
     public CompositeHealthContributor pooledLdapConnectionFactoryHealthIndicator(
+            @Qualifier("pooledLdapConnectionFactoryHealthIndicatorListFactoryBean")
             final ListFactoryBean pooledLdapConnectionFactoryHealthIndicatorListFactoryBean) {
         val ldaps = casProperties.getMonitor().getLdap();
         val connectionFactoryList = pooledLdapConnectionFactoryHealthIndicatorListFactoryBean.getObject();

--- a/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/LdapServiceRegistry.java
+++ b/support/cas-server-support-ldap-service-registry/src/main/java/org/apereo/cas/adaptors/ldap/services/LdapServiceRegistry.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.ldaptive.ConnectionFactory;
 import org.ldaptive.LdapException;
 import org.ldaptive.SearchResponse;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ import java.util.Objects;
  */
 @Slf4j
 @ToString
-public class LdapServiceRegistry extends AbstractServiceRegistry {
+public class LdapServiceRegistry extends AbstractServiceRegistry implements DisposableBean {
 
     private final ConnectionFactory connectionFactory;
 
@@ -203,5 +204,10 @@ public class LdapServiceRegistry extends AbstractServiceRegistry {
         val filter = LdapUtils.newLdaptiveSearchFilter(ldapProperties.getSearchFilter(),
             LdapUtils.LDAP_SEARCH_FILTER_DEFAULT_PARAM_NAME, CollectionUtils.wrap(id.toString()));
         return LdapUtils.executeSearchOperation(this.connectionFactory, this.baseDn, filter, ldapProperties.getPageSize());
+    }
+
+    @Override
+    public void destroy() {
+        connectionFactory.close();
     }
 }

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapAuthenticationHandler.java
@@ -21,6 +21,7 @@ import org.ldaptive.auth.AuthenticationRequest;
 import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.AuthenticationResultCode;
 import org.ldaptive.auth.Authenticator;
+import org.springframework.beans.factory.DisposableBean;
 
 import javax.security.auth.login.AccountNotFoundException;
 import javax.security.auth.login.FailedLoginException;
@@ -43,7 +44,7 @@ import java.util.Map;
 @Slf4j
 @Setter
 @Getter
-public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthenticationHandler {
+public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthenticationHandler implements DisposableBean {
 
     /**
      * Mapping of LDAP attribute name to principal attribute name.
@@ -99,6 +100,11 @@ public class LdapAuthenticationHandler extends AbstractUsernamePasswordAuthentic
         super(name, servicesManager, principalFactory, order);
         this.authenticator = authenticator;
         this.passwordPolicyHandlingStrategy = strategy;
+    }
+
+    @Override
+    public void destroy() {
+        authenticator.close();
     }
 
     @Override

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapPasswordSynchronizationAuthenticationPostProcessor.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/authentication/LdapPasswordSynchronizationAuthenticationPostProcessor.java
@@ -13,6 +13,7 @@ import org.ldaptive.ModifyOperation;
 import org.ldaptive.ModifyRequest;
 import org.ldaptive.ResultCode;
 import org.ldaptive.ad.UnicodePwdAttribute;
+import org.springframework.beans.factory.DisposableBean;
 
 import java.util.Collections;
 
@@ -23,13 +24,18 @@ import java.util.Collections;
  * @since 6.1.0
  */
 @Slf4j
-public class LdapPasswordSynchronizationAuthenticationPostProcessor implements AuthenticationPostProcessor {
+public class LdapPasswordSynchronizationAuthenticationPostProcessor implements AuthenticationPostProcessor, DisposableBean {
     private final ConnectionFactory searchFactory;
     private final AbstractLdapSearchProperties ldapProperties;
 
     public LdapPasswordSynchronizationAuthenticationPostProcessor(final AbstractLdapSearchProperties properties) {
         this.ldapProperties = properties;
         this.searchFactory = LdapUtils.newLdaptiveConnectionFactory(properties);
+    }
+
+    @Override
+    public void destroy() {
+        searchFactory.close();
     }
 
     @Override

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
@@ -24,9 +24,11 @@ import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.LdapUtils;
 
 import com.google.common.collect.Multimap;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.jooq.lambda.Unchecked;
 import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.AuthenticationResponseHandler;
 import org.ldaptive.auth.Authenticator;
@@ -35,9 +37,11 @@ import org.ldaptive.auth.ext.EDirectoryAuthenticationResponseHandler;
 import org.ldaptive.auth.ext.FreeIPAAuthenticationResponseHandler;
 import org.ldaptive.auth.ext.PasswordExpirationAuthenticationResponseHandler;
 import org.ldaptive.auth.ext.PasswordPolicyAuthenticationResponseHandler;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.SetFactoryBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
@@ -50,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This is {@link LdapAuthenticationConfiguration} that attempts to create
@@ -155,8 +160,24 @@ public class LdapAuthenticationConfiguration {
     }
 
     @Bean
+    public SetFactoryBean ldapAuthenticationHandlerSetFactoryBean() {
+        val bean = new SetFactoryBean() {
+            @Override
+            protected void destroyInstance(final Set set) {
+                set.forEach(Unchecked.consumer(handler -> {
+                    ((DisposableBean) handler).destroy();
+                }));
+            }
+        };
+        bean.setSourceSet(new HashSet());
+        return bean;
+    }
+
+    @Bean
+    @SneakyThrows
     @RefreshScope
-    public Collection<AuthenticationHandler> ldapAuthenticationHandlers() {
+    public Collection<AuthenticationHandler> ldapAuthenticationHandlers(
+            final SetFactoryBean ldapAuthenticationHandlerSetFactoryBean) {
         val handlers = new HashSet<AuthenticationHandler>();
 
         casProperties.getAuthn().getLdap()
@@ -229,6 +250,7 @@ public class LdapAuthenticationConfiguration {
                 handler.initialize();
                 handlers.add(handler);
             });
+        ((Set) ldapAuthenticationHandlerSetFactoryBean.getObject()).addAll(handlers);
         return handlers;
     }
 
@@ -251,9 +273,12 @@ public class LdapAuthenticationConfiguration {
 
     @ConditionalOnMissingBean(name = "ldapAuthenticationEventExecutionPlanConfigurer")
     @Bean
+    @Autowired
+    @Qualifier("ldapAuthenticationHandlerSetFactoryBean")
     @RefreshScope
-    public AuthenticationEventExecutionPlanConfigurer ldapAuthenticationEventExecutionPlanConfigurer() {
-        return plan -> ldapAuthenticationHandlers().forEach(handler -> {
+    public AuthenticationEventExecutionPlanConfigurer ldapAuthenticationEventExecutionPlanConfigurer(
+            final SetFactoryBean ldapAuthenticationHandlerSetFactoryBean) {
+        return plan -> ldapAuthenticationHandlers(ldapAuthenticationHandlerSetFactoryBean).forEach(handler -> {
             LOGGER.info("Registering LDAP authentication for [{}]", handler.getName());
             plan.registerAuthenticationHandlerWithPrincipalResolver(handler, defaultPrincipalResolver.getObject());
         });

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
@@ -164,12 +164,12 @@ public class LdapAuthenticationConfiguration {
         val bean = new SetFactoryBean() {
             @Override
             protected void destroyInstance(final Set set) {
-                set.forEach(Unchecked.consumer(handler -> {
-                    ((DisposableBean) handler).destroy();
-                }));
+                set.forEach(Unchecked.consumer(handler ->
+                    ((DisposableBean) handler).destroy()
+                ));
             }
         };
-        bean.setSourceSet(new HashSet());
+        bean.setSourceSet(new HashSet<>());
         return bean;
     }
 
@@ -177,6 +177,7 @@ public class LdapAuthenticationConfiguration {
     @SneakyThrows
     @RefreshScope
     public Collection<AuthenticationHandler> ldapAuthenticationHandlers(
+            @Qualifier("ldapAuthenticationHandlerSetFactoryBean")
             final SetFactoryBean ldapAuthenticationHandlerSetFactoryBean) {
         val handlers = new HashSet<AuthenticationHandler>();
 
@@ -274,9 +275,9 @@ public class LdapAuthenticationConfiguration {
     @ConditionalOnMissingBean(name = "ldapAuthenticationEventExecutionPlanConfigurer")
     @Bean
     @Autowired
-    @Qualifier("ldapAuthenticationHandlerSetFactoryBean")
     @RefreshScope
     public AuthenticationEventExecutionPlanConfigurer ldapAuthenticationEventExecutionPlanConfigurer(
+            @Qualifier("ldapAuthenticationHandlerSetFactoryBean")
             final SetFactoryBean ldapAuthenticationHandlerSetFactoryBean) {
         return plan -> ldapAuthenticationHandlers(ldapAuthenticationHandlerSetFactoryBean).forEach(handler -> {
             LOGGER.info("Registering LDAP authentication for [{}]", handler.getName());

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapPasswordSynchronizationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapPasswordSynchronizationConfiguration.java
@@ -38,12 +38,12 @@ public class LdapPasswordSynchronizationConfiguration {
         val bean = new ListFactoryBean() {
             @Override
             protected void destroyInstance(final List list) {
-                list.forEach(Unchecked.consumer(postProcessor -> {
-                    ((DisposableBean) postProcessor).destroy();
-                }));
+                list.forEach(Unchecked.consumer(postProcessor ->
+                    ((DisposableBean) postProcessor).destroy()
+                ));
             }
         };
-        bean.setSourceList(new ArrayList());
+        bean.setSourceList(new ArrayList<>());
         return bean;
     }
 
@@ -51,8 +51,8 @@ public class LdapPasswordSynchronizationConfiguration {
     @Bean
     @SneakyThrows
     @Autowired
-    @Qualifier("ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean")
     public AuthenticationEventExecutionPlanConfigurer ldapPasswordSynchronizationAuthenticationEventExecutionPlanConfigurer(
+            @Qualifier("ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean")
             final ListFactoryBean ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean) {
         val postProcessorList = ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean.getObject();
         return plan -> {

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/web/flow/client/LdapSpnegoKnownClientSystemsFilterAction.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.SearchOperation;
 import org.ldaptive.SearchResponse;
+import org.springframework.beans.factory.DisposableBean;
 
 import java.util.regex.Pattern;
 
@@ -19,7 +20,7 @@ import java.util.regex.Pattern;
  * @since 4.1
  */
 @Slf4j
-public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownClientSystemsFilterAction {
+public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownClientSystemsFilterAction implements DisposableBean {
 
     /**
      * The must-have attribute name.
@@ -128,5 +129,10 @@ public class LdapSpnegoKnownClientSystemsFilterAction extends BaseSpnegoKnownCli
      */
     protected boolean verifySpnegoAttributeValue(final LdapAttribute attribute) {
         return attribute != null && StringUtils.isNotBlank(attribute.getStringValue());
+    }
+
+    @Override
+    public void destroy() {
+        this.searchOperation.getConnectionFactory().close();
     }
 }

--- a/support/cas-server-support-surrogate-authentication-ldap/src/main/java/org/apereo/cas/authentication/surrogate/SurrogateLdapAuthenticationService.java
+++ b/support/cas-server-support-surrogate-authentication-ldap/src/main/java/org/apereo/cas/authentication/surrogate/SurrogateLdapAuthenticationService.java
@@ -11,6 +11,7 @@ import org.apereo.cas.util.RegexUtils;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.ldaptive.ConnectionFactory;
+import org.springframework.beans.factory.DisposableBean;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,7 +26,7 @@ import java.util.stream.Collectors;
  * @since 5.1.0
  */
 @Slf4j
-public class SurrogateLdapAuthenticationService extends BaseSurrogateAuthenticationService {
+public class SurrogateLdapAuthenticationService extends BaseSurrogateAuthenticationService implements DisposableBean {
 
     private final ConnectionFactory connectionFactory;
     private final SurrogateAuthenticationProperties.Ldap ldapProperties;
@@ -104,5 +105,10 @@ public class SurrogateLdapAuthenticationService extends BaseSurrogateAuthenticat
 
         LOGGER.debug("No accounts may be eligible for surrogate authentication");
         return new ArrayList<>(0);
+    }
+
+    @Override
+    public void destroy() {
+        connectionFactory.close();
     }
 }


### PR DESCRIPTION
Ref: #4804

Now I split this PR into smaller pieces. This should be the most straightforward one: declaring various beans as DisposableBean, and tracking prototype DisposableBean in DestroyPrototypeBeansPostProcessor for final disposal.

Unit test added for DestroyPrototypeBeansPostProcessor.