### PR TITLE
Move ClientInfoThreadLocalFilter after CharacterEncodingFilter

### DIFF
--- a/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
+++ b/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
@@ -129,7 +129,7 @@ public class CasCoreAuditConfiguration {
         bean.setUrlPatterns(CollectionUtils.wrap("/*"));
         bean.setName("CAS Client Info Logging Filter");
         bean.setAsyncSupported(true);
-        bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        bean.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
 
         val initParams = new HashMap<String, String>();
         if (StringUtils.isNotBlank(audit.getAlternateClientAddrHeaderName())) {


### PR DESCRIPTION
The latest implementation of  `ClientInfoThreadLocalFilter` calls internally `getParameter("geolocation")` on `HttpServletRequest` **BEFORE**  Spring Boot's  `CharacterEncodingFilter` assigns the correct character encoding to the request. Therefore the former filter decodes the POSTed data using wrong character encoding and the result is cached into the request for later processing. 

This is a critical bug because the username and the password in the login form will be broken if they contain any Unicode characters beyond simple US-ASCII letters. I believe we should change the order of `ClientInfoThreadLocalFilter` with +1 and keep the highest order only for `CharacterEncodingFilter`. 