### PR TITLE
Add Binary Attribute Handling to LDAP Repositories

### DIFF
--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryConfiguration.java
@@ -285,6 +285,11 @@ public class CasPersonDirectoryConfiguration {
                         ldapDao.setResultAttributeMapping(ldap.getAttributes());
                         val attributes = (String[]) ldap.getAttributes().keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
                         constraints.setReturningAttributes(attributes);
+
+                        if (ldap.getBinaryAttributes() != null && !ldap.getBinaryAttributes().isEmpty()) {
+                            LOGGER.debug("Setting binary attributes [{}]", ldap.getBinaryAttributes());
+                            ldapDao.setBinaryAttributes(ldap.getBinaryAttributes().toArray(new String[ldap.getBinaryAttributes().size()]));
+                        }
                     } else {
                         LOGGER.debug("Retrieving all attributes as no explicit attribute mappings are defined for [{}]", ldap.getLdapUrl());
                         constraints.setReturningAttributes(null);


### PR DESCRIPTION
Adds binary attribute handling to LDAP Attribute Repositories. Currently binary attributes only works with LDAP Authentication repositories.  Note needs a change on the Person Directory side as well: https://github.com/apereo/person-directory/pull/171