### PR TITLE
Exclude initToken and nextToken from SpnegoCredential.toString

### DIFF
--- a/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -51,11 +51,13 @@ public class SpnegoCredential implements Credential {
     /**
      * The SPNEGO Init Token.
      */
+    @ToString.Exclude
     private byte[] initToken;
 
     /**
      * The SPNEGO Next Token.
      */
+    @ToString.Exclude
     private byte[] nextToken;
 
     /**


### PR DESCRIPTION
Remove `initToken` and `nextToken` binary attributes from `SpnegoCredential.toString` method.

These attributes are useless in toString method and pollute audit log because of their huge size

and finally it is maybe sensible information we want to hide in audit log.

- Before
```
2020-07-09 11:13:16,072 {
  "who" : "FOO@BAR",
  "what" : "Supplied credentials: [SpnegoCredential(initToken=[96, -126, 28, 52, 6, 6, 43, 6, 1, 5, 5, 2, -96, -126, 28, 40, 48, -126, 28, 36, -96, 48, 48, 46, 6, 9, 42, -122, 72, -126, -9, 18, 1, 2, 2, 6, 9, 42, -122, 72, -122, -9, 18, 1, 2, 2, 6, 10, 43, 6, 1, 4, 1, -126, 55, 2, 2, 30, 6, 10, 43, 6, 1, 4, 1,...], nextToken=[-95, 127, 48, 125, -96, 3, 10, 1, 0, -95, 11, 6, 9, 42, -122, 72, -126, -9, 18, 1, 2, 2, -94, 105, 4, 103, 96, 101, 6, 9, 42, -122, 72, -122, -9, 18, 1,...], principal=SimplePrincipal(id=FOO@BAR, attributes={}), isNtlm=false)]",
  "action" : "AUTHENTICATION_SUCCESS",
  "application" : "xxx",
  "when" : "Thu Jul 09 11:13:16 CEST 2020",
  "clientIpAddress" : "10.x.x.x",
  "serverIpAddress" : "10.x.x.x"
}
```
- After
```
2020-07-09 11:13:16,072 {
  "who" : "FOO@BAR",
  "what" : "Supplied credentials: [SpnegoCredential(principal=SimplePrincipal(id=FOO@BAR, attributes={}), isNtlm=false)]",
  "action" : "AUTHENTICATION_SUCCESS",
  "application" : "xxx",
  "when" : "Thu Jul 09 11:13:16 CEST 2020",
  "clientIpAddress" : "10.x.x.x",
  "serverIpAddress" : "10.x.x.x"
}
```