### PR TITLE
Add a way to bypass unit test port available check

### DIFF
--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/junit/EnabledIfPortOpenCondition.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/junit/EnabledIfPortOpenCondition.java
@@ -19,11 +19,16 @@ import java.util.Arrays;
  */
 public class EnabledIfPortOpenCondition implements ExecutionCondition {
     private static final ConditionEvaluationResult ENABLED_BY_DEFAULT = ConditionEvaluationResult.enabled("@EnabledIfPortOpen is not present");
+    private static final String IGNORE_PORT_CHECK = "IGNORE_PORT_CHECK";
 
     private static ConditionEvaluationResult enableIfOpen(final EnabledIfPortOpen annotation, final AnnotatedElement element) {
         val ports = annotation.port();
         if (ports.length == 0) {
             throw new IllegalArgumentException("At least one port must be defined");
+        }
+        if (ignorePortCheck()) {
+            return ConditionEvaluationResult.enabled(
+                    String.format("%s is enabled because %s environment variable is set", element, IGNORE_PORT_CHECK));
         }
         for (val port : ports) {
             if (port > 0 && SocketUtils.isTcpPortAvailable(port)) {
@@ -42,5 +47,14 @@ public class EnabledIfPortOpenCondition implements ExecutionCondition {
         return AnnotationSupport.findAnnotation(element, EnabledIfPortOpen.class)
             .map(annotation -> enableIfOpen(annotation, element))
             .orElse(ENABLED_BY_DEFAULT);
+    }
+
+    /**
+     * The available port check doesn't always work on Windows so this provides a bypass mechanism.
+     * @return true if IGNORE_PORT_CHECK environment variable equals true
+     */
+    private static boolean ignorePortCheck() {
+        val ignorePortCheck = System.getenv(IGNORE_PORT_CHECK);
+        return "true".equalsIgnoreCase(ignorePortCheck);
     }
 }


### PR DESCRIPTION
CAS only runs some tests if something is listening on the port that the test will connect to. This doesn't seem to work on windows (at least for me, on two different computers hitting services on docker for windows). I tried various things to get the port available check to work but I was unsuccessful. This allows the checks to be bypassed with and environment variable. I think environment variable is easier than java system property b/c it doesn't require changing any existing scripts if running from command line. 

I thought about optionally having the IGNORE_PORT_CHECK allow specifying a list of ports to ignore the check for but the annotation takes a list of ports and it starts to get complicated coding that check when it probably isn't worth it. (e.g. if you only ignore the check for some of the ports listed in the annotation, do you proceed to do the port available check on the remaining ports). 