### PR TITLE
fix bean creation error for LDAP password sync

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/passwordsync/PasswordSynchronizationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/authentication/passwordsync/PasswordSynchronizationProperties.java
@@ -24,6 +24,11 @@ public class PasswordSynchronizationProperties implements Serializable {
     private static final long serialVersionUID = -3878237508646993100L;
 
     /**
+     * Allow password synchronization to be turned off globally.
+     */
+    private boolean enabled = true;
+
+    /**
      * Options for password sync via LDAP.
      */
     private List<LdapPasswordSynchronizationProperties> ldap = new ArrayList<>(0);

--- a/ci/tests/ldap/reset-ad-server.sh
+++ b/ci/tests/ldap/reset-ad-server.sh
@@ -10,4 +10,5 @@ docker exec samba bash -c "samba-tool user setpassword expireduser --newpassword
 docker exec samba bash -c "samba-tool user setpassword disableduser --newpassword=$DEFAULT_TESTUSER_PASSWORD"
 docker exec samba bash -c "samba-tool user setpassword changepassword --newpassword=$DEFAULT_TESTUSER_PASSWORD"
 docker exec samba bash -c "samba-tool user setpassword changepasswordnoreset --newpassword=$DEFAULT_TESTUSER_PASSWORD"
+docker exec samba bash -c "samba-tool user setpassword expirestomorrow --newpassword=$DEFAULT_TESTUSER_PASSWORD"
 

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -5404,6 +5404,7 @@ Common LDAP settings for this feature are available [here](Configuration-Propert
 the configuration key `cas.authn.passwordSync.ldap[0]`.
 
 ```properties
+# cas.authn.password-sync.enabled=true
 # cas.authn.password-sync.ldap[0].enabled=false
 ``` 
 

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapPasswordSynchronizationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapPasswordSynchronizationConfiguration.java
@@ -8,11 +8,13 @@ import org.apereo.cas.configuration.model.core.authentication.passwordsync.LdapP
 import lombok.SneakyThrows;
 import lombok.val;
 import org.jooq.lambda.Unchecked;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ListFactoryBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,11 +29,13 @@ import java.util.Objects;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-@Configuration(value = "ldapPasswordSynchronizationConfiguration", proxyBeanMethods = false)
+@Configuration(value = "ldapPasswordSynchronizationConfiguration", proxyBeanMethods = true)
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.authn.password-sync", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class LdapPasswordSynchronizationConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;
+
 
     @Bean
     @SneakyThrows
@@ -50,21 +54,24 @@ public class LdapPasswordSynchronizationConfiguration {
 
     @ConditionalOnMissingBean(name = "ldapPasswordSynchronizationAuthenticationEventExecutionPlanConfigurer")
     @Bean
-    @SneakyThrows
     @Autowired
     public AuthenticationEventExecutionPlanConfigurer ldapPasswordSynchronizationAuthenticationEventExecutionPlanConfigurer(
         @Qualifier("ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean")
         final ListFactoryBean ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean) {
-        val postProcessorList = ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean.getObject();
         return plan -> {
-            val ldap = casProperties.getAuthn().getPasswordSync().getLdap();
-            ldap.stream()
-                .filter(LdapPasswordSynchronizationProperties::isEnabled)
-                .forEach(instance -> {
-                    val postProcessor = new LdapPasswordSynchronizationAuthenticationPostProcessor(instance);
-                    postProcessorList.add(postProcessor);
-                    plan.registerAuthenticationPostProcessor(postProcessor);
-                });
+            try {
+                val postProcessorList = Objects.requireNonNull(ldapPasswordSynchronizationAuthenticationPostProcessorListFactoryBean.getObject());
+                val ldap = casProperties.getAuthn().getPasswordSync().getLdap();
+                ldap.stream()
+                    .filter(LdapPasswordSynchronizationProperties::isEnabled)
+                    .forEach(instance -> {
+                        val postProcessor = new LdapPasswordSynchronizationAuthenticationPostProcessor(instance);
+                        postProcessorList.add(postProcessor);
+                        plan.registerAuthenticationPostProcessor(postProcessor);
+                    });
+            } catch (final Exception e) {
+                throw new BeanCreationException("Error creating ldapPasswordSynchronizationAuthenticationEventExecutionPlanConfigurer: " + e.getMessage(), e);
+            }
         };
     }
 }


### PR DESCRIPTION
I was getting a bean in process of creation or bean cycle error when running in an overlay. This moves bean creation inside of lambda function which was first attempt to avoid the error. That didn't help so I had to turn set proxyBeanMethods=true. The latter is probably sufficient and I can back out moving the bean creation into the lambda (which is little messier since it can't leverage sneakythrows). I was only able to recreate this error in the overlay. 