### PR TITLE
ServicesManager should use ServiceRegistry for find operations

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
@@ -164,7 +164,22 @@ public class ServiceRegistryProperties implements Serializable {
      * </ul>
      */
     private ServiceManagementTypes managementType = ServiceManagementTypes.DEFAULT;
+    
+    /**
+     * services cache duration.
+    */
+    private String cache = "PT5M";
 
+    /**
+     * services cache size.
+    */
+    private long cacheSize = Long.MAX_VALUE;
+
+    /**
+     * services cache capacity.
+    */
+    private int cachCapacity = Integer.MAX_VALUE;
+    
     /**
      * Types of service managers that one can control.
      */

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
@@ -166,17 +166,17 @@ public class ServiceRegistryProperties implements Serializable {
     private ServiceManagementTypes managementType = ServiceManagementTypes.DEFAULT;
     
     /**
-     * services cache duration.
+     * services cache duration specifies the fixed duration for an entry to be automatically removed from the cache after its creation or update.
     */
     private String cache = "PT5M";
 
     /**
-     * services cache size.
+     * services cache size specifies the maximum number of entries the cache may contain.
     */
     private long cacheSize = Long.MAX_VALUE;
 
     /**
-     * services cache capacity.
+     * services cache capacity sets the minimum total size for the internal data structures.
     */
     private int cachCapacity = Integer.MAX_VALUE;
     

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
@@ -166,17 +166,17 @@ public class ServiceRegistryProperties implements Serializable {
     private ServiceManagementTypes managementType = ServiceManagementTypes.DEFAULT;
     
     /**
-     * services cache duration specifies the fixed duration for an entry to be automatically removed from the cache after its creation or update.
+     * Services cache duration specifies the fixed duration for an entry to be automatically removed from the cache after its creation or update.
     */
     private String cache = "PT5M";
 
     /**
-     * services cache size specifies the maximum number of entries the cache may contain.
+     * Services cache size specifies the maximum number of entries the cache may contain.
     */
-    private long cacheSize = Long.MAX_VALUE;
+    private long cacheSize = 1000L;
 
     /**
-     * services cache capacity sets the minimum total size for the internal data structures.
+     * Services cache capacity sets the minimum total size for the internal data structures.
     */
     private int cachCapacity = Integer.MAX_VALUE;
     

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/services/ServiceRegistryProperties.java
@@ -178,7 +178,7 @@ public class ServiceRegistryProperties implements Serializable {
     /**
      * Services cache capacity sets the minimum total size for the internal data structures.
     */
-    private int cachCapacity = Integer.MAX_VALUE;
+    private int cachCapacity = 1000;
     
     /**
      * Types of service managers that one can control.

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistry.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistry.java
@@ -80,6 +80,18 @@ public interface ServiceRegistry {
         }
         return clazz.cast(service);
     }
+    
+    /**
+     * Find a service by matching with the service id.
+     *
+     * @param id the id to match with.
+     * @return the registered service
+     */
+    default RegisteredService findServiceBy(final String id) {
+        return getServicesStream().filter(r -> r.matches(id))
+                .findFirst()
+                .orElse(null);
+    }
 
     /**
      * Find a service by an exact match of the service id.

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistry.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServiceRegistry.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -135,12 +136,11 @@ public interface ServiceRegistry {
      * @param predicate the predicate
      * @return the registered service
      */
-    default RegisteredService findServicePredicate(final Predicate<RegisteredService> predicate) {
+    default Collection<RegisteredService> findServicePredicate(final Predicate<RegisteredService> predicate) {
         return load()
             .stream()
             .filter(predicate)
-            .findFirst()
-            .orElse(null);
+            .collect(Collectors.toList());
     }
 
     /**

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
@@ -132,6 +132,30 @@ public interface ServicesManager {
         }
         return null;
     }
+    
+    /**
+     * Find a RegisteredService by matching with the supplied name.
+     *
+     * @param name the name to match with.
+     * @return the RegisteredService that matches the supplied service.
+     */
+    RegisteredService findServiceByName(String name);
+
+    /**
+     * Find a RegisteredService by matching with the supplied name.
+     *
+     * @param <T>   the type parameter
+     * @param name    the name to match with.
+     * @param clazz the clazz
+     * @return the RegisteredService that matches the supplied service.
+     */
+    default <T extends RegisteredService> T findServiceByName(final String name, final Class<T> clazz) {
+        val service = findServiceByName(name);
+        if (service != null && clazz.isAssignableFrom(service.getClass())) {
+            return (T) service;
+        }
+        return null;
+    }
 
     /**
      * Retrieve the collection of all registered services.
@@ -169,7 +193,7 @@ public interface ServicesManager {
      *
      * @return the count/size of registry.
      */
-    default int count() {
+    default long count() {
         return 0;
     }
 

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
@@ -21,17 +21,17 @@ public interface ServicesManager {
     /**
      * Register a service with CAS, or update an existing an entry.
      *
-     * @param registeredService the RegisteredService to update or add.
-     * @return newly persisted RegisteredService instance
+     * @param registeredService the {@link RegisteredService} to update or add.
+     * @return newly persisted {@link RegisteredService} instance
      */
     RegisteredService save(RegisteredService registeredService);
 
     /**
      * Register a service with CAS, or update an existing an entry.
      *
-     * @param registeredService the RegisteredService to update or add.
+     * @param registeredService the {@link RegisteredService} to update or add.
      * @param publishEvent      whether events should be published to indicate the save operation.
-     * @return newly persisted RegisteredService instance
+     * @return newly persisted {@link RegisteredService} instance
      */
     RegisteredService save(RegisteredService registeredService, boolean publishEvent);
 
@@ -50,7 +50,7 @@ public interface ServicesManager {
     void deleteAll();
 
     /**
-     * Delete the entry for this RegisteredService.
+     * Delete the entry for this {@link RegisteredService}.
      *
      * @param id the id of the registeredService to delete.
      * @return the registered service that was deleted, null if there was none.
@@ -58,7 +58,7 @@ public interface ServicesManager {
     RegisteredService delete(long id);
 
     /**
-     * Delete the entry for this RegisteredService.
+     * Delete the entry for this {@link RegisteredService}.
      *
      * @param svc the registered service to delete.
      * @return the registered service that was deleted, null if there was none.
@@ -66,18 +66,18 @@ public interface ServicesManager {
     RegisteredService delete(RegisteredService svc);
 
     /**
-     * Find a RegisteredService by matching with the supplied service.
+     * Find a {@link RegisteredService} by matching with the supplied service.
      *
      * @param serviceId the service to match with.
-     * @return the RegisteredService that matches the supplied service.
+     * @return the {@link RegisteredService} that matches the supplied service.
      */
     RegisteredService findServiceBy(String serviceId);
     
     /**
-     * Find a RegisteredService by matching with the supplied service.
+     * Find a {@link RegisteredService} by matching with the supplied service.
      *
      * @param service the service to match with.
-     * @return the RegisteredService that matches the supplied service.
+     * @return the {@link RegisteredService} that matches the supplied service.
      */
     RegisteredService findServiceBy(Service service);
     
@@ -110,20 +110,20 @@ public interface ServicesManager {
     <T extends RegisteredService> T findServiceBy(String serviceId, Class<T> clazz);
 
     /**
-     * Find a RegisteredService by matching with the supplied id.
+     * Find a {@link RegisteredService} by matching with the supplied id.
      *
      * @param id the id to match with.
-     * @return the RegisteredService that matches the supplied service.
+     * @return the {@link RegisteredService} that matches the supplied service.
      */
     RegisteredService findServiceBy(long id);
     
     /**
-     * Find a RegisteredService by matching with the supplied id.
+     * Find a {@link RegisteredService} by matching with the supplied id.
      *
      * @param <T>   the type parameter
      * @param id    the id to match with.
      * @param clazz the clazz
-     * @return the RegisteredService that matches the supplied service.
+     * @return the {@link RegisteredService} that matches the supplied service.
      */
     default <T extends RegisteredService> T findServiceBy(final long id, final Class<T> clazz) {
         val service = findServiceBy(id);
@@ -134,28 +134,28 @@ public interface ServicesManager {
     }
     
     /**
-     * Find a RegisteredService by exact service id.
+     * Find a {@link RegisteredService} by exact service id.
      *
      * @param serviceId the service
-     * @return the RegisteredService
+     * @return the {@link RegisteredService} defention or null
      */
     RegisteredService findServiceByExactServiceId(String serviceId);
     
     /**
-     * Find a RegisteredService by matching with the supplied name.
+     * Find a {@link RegisteredService} by matching with the supplied name.
      *
      * @param name the name to match with.
-     * @return the RegisteredService that matches the supplied service.
+     * @return the {@link RegisteredService}  that matches the supplied service.
      */
     RegisteredService findServiceByName(String name);
 
     /**
-     * Find a RegisteredService by matching with the supplied name.
+     * Find a {@link RegisteredService} by matching with the supplied name.
      *
      * @param <T>   the type parameter
      * @param name    the name to match with.
      * @param clazz the clazz
-     * @return the RegisteredService that matches the supplied service.
+     * @return the {@link RegisteredService} that matches the supplied service.
      */
     default <T extends RegisteredService> T findServiceByName(final String name, final Class<T> clazz) {
         val service = findServiceByName(name);

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
@@ -72,7 +72,7 @@ public interface ServicesManager {
      * @return the RegisteredService that matches the supplied service.
      */
     RegisteredService findServiceBy(String serviceId);
-
+    
     /**
      * Find a RegisteredService by matching with the supplied service.
      *
@@ -80,7 +80,7 @@ public interface ServicesManager {
      * @return the RegisteredService that matches the supplied service.
      */
     RegisteredService findServiceBy(Service service);
-
+    
     /**
      * Find a collection of services by type.
      *
@@ -116,7 +116,7 @@ public interface ServicesManager {
      * @return the RegisteredService that matches the supplied service.
      */
     RegisteredService findServiceBy(long id);
-
+    
     /**
      * Find a RegisteredService by matching with the supplied id.
      *
@@ -132,6 +132,14 @@ public interface ServicesManager {
         }
         return null;
     }
+    
+    /**
+     * Find a RegisteredService by exact service id.
+     *
+     * @param serviceId the service
+     * @return the RegisteredService
+     */
+    RegisteredService findServiceByExactServiceId(String serviceId);
     
     /**
      * Find a RegisteredService by matching with the supplied name.

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -269,6 +269,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
     @Override
     public Collection<RegisteredService> load() {
         LOGGER.trace("Loading services from [{}]", serviceRegistry.getName());
+        this.services.invalidateAll();
         this.services.putAll(this.serviceRegistry.load()
                 .stream()
                 .collect(Collectors.toMap(r -> {

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -55,7 +55,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
     @Override
     public synchronized RegisteredService save(final RegisteredService registeredService, final boolean publishEvent) {
         publishEvent(new CasRegisteredServicePreSaveEvent(this, registeredService));
-        var r = this.serviceRegistry.save(registeredService);
+        val r = this.serviceRegistry.save(registeredService);
         this.services.put(r.getId(), r);
         saveInternal(registeredService);
 
@@ -102,9 +102,13 @@ public abstract class AbstractServicesManager implements ServicesManager {
                 .orElse(null);
 
         if (service == null) {
+            LOGGER.trace("The service that matches the serviceId {} is not found in the cache, try to find it from [{}]",
+                    serviceId, serviceRegistry.getName());
             service = serviceRegistry.findServiceBy(serviceId);
             if (service != null) {
                 services.put(service.getId(), service);
+                LOGGER.trace("The service is found in [{}] and populated to the cache {}  ", serviceRegistry.getName(), 
+                        service);
             }
         }
 
@@ -126,7 +130,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
         if (predicate == null) {
             return new ArrayList<>(0);
         }
-        var results= serviceRegistry.findServicePredicate(predicate).
+        val results = serviceRegistry.findServicePredicate(predicate).
                 stream().
                 sorted().
                 peek(RegisteredService::initialize).
@@ -156,14 +160,16 @@ public abstract class AbstractServicesManager implements ServicesManager {
 
     @Override
     public RegisteredService findServiceBy(final long id) {
-        var result = this.services.get(id, k -> this.serviceRegistry.findServiceById(id));
+        val result = this.services.get(id, k -> this.serviceRegistry.findServiceById(id));
         return validateRegisteredService(result);
     }
 
     @Override
     public <T extends RegisteredService> T findServiceBy(final long id, final Class<T> clazz) {
-        var result= this.serviceRegistry.findServiceById(id, clazz);
-        services.get(result.getId(), k-> result);
+        val result = this.serviceRegistry.findServiceById(id, clazz);
+        if (result != null) {
+            services.get(result.getId(), k -> result);
+        }
         return result;
     }
 
@@ -179,9 +185,13 @@ public abstract class AbstractServicesManager implements ServicesManager {
                 .orElse(null);
 
         if (service == null) {
+            LOGGER.trace("The service with name {} is not found in the cache, try to find it from [{}]",
+                    name, serviceRegistry.getName());
             service = serviceRegistry.findServiceByExactServiceName(name);
             if (service != null) {
                 services.put(service.getId(), service);
+                LOGGER.trace("The service is found in [{}] and populated to the cache {}  ", serviceRegistry.getName(),
+                        service);
             }
         }
 
@@ -193,8 +203,10 @@ public abstract class AbstractServicesManager implements ServicesManager {
     
     @Override
     public <T extends RegisteredService> T findServiceByName(final String name, final Class<T> clazz) {
-        var result= this.serviceRegistry.findServiceByExactServiceName(name, clazz);
-        services.get(result.getId(), k-> result);
+        val result = this.serviceRegistry.findServiceByExactServiceName(name, clazz);
+        if (result != null) {
+            services.get(result.getId(), k -> result);
+        }
         return result;
     }
 
@@ -210,9 +222,13 @@ public abstract class AbstractServicesManager implements ServicesManager {
                 .orElse(null);
 
         if (service == null) {
+            LOGGER.trace("The service with serviceId {} is not found in the cache, try to find it from [{}]",
+                    serviceId, serviceRegistry.getName());
             service = serviceRegistry.findServiceByExactServiceId(serviceId);
             if (service != null) {
                 services.put(service.getId(), service);
+                LOGGER.trace("The service is found in [{}] and populated to the cache {}  ", serviceRegistry.getName(),
+                        service);
             }
         }
 
@@ -244,7 +260,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
         this.services.putAll(this.serviceRegistry.load()
                 .stream()
                 .collect(Collectors.toMap(r -> {
-                    LOGGER.debug("Adding registered service [{}] with name [{}] and internal identifier [{}]",
+                    LOGGER.trace("Adding registered service [{}] with name [{}] and internal identifier [{}]",
                             r.getServiceId(), r.getName(), r.getId());
                     return r.getId();
                 }, Function.identity(), (r, s) -> s)));

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServicesManager.java
@@ -105,7 +105,7 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
         val manager = findServicesManager(service);
         return manager.map(servicesManager -> servicesManager.findServiceBy(service)).orElse(null);
     }
-
+    
     @Override
     public Collection<RegisteredService> findServiceBy(final Predicate<RegisteredService> clazz) {
         return serviceManagers.stream()
@@ -153,6 +153,15 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     public <T extends RegisteredService> T findServiceByName(final String name, final Class<T> clazz) {
         val manager = findServicesManager(clazz);
         return manager.map(servicesManager -> servicesManager.findServiceByName(name, clazz)).orElse(null);
+    }
+    
+    @Override
+    public RegisteredService findServiceByExactServiceId(final String serviceId) {
+        return serviceManagers.stream()
+                .map(s -> s.findServiceByExactServiceId(serviceId))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
     }
 
     @Override

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServicesManager.java
@@ -48,8 +48,8 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     }
 
     @Audit(action = "SAVE_SERVICE",
-        actionResolverName = "SAVE_SERVICE_ACTION_RESOLVER",
-        resourceResolverName = "SAVE_SERVICE_RESOURCE_RESOLVER")
+            actionResolverName = "SAVE_SERVICE_ACTION_RESOLVER",
+            resourceResolverName = "SAVE_SERVICE_RESOURCE_RESOLVER")
     @Override
     public RegisteredService save(final RegisteredService registeredService) {
         val manager = findServicesManager(registeredService);
@@ -57,8 +57,8 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     }
 
     @Audit(action = "SAVE_SERVICE",
-        actionResolverName = "SAVE_SERVICE_ACTION_RESOLVER",
-        resourceResolverName = "SAVE_SERVICE_RESOURCE_RESOLVER")
+            actionResolverName = "SAVE_SERVICE_ACTION_RESOLVER",
+            resourceResolverName = "SAVE_SERVICE_RESOURCE_RESOLVER")
     @Override
     public RegisteredService save(final RegisteredService registeredService, final boolean publishEvent) {
         val manager = findServicesManager(registeredService);
@@ -71,20 +71,20 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     }
 
     @Audit(action = "DELETE_SERVICE",
-        actionResolverName = "DELETE_SERVICE_ACTION_RESOLVER",
-        resourceResolverName = "DELETE_SERVICE_RESOURCE_RESOLVER")
+            actionResolverName = "DELETE_SERVICE_ACTION_RESOLVER",
+            resourceResolverName = "DELETE_SERVICE_RESOURCE_RESOLVER")
     @Override
     public RegisteredService delete(final long id) {
         return serviceManagers.stream()
-            .map(s -> s.delete(id))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+                .map(s -> s.delete(id))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
     }
 
     @Audit(action = "DELETE_SERVICE",
-        actionResolverName = "DELETE_SERVICE_ACTION_RESOLVER",
-        resourceResolverName = "DELETE_SERVICE_RESOURCE_RESOLVER")
+            actionResolverName = "DELETE_SERVICE_ACTION_RESOLVER",
+            resourceResolverName = "DELETE_SERVICE_RESOURCE_RESOLVER")
     @Override
     public RegisteredService delete(final RegisteredService svc) {
         val manager = findServicesManager(svc);
@@ -94,10 +94,10 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     @Override
     public RegisteredService findServiceBy(final String serviceId) {
         return serviceManagers.stream()
-            .map(s -> s.findServiceBy(serviceId))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+                .map(s -> s.findServiceBy(serviceId))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
     }
 
     @Override
@@ -109,8 +109,8 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     @Override
     public Collection<RegisteredService> findServiceBy(final Predicate<RegisteredService> clazz) {
         return serviceManagers.stream()
-            .flatMap(s -> s.findServiceBy(clazz).stream())
-            .collect(Collectors.toList());
+                .flatMap(s -> s.findServiceBy(clazz).stream())
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -128,48 +128,69 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     @Override
     public RegisteredService findServiceBy(final long id) {
         return serviceManagers.stream()
-            .map(s -> s.findServiceBy(id))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+                .map(s -> s.findServiceBy(id))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public <T extends RegisteredService> T findServiceBy(final long id, final Class<T> clazz) {
+        val manager = findServicesManager(clazz);
+        return manager.map(servicesManager -> servicesManager.findServiceBy(id, clazz)).orElse(null);
+    }
+
+    @Override
+    public RegisteredService findServiceByName(final String name) {
+        return serviceManagers.stream()
+                .map(s -> s.findServiceByName(name))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public <T extends RegisteredService> T findServiceByName(final String name, final Class<T> clazz) {
+        val manager = findServicesManager(clazz);
+        return manager.map(servicesManager -> servicesManager.findServiceByName(name, clazz)).orElse(null);
     }
 
     @Override
     public Stream<String> getDomains() {
         return serviceManagers.stream()
-            .filter(mgr -> mgr instanceof DomainAwareServicesManager)
-            .map(DomainAwareServicesManager.class::cast)
-            .flatMap(DomainAwareServicesManager::getDomains);
+                .filter(mgr -> mgr instanceof DomainAwareServicesManager)
+                .map(DomainAwareServicesManager.class::cast)
+                .flatMap(DomainAwareServicesManager::getDomains);
     }
 
     @Override
     public Collection<RegisteredService> getAllServices() {
         return serviceManagers.stream()
-            .flatMap(s -> s.getAllServices().stream())
-            .collect(Collectors.toList());
+                .flatMap(s -> s.getAllServices().stream())
+                .collect(Collectors.toList());
     }
 
     @Override
     public Collection<RegisteredService> load() {
         return serviceManagers.stream()
-            .flatMap(s -> s.load().stream())
-            .collect(Collectors.toList());
+                .flatMap(s -> s.load().stream())
+                .collect(Collectors.toList());
     }
 
     @Override
     public Collection<RegisteredService> getServicesForDomain(final String domain) {
         return serviceManagers.stream()
-            .filter(mgr -> mgr instanceof DomainAwareServicesManager)
-            .map(DomainAwareServicesManager.class::cast)
-            .flatMap(d -> d.getServicesForDomain(domain).stream())
-            .collect(Collectors.toList());
+                .filter(mgr -> mgr instanceof DomainAwareServicesManager)
+                .map(DomainAwareServicesManager.class::cast)
+                .flatMap(d -> d.getServicesForDomain(domain).stream())
+                .collect(Collectors.toList());
     }
 
     @Override
-    public int count() {
+    public long count() {
         return serviceManagers.stream()
-            .mapToInt(ServicesManager::count)
-            .sum();
+                .mapToLong(ServicesManager::count)
+                .sum();
     }
 
     @Override
@@ -186,4 +207,5 @@ public class ChainingServicesManager implements ServicesManager, DomainAwareServ
     public boolean supports(final Class clazz) {
         return findServicesManager(clazz).isPresent();
     }
+
 }

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultServicesManager.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.services;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Comparator;
@@ -15,14 +16,15 @@ import java.util.stream.Stream;
 public class DefaultServicesManager extends AbstractServicesManager {
 
     public DefaultServicesManager(final ServiceRegistry serviceRegistry,
-                                  final ApplicationEventPublisher eventPublisher,
-                                  final Set<String> environments) {
-        super(serviceRegistry, eventPublisher, environments);
+            final ApplicationEventPublisher eventPublisher,
+            final Set<String> environments,
+            final Cache<Long, RegisteredService> services) {
+        super(serviceRegistry, eventPublisher, environments, services);
     }
 
     @Override
     protected Stream<RegisteredService> getCandidateServicesToMatch(final String serviceId) {
-        return getServices().values().stream().sorted(Comparator.naturalOrder());
+        return getServices().asMap().values().stream().sorted(Comparator.naturalOrder());
     }
 
 }

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/domain/DefaultDomainAwareServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/domain/DefaultDomainAwareServicesManager.java
@@ -6,6 +6,7 @@ import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.ServiceRegistry;
 import org.apereo.cas.services.ServicesManager;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -33,10 +34,11 @@ public class DefaultDomainAwareServicesManager extends AbstractServicesManager i
     private final RegisteredServiceDomainExtractor registeredServiceDomainExtractor;
 
     public DefaultDomainAwareServicesManager(final ServiceRegistry serviceRegistry,
-                                             final ApplicationEventPublisher eventPublisher,
-                                             final RegisteredServiceDomainExtractor registeredServiceDomainExtractor,
-                                             final Set<String> environments) {
-        super(serviceRegistry, eventPublisher, environments);
+            final ApplicationEventPublisher eventPublisher,
+            final RegisteredServiceDomainExtractor registeredServiceDomainExtractor,
+            final Set<String> environments,
+            final Cache<Long, RegisteredService> services) {
+        super(serviceRegistry, eventPublisher, environments, services);
         this.registeredServiceDomainExtractor = registeredServiceDomainExtractor;
     }
 

--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/config/CasCoreServicesConfiguration.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/config/CasCoreServicesConfiguration.java
@@ -9,6 +9,7 @@ import org.apereo.cas.authentication.principal.ShibbolethCompatiblePersistentIdG
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.authentication.principal.WebApplicationServiceResponseBuilder;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.services.ChainingServiceRegistry;
 import org.apereo.cas.services.ChainingServicesManager;
 import org.apereo.cas.services.DefaultChainingServiceRegistry;
@@ -37,6 +38,8 @@ import org.apereo.cas.services.resource.RegisteredServiceResourceNamingStrategy;
 import org.apereo.cas.services.util.RegisteredServiceYamlHttpMessageConverter;
 import org.apereo.cas.util.io.CommunicationsManager;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import lombok.extern.slf4j.Slf4j;
@@ -231,13 +234,25 @@ public class CasCoreServicesConfiguration {
         servicesManager().load();
     }
 
+    @RefreshScope
+    @Bean
+    @ConditionalOnMissingBean(name = "servicesManagerCache")
+    public Cache<Long, RegisteredService> servicesManagerCache() {
+        var duration = Beans.newDuration(casProperties.getServiceRegistry().getCache());
+        return Caffeine.newBuilder()
+                .initialCapacity(casProperties.getServiceRegistry().getCachCapacity())
+                .maximumSize(casProperties.getServiceRegistry().getCacheSize())
+                .expireAfterWrite(duration)
+                .build();
+    }
+
     @Bean
     @ConditionalOnMissingBean(name = "defaultServicesManagerExecutionPlanConfigurer")
     @ConditionalOnProperty(prefix = "cas.service-registry", name = "management-type", havingValue = "DEFAULT", matchIfMissing = true)
     public ServicesManagerExecutionPlanConfigurer defaultServicesManagerExecutionPlanConfigurer() {
         return () -> {
             val activeProfiles = Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toSet());
-            return new DefaultServicesManager(serviceRegistry(), applicationContext, activeProfiles);
+            return new DefaultServicesManager(serviceRegistry(), applicationContext, activeProfiles, servicesManagerCache());
         };
     }
 
@@ -249,7 +264,7 @@ public class CasCoreServicesConfiguration {
             val activeProfiles = Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toSet());
             return new DefaultDomainAwareServicesManager(serviceRegistry(), applicationContext,
                 new DefaultRegisteredServiceDomainExtractor(),
-                activeProfiles);
+                activeProfiles, servicesManagerCache());
         };
     }
 

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/SimpleWebApplicationServiceImplTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/SimpleWebApplicationServiceImplTests.java
@@ -6,6 +6,7 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServiceRegistry;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
@@ -48,7 +49,7 @@ public class SimpleWebApplicationServiceImplTests {
         request.setParameter(CasProtocolConstants.PARAMETER_SERVICE, SERVICE);
         val impl = new WebApplicationServiceFactory().createService(request);
         val response = new WebApplicationServiceResponseBuilder(
-            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(), Caffeine.newBuilder().build()))
             .build(impl, "ticketId", RegisteredServiceTestUtils.getAuthentication());
         assertNotNull(response);
         assertEquals(Response.ResponseType.REDIRECT, response.getResponseType());
@@ -78,7 +79,7 @@ public class SimpleWebApplicationServiceImplTests {
         val impl = new WebApplicationServiceFactory().createService(request);
 
         val response = new WebApplicationServiceResponseBuilder(
-            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(), Caffeine.newBuilder().build()))
             .build(impl, null,
                 RegisteredServiceTestUtils.getAuthentication());
         assertNotNull(response);
@@ -92,7 +93,7 @@ public class SimpleWebApplicationServiceImplTests {
         request.setParameter(SERVICE, "http://foo.com/");
         val impl = new WebApplicationServiceFactory().createService(request);
         val response = new WebApplicationServiceResponseBuilder(
-            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(), Caffeine.newBuilder().build()))
             .build(impl, null,
                 RegisteredServiceTestUtils.getAuthentication());
         assertNotNull(response);
@@ -107,7 +108,7 @@ public class SimpleWebApplicationServiceImplTests {
         request.setParameter(CasProtocolConstants.PARAMETER_SERVICE, "http://foo.com/?param=test");
         val impl = new WebApplicationServiceFactory().createService(request);
         val response = new WebApplicationServiceResponseBuilder(
-            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(), Caffeine.newBuilder().build()))
             .build(impl, null, RegisteredServiceTestUtils.getAuthentication());
         assertNotNull(response);
         assertEquals(Response.ResponseType.REDIRECT, response.getResponseType());

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServiceRegistryTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServiceRegistryTests.java
@@ -40,6 +40,8 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Collection;
+
 /**
  * Abstracted service registry tests for all implementations.
  *
@@ -191,8 +193,9 @@ public abstract class AbstractServiceRegistryTests {
         assertEquals(rs3.getServiceId(), rs.getServiceId());
         assertEquals(rs3.getTheme(), rs.getTheme());
 
-        val rs4 = this.serviceRegistry.findServicePredicate(registeredService -> registeredService.getId() == rs.getId());
-        assertEquals(rs4.getName(), rs.getName());
+        Collection<RegisteredService> rs4 =
+                this.serviceRegistry.findServicePredicate(registeredService -> registeredService.getId() == rs.getId());
+        assertTrue(rs4.stream().map(rs5-> rs5.getName().equals(rs.getName())).findFirst().isPresent());
     }
 
     @ParameterizedTest

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServiceRegistryTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServiceRegistryTests.java
@@ -31,6 +31,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,8 +40,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Collection;
 
 /**
  * Abstracted service registry tests for all implementations.

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.services;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
     }
 
     protected ServicesManager getServicesManagerInstance() {
-        return new DefaultServicesManager(serviceRegistry, mock(ApplicationEventPublisher.class), new HashSet<>());
+        return new DefaultServicesManager(serviceRegistry, mock(ApplicationEventPublisher.class), new HashSet<>(), Caffeine.newBuilder().build());
     }
 
     protected ServiceRegistry getServiceRegistryInstance() {
@@ -65,7 +66,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         servicesManager.save(services);
         assertNotNull(this.servicesManager.findServiceBy(1100));
         assertNotNull(this.servicesManager.findServiceByName(TEST));
-        assertNotNull(this.servicesManager.findServiceByName(TEST,RegexRegisteredService.class));
+        assertNotNull(this.servicesManager.findServiceByName(TEST, RegexRegisteredService.class));
         assertTrue(this.servicesManager.count() > 0);
     }
 

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -108,9 +108,9 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         assertFalse(isServiceInCache(null, 4100));
         this.servicesManager.save(service);
         assertTrue(isServiceInCache(null, 4100));
-        TimeUnit.SECONDS.sleep(2L);
+        Thread.sleep(1000);
         assertTrue(isServiceInCache(null, 4100));
-        TimeUnit.SECONDS.sleep(4L);
+        Thread.sleep(5000);
         assertFalse(isServiceInCache(null, 4100));
     }
 

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -64,6 +64,8 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         services.setServiceId(TEST);
         servicesManager.save(services);
         assertNotNull(this.servicesManager.findServiceBy(1100));
+        assertNotNull(this.servicesManager.findServiceByName(TEST));
+        assertNotNull(this.servicesManager.findServiceByName(TEST,RegexRegisteredService.class));
         assertTrue(this.servicesManager.count() > 0);
     }
 
@@ -108,6 +110,5 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         this.servicesManager.save(r);
         assertNull(this.servicesManager.findServiceBy(r.getServiceId()));
     }
-
 
 }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -68,6 +68,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         services.setServiceId(TEST);
         servicesManager.save(services);
         assertNotNull(this.servicesManager.findServiceBy(1100));
+        assertNotNull(this.servicesManager.findServiceBy(1100, RegexRegisteredService.class));
         assertNotNull(this.servicesManager.findServiceByName(TEST));
         assertNotNull(this.servicesManager.findServiceByName(TEST, RegexRegisteredService.class));
         assertTrue(this.servicesManager.count() > 0);
@@ -96,6 +97,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         serviceRegistry.save(service);
         assertNotNull(serviceRegistry.findServiceByExactServiceId(TEST));
         assertNotNull(servicesManager.findServiceByExactServiceId(TEST));
+        assertNotNull(servicesManager.findServiceBy(TEST, RegexRegisteredService.class));
         assertTrue(isServiceInCache(TEST, 0));
     }
     

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -13,7 +13,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -102,21 +101,6 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
     }
     
     @Test
-    public void verifySaveAndRemoveFromCache() throws InterruptedException{
-        val service = new RegexRegisteredService();
-        service.setId(4100);
-        service.setName(TEST);
-        service.setServiceId(TEST);
-        assertFalse(isServiceInCache(null, 4100));
-        this.servicesManager.save(service);
-        assertTrue(isServiceInCache(null, 4100));
-        Thread.sleep(1000);
-        assertTrue(isServiceInCache(null, 4100));
-        Thread.sleep(5000);
-        assertFalse(isServiceInCache(null, 4100));
-    }
-
-    @Test
     public void verifyDelete() {
         val r = new RegexRegisteredService();
         r.setId(1000);
@@ -160,7 +144,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         assertNull(this.servicesManager.findServiceBy(r.getServiceId()));
     }
 
-    private boolean isServiceInCache(final String serviceId, final long id) {
+    protected boolean isServiceInCache(final String serviceId, final long id) {
         return servicesManager.getAllServices().stream().filter(r -> serviceId != null
                 ? r.getServiceId().equals(serviceId) : r.getId() == id).findFirst().isPresent();
     }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/ChainingServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/ChainingServicesManagerTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.services;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ public class ChainingServicesManagerTests extends AbstractServicesManagerTests {
     @Override
     protected ServicesManager getServicesManagerInstance() {
         val chain = new ChainingServicesManager();
-        val manager = new DefaultServicesManager(serviceRegistry, mock(ApplicationEventPublisher.class), new HashSet<>());
+        val manager = new DefaultServicesManager(serviceRegistry, mock(ApplicationEventPublisher.class), new HashSet<>(), Caffeine.newBuilder().build());
         chain.registerServiceManager(manager);
         return chain;
     }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultDomainAwareServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultDomainAwareServicesManagerTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.services;
 import org.apereo.cas.services.domain.DefaultDomainAwareServicesManager;
 import org.apereo.cas.services.domain.DefaultRegisteredServiceDomainExtractor;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -25,9 +26,11 @@ public class DefaultDomainAwareServicesManagerTests extends AbstractServicesMana
 
     @Override
     protected ServicesManager getServicesManagerInstance() {
-        defaultDomainAwareServicesManager = new DefaultDomainAwareServicesManager(serviceRegistry, mock(ApplicationEventPublisher.class),
-            new DefaultRegisteredServiceDomainExtractor(),
-            new HashSet<>());
+        defaultDomainAwareServicesManager = new DefaultDomainAwareServicesManager(serviceRegistry, mock(
+                ApplicationEventPublisher.class),
+                new DefaultRegisteredServiceDomainExtractor(),
+                new HashSet<>(),
+                Caffeine.newBuilder().build());
         return defaultDomainAwareServicesManager;
     }
 

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultServicesManagerByEnvironmentTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultServicesManagerByEnvironmentTests.java
@@ -2,6 +2,7 @@ package org.apereo.cas.services;
 
 import org.apereo.cas.util.CollectionUtils;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ public class DefaultServicesManagerByEnvironmentTests extends AbstractServicesMa
     @Override
     protected ServicesManager getServicesManagerInstance() {
         return new DefaultServicesManager(serviceRegistry, mock(ApplicationEventPublisher.class),
-            CollectionUtils.wrapSet("prod1", "qa1"));
+            CollectionUtils.wrapSet("prod1", "qa1"), Caffeine.newBuilder().build());
     }
 
     @Test

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/DefaultServicesManagerTests.java
@@ -1,7 +1,11 @@
 package org.apereo.cas.services;
 
-
+import lombok.val;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author battags
@@ -9,4 +13,21 @@ import org.junit.jupiter.api.Tag;
  */
 @Tag("Simple")
 public class DefaultServicesManagerTests extends AbstractServicesManagerTests {
+
+    private static final String TEST = "test";
+
+    @Test
+    public void verifySaveAndRemoveFromCache() throws InterruptedException {
+        val service = new RegexRegisteredService();
+        service.setId(4100);
+        service.setName(TEST);
+        service.setServiceId(TEST);
+        assertFalse(isServiceInCache(null, 4100));
+        this.servicesManager.save(service);
+        assertTrue(isServiceInCache(null, 4100));
+        Thread.sleep(1_000);
+        assertTrue(isServiceInCache(null, 4100));
+        Thread.sleep(5_000);
+        assertFalse(isServiceInCache(null, 4100));
+    }
 }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceAuthenticationHandlerResolverTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceAuthenticationHandlerResolverTests.java
@@ -9,6 +9,7 @@ import org.apereo.cas.authentication.handler.DefaultAuthenticationHandlerResolve
 import org.apereo.cas.authentication.handler.RegisteredServiceAuthenticationHandlerResolver;
 import org.apereo.cas.util.CollectionUtils;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -55,7 +56,7 @@ public class RegisteredServiceAuthenticationHandlerResolverTests {
         appCtx.refresh();
         val dao = new InMemoryServiceRegistry(appCtx, list, new ArrayList<>());
 
-        this.defaultServicesManager = new DefaultServicesManager(dao, mock(ApplicationEventPublisher.class), new HashSet<>());
+        this.defaultServicesManager = new DefaultServicesManager(dao, mock(ApplicationEventPublisher.class), new HashSet<>(), Caffeine.newBuilder().build());
         this.defaultServicesManager.load();
 
         val handler1 = new AcceptUsersAuthenticationHandler("handler1");

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceAuthenticationPolicyResolverTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/RegisteredServiceAuthenticationPolicyResolverTests.java
@@ -10,6 +10,7 @@ import org.apereo.cas.authentication.policy.NotPreventedAuthenticationPolicy;
 import org.apereo.cas.authentication.policy.RegisteredServiceAuthenticationPolicyResolver;
 import org.apereo.cas.authentication.policy.RestfulAuthenticationPolicy;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -84,7 +85,7 @@ public class RegisteredServiceAuthenticationPolicyResolverTests {
 
         val dao = new InMemoryServiceRegistry(appCtx, list, new ArrayList<>());
 
-        this.servicesManager = new DefaultServicesManager(dao, appCtx, new HashSet<>());
+        this.servicesManager = new DefaultServicesManager(dao, appCtx, new HashSet<>(), Caffeine.newBuilder().build());
         this.servicesManager.load();
     }
 

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
@@ -124,7 +124,7 @@ public class MockWebServer implements AutoCloseable {
         /**
          * Separates HTTP header from body.
          */
-        private static final String SEPARATOR = "\r\n";
+        private static final String SEPARATOR = "\r%n";
 
         /**
          * Response buffer size.

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
@@ -124,7 +124,7 @@ public class MockWebServer implements AutoCloseable {
         /**
          * Separates HTTP header from body.
          */
-        private static final String SEPARATOR = "\r%n";
+        private static final String SEPARATOR = "\r\n";
 
         /**
          * Response buffer size.

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceResponseHeadersEnforcementFilterTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceResponseHeadersEnforcementFilterTests.java
@@ -13,6 +13,7 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.web.support.RegisteredServiceResponseHeadersEnforcementFilter;
 import org.apereo.cas.web.support.DefaultArgumentExtractor;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Tag;
@@ -185,7 +186,7 @@ public class RegisteredServiceResponseHeadersEnforcementFilterTests {
         val appCtx = new StaticApplicationContext();
         appCtx.refresh();
         val servicesManager = new DefaultServicesManager(new InMemoryServiceRegistry(appCtx),
-            appCtx, new LinkedHashSet<>());
+            appCtx, new LinkedHashSet<>(), Caffeine.newBuilder().build());
         val argumentExtractor = new DefaultArgumentExtractor(new WebApplicationServiceFactory());
 
         val service = RegisteredServiceTestUtils.getRegisteredService("service-0");

--- a/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/authentication/RequiredAuthenticationHandlersSingleSignOnParticipationStrategyTests.java
+++ b/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/authentication/RequiredAuthenticationHandlersSingleSignOnParticipationStrategyTests.java
@@ -12,6 +12,7 @@ import org.apereo.cas.ticket.registry.DefaultTicketRegistry;
 import org.apereo.cas.ticket.registry.DefaultTicketRegistrySupport;
 import org.apereo.cas.web.support.WebUtils;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,7 @@ public class RequiredAuthenticationHandlersSingleSignOnParticipationStrategyTest
         val svc = CoreAuthenticationTestUtils.getRegisteredService("serviceid1");
         val dao = new InMemoryServiceRegistry(appCtx, List.of(svc), new ArrayList<>());
 
-        val defaultServicesManager = new DefaultServicesManager(dao, appCtx, new HashSet<>());
+        val defaultServicesManager = new DefaultServicesManager(dao, appCtx, new HashSet<>(), Caffeine.newBuilder().build());
         defaultServicesManager.load();
 
         val strategy = new RequiredAuthenticationHandlersSingleSignOnParticipationStrategy(defaultServicesManager,
@@ -83,7 +84,7 @@ public class RequiredAuthenticationHandlersSingleSignOnParticipationStrategyTest
             List.of(svc), new ArrayList<>());
 
         val servicesManager = new DefaultServicesManager(dao,
-            appCtx, new HashSet<>());
+            appCtx, new HashSet<>(), Caffeine.newBuilder().build());
         servicesManager.load();
 
         val ticketRegistry = new DefaultTicketRegistry();
@@ -120,7 +121,7 @@ public class RequiredAuthenticationHandlersSingleSignOnParticipationStrategyTest
             List.of(svc), new ArrayList<>());
 
         val servicesManager = new DefaultServicesManager(dao,
-            appCtx, new HashSet<>());
+            appCtx, new HashSet<>(), Caffeine.newBuilder().build());
         servicesManager.load();
 
         val ticketRegistry = new DefaultTicketRegistry();

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -4464,6 +4464,18 @@ To learn more about this topic, [please review this guide](../services/JPA-Servi
 Database settings for this feature are available [here](Configuration-Properties-Common.html#database-settings) 
 under the configuration key `cas.service-registry.jpa`.
 
+### Cache Service Registry
+
+Services cache duration specifies the fixed duration for an entry to be automatically removed from the cache after its creation or update.
+
+### Cache Size Service Registry
+
+Services cache size specifies the maximum number of entries the cache may contain.
+
+### Cach Capacity Service Registry
+
+Services cache capacity sets the minimum total size for the internal data structures.
+
 ## Service Registry Replication
 
 Control how CAS services definition files should be replicated across a CAS cluster.

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/LogoutActionTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/LogoutActionTests.java
@@ -12,6 +12,7 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.web.flow.logout.LogoutAction;
 import org.apereo.cas.web.support.WebUtils;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -61,7 +62,7 @@ public class LogoutActionTests extends AbstractWebflowActionsTests {
 
         val appCtx = new StaticApplicationContext();
         appCtx.refresh();
-        this.serviceManager = new DefaultServicesManager(new InMemoryServiceRegistry(appCtx), appCtx, new HashSet<>());
+        this.serviceManager = new DefaultServicesManager(new InMemoryServiceRegistry(appCtx), appCtx, new HashSet<>(), Caffeine.newBuilder().build());
         this.serviceManager.load();
     }
 

--- a/support/cas-server-support-openid/src/test/java/org/apereo/cas/support/openid/authentication/principal/OpenIdServiceTests.java
+++ b/support/cas-server-support-openid/src/test/java/org/apereo/cas/support/openid/authentication/principal/OpenIdServiceTests.java
@@ -9,6 +9,7 @@ import org.apereo.cas.support.openid.AbstractOpenIdTests;
 import org.apereo.cas.support.openid.OpenIdProtocolConstants;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
@@ -102,7 +103,8 @@ public class OpenIdServiceTests extends AbstractOpenIdTests {
 
             val response = new OpenIdServiceResponseBuilder(OPEN_ID_PREFIX_URL,
                 serverManager, centralAuthenticationService,
-                new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+                new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(),
+                    Caffeine.newBuilder().build()))
                 .build(openIdService, "something", CoreAuthenticationTestUtils.getAuthentication());
             assertNotNull(response);
 
@@ -112,7 +114,8 @@ public class OpenIdServiceTests extends AbstractOpenIdTests {
 
             val response2 = new OpenIdServiceResponseBuilder(OPEN_ID_PREFIX_URL, serverManager,
                 centralAuthenticationService,
-                new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+                new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(),
+                    Caffeine.newBuilder().build()))
                 .build(openIdService, null, CoreAuthenticationTestUtils.getAuthentication());
             assertEquals("cancel", response2.getAttributes().get(OpenIdProtocolConstants.OPENID_MODE));
         } catch (final Exception e) {
@@ -141,8 +144,9 @@ public class OpenIdServiceTests extends AbstractOpenIdTests {
             }
             val response = new OpenIdServiceResponseBuilder(OPEN_ID_PREFIX_URL, serverManager,
                 centralAuthenticationService,
-                new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
-                .build(openIdService, st, CoreAuthenticationTestUtils.getAuthentication());
+                new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(),
+                    Caffeine.newBuilder().build()))
+                .build(openIdService, st, CoreAuthenticationTestUtils.getAuthentication()); 
             assertNotNull(response);
 
             assertEquals(2, response.getAttributes().size());

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlRegisteredServiceTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlRegisteredServiceTests.java
@@ -11,6 +11,7 @@ import org.apereo.cas.services.resource.DefaultRegisteredServiceResourceNamingSt
 import org.apereo.cas.util.io.WatcherService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -99,7 +100,7 @@ public class SamlRegisteredServiceTests {
         service.setServiceId("^http://.+");
         service.setMetadataLocation(METADATA_LOCATION);
         val dao = new InMemoryServiceRegistry(appCtx, List.of(service), new ArrayList<>());
-        val impl = new DefaultServicesManager(dao, appCtx, new HashSet<>());
+        val impl = new DefaultServicesManager(dao, appCtx, new HashSet<>(), Caffeine.newBuilder().build());
         impl.load();
 
         val s = impl.findServiceBy(new WebApplicationServiceFactory()

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/authentication/principal/SamlServiceTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/authentication/principal/SamlServiceTests.java
@@ -15,6 +15,7 @@ import org.apereo.cas.support.saml.SamlProtocolConstants;
 import org.apereo.cas.web.support.DefaultArgumentExtractor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
@@ -61,7 +62,8 @@ public class SamlServiceTests extends AbstractOpenSamlTests {
         val impl = samlServiceFactory.createService(request);
 
         val response = new SamlServiceResponseBuilder(
-            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(),
+                        Caffeine.newBuilder().build()))
             .build(impl, "ticketId", CoreAuthenticationTestUtils.getAuthentication());
         assertNotNull(response);
         assertEquals(Response.ResponseType.REDIRECT, response.getResponseType());
@@ -83,7 +85,8 @@ public class SamlServiceTests extends AbstractOpenSamlTests {
         request.setParameter(SamlProtocolConstants.CONST_PARAM_TARGET, "service");
         val impl = samlServiceFactory.createService(request);
         val response = new SamlServiceResponseBuilder(
-            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>()))
+            new DefaultServicesManager(mock(ServiceRegistry.class), mock(ApplicationEventPublisher.class), new HashSet<>(),
+                        Caffeine.newBuilder().build()))
             .build(impl, null, CoreAuthenticationTestUtils.getAuthentication());
         assertNotNull(response);
         assertEquals(Response.ResponseType.REDIRECT, response.getResponseType());

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
@@ -22,6 +22,7 @@ import org.apereo.cas.validation.DefaultAssertionBuilder;
 import org.apereo.cas.web.support.DefaultArgumentExtractor;
 import org.apereo.cas.web.view.attributes.NoOpProtocolAttributesRenderer;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -66,7 +67,7 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
         list.add(RegisteredServiceTestUtils.getRegisteredService("https://.+"));
         val dao = new InMemoryServiceRegistry(appCtx, list, new ArrayList<>());
 
-        val mgmr = new DefaultServicesManager(dao, appCtx, new HashSet<>());
+        val mgmr = new DefaultServicesManager(dao, appCtx, new HashSet<>(), Caffeine.newBuilder().build());
         mgmr.load();
 
         val protocolAttributeEncoder = new DefaultCasProtocolAttributeEncoder(mgmr, CipherExecutor.noOpOfStringToString());


### PR DESCRIPTION
This pull request fixes the fact that find operations of the ServiceRegistry is not fully utilized by the ServicesManager instead it does its own filtering logic.
