### PR TITLE
Fix metadata backup directory path

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/SamlIdPMetadataProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/SamlIdPMetadataProperties.java
@@ -55,7 +55,7 @@ public class SamlIdPMetadataProperties implements Serializable {
      * This directory will be used to hold the configuration files.
      */
     @RequiredProperty
-    private String location = "file:/etc/cas/saml";
+    private String location = "/etc/cas/saml";
 
     /**
      * Properties pertaining to mongo db saml metadata resolvers.


### PR DESCRIPTION
When starting CAS, the following error message appears in the logs and the metadata backup directory is not created.

`ERROR [org.apereo.cas.support.saml.services.idp.metadata.cache.resolver.UrlResourceMetadataResolver] - <Unable to create metadata backup directory [file:/etc/cas/saml/metadata-backups] to store downloaded metadata. This is likely due to a permission issue>
`

By removing the 'file:' part from the location string, everything works as expected.