### PR TITLE
Updated documentation for UI related to Material Design implementation

### DIFF
--- a/docs/cas-server-documentation/ux/User-Interface-Customization-CSSJS.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization-CSSJS.md
@@ -6,7 +6,8 @@ category: User Interface
 
 # CSS
 
-The default styles are all contained in two single files located in `src/main/resources/static/css/cas.css` and `src/main/resources/static/css/admin.css`. This location is set in `cas-theme-default.properties`.
+The default styles are all contained in two single files located in `src/main/resources/static/css/cas.css` and `src/main/resources/static/css/admin.css`. This location is set in `cas-theme-default.properties`. CAS by default uses [Material.io](https://material.io/) library and design specification as a base for its user experience.
+
 If you would like to create your own `css/custom.css file`, for example, you will need to update `cas.standard.css.file` key in that file.
 
 ```bash
@@ -16,13 +17,13 @@ cas.standard.js.file=/js/cas.js
 
 ## Responsive Design
 
-CSS media queries bring responsive design features to CAS which would allow the adopter to focus on one theme for all appropriate devices and platforms. These queries are defined in the same `cas.css` file.
+CSS media queries bring responsive design features to CAS which would allow the adopter to focus on one theme for all appropriate devices and platforms. These queries are defined in the same `cas.css` file. They follow the Twitter Bootstrap breakpoints and grid.
 
 # Javascript
 
 If you need to add some JavaScript, feel free to append `src/main/resources/static/js/cas.js`.
 
-You can also create your own `custom.js` file, for example, and call it from within `bottom.html` like so:
+You can also create your own `custom.js` file, for example, and call it from within `scripts.html` like so:
 
 ```html
 <script type="text/javascript" src="/js/custom.js"></script>
@@ -32,15 +33,13 @@ If you are developing themes per service, each theme also has the ability to spe
 
 Most importantly, the following Javascript libraries are utilized by CAS automatically:
 
-* JQuery
-* Bootstrap
-* Bootstrap Material Web Components
+* [JQuery](https://jquery.com/)
+* [Bootstrap for grid / flex utilities](https://getbootstrap.com/docs/4.5/getting-started/contents/#css-files)
+* [Material.io](https://material.io/)
 
 ## Script Loading
 
-CAS provides a callback function that allows
-adopters to be notified when script loading has completed and this would be a safe time to execute/load other Javascript-related
-functions that depend on JQuery inside the actual page.
+CAS provides a callback function that allows adopters to be notified when script loading has completed and this would be a safe time to execute/load other Javascript-related functions that depend on JQuery inside the actual page.
 
 ```javascript
 function jqueryReady() {

--- a/docs/cas-server-documentation/ux/User-Interface-Customization-Views.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization-Views.md
@@ -15,8 +15,7 @@ from the CAS web application to the correct location in the CAS overlay.
 Views also may be externalized outside the web application conditionally and individually, provided the external path 
 via CAS settings. If a view template file is not found at the externalized path, the default one that ships with CAS will be used as the fallback.
 
-Views may also be found using an external URL in CAS settings that is responsible to produce the full view body in the response. This URL endpoint will receive
-the available request headers as well as the following headers in its request:
+Views may also be found using an external URL in CAS settings that is responsible to produce the full view body in the response. This URL endpoint will receive the available request headers as well as the following headers in its request:
 
 | Header             
 |-------------------------------------
@@ -29,6 +28,12 @@ the available request headers as well as the following headers in its request:
 Upon a successful `200` status result, the response body is expected to contain the view that will be rendered by CAS.
  
 To see the relevant list of CAS properties, please [review this guide](../configuration/Configuration-Properties.html#views).
+
+## Thymeleaf
+
+CAS uses [Thymeleaf (v3.x)](https://www.thymeleaf.org) for its markup rendering engine. Each template is decorated by `layout.html` template file, which provides a layout structure for the template's content. Individual components optimized for re-use among multiple templates are stored in the `src/main/resources/templates/fragments` folder, and referenced by the templates in `src/main/resources/templates`.
+
+Refer to the [Thymeleaf documentation](https://www.thymeleaf.org/doc/tutorials/3.0/usingthymeleaf.html) for more information on its use and syntax.
 
 ## Warning Before Accessing Application
 

--- a/docs/cas-server-documentation/ux/User-Interface-Customization.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization.md
@@ -21,6 +21,8 @@ CAS user interface should properly and comfortably lend itself to all major brow
 
 Note that certain older version of IE, particularly IE 11 and below may impose additional difficulty in getting the right UI configuration in place.
 
+<div class="alert alert-info"><strong>Supported Browsers</strong><p>The supported browsers listed here are in reference to the default CAS user interface. Customizations can be implemented to support other browsers using the overlay, themes, etc.</p></div>
+
 ## Internet Explorer
 
 To instruct CAS to render UI in compatibility mode, the following is added automatically to relevant UI components:

--- a/docs/cas-server-documentation/ux/User-Interface-Customization.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization.md
@@ -17,9 +17,9 @@ CAS user interface should properly and comfortably lend itself to all major brow
 * Google Chrome
 * Mozilla Firefox
 * Apple Safari
-* Microsoft Internet Explorer
+* Microsoft Edge
 
-Note that certain older version of IE, particularly IE 9 and below may impose additional difficulty in getting the right UI configuration in place.
+Note that certain older version of IE, particularly IE 11 and below may impose additional difficulty in getting the right UI configuration in place.
 
 ## Internet Explorer
 


### PR DESCRIPTION
Updated documentation for user interface related to Material Design implementation (#4730). Also included update to supported browsers (swapped IE for Edge) and added section regarding Thymeleaf and documentation. Added links to UI libraries for reference purposes.