### PR TITLE
pac4j update from 4.0.0-RC2 to 4.0.0 in release 6.1.6 breaks default behavior

### DIFF
--- a/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
+++ b/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
@@ -41,7 +41,7 @@ import org.apereo.cas.uma.web.controllers.rpt.UmaRequestingPartyTokenJwksEndpoin
 import org.apereo.cas.util.DefaultUniqueTicketIdGenerator;
 
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
+import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.authenticator.Authenticator;
@@ -243,7 +243,7 @@ public class CasOAuthUmaConfiguration implements WebMvcConfigurer {
         val config = new Config(OAuth20Utils.casOAuthCallbackUrl(casProperties.getServer().getPrefix()), headerClient);
         config.setSessionStore(oauthDistributedSessionStore.getObject());
         val interceptor = new SecurityInterceptor(config, clients, JEEHttpActionAdapter.INSTANCE);
-        interceptor.setAuthorizers(StringUtils.EMPTY);
+        interceptor.setAuthorizers(DefaultAuthorizers.NONE);
         return interceptor;
     }
 

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
@@ -9,7 +9,7 @@ import org.apereo.cas.throttle.AuthenticationThrottlingExecutionPlan;
 import org.apereo.cas.throttle.AuthenticationThrottlingExecutionPlanConfigurer;
 
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
+import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.DirectClient;
 import org.pac4j.core.config.Config;
@@ -56,7 +56,7 @@ public class CasOAuth20ThrottleConfiguration {
     public SecurityInterceptor requiresAuthenticationAuthorizeInterceptor() {
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(),
             Authenticators.CAS_OAUTH_CLIENT, JEEHttpActionAdapter.INSTANCE);
-        interceptor.setAuthorizers(StringUtils.EMPTY);
+        interceptor.setAuthorizers(DefaultAuthorizers.NONE);
         return interceptor;
     }
 
@@ -71,7 +71,7 @@ public class CasOAuth20ThrottleConfiguration {
             .map(Client::getName)
             .collect(Collectors.joining(","));
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(), clients, JEEHttpActionAdapter.INSTANCE);
-        interceptor.setAuthorizers(StringUtils.EMPTY);
+        interceptor.setAuthorizers(DefaultAuthorizers.NONE);
         return interceptor;
     }
 

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -114,6 +114,7 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwk.PublicJsonWebKey;
 import org.pac4j.cas.client.CasClient;
+import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.TokenCredentials;
@@ -335,7 +336,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
             Authenticators.CAS_OAUTH_CLIENT_DIRECT_FORM,
             Authenticators.CAS_OAUTH_CLIENT_USER_FORM);
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(), clients, JEEHttpActionAdapter.INSTANCE);
-        interceptor.setAuthorizers(StringUtils.EMPTY);
+        interceptor.setAuthorizers(DefaultAuthorizers.NONE);
         return interceptor;
     }
 
@@ -343,7 +344,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
     public HandlerInterceptorAdapter requiresAuthenticationClientConfigurationInterceptor() {
         val clients = String.join(",", OidcConstants.CAS_OAUTH_CLIENT_CONFIG_ACCESS_TOKEN_AUTHN);
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(), clients, JEEHttpActionAdapter.INSTANCE);
-        interceptor.setAuthorizers(StringUtils.EMPTY);
+        interceptor.setAuthorizers(DefaultAuthorizers.NONE);
         return interceptor;
     }
 


### PR DESCRIPTION
fixing pac4j update from 4.0.0-RC2 to 4.0.0 in release 6.1.6 which breaks default behavior of cas	

see warning https://www.pac4j.org/docs/authorizers.html