### PR TITLE
Exclude initToken and nextToken from SpnegoCredential.toString

### DIFF
--- a/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -50,11 +50,13 @@ public class SpnegoCredential implements Credential {
     /**
      * The SPNEGO Init Token.
      */
+    @ToString.Exclude
     private byte[] initToken;
 
     /**
      * The SPNEGO Next Token.
      */
+    @ToString.Exclude
     private byte[] nextToken;
 
     /**


### PR DESCRIPTION
Backport [PR 4897](https://github.com/apereo/cas/pull/4897)