### PR TITLE
Improve RestEndpointMultifactorAuthenticationTrigger

### DIFF
--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/trigger/RestEndpointMultifactorAuthenticationTrigger.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/trigger/RestEndpointMultifactorAuthenticationTrigger.java
@@ -20,7 +20,10 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletRequest;
@@ -85,7 +88,9 @@ public class RestEndpointMultifactorAuthenticationTrigger implements Multifactor
     protected String callRestEndpointForMultifactor(final Principal principal, final Service resolvedService) {
         val restEndpoint = casProperties.getAuthn().getMfa().getRestEndpoint();
         val entity = new RestEndpointEntity(principal.getId(), resolvedService.getId());
-        val responseEntity = restTemplate.postForEntity(restEndpoint, entity, String.class);
+        val headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        val responseEntity = restTemplate.postForEntity(restEndpoint, new HttpEntity<>(entity, headers), String.class);
         if (responseEntity.getStatusCode() == HttpStatus.OK) {
             return responseEntity.getBody();
         }

--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/trigger/RestEndpointMultifactorAuthenticationTrigger.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/trigger/RestEndpointMultifactorAuthenticationTrigger.java
@@ -40,6 +40,7 @@ public class RestEndpointMultifactorAuthenticationTrigger implements Multifactor
     private final CasConfigurationProperties casProperties;
     private final MultifactorAuthenticationProviderResolver multifactorAuthenticationProviderResolver;
     private final ApplicationContext applicationContext;
+    private final RestTemplate restTemplate;
 
     private int order = Ordered.LOWEST_PRECEDENCE;
 
@@ -82,7 +83,6 @@ public class RestEndpointMultifactorAuthenticationTrigger implements Multifactor
      * @return return the rest response, typically the mfa id.
      */
     protected String callRestEndpointForMultifactor(final Principal principal, final Service resolvedService) {
-        val restTemplate = new RestTemplate();
         val restEndpoint = casProperties.getAuthn().getMfa().getRestEndpoint();
         val entity = new RestEndpointEntity(principal.getId(), resolvedService.getId());
         val responseEntity = restTemplate.postForEntity(restEndpoint, entity, String.class);

--- a/core/cas-server-core-authentication-mfa-api/src/test/java/org/apereo/cas/authentication/mfa/trigger/RestEndpointMultifactorAuthenticationTriggerTests.java
+++ b/core/cas-server-core-authentication-mfa-api/src/test/java/org/apereo/cas/authentication/mfa/trigger/RestEndpointMultifactorAuthenticationTriggerTests.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
 
@@ -37,7 +38,7 @@ public class RestEndpointMultifactorAuthenticationTriggerTests extends BaseMulti
             props.getAuthn().getMfa().setRestEndpoint("http://localhost:9313");
             val trigger = new RestEndpointMultifactorAuthenticationTrigger(props,
                 new DefaultMultifactorAuthenticationProviderResolver((providers, service, principal) -> providers.iterator().next()),
-                applicationContext);
+                applicationContext, new RestTemplate());
             val result = trigger.isActivated(authentication, registeredService, this.httpRequest, mock(Service.class));
             assertTrue(result.isPresent());
         }

--- a/core/cas-server-core-webflow-mfa/src/main/java/org/apereo/cas/web/flow/config/CasMultifactorAuthenticationWebflowConfiguration.java
+++ b/core/cas-server-core-webflow-mfa/src/main/java/org/apereo/cas/web/flow/config/CasMultifactorAuthenticationWebflowConfiguration.java
@@ -57,6 +57,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -140,6 +141,9 @@ public class CasMultifactorAuthenticationWebflowConfiguration {
     @Autowired
     @Qualifier("failureModeEvaluator")
     private ObjectProvider<MultifactorAuthenticationFailureModeEvaluator> failureModeEvaluator;
+
+    @Autowired
+    private ObjectProvider<RestTemplateBuilder> restTemplateBuilder;
 
     @Bean
     @ConditionalOnMissingBean(name = "multifactorAuthenticationProviderResolver")
@@ -289,7 +293,7 @@ public class CasMultifactorAuthenticationWebflowConfiguration {
     @ConditionalOnMissingBean(name = "restEndpointMultifactorAuthenticationTrigger")
     @RefreshScope
     public MultifactorAuthenticationTrigger restEndpointMultifactorAuthenticationTrigger() {
-        return new RestEndpointMultifactorAuthenticationTrigger(casProperties, multifactorAuthenticationProviderResolver(), applicationContext);
+        return new RestEndpointMultifactorAuthenticationTrigger(casProperties, multifactorAuthenticationProviderResolver(), applicationContext, restTemplateBuilder.getObject().build());
     }
 
     @ConditionalOnMissingBean(name = "restEndpointAuthenticationPolicyWebflowEventResolver")


### PR DESCRIPTION
- Creating a new RestTemplate on every login is expensive.
- This way the RestTemplate can be customized if necessary
- If Jackson XML is on the classpath, the request body would be sent as XML instead of JSON

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
