### PR TITLE
Remove static modifier from augmentSuccessViewModelObjects()

### DIFF
--- a/support/cas-server-support-validation-core/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
+++ b/support/cas-server-support-validation-core/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
@@ -369,7 +369,7 @@ public abstract class AbstractServiceValidateController extends AbstractDelegate
      * @param assertion the assertion
      * @return map of objects each keyed to a name
      */
-    protected static Map<String, ?> augmentSuccessViewModelObjects(final Assertion assertion) {
+    protected Map<String, ?> augmentSuccessViewModelObjects(final Assertion assertion) {
         return new HashMap<>(0);
     }
 


### PR DESCRIPTION
The javadoc comment says `augmentSuccessViewModelObjects()` method defined in `AbstractServiceValidateController` class is provided as a way for extension of the controllers, but `static` modifier of the method prevents developers from overriding it. I believe this modifier was added by accident.
