### PR TITLE
fix cache control static resources pattern

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
@@ -79,7 +79,8 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
      */
     public static final String INIT_PARAM_CONTENT_SECURITY_POLICY = "contentSecurityPolicy";
 
-    private static final Pattern CACHE_CONTROL_STATIC_RESOURCES_PATTERN = Pattern.compile(".css|.js|.png|.txt|.jpg|.ico|.jpeg|.bmp|.gif");
+    private static final Pattern CACHE_CONTROL_STATIC_RESOURCES_PATTERN = 
+                    Pattern.compile("^.+\\.(css|js|png|txt|jpg|ico|jpeg|bmp|gif)$", Pattern.CASE_INSENSITIVE);
 
     private final Object lock = new Object();
 


### PR DESCRIPTION
Static resources are never cached because the regex pattern never matches