### PR TITLE
Adding new Spring Boot Actuator Endpoint: /registeredAuthnHandlers

### DIFF
--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/repository/token/OneTimeTokenRepositoryCleaner.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/repository/token/OneTimeTokenRepositoryCleaner.java
@@ -27,6 +27,6 @@ public class OneTimeTokenRepositoryCleaner {
         val now = ZonedDateTime.now(ZoneId.systemDefault());
         LOGGER.debug("Starting to clean previously used authenticator tokens from [{}] at [{}]", this.tokenRepository, now);
         tokenRepository.clean();
-        LOGGER.info("Finished cleaning authenticator tokens at [{}]", now);
+        LOGGER.debug("Finished cleaning authenticator tokens at [{}]", now);
     }
 }

--- a/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/RegisteredAuthnHandlersEndpoint.java
+++ b/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/RegisteredAuthnHandlersEndpoint.java
@@ -1,0 +1,66 @@
+package org.apereo.cas.web.report;
+
+import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
+import org.apereo.cas.authentication.AuthenticationHandler;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.web.BaseCasActuatorEndpoint;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.http.ActuatorMediaType;
+import org.springframework.http.MediaType;
+
+import java.util.Collection;
+
+/**
+ * This is {@link RegisteredAuthnHandlersEndpoint}.
+ *
+ * @author Francesco Chicchiriccò
+ * @since 6.3.0
+ */
+@Endpoint(id = "registeredAuthnHandlers", enableByDefault = false)
+public class RegisteredAuthnHandlersEndpoint extends BaseCasActuatorEndpoint {
+
+    private final AuthenticationEventExecutionPlan authenticationEventExecutionPlan;
+
+    /**
+     * Instantiates a new mvc endpoint.
+     * Endpoints are by default sensitive.
+     *
+     * @param casProperties the cas properties
+     * @param authenticationEventExecutionPlan the authentication event execution plan
+     */
+    public RegisteredAuthnHandlersEndpoint(
+            final CasConfigurationProperties casProperties,
+            final AuthenticationEventExecutionPlan authenticationEventExecutionPlan) {
+
+        super(casProperties);
+        this.authenticationEventExecutionPlan = authenticationEventExecutionPlan;
+    }
+
+    /**
+     * Handle and produce a list of authn handlers from uthentication event execution plan.
+     *
+     * @return the web async task
+     */
+    @ReadOperation(produces = {
+        ActuatorMediaType.V2_JSON, "application/vnd.cas.services+yaml", MediaType.APPLICATION_JSON_VALUE })
+    public Collection<AuthenticationHandler> handle() {
+        return this.authenticationEventExecutionPlan.getAuthenticationHandlers();
+    }
+
+    /**
+     * Fetch authn handler by name.
+     *
+     * @param name the name
+     * @return the authentication handler
+     */
+    @ReadOperation(produces = {
+        ActuatorMediaType.V2_JSON, "application/vnd.cas.services+yaml", MediaType.APPLICATION_JSON_VALUE })
+    public AuthenticationHandler fetchAuthnHandler(@Selector final String name) {
+        return this.authenticationEventExecutionPlan.getAuthenticationHandlers().stream().
+                filter(authnHandler -> authnHandler.getName().equals(name)).
+                findFirst().orElse(null);
+    }
+}

--- a/support/cas-server-support-reports/src/main/java/org/apereo/cas/config/CasReportsConfiguration.java
+++ b/support/cas-server-support-reports/src/main/java/org/apereo/cas/config/CasReportsConfiguration.java
@@ -2,6 +2,7 @@ package org.apereo.cas.config;
 
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.audit.AuditTrailExecutionPlan;
+import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
@@ -16,6 +17,7 @@ import org.apereo.cas.web.report.CasInfoEndpointContributor;
 import org.apereo.cas.web.report.CasReleaseAttributesReportEndpoint;
 import org.apereo.cas.web.report.CasResolveAttributesReportEndpoint;
 import org.apereo.cas.web.report.ExportRegisteredServicesEndpoint;
+import org.apereo.cas.web.report.RegisteredAuthnHandlersEndpoint;
 import org.apereo.cas.web.report.RegisteredServicesEndpoint;
 import org.apereo.cas.web.report.SingleSignOnSessionStatusEndpoint;
 import org.apereo.cas.web.report.SingleSignOnSessionsEndpoint;
@@ -86,6 +88,10 @@ public class CasReportsConfiguration {
     @Qualifier("principalFactory")
     private ObjectProvider<PrincipalFactory> principalFactory;
 
+    @Autowired
+    @Qualifier("authenticationEventExecutionPlan")
+    private ObjectProvider<AuthenticationEventExecutionPlan> authenticationEventExecutionPlan;
+
     @Bean
     @ConditionalOnAvailableEndpoint
     public SpringWebflowEndpoint springWebflowEndpoint() {
@@ -108,6 +114,12 @@ public class CasReportsConfiguration {
     @ConditionalOnAvailableEndpoint
     public ExportRegisteredServicesEndpoint exportRegisteredServicesEndpoint() {
         return new ExportRegisteredServicesEndpoint(casProperties, servicesManager.getObject());
+    }
+
+    @Bean
+    @ConditionalOnAvailableEndpoint
+    public RegisteredAuthnHandlersEndpoint registeredAuthnHandlersEndpoint() {
+        return new RegisteredAuthnHandlersEndpoint(casProperties, authenticationEventExecutionPlan.getObject());
     }
 
     @Bean

--- a/support/cas-server-support-reports/src/test/java/org/apereo/cas/AllCasReportsTestsSuite.java
+++ b/support/cas-server-support-reports/src/test/java/org/apereo/cas/AllCasReportsTestsSuite.java
@@ -6,6 +6,7 @@ import org.apereo.cas.web.report.CasReleaseAttributesReportEndpointTests;
 import org.apereo.cas.web.report.CasResolveAttributesReportEndpointTests;
 import org.apereo.cas.web.report.ExportRegisteredServicesEndpointTests;
 import org.apereo.cas.web.report.LoggingConfigurationEndpointTests;
+import org.apereo.cas.web.report.RegisteredAuthnHandlersEndpointTests;
 import org.apereo.cas.web.report.RegisteredServicesEndpointTests;
 import org.apereo.cas.web.report.SingleSignOnSessionsEndpointTests;
 import org.apereo.cas.web.report.SpringWebflowEndpointTests;
@@ -26,6 +27,7 @@ import org.junit.runner.RunWith;
 @SelectClasses({
     AuditLogEndpointTests.class,
     RegisteredServicesEndpointTests.class,
+    RegisteredAuthnHandlersEndpointTests.class,
     StatusEndpointTests.class,
     StatusEndpointWithHealthTests.class,
     StatisticsEndpointTests.class,

--- a/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/AbstractCasEndpointTests.java
+++ b/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/AbstractCasEndpointTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.audit.AuditTrailExecutionPlan;
 import org.apereo.cas.audit.AuditTrailExecutionPlanConfigurer;
 import org.apereo.cas.audit.spi.MockAuditTrailManager;
 import org.apereo.cas.audit.spi.config.CasCoreAuditConfiguration;
+import org.apereo.cas.authentication.AuthenticationEventExecutionPlan;
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationHandlersConfiguration;
@@ -69,6 +70,10 @@ public abstract class AbstractCasEndpointTests {
     @Qualifier("servicesManager")
     protected ServicesManager servicesManager;
 
+    @Autowired
+    @Qualifier("authenticationEventExecutionPlan")
+    protected AuthenticationEventExecutionPlan authenticationEventExecutionPlan;
+    
     @TestConfiguration
     @Lazy(false)
     public static class AuditTestConfiguration implements AuditTrailExecutionPlanConfigurer {

--- a/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/RegisteredAuthnHandlersEndpointTests.java
+++ b/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/RegisteredAuthnHandlersEndpointTests.java
@@ -14,14 +14,14 @@ import org.springframework.test.context.TestPropertySource;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This is {@link RegisteredAuthnHandlersTests}.
+ * This is {@link RegisteredAuthnHandlersEndpointTests}.
  *
  * @author Francesco Chicchiriccò
  * @since 6.3.0
  */
 @TestPropertySource(properties = "management.endpoint.registeredAuthnHandlers.enabled=true")
 @Tag("Simple")
-public class RegisteredAuthnHandlersTests extends AbstractCasEndpointTests {
+public class RegisteredAuthnHandlersEndpointTests extends AbstractCasEndpointTests {
 
     @Autowired
     @Qualifier("registeredAuthnHandlersReportEndpoint")

--- a/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/RegisteredAuthnHandlersTests.java
+++ b/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/RegisteredAuthnHandlersTests.java
@@ -1,0 +1,39 @@
+package org.apereo.cas.web.report;
+
+import org.apereo.cas.authentication.handler.support.HttpBasedServiceCredentialsAuthenticationHandler;
+import org.apereo.cas.util.http.SimpleHttpClientFactoryBean;
+
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link RegisteredAuthnHandlersTests}.
+ *
+ * @author Francesco Chicchiriccò
+ * @since 6.3.0
+ */
+@TestPropertySource(properties = "management.endpoint.registeredAuthnHandlers.enabled=true")
+@Tag("Simple")
+public class RegisteredAuthnHandlersTests extends AbstractCasEndpointTests {
+
+    @Autowired
+    @Qualifier("registeredAuthnHandlersReportEndpoint")
+    private RegisteredAuthnHandlersEndpoint endpoint;
+
+    @Test
+    public void verifyOperation() {
+        val handler = new HttpBasedServiceCredentialsAuthenticationHandler(
+                StringUtils.EMPTY, null, null, null, new SimpleHttpClientFactoryBean().getObject());
+        this.authenticationEventExecutionPlan.registerAuthenticationHandler(handler);
+
+        assertFalse(endpoint.handle().isEmpty());
+        assertNotNull(endpoint.fetchAuthnHandler(handler.getName()));
+    }
+}

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/SyncopeAuthenticationConfiguration.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/SyncopeAuthenticationConfiguration.java
@@ -20,7 +20,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -35,7 +34,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration("syncopeAuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnProperty(name = "cas.authn.syncope.url")
 public class SyncopeAuthenticationConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;


### PR DESCRIPTION
Similar to the existing `/registeredServices`, a new Endpoint to inspect the configured Authentication Handlers.