### PR TITLE
fix bean creation error and fix saml metadata resolver

### DIFF
--- a/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
+++ b/support/cas-server-support-ldap-monitor/src/main/java/org/apereo/cas/monitor/config/LdapMonitorConfiguration.java
@@ -33,7 +33,7 @@ import java.util.UUID;
  * @author Misagh Moayyed
  * @since 5.0.0
  */
-@Configuration(value = "ldapMonitorConfiguration", proxyBeanMethods = false)
+@Configuration(value = "ldapMonitorConfiguration", proxyBeanMethods = true)
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class LdapMonitorConfiguration {
     private static final int MAP_SIZE = 8;

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/JsonResourceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/JsonResourceMetadataResolver.java
@@ -60,7 +60,8 @@ public class JsonResourceMetadataResolver extends BaseSamlRegisteredServiceMetad
             this.metadataTemplate = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
             val md = samlIdPProperties.getMetadata();
             val location = SpringExpressionLanguageValueResolver.getInstance().resolve(md.getLocation());
-            this.jsonResource = new FileSystemResource(new File(location, "saml-sp-metadata.json"));
+            val metadataDir = ResourceUtils.getRawResourceFrom(location).getFile();
+            this.jsonResource = new FileSystemResource(new File(metadataDir, "saml-sp-metadata.json"));
             if (this.jsonResource.exists()) {
                 this.metadataMap = readDecisionsFromJsonResource();
                 this.watcherService = new FileWatcherService(jsonResource.getFile(), file -> this.metadataMap = readDecisionsFromJsonResource());

--- a/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/JsonResourceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/JsonResourceMetadataResolverTests.java
@@ -31,7 +31,8 @@ public class JsonResourceMetadataResolverTests extends BaseSamlIdPServicesTests 
     @Test
     public void verifyResolverResolves() throws Exception {
         val props = new SamlIdPProperties();
-        props.getMetadata().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
+        val dir = new FileSystemResource(FileUtils.getTempDirectory());
+        props.getMetadata().setLocation(dir.getFile().getCanonicalPath());
         FileUtils.copyFile(new ClassPathResource("saml-sp-metadata.json").getFile(),
             new File(FileUtils.getTempDirectory(), "saml-sp-metadata.json"));
         val service = new SamlRegisteredService();
@@ -48,5 +49,16 @@ public class JsonResourceMetadataResolverTests extends BaseSamlIdPServicesTests 
         val metadataResolver = results.iterator().next();
         val resolved = metadataResolver.resolveSingle(new CriteriaSet(new EntityIdCriterion("https://example.org/saml")));
         assertNotNull(resolved);
+    }
+
+    /**
+     * Make sure default file:/etc/cas/saml URI syntax is parsed correctly.
+     */
+    @Test
+    public void verifyResolverResolvesWithFileUri() throws Exception {
+        val props = new SamlIdPProperties();
+        props.getMetadata().setLocation("file:/etc/cas/saml");
+        val resolver = new JsonResourceMetadataResolver(props, openSamlConfigBean);
+        assertNotNull(resolver);
     }
 }


### PR DESCRIPTION
There is another bean creation error in LdapMonitorConfiguration. I am turning on proxyBeanMethods similar to the last fix. 

Also, the JsonResourceMetadataResolver is blowing up on `file:/etc/cas/saml` which is the default value for the metadata directory. I added a test that just creates the object and it would fail with the changes to the JsonResourceMetadataResolver. 
