### PR TITLE
Ensure OIDC uses appropriate settings for issuer and JwtBuilder

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/AbstractCipherExecutor.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/AbstractCipherExecutor.java
@@ -47,9 +47,9 @@ public abstract class AbstractCipherExecutor<T, R> implements CipherExecutor<T, 
         Security.addProvider(new BouncyCastleProvider());
     }
     
-    private Key signingKey;
+    protected Key signingKey;
 
-    private Map<String, Object> customHeaders = new LinkedHashMap<>(MAP_SIZE);
+    protected Map<String, Object> customHeaders = new LinkedHashMap<>(MAP_SIZE);
     
     /**
      * Extract private key from resource private key.

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcRegisteredServiceJwtAccessTokenCipherExecutor.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcRegisteredServiceJwtAccessTokenCipherExecutor.java
@@ -132,10 +132,12 @@ public class OidcRegisteredServiceJwtAccessTokenCipherExecutor extends OAuth20Re
 
             @Override
             protected byte[] sign(final byte[] value) {
-                val jwks = defaultJsonWebKeystoreCache.get(
-                        OidcRegisteredServiceJwtAccessTokenCipherExecutor.this.issuer);
-                if (jwks.isPresent()) {
-                    return EncodingUtils.signJws(this.signingKey, value, jwks.get().getAlgorithm(), this.customHeaders);
+                if (EncodingUtils.isJsonWebKey(signingKey)) {
+                    val jwks = defaultJsonWebKeystoreCache.get(
+                            OidcRegisteredServiceJwtAccessTokenCipherExecutor.this.issuer);
+                    if (jwks.isPresent()) {
+                        return signWith(value, jwks.get().getAlgorithm());
+                    }
                 }
                 return super.sign(value);
             }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcRegisteredServiceJwtAccessTokenCipherExecutor.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcRegisteredServiceJwtAccessTokenCipherExecutor.java
@@ -129,6 +129,16 @@ public class OidcRegisteredServiceJwtAccessTokenCipherExecutor extends OAuth20Re
                 }
                 return super.decode(value, parameters);
             }
+
+            @Override
+            protected byte[] sign(final byte[] value) {
+                val jwks = defaultJsonWebKeystoreCache.get(
+                        OidcRegisteredServiceJwtAccessTokenCipherExecutor.this.issuer);
+                if (jwks.isPresent()) {
+                    return EncodingUtils.signJws(this.signingKey, value, jwks.get().getAlgorithm(), this.customHeaders);
+                }
+                return super.sign(value);
+            }
         };
         if (EncodingUtils.isJsonWebKey(encryptionKey) || EncodingUtils.isJsonWebKey(signingKey)) {
             cipher.setEncryptionAlgorithm(KeyManagementAlgorithmIdentifiers.RSA_OAEP_256);

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -88,19 +88,28 @@ import org.apereo.cas.support.oauth.validator.token.OAuth20TokenRequestValidator
 import org.apereo.cas.support.oauth.web.endpoints.OAuth20ConfigurationContext;
 import org.apereo.cas.support.oauth.web.response.OAuth20CasClientRedirectActionBuilder;
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerator;
+import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20DefaultTokenGenerator;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenGrantRequestExtractor;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20AccessTokenResponseGenerator;
+import org.apereo.cas.support.oauth.web.response.callback.OAuth20AuthorizationCodeAuthorizationResponseBuilder;
 import org.apereo.cas.support.oauth.web.response.callback.OAuth20AuthorizationResponseBuilder;
+import org.apereo.cas.support.oauth.web.response.callback.OAuth20ClientCredentialsResponseBuilder;
+import org.apereo.cas.support.oauth.web.response.callback.OAuth20ResourceOwnerCredentialsResponseBuilder;
+import org.apereo.cas.support.oauth.web.response.callback.OAuth20TokenAuthorizationResponseBuilder;
 import org.apereo.cas.support.oauth.web.views.ConsentApprovalViewResolver;
 import org.apereo.cas.support.oauth.web.views.OAuth20CallbackAuthorizeViewResolver;
 import org.apereo.cas.support.oauth.web.views.OAuth20UserProfileViewRenderer;
 import org.apereo.cas.ticket.ExpirationPolicyBuilder;
 import org.apereo.cas.ticket.IdTokenGeneratorService;
 import org.apereo.cas.ticket.OAuth20TokenSigningAndEncryptionService;
+import org.apereo.cas.ticket.UniqueTicketIdGenerator;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessTokenFactory;
+import org.apereo.cas.ticket.accesstoken.OAuth20DefaultAccessTokenFactory;
+import org.apereo.cas.ticket.accesstoken.OAuth20JwtBuilder;
 import org.apereo.cas.ticket.code.OAuth20CodeFactory;
 import org.apereo.cas.ticket.device.OAuth20DeviceTokenFactory;
 import org.apereo.cas.ticket.device.OAuth20DeviceUserCodeFactory;
+import org.apereo.cas.ticket.refreshtoken.OAuth20RefreshTokenFactory;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.token.JwtBuilder;
@@ -161,6 +170,7 @@ import org.springframework.webflow.execution.Action;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -185,10 +195,6 @@ public class OidcConfiguration implements WebMvcConfigurer {
     private ObjectProvider<SessionStore> oauthDistributedSessionStore;
 
     @Autowired
-    @Qualifier("accessTokenJwtBuilder")
-    private ObjectProvider<JwtBuilder> accessTokenJwtBuilder;
-
-    @Autowired
     @Qualifier("accessTokenGrantAuditableRequestExtractor")
     private ObjectProvider<AuditableExecution> accessTokenGrantAuditableRequestExtractor;
 
@@ -207,14 +213,6 @@ public class OidcConfiguration implements WebMvcConfigurer {
     @Autowired
     @Qualifier("grantingTicketExpirationPolicy")
     private ObjectProvider<ExpirationPolicyBuilder> grantingTicketExpirationPolicy;
-
-    @Autowired
-    @Qualifier("oauthTokenGenerator")
-    private ObjectProvider<OAuth20TokenGenerator> oauthTokenGenerator;
-
-    @Autowired
-    @Qualifier("oauthAuthorizationResponseBuilders")
-    private ObjectProvider<Set<OAuth20AuthorizationResponseBuilder>> oauthAuthorizationResponseBuilders;
 
     @Autowired
     @Qualifier("webApplicationServiceFactory")
@@ -290,10 +288,6 @@ public class OidcConfiguration implements WebMvcConfigurer {
     private ObjectProvider<TicketRegistrySupport> ticketRegistrySupport;
 
     @Autowired
-    @Qualifier("defaultAccessTokenFactory")
-    private ObjectProvider<OAuth20AccessTokenFactory> defaultAccessTokenFactory;
-
-    @Autowired
     @Qualifier("defaultDeviceTokenFactory")
     private ObjectProvider<OAuth20DeviceTokenFactory> defaultDeviceTokenFactory;
 
@@ -339,6 +333,18 @@ public class OidcConfiguration implements WebMvcConfigurer {
     @Autowired
     @Qualifier("authenticationServiceSelectionPlan")
     private ObjectProvider<AuthenticationServiceSelectionPlan> authenticationServiceSelectionPlan;
+
+    @Autowired
+    @Qualifier("oauthAccessTokenJwtCipherExecutor")
+    private ObjectProvider<CipherExecutor> oauthAccessTokenJwtCipherExecutor;
+
+    @Autowired
+    @Qualifier("accessTokenIdGenerator")
+    private ObjectProvider<UniqueTicketIdGenerator> accessTokenIdGenerator;
+
+    @Autowired
+    @Qualifier("defaultRefreshTokenFactory")
+    private ObjectProvider<OAuth20RefreshTokenFactory> defaultRefreshTokenFactory;
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
@@ -417,8 +423,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
     @Bean
     @RefreshScope
     public OAuth20AccessTokenResponseGenerator oidcAccessTokenResponseGenerator() {
-        return new OidcAccessTokenResponseGenerator(oidcIdTokenGenerator(),
-            accessTokenJwtBuilder.getObject(), casProperties);
+        return new OidcAccessTokenResponseGenerator(oidcIdTokenGenerator(), oidcAccessTokenJwtBuilder(), casProperties);
     }
 
     @Bean
@@ -724,17 +729,86 @@ public class OidcConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcImplicitIdTokenCallbackUrlBuilder")
     public OAuth20AuthorizationResponseBuilder oidcImplicitIdTokenCallbackUrlBuilder() {
-        return new OidcImplicitIdTokenAuthorizationResponseBuilder(oidcIdTokenGenerator(), oauthTokenGenerator.getObject(),
-            accessTokenExpirationPolicy.getObject(), grantingTicketExpirationPolicy.getObject(),
-            servicesManager.getObject(), accessTokenJwtBuilder.getObject(), casProperties);
+        return new OidcImplicitIdTokenAuthorizationResponseBuilder(
+                oidcIdTokenGenerator(),
+                oidcTokenGenerator(),
+                accessTokenExpirationPolicy.getObject(),
+                grantingTicketExpirationPolicy.getObject(),
+                servicesManager.getObject(),
+                oidcAccessTokenJwtBuilder(),
+                casProperties);
     }
 
     @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcImplicitIdTokenAndTokenCallbackUrlBuilder")
     public OAuth20AuthorizationResponseBuilder oidcImplicitIdTokenAndTokenCallbackUrlBuilder() {
-        return new OidcImplicitIdTokenAndTokenAuthorizationResponseBuilder(oidcIdTokenGenerator(), oauthTokenGenerator.getObject(),
-            accessTokenExpirationPolicy.getObject(), grantingTicketExpirationPolicy.getObject(),
-            servicesManager.getObject(), accessTokenJwtBuilder.getObject(), casProperties);
+        return new OidcImplicitIdTokenAndTokenAuthorizationResponseBuilder(
+                oidcIdTokenGenerator(),
+                oidcTokenGenerator(),
+                accessTokenExpirationPolicy.getObject(),
+                grantingTicketExpirationPolicy.getObject(),
+                servicesManager.getObject(),
+                oidcAccessTokenJwtBuilder(),
+                casProperties);
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcResourceOwnerCredentialsResponseBuilder")
+    public OAuth20AuthorizationResponseBuilder oidcResourceOwnerCredentialsResponseBuilder() {
+        return new OAuth20ResourceOwnerCredentialsResponseBuilder(
+                oidcAccessTokenResponseGenerator(), 
+                oidcTokenGenerator(),
+                accessTokenExpirationPolicy.getObject(),
+                casProperties);
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcClientCredentialsResponseBuilder")
+    public OAuth20AuthorizationResponseBuilder oidcClientCredentialsResponseBuilder() {
+        return new OAuth20ClientCredentialsResponseBuilder(
+                oidcAccessTokenResponseGenerator(),
+                oidcTokenGenerator(),
+                accessTokenExpirationPolicy.getObject(),
+                casProperties);
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcTokenResponseBuilder")
+    public OAuth20AuthorizationResponseBuilder oidcTokenResponseBuilder() {
+        return new OAuth20TokenAuthorizationResponseBuilder(
+                oidcTokenGenerator(), 
+                accessTokenExpirationPolicy.getObject(),
+                servicesManager.getObject(), 
+                oidcAccessTokenJwtBuilder(), 
+                casProperties);
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcAuthorizationCodeResponseBuilder")
+    public OAuth20AuthorizationResponseBuilder oidcAuthorizationCodeResponseBuilder() {
+        return new OAuth20AuthorizationCodeAuthorizationResponseBuilder(
+                ticketRegistry.getObject(),
+                defaultOAuthCodeFactory.getObject(), 
+                servicesManager.getObject());
+    }
+    
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcAuthorizationResponseBuilders")
+    public Set<OAuth20AuthorizationResponseBuilder> oidcAuthorizationResponseBuilders() {
+        val builders = applicationContext.getBeansOfType(OAuth20AuthorizationResponseBuilder.class, false, true);
+        return builders.entrySet().stream().
+                filter(e -> !e.getKey().startsWith("oauth")).
+                map(Map.Entry::getValue).
+                collect(Collectors.toSet());
     }
 
     @Bean
@@ -751,7 +825,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
             val accessTokenClient = new HeaderClient();
             accessTokenClient.setCredentialsExtractor(new BearerAuthExtractor());
             accessTokenClient.setAuthenticator(new OidcClientConfigurationAccessTokenAuthenticator(ticketRegistry.getObject(),
-                accessTokenJwtBuilder.getObject()));
+                oidcAccessTokenJwtBuilder()));
             accessTokenClient.setName(OidcConstants.CAS_OAUTH_CLIENT_CONFIG_ACCESS_TOKEN_AUTHN);
             accessTokenClient.init();
             return accessTokenClient;
@@ -798,7 +872,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
     public Authenticator<TokenCredentials> oAuthAccessTokenAuthenticator() {
         return new OidcAccessTokenAuthenticator(ticketRegistry.getObject(),
             oidcTokenSigningAndEncryptionService(), servicesManager.getObject(),
-            accessTokenJwtBuilder.getObject());
+            oidcAccessTokenJwtBuilder());
     }
 
     @ConditionalOnMissingBean(name = "oidcCasWebflowExecutionPlanConfigurer")
@@ -847,13 +921,49 @@ public class OidcConfiguration implements WebMvcConfigurer {
         return plan -> plan.registerSingleLogoutServiceMessageHandler(oidcSingleLogoutServiceMessageHandler());
     }
 
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcAccessTokenJwtBuilder")
+    public JwtBuilder oidcAccessTokenJwtBuilder() {
+        val oidc = casProperties.getAuthn().getOidc();
+        return new OAuth20JwtBuilder(
+                oidc.getIssuer(),
+                oauthAccessTokenJwtCipherExecutor.getObject(),
+                servicesManager.getObject(),
+                oauthRegisteredServiceJwtAccessTokenCipherExecutor());
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcAccessTokenFactory")
+    public OAuth20AccessTokenFactory oidcAccessTokenFactory() {
+        return new OAuth20DefaultAccessTokenFactory(
+                accessTokenIdGenerator.getObject(),
+                accessTokenExpirationPolicy.getObject(),
+                oidcAccessTokenJwtBuilder(),
+                servicesManager.getObject());
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "oidcTokenGenerator")
+    public OAuth20TokenGenerator oidcTokenGenerator() {
+        return new OAuth20DefaultTokenGenerator(
+                oidcAccessTokenFactory(),
+                defaultDeviceTokenFactory.getObject(),
+                defaultDeviceUserCodeFactory.getObject(),
+                defaultRefreshTokenFactory.getObject(),
+                centralAuthenticationService.getObject(),
+                casProperties);
+    }
+    
     private OAuth20ConfigurationContext buildConfigurationContext() {
         return OAuth20ConfigurationContext.builder()
             .registeredServiceCipherExecutor(oauthRegisteredServiceCipherExecutor.getObject())
             .sessionStore(oauthDistributedSessionStore.getObject())
             .servicesManager(servicesManager.getObject())
             .ticketRegistry(ticketRegistry.getObject())
-            .accessTokenFactory(defaultAccessTokenFactory.getObject())
+            .accessTokenFactory(oidcAccessTokenFactory())
             .deviceTokenFactory(defaultDeviceTokenFactory.getObject())
             .deviceUserCodeFactory(defaultDeviceUserCodeFactory.getObject())
             .clientRegistrationRequestSerializer(clientRegistrationRequestSerializer())
@@ -869,7 +979,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
             .centralAuthenticationService(centralAuthenticationService.getObject())
             .callbackAuthorizeViewResolver(callbackAuthorizeViewResolver())
             .profileScopeToAttributesFilter(profileScopeToAttributesFilter())
-            .accessTokenGenerator(oauthTokenGenerator.getObject())
+            .accessTokenGenerator(oidcTokenGenerator())
             .accessTokenResponseGenerator(oidcAccessTokenResponseGenerator())
             .accessTokenExpirationPolicy(accessTokenExpirationPolicy.getObject())
             .deviceTokenExpirationPolicy(deviceTokenExpirationPolicy.getObject())
@@ -879,11 +989,11 @@ public class OidcConfiguration implements WebMvcConfigurer {
             .oAuthCodeFactory(defaultOAuthCodeFactory.getObject())
             .consentApprovalViewResolver(consentApprovalViewResolver())
             .authenticationBuilder(authenticationBuilder.getObject())
-            .oauthAuthorizationResponseBuilders(oauthAuthorizationResponseBuilders.getObject())
+            .oauthAuthorizationResponseBuilders(oidcAuthorizationResponseBuilders())
             .oauthRequestValidators(oauthRequestValidators.getObject())
             .singleLogoutServiceLogoutUrlBuilder(singleLogoutServiceLogoutUrlBuilder.getObject())
             .idTokenSigningAndEncryptionService(oidcTokenSigningAndEncryptionService())
-            .accessTokenJwtBuilder(accessTokenJwtBuilder.getObject())
+            .accessTokenJwtBuilder(oidcAccessTokenJwtBuilder())
             .build();
     }
 }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -87,8 +87,8 @@ import org.apereo.cas.support.oauth.validator.authorization.OAuth20Authorization
 import org.apereo.cas.support.oauth.validator.token.OAuth20TokenRequestValidator;
 import org.apereo.cas.support.oauth.web.endpoints.OAuth20ConfigurationContext;
 import org.apereo.cas.support.oauth.web.response.OAuth20CasClientRedirectActionBuilder;
-import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerator;
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20DefaultTokenGenerator;
+import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerator;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenGrantRequestExtractor;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20AccessTokenResponseGenerator;
 import org.apereo.cas.support.oauth.web.response.callback.OAuth20AuthorizationCodeAuthorizationResponseBuilder;

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/AbstractOidcTests.java
@@ -81,6 +81,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jose4j.jwe.ContentEncryptionAlgorithmIdentifiers;
 import org.jose4j.jwe.KeyManagementAlgorithmIdentifiers;
 import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.NumericDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -253,8 +254,8 @@ public abstract class AbstractOidcTests {
     protected ConsentApprovalViewResolver consentApprovalViewResolver;
 
     @Autowired
-    @Qualifier("accessTokenJwtBuilder")
-    protected JwtBuilder accessTokenJwtBuilder;
+    @Qualifier("oidcAccessTokenJwtBuilder")
+    protected JwtBuilder oidcAccessTokenJwtBuilder;
 
     protected static OidcRegisteredService getOidcRegisteredService() {
         return getOidcRegisteredService(true, true);

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/authn/OidcAccessTokenAuthenticatorTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/authn/OidcAccessTokenAuthenticatorTests.java
@@ -27,7 +27,7 @@ public class OidcAccessTokenAuthenticatorTests extends AbstractOidcTests {
         val ctx = new JEEContext(request, new MockHttpServletResponse());
         val token = oidcTokenSigningAndEncryptionService.encode(getOidcRegisteredService(), getClaims());
         val auth = new OidcAccessTokenAuthenticator(ticketRegistry, oidcTokenSigningAndEncryptionService,
-            servicesManager, accessTokenJwtBuilder);
+            servicesManager, oidcAccessTokenJwtBuilder);
         val at = getAccessToken(token, "clientid");
         ticketRegistry.addTicket(at);
         val credentials = new TokenCredentials(at.getId());

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/authn/OidcClientConfigurationAccessTokenAuthenticatorTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/authn/OidcClientConfigurationAccessTokenAuthenticatorTests.java
@@ -29,7 +29,7 @@ public class OidcClientConfigurationAccessTokenAuthenticatorTests extends Abstra
     public void verifyOperation() {
         val request = new MockHttpServletRequest();
         val ctx = new JEEContext(request, new MockHttpServletResponse());
-        val auth = new OidcClientConfigurationAccessTokenAuthenticator(ticketRegistry, accessTokenJwtBuilder);
+        val auth = new OidcClientConfigurationAccessTokenAuthenticator(ticketRegistry, oidcAccessTokenJwtBuilder);
         val at = getAccessToken();
         when(at.getScopes()).thenReturn(Set.of(OidcConstants.CLIENT_REGISTRATION_SCOPE));
         ticketRegistry.addTicket(at);

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorServiceTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorServiceTests.java
@@ -192,7 +192,7 @@ public class OidcIdTokenGeneratorServiceTests extends AbstractOidcTests {
             .registeredService(registeredService)
             .service(accessToken.getService())
             .casProperties(casProperties)
-            .accessTokenJwtBuilder(accessTokenJwtBuilder)
+            .accessTokenJwtBuilder(oidcAccessTokenJwtBuilder)
             .build()
             .encode();
         val newHash = OAuth20AccessTokenAtHashGenerator.builder()

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcJwtAccessTokenEncoderTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcJwtAccessTokenEncoderTests.java
@@ -33,7 +33,7 @@ public class OidcJwtAccessTokenEncoderTests extends AbstractOidcTests {
             .accessToken(accessToken)
             .registeredService(registeredService)
             .service(accessToken.getService())
-            .accessTokenJwtBuilder(accessTokenJwtBuilder)
+            .accessTokenJwtBuilder(oidcAccessTokenJwtBuilder)
             .casProperties(casProperties)
             .build();
     }

--- a/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/JwtBuilder.java
+++ b/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/JwtBuilder.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 public class JwtBuilder {
     private static final int MAP_SIZE = 8;
 
-    private final String casSeverPrefix;
+    private final String issuer;
 
     private final CipherExecutor<Serializable, String> defaultTokenCipherExecutor;
 
@@ -125,7 +125,7 @@ public class JwtBuilder {
         val serviceAudience = payload.getServiceAudience();
         val claims = new JWTClaimsSet.Builder()
             .audience(serviceAudience)
-            .issuer(casSeverPrefix)
+            .issuer(issuer)
             .jwtID(payload.getJwtId())
             .issueTime(payload.getIssueDate())
             .subject(payload.getSubject());

--- a/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/JwtTokenTicketBuilder.java
+++ b/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/JwtTokenTicketBuilder.java
@@ -77,7 +77,7 @@ public class JwtTokenTicketBuilder implements TokenTicketBuilder {
         val validUntilDate = DateTimeUtils.dateOf(dt);
 
         val builder = JwtBuilder.JwtRequest.builder();
-        val request = builder.serviceAudience(jwtBuilder.getCasSeverPrefix())
+        val request = builder.serviceAudience(jwtBuilder.getIssuer())
             .registeredService(Optional.empty())
             .issueDate(DateTimeUtils.dateOf(ticketGrantingTicket.getCreationTime()))
             .jwtId(ticketGrantingTicket.getId())


### PR DESCRIPTION
This PR allows to:
* set JWT access token's issuer as `cas.authn.oidc.issuer`
* use the same signing algorithm as specified for the configured JsonWeb keystore.