### PR TITLE
add a QuerySakaiDatabaseAuthenticationHandler

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jdbc/SakaiJdbcAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jdbc/SakaiJdbcAuthenticationProperties.java
@@ -1,0 +1,87 @@
+package org.apereo.cas.configuration.model.support.jdbc;
+
+import org.apereo.cas.configuration.model.core.authentication.PasswordEncoderProperties;
+import org.apereo.cas.configuration.model.core.authentication.PrincipalTransformationProperties;
+import org.apereo.cas.configuration.model.support.jpa.AbstractJpaProperties;
+import org.apereo.cas.configuration.support.RequiresModule;
+import org.apereo.cas.configuration.support.RequiredProperty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * This is {@link SakaiJdbcAuthenticationProperties}.
+ *
+ * @author Shoji Kajita
+ * @since 5.3.x
+ */
+@RequiresModule(name = "cas-server-support-jdbc-authentication")
+
+@Getter
+@Setter
+public class SakaiJdbcAuthenticationProperties extends AbstractJpaProperties {
+
+    private static final long serialVersionUID = 7806132208223986681L;
+
+    /**
+     * SQL query to execute. Example: {@code SELECT * FROM table WHERE name=?}.
+     */
+    @RequiredProperty
+    private String sql;
+
+    /**
+     * A number of authentication handlers are allowed to determine whether they can operate on the provided credential
+     * and as such lend themselves to be tried and tested during the authentication handler selection phase.
+     * The credential criteria may be one of the following options:<ul>
+     * <li>1) A regular expression pattern that is tested against the credential identifier.</li>
+     * <li>2) A fully qualified class name of your own design that implements {@code Predicate<Credential>}.</li>
+     * <li>3) Path to an external Groovy script that implements the same interface.</li>
+     * </ul>
+     */
+    private String credentialCriteria;
+
+    /**
+     * Password field/column name to retrieve.
+     */
+    @RequiredProperty
+    private String fieldPassword;
+
+    /**
+     * Boolean field that should indicate whether the account is expired.
+     */
+    private String fieldExpired;
+
+    /**
+     * Boolean field that should indicate whether the account is disabled.
+     */
+    private String fieldDisabled;
+
+    /**
+     * List of column names to fetch as user attributes.
+     */
+    private List<String> principalAttributeList = new ArrayList<>();
+
+    /**
+     * Principal transformation settings for this authentication.
+     */
+    @NestedConfigurationProperty
+    private PrincipalTransformationProperties principalTransformation = new PrincipalTransformationProperties();
+
+    /**
+     * Password encoding strategies for this authentication.
+     */
+    @NestedConfigurationProperty
+    private PasswordEncoderProperties passwordEncoder = new PasswordEncoderProperties();
+
+    /**
+     * Name of the authentication handler.
+     */
+    private String name;
+
+    /**
+     * Order of the authentication handler in the chain.
+     */
+    private int order = Integer.MAX_VALUE;
+}

--- a/support/cas-server-support-jdbc-authentication/build.gradle
+++ b/support/cas-server-support-jdbc-authentication/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 
     implementation libraries.shiro
 
+    implementation 'org.sakaiproject.kernel:sakai-kernel-impl:12.2'
+
     runtimeOnly project(":support:cas-server-support-jdbc-drivers")
     
     testImplementation project(path: ":core:cas-server-core-authentication", configuration: "tests")

--- a/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/adaptors/jdbc/QuerySakaiDatabaseAuthenticationHandler.java
+++ b/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/adaptors/jdbc/QuerySakaiDatabaseAuthenticationHandler.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2012 The JA-SIG Collaborative. All rights reserved. See license
+ * distributed with this file and available online at
+ * http://www.ja-sig.org/products/cas/overview/license/
+ */
+package org.apereo.cas.adaptors.jdbc;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.authentication.AuthenticationHandlerExecutionResult;
+import org.apereo.cas.authentication.PreventedException;
+import org.apereo.cas.authentication.UsernamePasswordCredential;
+import org.apereo.cas.authentication.exceptions.AccountDisabledException;
+import org.apereo.cas.authentication.exceptions.AccountPasswordMustChangeException;
+import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.authentication.principal.PrincipalFactory;
+import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.util.CollectionUtils;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+
+import javax.security.auth.login.AccountNotFoundException;
+import javax.security.auth.login.FailedLoginException;
+import javax.sql.DataSource;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.sakaiproject.user.impl.PasswordService;
+
+/**
+ * Class that if provided a query that returns a password (parameter of query
+ * must be username) will compare by using Sakai PasswordService.
+ * 
+ * @author Shoji Kajita
+ * @since 3.4
+ */
+@Slf4j
+public class QuerySakaiDatabaseAuthenticationHandler extends QueryDatabaseAuthenticationHandler {
+
+    private final String sql;
+    private final String fieldPassword;
+    private final String fieldExpired;
+    private final String fieldDisabled;
+    private final Map<String, Object> principalAttributeMap;
+    private final PasswordService pwdService;
+
+    public QuerySakaiDatabaseAuthenticationHandler(final String name, final ServicesManager servicesManager,
+                                              final PrincipalFactory principalFactory,
+                                              final Integer order, final DataSource dataSource, final String sql,
+                                              final String fieldPassword, final String fieldExpired, final String fieldDisabled,
+                                              final Map<String, Object> attributes) {
+
+        super(name, servicesManager, principalFactory, order, dataSource, sql, fieldPassword, fieldExpired, fieldDisabled, attributes);
+        this.sql = sql;
+        this.fieldPassword = fieldPassword;
+        this.fieldExpired = fieldExpired;
+        this.fieldDisabled = fieldDisabled;
+        this.principalAttributeMap = attributes;
+        this.pwdService = new PasswordService();
+    }
+
+    @Override
+    protected AuthenticationHandlerExecutionResult authenticateUsernamePasswordInternal(final UsernamePasswordCredential credential, final String originalPassword)
+        throws GeneralSecurityException, PreventedException {
+        if (StringUtils.isBlank(this.sql) || getJdbcTemplate() == null) {
+            throw new GeneralSecurityException("Authentication handler is not configured correctly. "
+                + "No SQL statement or JDBC template is found.");
+        }
+
+        final Map<String, Object> attributes = new LinkedHashMap<>(this.principalAttributeMap.size());
+        final String username = credential.getUsername();
+        final String password = credential.getPassword();
+
+        try {
+            final Map<String, Object> dbFields = query(credential);
+            if (dbFields.containsKey(this.fieldPassword)) {
+                final String dbPassword = (String) dbFields.get(this.fieldPassword);
+
+                if (!pwdService.check(password, dbPassword)) {
+                    throw new FailedLoginException("Password does not match value on record.");
+                }
+            }
+
+            if (StringUtils.isNotBlank(this.fieldDisabled) && dbFields.containsKey(this.fieldDisabled)) {
+                final String dbDisabled = dbFields.get(this.fieldDisabled).toString();
+                if (BooleanUtils.toBoolean(dbDisabled) || "1".equals(dbDisabled)) {
+                    throw new AccountDisabledException("Account has been disabled");
+                }
+            }
+            if (StringUtils.isNotBlank(this.fieldExpired) && dbFields.containsKey(this.fieldExpired)) {
+                final String dbExpired = dbFields.get(this.fieldExpired).toString();
+                if (BooleanUtils.toBoolean(dbExpired) || "1".equals(dbExpired)) {
+                    throw new AccountPasswordMustChangeException("Password has expired");
+                }
+            }
+            collectPrincipalAttributes(attributes, dbFields);
+        } catch (final IncorrectResultSizeDataAccessException e) {
+            if (e.getActualSize() == 0) {
+                throw new AccountNotFoundException(username + " not found with SQL query");
+            }
+            throw new FailedLoginException("Multiple records found for " + username);
+        } catch (final DataAccessException e) {
+            throw new PreventedException("SQL exception while executing query for " + username, e);
+        }
+        final Principal principal = this.principalFactory.createPrincipal(username, attributes);
+        return createHandlerResult(credential, principal, new ArrayList<>(0));
+    }
+
+    private Map<String, Object> query(final UsernamePasswordCredential credential) {
+        if (this.sql.contains("?")) {
+            return getJdbcTemplate().queryForMap(this.sql, credential.getUsername());
+        }
+        final Map parameters = new LinkedHashMap();
+        parameters.put("username", credential.getUsername());
+        parameters.put("password", credential.getPassword());
+        return getNamedJdbcTemplate().queryForMap(this.sql, parameters);
+    }
+
+    private void collectPrincipalAttributes(final Map<String, Object> attributes, final Map<String, Object> dbFields) {
+        this.principalAttributeMap.forEach((key, names) -> {
+            final Object attribute = dbFields.get(key);
+            if (attribute != null) {
+                LOGGER.debug("Found attribute [{}] from the query results", key);
+                final Collection<String> attributeNames = (Collection<String>) names;
+                attributeNames.forEach(s -> {
+                    LOGGER.debug("Principal attribute [{}] is virtually remapped/renamed to [{}]", key, s);
+                    attributes.put(s, CollectionUtils.wrap(attribute.toString()));
+                });
+            } else {
+                LOGGER.warn("Requested attribute [{}] could not be found in the query results", key);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This QuerySakaiDatabaseAuthenticationHandler allows CAS server to authenticate Sakai local users. 

- This extends QueryDatabaseAuthenticationHandler to handle Sakai local users by using Sakai's Password Service.
- We have tested it for CAS 5.3.x and operated in our production system at Kyoto University
- We haven't tested for CAS 6.x but we hope it works without any modifications.
- To use, the following settings are required in cas.properties:
```
# Example for Oracle Database backend
cas.authn.jdbc.sakai[2].order=3
cas.authn.jdbc.sakai[2].sql=select a.pw from sakai_user a, sakai_user_id_map b where a.user_id=b.user_id and b.eid=?
cas.authn.jdbc.sakai[2].url=jdbc:oracle:thin:@db:1521:orcl
cas.authn.jdbc.sakai[2].dialect=org.hibernate.dialect.Oracle10gDialect
cas.authn.jdbc.sakai[2].user=sakai
cas.authn.jdbc.sakai[2].password=pw
cas.authn.jdbc.sakai[2].driverClass=oracle.jdbc.driver.OracleDriver
cas.authn.jdbc.sakai[2].fieldPassword=pw
```
For more information, please join our session on Thursday, June 18th at Open Apereo 2020 Online: https://na.eventscloud.com/website/6430/agenda/ 