### PR TITLE
Delegated OAuth2: reponse_type is static

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -74,11 +74,6 @@ public class OAuthProperties implements Serializable {
     private UserProfileViewTypes userProfileViewType = UserProfileViewTypes.NESTED;
 
     /**
-     * Response type determines the authentication flow on the Authentication Server.
-     */
-    private String responseType = "code";
-
-    /**
      * Profile view types.
      */
     public enum UserProfileViewTypes {

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -74,6 +74,11 @@ public class OAuthProperties implements Serializable {
     private UserProfileViewTypes userProfileViewType = UserProfileViewTypes.NESTED;
 
     /**
+     * Configurable response_type parameter in pac4j.
+     */
+    private String response_type = "code";
+
+    /**
      * Profile view types.
      */
     public enum UserProfileViewTypes {

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -74,9 +74,9 @@ public class OAuthProperties implements Serializable {
     private UserProfileViewTypes userProfileViewType = UserProfileViewTypes.NESTED;
 
     /**
-     * Configurable response_type parameter in pac4j.
+     * Response type determines the authentication flow on the Authentication Server.
      */
-    private String response_type = "code";
+    private String responseType = "code";
 
     /**
      * Profile view types.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oauth/Pac4jOAuth20ClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oauth/Pac4jOAuth20ClientProperties.java
@@ -59,6 +59,11 @@ public class Pac4jOAuth20ClientProperties extends Pac4jIdentifiableClientPropert
     private String profileVerb = "POST";
 
     /**
+     * Response type determines the authentication flow on the Authentication Server.
+     */
+    private String responseType = "code";
+
+    /**
      * Profile attributes to request and collect in form of key-value pairs.
      */
     private Map<String, String> profileAttrs = new LinkedHashMap<>(1);

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3628,6 +3628,7 @@ identity provider are available [here](Configuration-Properties-Common.html#dele
 # cas.authn.pac4j.oauth2[0].profile-path=
 # cas.authn.pac4j.oauth2[0].scope=
 # cas.authn.pac4j.oauth2[0].profile-verb=GET|POST
+# cas.authn.pac4j.oauth2[0].response_type=code
 # cas.authn.pac4j.oauth2[0].profile-attrs.attr1=path-to-attr-in-profile
 # cas.authn.pac4j.oauth2[0].custom-params.param1=value1
 ```

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3628,7 +3628,7 @@ identity provider are available [here](Configuration-Properties-Common.html#dele
 # cas.authn.pac4j.oauth2[0].profile-path=
 # cas.authn.pac4j.oauth2[0].scope=
 # cas.authn.pac4j.oauth2[0].profile-verb=GET|POST
-# cas.authn.pac4j.oauth2[0].response_type=code
+# cas.authn.pac4j.oauth2[0].response-type=code
 # cas.authn.pac4j.oauth2[0].profile-attrs.attr1=path-to-attr-in-profile
 # cas.authn.pac4j.oauth2[0].custom-params.param1=value1
 ```

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
@@ -520,7 +520,7 @@ public class DefaultDelegatedClientFactory implements DelegatedClientFactory<Ind
                 client.setAuthUrl(oauth.getAuthUrl());
                 client.setScope(oauth.getScope());
                 client.setCustomParams(oauth.getCustomParams());
-                client.getConfiguration().setResponseType(oauth.getResponseType())
+                client.getConfiguration().setResponseType(oauth.getResponseType());
 
                 if (StringUtils.isBlank(oauth.getClientName())) {
                     val count = index.intValue();

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
@@ -521,7 +521,7 @@ public class DefaultDelegatedClientFactory implements DelegatedClientFactory<Ind
                 client.setScope(oauth.getScope());
                 client.setCustomParams(oauth.getCustomParams());
                 client.getConfiguration().setResponseType(oauth.getResponseType())
-                System.out.println(oauth.getResponseType());
+
                 if (StringUtils.isBlank(oauth.getClientName())) {
                     val count = index.intValue();
                     client.setName(client.getClass().getSimpleName() + count);

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
@@ -520,6 +520,8 @@ public class DefaultDelegatedClientFactory implements DelegatedClientFactory<Ind
                 client.setAuthUrl(oauth.getAuthUrl());
                 client.setScope(oauth.getScope());
                 client.setCustomParams(oauth.getCustomParams());
+                client.getConfiguration().setResponseType(oauth.getResponseType())
+                System.out.println(oauth.getResponseType());
                 if (StringUtils.isBlank(oauth.getClientName())) {
                     val count = index.intValue();
                     client.setName(client.getClass().getSimpleName() + count);


### PR DESCRIPTION
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->

Hi,

I was in need to change the `response_type` parameter when CAS delegates to an OAuth2 IdP, but it defaults to `code`. If I add this custom value to `cas.authn.pac4j.oauth2[0].customParams.response_type`, the request is made with an array instead of overwriting it.

I've checked the pac4j source and [opened an issue](https://github.com/pac4j/pac4j/issues/1583), which resulted in [this commit](https://github.com/pac4j/pac4j/commit/9ef4f5186e971cc14adc59544867e4a18feff560). After that, I've found the configuration for this value, and I tried to change it through the configuration files, which you can see in the diff for this PR.

This is resulting in an unexpected error in the report from `./gradlew check` , saying that the value should comply a certain RegEx:
```
Name 'response_type' must match pattern '^[a-z][a-zA-Z0-9]*$'.
```

As you can see, I have a default value. What am I doing wrong?


