### PR TITLE
Add exclude from cascade in TransientSessionTicket

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketCatalogConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketCatalogConfiguration.java
@@ -72,6 +72,7 @@ public class CasCoreTicketCatalogConfiguration extends BaseTicketCatalogConfigur
     }
 
     protected void buildAndRegisterTransientSessionTicketDefinition(final TicketCatalog plan, final TicketDefinition metadata) {
+        metadata.getProperties().setExcludeFromCascade(true);
         registerTicketDefinition(plan, metadata);
     }
 }


### PR DESCRIPTION
The JpaTicketRegistry tries to traverse ticketGrantingTicket attribute using HQL. TransientSessionTicket has always ticketGrantingTicket constant, and is implemented as a getter returning null and therefore does not have HQL equivalent. It could be changed in JpaTicketRegistryTicketCatalogConfiguration as the bug seems to be just in JPA registry but the core package seems more adecuate.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
