### PR TITLE
Gauth registration token

### DIFF
--- a/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/validator/GoogleAuthenticatorAccountValidator.java
+++ b/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/validator/GoogleAuthenticatorAccountValidator.java
@@ -1,0 +1,30 @@
+package org.apereo.cas.gauth.validator;
+
+import org.apereo.cas.authentication.OneTimeTokenAccount;
+import org.apereo.cas.otp.validator.OneTimeTokenAccountValidator;
+
+import com.warrenstrange.googleauth.IGoogleAuthenticator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is {@link GoogleAuthenticatorAccountValidator}.
+ *
+ * Implements {@link OneTimeTokenAccountValidator} to
+ * provide validation of Google Authenticator credentials.
+ *
+ * @author Hayden Sartoris
+ * @since 6.2.0-RC5
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class GoogleAuthenticatorAccountValidator implements OneTimeTokenAccountValidator {
+    private final IGoogleAuthenticator googleAuthenticatorInstance;
+
+    @Override
+    public boolean isValid(final OneTimeTokenAccount account,
+                           final int token) {
+        LOGGER.trace("Testing token [{}] against account [{}]", token, account);
+        return this.googleAuthenticatorInstance.authorize(account.getSecretKey(), token);
+    }
+}

--- a/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/validator/GoogleAuthenticatorAccountValidator.java
+++ b/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/validator/GoogleAuthenticatorAccountValidator.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
  * provide validation of Google Authenticator credentials.
  *
  * @author Hayden Sartoris
- * @since 6.2.0-RC5
+ * @since 6.2.0
  */
 @Slf4j
 @RequiredArgsConstructor

--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -196,7 +196,9 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
         return CipherExecutor.noOp();
     }
 
+    @ConditionalOnMissingBean(name = "googleAuthenticatorAccountValidator")
     @Bean
+    @RefreshScope
     public OneTimeTokenAccountValidator googleAuthenticatorAccountValidator() {
         return new GoogleAuthenticatorAccountValidator(googleAuthenticatorInstance());
     }

--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -19,10 +19,12 @@ import org.apereo.cas.gauth.credential.GoogleAuthenticatorTokenCredentialReposit
 import org.apereo.cas.gauth.credential.InMemoryGoogleAuthenticatorTokenCredentialRepository;
 import org.apereo.cas.gauth.credential.JsonGoogleAuthenticatorTokenCredentialRepository;
 import org.apereo.cas.gauth.credential.RestGoogleAuthenticatorTokenCredentialRepository;
+import org.apereo.cas.gauth.validator.GoogleAuthenticatorAccountValidator;
 import org.apereo.cas.otp.repository.credentials.OneTimeTokenAccountCipherExecutor;
 import org.apereo.cas.otp.repository.credentials.OneTimeTokenCredentialRepository;
 import org.apereo.cas.otp.repository.token.OneTimeTokenRepository;
 import org.apereo.cas.otp.repository.token.OneTimeTokenRepositoryCleaner;
+import org.apereo.cas.otp.validator.OneTimeTokenAccountValidator;
 import org.apereo.cas.otp.web.flow.OneTimeTokenAccountCheckRegistrationAction;
 import org.apereo.cas.otp.web.flow.OneTimeTokenAccountSaveRegistrationAction;
 import org.apereo.cas.services.ServicesManager;
@@ -195,10 +197,15 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
     }
 
     @Bean
+    public OneTimeTokenAccountValidator googleAuthenticatorAccountValidator() {
+        return new GoogleAuthenticatorAccountValidator(googleAuthenticatorInstance());
+    }
+
+    @Bean
     @RefreshScope
     public Action googleSaveAccountRegistrationAction() {
         return new OneTimeTokenAccountSaveRegistrationAction(googleAuthenticatorAccountRegistry.getObject(),
-                googleAuthenticatorInstance());
+                googleAuthenticatorAccountValidator());
     }
 
     @ConditionalOnMissingBean(name = "googlePrincipalFactory")

--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -197,7 +197,8 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
     @Bean
     @RefreshScope
     public Action googleSaveAccountRegistrationAction() {
-        return new OneTimeTokenAccountSaveRegistrationAction(googleAuthenticatorAccountRegistry.getObject());
+        return new OneTimeTokenAccountSaveRegistrationAction(googleAuthenticatorAccountRegistry.getObject(),
+                googleAuthenticatorInstance());
     }
 
     @ConditionalOnMissingBean(name = "googlePrincipalFactory")

--- a/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
+++ b/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
@@ -33,7 +33,7 @@
     <action-state id="saveRegistration">
         <evaluate expression="googleSaveAccountRegistrationAction" />
         <transition on="success" to="realSubmit"/>
-        <transition on="error" to="initializeLoginForm" />
+        <transition on="register" to="initializeLoginForm" />
     </action-state>
     
     <view-state id="viewLoginForm" view="casGoogleAuthenticatorLoginView" model="credential">

--- a/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
+++ b/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
@@ -20,16 +20,20 @@
         <transition on="success" to="viewLoginForm"/>
     </action-state>
 
-    <view-state id="viewRegistration" view="casGoogleAuthenticatorRegistrationView">
+    <view-state id="viewRegistration" view="casGoogleAuthenticatorRegistrationView" model="credential">
+        <binder>
+            <binding property="token" required="true" />
+        </binder>
         <on-entry>
             <set name="viewScope.principal" value="conversationScope.authentication.principal" />
         </on-entry>
-        <transition on="submit" to="saveRegistration"/>
+        <transition on="submit" bind="true" validate="true" to="saveRegistration" />
     </view-state>
     
     <action-state id="saveRegistration">
         <evaluate expression="googleSaveAccountRegistrationAction" />
-        <transition on="success" to="viewLoginForm"/>
+        <transition on="success" to="realSubmit"/>
+        <transition on="error" to="initializeLoginForm" />
     </action-state>
     
     <view-state id="viewLoginForm" view="casGoogleAuthenticatorLoginView" model="credential">

--- a/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
+++ b/support/cas-server-support-gauth/src/main/resources/webflow/mfa-gauth/mfa-gauth-webflow.xml
@@ -33,7 +33,7 @@
     <action-state id="saveRegistration">
         <evaluate expression="googleSaveAccountRegistrationAction" />
         <transition on="success" to="realSubmit"/>
-        <transition on="register" to="initializeLoginForm" />
+        <transition on="register" to="viewRegistration" />
     </action-state>
     
     <view-state id="viewLoginForm" view="casGoogleAuthenticatorLoginView" model="credential">

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
@@ -1,0 +1,26 @@
+package org.apereo.cas.otp.validator;
+
+import org.apereo.cas.authentication.OneTimeTokenAccount;
+
+/**
+ * This is {@link OneTimeTokenAccountValidator}.
+ *
+ * Provides a common interface for objects that can
+ * validate OTP credentials.
+ *
+ * @author Hayden Sartoris
+ * @since 6.2.0-RC5
+ */
+@FunctionalInterface
+public interface OneTimeTokenAccountValidator {
+
+    /**
+     * Is the token valid for the given account?
+     *
+     * @param account the OTP account
+     * @param token   the token to validate
+     * @return true/false
+     */
+    boolean isValid(OneTimeTokenAccount account, int token);
+
+}

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
@@ -1,10 +1,7 @@
 package org.apereo.cas.otp.validator;
 
-import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.OneTimeTokenAccount;
 import org.apereo.cas.authentication.credential.OneTimeTokenCredential;
-
-import lombok.val;
 
 /**
  * This is {@link OneTimeTokenAccountValidator}.
@@ -20,8 +17,6 @@ public interface OneTimeTokenAccountValidator {
     /**
      * Is the token valid for the given account?
      *
-     * Assumes parsing logic has taken place.
-     *
      * @param account the OTP account
      * @param token   the token to validate
      * @return true/false
@@ -34,14 +29,11 @@ public interface OneTimeTokenAccountValidator {
      * @param credential the Credential presumed to contain the token
      * @return the integer token
      */
-    default int parseToken(final Credential credential) throws IllegalArgumentException {
+    default int parseToken(final OneTimeTokenCredential credential) {
         try {
-            val cred = (OneTimeTokenCredential) credential;
-            return Integer.parseInt(cred.getToken());
-        } catch (final ClassCastException e) {
-            throw new IllegalArgumentException("Provided credential could not be cast to OneTimeTokenCredential", e);
+            return Integer.parseInt(credential.getToken());
         } catch (final NumberFormatException e) {
-            throw new IllegalArgumentException("Token could not be parsed: " + ((OneTimeTokenCredential) credential).getToken(), e);
+            return -1;
         }
     }
 }

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
@@ -4,6 +4,8 @@ import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.OneTimeTokenAccount;
 import org.apereo.cas.authentication.credential.OneTimeTokenCredential;
 
+import lombok.val;
+
 /**
  * This is {@link OneTimeTokenAccountValidator}.
  *
@@ -34,11 +36,11 @@ public interface OneTimeTokenAccountValidator {
      */
     default int parseToken(Credential credential) throws IllegalArgumentException {
         try {
-            OneTimeTokenCredential cred = (OneTimeTokenCredential) credential;
+            val cred = (OneTimeTokenCredential) credential;
             return Integer.parseInt(cred.getToken());
-        } catch (ClassCastException e) {
+        } catch (final ClassCastException e) {
             throw new IllegalArgumentException("Provided credential could not be cast to OneTimeTokenCredential", e);
-        } catch (NumberFormatException e) {
+        } catch (final NumberFormatException e) {
             throw new IllegalArgumentException("Token could not be parsed: " + ((OneTimeTokenCredential) credential).getToken(), e);
         }
     }

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
@@ -1,6 +1,8 @@
 package org.apereo.cas.otp.validator;
 
+import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.OneTimeTokenAccount;
+import org.apereo.cas.authentication.credential.OneTimeTokenCredential;
 
 /**
  * This is {@link OneTimeTokenAccountValidator}.
@@ -11,11 +13,12 @@ import org.apereo.cas.authentication.OneTimeTokenAccount;
  * @author Hayden Sartoris
  * @since 6.2.0-RC5
  */
-@FunctionalInterface
 public interface OneTimeTokenAccountValidator {
 
     /**
      * Is the token valid for the given account?
+     *
+     * Assumes parsing logic has taken place.
      *
      * @param account the OTP account
      * @param token   the token to validate
@@ -23,4 +26,20 @@ public interface OneTimeTokenAccountValidator {
      */
     boolean isValid(OneTimeTokenAccount account, int token);
 
+    /**
+     * Parse presumed OTP from a Credential.
+     *
+     * @param credential the Credential presumed to contain the token
+     * @return the integer token
+     */
+    default int parseToken(Credential credential) throws IllegalArgumentException {
+        try {
+            OneTimeTokenCredential cred = (OneTimeTokenCredential) credential;
+            return Integer.parseInt(cred.getToken());
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("Provided credential could not be cast to OneTimeTokenCredential", e);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Token could not be parsed: " + ((OneTimeTokenCredential) credential).getToken(), e);
+        }
+    }
 }

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/validator/OneTimeTokenAccountValidator.java
@@ -13,7 +13,7 @@ import lombok.val;
  * validate OTP credentials.
  *
  * @author Hayden Sartoris
- * @since 6.2.0-RC5
+ * @since 6.2.0
  */
 public interface OneTimeTokenAccountValidator {
 
@@ -34,7 +34,7 @@ public interface OneTimeTokenAccountValidator {
      * @param credential the Credential presumed to contain the token
      * @return the integer token
      */
-    default int parseToken(Credential credential) throws IllegalArgumentException {
+    default int parseToken(final Credential credential) throws IllegalArgumentException {
         try {
             val cred = (OneTimeTokenCredential) credential;
             return Integer.parseInt(cred.getToken());

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
@@ -44,7 +44,7 @@ public class OneTimeTokenAccountCheckRegistrationAction extends AbstractAction {
         val keyUriFmt = "otpauth://totp/" + this.label + ":" + uid + "?secret=%s&issuer=" + this.issuer;
 
         if (auth.getAttributes().containsKey("isNewOtpRegistration")) {
-            LOGGER.debug("Arrrived back at registration check with isNewOtpRegistration set; returning register");
+            LOGGER.debug("Arrived back at registration check with isNewOtpRegistration set; returning register");
             return new EventFactorySupport().event(this, "register");
         }
 

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
@@ -43,6 +43,11 @@ public class OneTimeTokenAccountCheckRegistrationAction extends AbstractAction {
         val uid = auth.getPrincipal().getId();
         val keyUriFmt = "otpauth://totp/" + this.label + ":" + uid + "?secret=%s&issuer=" + this.issuer;
 
+        if (auth.getAttributes().containsKey("isNewOtpRegistration")) {
+            LOGGER.debug("Arrrived back at registration check with isNewOtpRegistration set; returning register");
+            return new EventFactorySupport().event(this, "register");
+        }
+
         val acct = repository.get(uid);
         if (acct == null || StringUtils.isBlank(acct.getSecretKey())) {
             val keyAccount = this.repository.create(uid);
@@ -52,10 +57,6 @@ public class OneTimeTokenAccountCheckRegistrationAction extends AbstractAction {
             flowScope.put(FLOW_SCOPE_ATTR_ACCOUNT_URI, keyUri);
             LOGGER.debug("Registration key URI is [{}]", keyUri);
             return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_REGISTER);
-        }
-        if (auth.getAttributes().containsKey("isNewOtpRegistration")) {
-            LOGGER.debug("Arrrived back at registration check with isNewOtpRegistration set; returning register");
-            return new EventFactorySupport().event(this, "register");
         }
         return success();
     }

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
@@ -39,14 +39,7 @@ public class OneTimeTokenAccountCheckRegistrationAction extends AbstractAction {
 
     @Override
     protected Event doExecute(final RequestContext requestContext) {
-        val auth = WebUtils.getAuthentication(requestContext);
-        val uid = auth.getPrincipal().getId();
-        val keyUriFmt = "otpauth://totp/" + this.label + ":" + uid + "?secret=%s&issuer=" + this.issuer;
-
-        if (auth.getAttributes().containsKey("isNewOtpRegistration")) {
-            LOGGER.debug("Arrived back at registration check with isNewOtpRegistration set; returning register");
-            return new EventFactorySupport().event(this, "register");
-        }
+        val uid = WebUtils.getAuthentication(requestContext).getPrincipal().getId();
 
         val acct = repository.get(uid);
         if (acct == null || StringUtils.isBlank(acct.getSecretKey())) {

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
@@ -3,9 +3,10 @@ package org.apereo.cas.otp.web.flow;
 import org.apereo.cas.authentication.OneTimeTokenAccount;
 import org.apereo.cas.authentication.credential.OneTimeTokenCredential;
 import org.apereo.cas.otp.repository.credentials.OneTimeTokenCredentialRepository;
+import org.apereo.cas.otp.validator.OneTimeTokenAccountValidator;
 import org.apereo.cas.web.support.WebUtils;
 
-import com.warrenstrange.googleauth.IGoogleAuthenticator;
+//import com.warrenstrange.googleauth.IGoogleAuthenticator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -24,7 +25,8 @@ import org.springframework.webflow.execution.RequestContext;
 @RequiredArgsConstructor
 public class OneTimeTokenAccountSaveRegistrationAction extends AbstractAction {
     private final OneTimeTokenCredentialRepository repository;
-    private final IGoogleAuthenticator googleAuthenticatorInstance;
+    //private final IGoogleAuthenticator googleAuthenticatorInstance;
+    private final OneTimeTokenAccountValidator tokenValidator;
 
     @Override
     protected Event doExecute(final RequestContext requestContext) {
@@ -41,7 +43,8 @@ public class OneTimeTokenAccountSaveRegistrationAction extends AbstractAction {
         val token = Integer.parseInt(credential.getToken());
 
         LOGGER.debug("Attempting to validate OTP token [{}] with [{}]", token, account);
-        val isCodeValid = this.googleAuthenticatorInstance.authorize(account.getSecretKey(), token);
+        //val isCodeValid = this.googleAuthenticatorInstance.authorize(account.getSecretKey(), token);
+        val isCodeValid = this.tokenValidator.isValid(account, token);
 
         if (!isCodeValid && account.getScratchCodes().contains(token)) {
             LOGGER.warn("User [{}] attempted to use scratch code during OTP registration; this is likely a mistake.", uid);

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
@@ -32,7 +32,6 @@ public class OneTimeTokenAccountSaveRegistrationAction extends AbstractAction {
             .get(OneTimeTokenAccountCheckRegistrationAction.FLOW_SCOPE_ATTR_ACCOUNT, OneTimeTokenAccount.class);
         val uid = WebUtils.getAuthentication(requestContext).getPrincipal().getId();
         val credential = WebUtils.getCredential(requestContext, OneTimeTokenCredential.class);
-        //val credential = (OneTimeTokenCredential) WebUtils.getCredential(requestContext);
 
         if (!StringUtils.isNumeric(credential.getToken())) {
             LOGGER.error("Non-numeric OTP token provided: [{}]", credential.getToken());

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
@@ -10,7 +10,6 @@ import org.apereo.cas.web.support.WebUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.action.EventFactorySupport;
 import org.springframework.webflow.execution.Event;
@@ -39,7 +38,7 @@ public class OneTimeTokenAccountSaveRegistrationAction extends AbstractAction {
         int token;
         try {
             token = tokenValidator.parseToken(credential);
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             LOGGER.error("Unable to extract token from Credential [{}] for user [{}]",
                     credential, uid);
             return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_REGISTER);

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
@@ -1,11 +1,15 @@
 package org.apereo.cas.otp.web.flow;
 
 import org.apereo.cas.authentication.OneTimeTokenAccount;
+import org.apereo.cas.authentication.credential.OneTimeTokenCredential;
 import org.apereo.cas.otp.repository.credentials.OneTimeTokenCredentialRepository;
 import org.apereo.cas.web.support.WebUtils;
 
+import com.warrenstrange.googleauth.IGoogleAuthenticator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
@@ -16,16 +20,41 @@ import org.springframework.webflow.execution.RequestContext;
  * @author Misagh Moayyed
  * @since 5.0.0
  */
+@Slf4j
 @RequiredArgsConstructor
 public class OneTimeTokenAccountSaveRegistrationAction extends AbstractAction {
     private final OneTimeTokenCredentialRepository repository;
+    private final IGoogleAuthenticator googleAuthenticatorInstance;
 
     @Override
     protected Event doExecute(final RequestContext requestContext) {
         val account = requestContext.getFlowScope()
             .get(OneTimeTokenAccountCheckRegistrationAction.FLOW_SCOPE_ATTR_ACCOUNT, OneTimeTokenAccount.class);
         val uid = WebUtils.getAuthentication(requestContext).getPrincipal().getId();
-        repository.save(uid, account.getSecretKey(), account.getValidationCode(), account.getScratchCodes());
-        return success();
+        val credential = WebUtils.getCredential(requestContext, OneTimeTokenCredential.class);
+        //val credential = (OneTimeTokenCredential) WebUtils.getCredential(requestContext);
+
+        if (!StringUtils.isNumeric(credential.getToken())) {
+            LOGGER.error("Non-numeric OTP token provided: [{}]", credential.getToken());
+            return error();
+        }
+
+        val token = Integer.parseInt(credential.getToken());
+
+        LOGGER.debug("Attempting to validate OTP token [{}] with [{}]", token, account);
+        val isCodeValid = this.googleAuthenticatorInstance.authorize(account.getSecretKey(), token);
+
+        if (!isCodeValid && account.getScratchCodes().contains(token)) {
+            LOGGER.warn("User [{}] attempted to use scratch code during OTP registration; this is likely a mistake.", uid);
+            return error();
+        }
+        if (isCodeValid) {
+            LOGGER.debug("Validated OTP token [{}] to register user [{}]", token, uid);
+            repository.save(uid, account.getSecretKey(), account.getValidationCode(), account.getScratchCodes());
+            return success();
+        }
+
+        LOGGER.warn("Failed to validate token [{}] to register user [{}]", token, uid);
+        return error();
     }
 }

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationAction.java
@@ -4,14 +4,15 @@ import org.apereo.cas.authentication.OneTimeTokenAccount;
 import org.apereo.cas.authentication.credential.OneTimeTokenCredential;
 import org.apereo.cas.otp.repository.credentials.OneTimeTokenCredentialRepository;
 import org.apereo.cas.otp.validator.OneTimeTokenAccountValidator;
+import org.apereo.cas.web.flow.CasWebflowConstants;
 import org.apereo.cas.web.support.WebUtils;
 
-//import com.warrenstrange.googleauth.IGoogleAuthenticator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.action.AbstractAction;
+import org.springframework.webflow.action.EventFactorySupport;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
 
@@ -25,7 +26,6 @@ import org.springframework.webflow.execution.RequestContext;
 @RequiredArgsConstructor
 public class OneTimeTokenAccountSaveRegistrationAction extends AbstractAction {
     private final OneTimeTokenCredentialRepository repository;
-    //private final IGoogleAuthenticator googleAuthenticatorInstance;
     private final OneTimeTokenAccountValidator tokenValidator;
 
     @Override
@@ -34,29 +34,31 @@ public class OneTimeTokenAccountSaveRegistrationAction extends AbstractAction {
             .get(OneTimeTokenAccountCheckRegistrationAction.FLOW_SCOPE_ATTR_ACCOUNT, OneTimeTokenAccount.class);
         val uid = WebUtils.getAuthentication(requestContext).getPrincipal().getId();
         val credential = WebUtils.getCredential(requestContext, OneTimeTokenCredential.class);
+        val account = requestContext.getFlowScope().get("key", OneTimeTokenAccount.class);
 
-        if (!StringUtils.isNumeric(credential.getToken())) {
-            LOGGER.error("Non-numeric OTP token provided: [{}]", credential.getToken());
-            return error();
+        int token;
+        try {
+            token = tokenValidator.parseToken(credential);
+        } catch (IllegalArgumentException e) {
+            LOGGER.error("Unable to extract token from Credential [{}] for user [{}]",
+                    credential, uid);
+            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_REGISTER);
         }
-
-        val token = Integer.parseInt(credential.getToken());
 
         LOGGER.debug("Attempting to validate OTP token [{}] with [{}]", token, account);
-        //val isCodeValid = this.googleAuthenticatorInstance.authorize(account.getSecretKey(), token);
-        val isCodeValid = this.tokenValidator.isValid(account, token);
+        val isCodeValid = tokenValidator.isValid(account, token);
 
-        if (!isCodeValid && account.getScratchCodes().contains(token)) {
-            LOGGER.warn("User [{}] attempted to use scratch code during OTP registration; this is likely a mistake.", uid);
-            return error();
-        }
         if (isCodeValid) {
             LOGGER.debug("Validated OTP token [{}] to register user [{}]", token, uid);
             repository.save(uid, account.getSecretKey(), account.getValidationCode(), account.getScratchCodes());
             return success();
         }
+        if (account.getScratchCodes().contains(token)) {
+            LOGGER.warn("User [{}] attempted to use scratch code during OTP registration; this is likely a mistake.", uid);
+            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_REGISTER);
+        }
 
         LOGGER.warn("Failed to validate token [{}] to register user [{}]", token, uid);
-        return error();
+        return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_REGISTER);
     }
 }

--- a/support/cas-server-support-otp-mfa/src/test/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationActionTests.java
+++ b/support/cas-server-support-otp-mfa/src/test/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationActionTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.otp.web.flow;
 import org.apereo.cas.authentication.OneTimeTokenAccount;
 import org.apereo.cas.otp.repository.credentials.OneTimeTokenCredentialRepository;
 import org.apereo.cas.otp.repository.token.BaseOneTimeTokenRepositoryTests;
+import org.apereo.cas.otp.validator.OneTimeTokenAccountValidator;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.util.MockServletContext;
 import org.apereo.cas.web.flow.CasWebflowConstants;
@@ -38,7 +39,9 @@ public class OneTimeTokenAccountSaveRegistrationActionTests {
     public void verifyCreateAccount() {
         val account = new OneTimeTokenAccount("casuser", UUID.randomUUID().toString(), 123456, List.of());
         val repository = mock(OneTimeTokenCredentialRepository.class);
-        val action = new OneTimeTokenAccountSaveRegistrationAction(repository);
+        val validator = mock(OneTimeTokenAccountValidator.class);
+        when(validator.isValid(any(), any())).thenReturn(true);
+        val action = new OneTimeTokenAccountSaveRegistrationAction(repository, validator);
 
         val context = new MockRequestContext();
         val request = new MockHttpServletRequest();

--- a/support/cas-server-support-otp-mfa/src/test/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationActionTests.java
+++ b/support/cas-server-support-otp-mfa/src/test/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountSaveRegistrationActionTests.java
@@ -53,4 +53,23 @@ public class OneTimeTokenAccountSaveRegistrationActionTests {
         context.getFlowScope().put(OneTimeTokenAccountCheckRegistrationAction.FLOW_SCOPE_ATTR_ACCOUNT, account);
         assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, action.doExecute(context).getId());
     }
+
+    @Test
+    public void verifyFailsBadToken() {
+        val account = new OneTimeTokenAccount("casuser", UUID.randomUUID().toString(), 123456, List.of());
+        val repository = mock(OneTimeTokenCredentialRepository.class);
+        val validator = mock(OneTimeTokenAccountValidator.class);
+        when(validator.isValid(any(), any())).thenReturn(false);
+        val action = new OneTimeTokenAccountSaveRegistrationAction(repository, validator);
+
+        val context = new MockRequestContext();
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, response));
+        RequestContextHolder.setRequestContext(context);
+        ExternalContextHolder.setExternalContext(context.getExternalContext());
+        WebUtils.putAuthentication(RegisteredServiceTestUtils.getAuthentication("casuser"), context);
+        context.getFlowScope().put(OneTimeTokenAccountCheckRegistrationAction.FLOW_SCOPE_ATTR_ACCOUNT, account);
+        assertEquals(CasWebflowConstants.TRANSITION_ID_REGISTER, action.doExecute(context).getId());
+    }
 }

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casGoogleAuthenticatorRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casGoogleAuthenticatorRegistrationView.html
@@ -16,7 +16,10 @@
                 to
                 register your device with CAS.</h3>
 
-            <form method="post" id="fm1" class="fm-v clearfix" th:action="@{/login}">
+            <form method="post" id="fm1" class="fm-v clearfix" th:action="@{/login}" th:object="${credential}">
+                <div id="msg" class="banner banner-danger my-2" th:if="${#fields.hasErrors('*')}">
+                    <span th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}" />
+                </div>
                 <div class="d-flex flex-column align-items-center">
                     <img th:src="@{/otp/qrgen(key=${keyUri})}" />
                     <div class="my-2">
@@ -30,6 +33,19 @@
                             <li th:each="code : ${key.getScratchCodes()}" th:text="${code}">code</li>
                         </ul>
                     </div>
+                    <section class="cas-field my-3 mdc-input-group">
+                        <div class="mdc-input-group-field mdc-input-group-field-append">
+                            <div class="mdc-text-field d-flex">
+                                <!-- TODO: size from parameters -->
+                                <input class="mdc-text-field__input"
+                                    id="token"
+                                    size="6"
+                                    th:field="*{token}"
+                                    th:accesskey="#{screen.welcome.label.password.accesskey}" />
+                                <label for="token" class="mdc-floating-label" th:utext="#{cas.mfa.googleauth.label.token}">Token</label>
+                            </div>
+                        </div>
+                    </section>
                     <input type="hidden" name="_eventId" value="submit" />
                     <div class="d-flex justify-content-center">
                         <button class="mdc-button mdc-button--raised mr-2" name="submit" accesskey="l" value="Register">


### PR DESCRIPTION
I previously had a pass at this in #4590, but this is a much cleaner implementation. The goal is to prevent the possibility of users moving past the registration page without actually setting up an authenticator app.

This is achieved through the following:
1. Modify the `mfa-gauth` webflow to bind a `GoogleAuthenticatorTokenCredential` to `viewRegistration`, to transition to `realSubmit` upon a `success` event from `saveRegistration`, rather than to `viewLoginForm`, and to transition back to `initializeLoginForm` on `error` from `saveRegistration`.
2. Update `OneTimeTokenAccountSaveRegistrationAction` to require an `IGoogleAuthenticator` instance, which it uses in conjunction with the `Credential` from the registration form to validate the OTP. It explicitly rejects usage of a scratch code, which is mostly for logging.
3. Update `casGoogleAuthenticatorRegistrationView` to reflect the addition of a binding and collect a token from the user.
4. Update `OneTimeTokenAccountCheckRegistrationAction` to look for an authentication attribute `isNewOtpRegistration` before creating an account, which indicates that the information for that account is already in scope; i.e., the user tried to submit an invalid token. The action adds this authentication attribute in the event that it is a totally new registration.

This works at the moment, but could use a little attention on the frontend side of things. I hacked together a form, but it's not particularly visually pleasing. Additionally, the change to `OneTimeTokenAccountSaveRegistrationAction`, while arguably actually quite generic, does require the `IGoogleAuthenticator` interface on an more generic class. I could achieve better separation by creating an `Action` within the gauth module that extends this one, with the additional logic on top. This could also be used to help reduce code reuse, as a lot of the code added to that action is pulled from `GoogleAuthenticatorAuthenticationHandler`; having a class that performs validations of OTP codes, for example, would allow for pulling all functionality into one place and then passing the Bean to both the AuthenticationHandler and the action.