### PR TITLE
Move ClientInfoThreadLocalFilter after CharacterEncodingFilter

### DIFF
--- a/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
+++ b/core/cas-server-core-audit/src/main/java/org/apereo/cas/audit/spi/config/CasCoreAuditConfiguration.java
@@ -129,7 +129,7 @@ public class CasCoreAuditConfiguration {
         bean.setUrlPatterns(CollectionUtils.wrap("/*"));
         bean.setName("CAS Client Info Logging Filter");
         bean.setAsyncSupported(true);
-        bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        bean.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
 
         val initParams = new HashMap<String, String>();
         if (StringUtils.isNotBlank(audit.getAlternateClientAddrHeaderName())) {


### PR DESCRIPTION
Backport of PR #4901 
This patch fixes the problem that was preventing users from logging in when they use username and/or password containing any Unicode characters. The same issue does not occur in 6.1.x or older releases.