### PR TITLE
Small enhancements to Syncope auth

### DIFF
--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcAddressScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcAddressScopeAttributeReleasePolicy.java
@@ -15,11 +15,14 @@ import java.util.List;
 public class OidcAddressScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    public static final List<String> ALLOWED_ATTRIBUTES = List.of("address");
+    /**
+     * Claims allowed by this attribute release policy.
+     */
+    public static final List<String> ALLOWED_CLAIMS = List.of("address");
 
     public OidcAddressScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.ADDRESS.getScope());
-        setAllowedAttributes(ALLOWED_ATTRIBUTES);
+        setAllowedAttributes(ALLOWED_CLAIMS);
     }
 
     @JsonIgnore

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcAddressScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcAddressScopeAttributeReleasePolicy.java
@@ -5,8 +5,6 @@ import org.apereo.cas.oidc.OidcConstants;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This is {@link OidcAddressScopeAttributeReleasePolicy}.
@@ -17,11 +15,11 @@ import java.util.stream.Stream;
 public class OidcAddressScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    private List<String> allowedAttributes = Stream.of("address").collect(Collectors.toList());
+    public static final List<String> ALLOWED_ATTRIBUTES = List.of("address");
 
     public OidcAddressScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.ADDRESS.getScope());
-        setAllowedAttributes(allowedAttributes);
+        setAllowedAttributes(ALLOWED_ATTRIBUTES);
     }
 
     @JsonIgnore

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcEmailScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcEmailScopeAttributeReleasePolicy.java
@@ -5,8 +5,6 @@ import org.apereo.cas.oidc.OidcConstants;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This is {@link OidcEmailScopeAttributeReleasePolicy}.
@@ -17,7 +15,7 @@ import java.util.stream.Stream;
 public class OidcEmailScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    private static final List<String> ALLOWED_ATTRIBUTES = Stream.of("email", "email_verified").collect(Collectors.toList());
+    public static final List<String> ALLOWED_ATTRIBUTES = List.of("email", "email_verified");
 
     public OidcEmailScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.EMAIL.getScope());

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcEmailScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcEmailScopeAttributeReleasePolicy.java
@@ -15,11 +15,14 @@ import java.util.List;
 public class OidcEmailScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    public static final List<String> ALLOWED_ATTRIBUTES = List.of("email", "email_verified");
+    /**
+     * Claims allowed by this attribute release policy.
+     */
+    public static final List<String> ALLOWED_CLAIMS = List.of("email", "email_verified");
 
     public OidcEmailScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.EMAIL.getScope());
-        setAllowedAttributes(ALLOWED_ATTRIBUTES);
+        setAllowedAttributes(ALLOWED_CLAIMS);
     }
 
     @JsonIgnore

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcPhoneScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcPhoneScopeAttributeReleasePolicy.java
@@ -15,11 +15,14 @@ import java.util.List;
 public class OidcPhoneScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    public static final List<String> ALLOWED_ATTRIBUTES = List.of("phone_number", "phone_number_verified");
+    /**
+     * Claims allowed by this attribute release policy.
+     */
+    public static final List<String> ALLOWED_CLAIMS = List.of("phone_number", "phone_number_verified");
 
     public OidcPhoneScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.PHONE.getScope());
-        setAllowedAttributes(ALLOWED_ATTRIBUTES);
+        setAllowedAttributes(ALLOWED_CLAIMS);
     }
 
     @JsonIgnore

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcPhoneScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcPhoneScopeAttributeReleasePolicy.java
@@ -5,8 +5,6 @@ import org.apereo.cas.oidc.OidcConstants;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This is {@link OidcPhoneScopeAttributeReleasePolicy}.
@@ -17,11 +15,11 @@ import java.util.stream.Stream;
 public class OidcPhoneScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    private final List<String> allowedAttributes = Stream.of("phone_number", "phone_number_verified").collect(Collectors.toList());
+    public static final List<String> ALLOWED_ATTRIBUTES = List.of("phone_number", "phone_number_verified");
 
     public OidcPhoneScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.PHONE.getScope());
-        setAllowedAttributes(allowedAttributes);
+        setAllowedAttributes(ALLOWED_ATTRIBUTES);
     }
 
     @JsonIgnore

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcProfileScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcProfileScopeAttributeReleasePolicy.java
@@ -15,13 +15,16 @@ import java.util.List;
 public class OidcProfileScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    public static final List<String> ALLOWED_ATTRIBUTES = List.of("name", "family_name", "given_name",
+    /**
+     * Claims allowed by this attribute release policy.
+     */
+    public static final List<String> ALLOWED_CLAIMS = List.of("name", "family_name", "given_name",
         "middle_name", "nickname", "preferred_username", "profile", "picture", "website",
         "gender", "birthdate", "zoneinfo", "locale", "updated_at");
 
     public OidcProfileScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.PROFILE.getScope());
-        setAllowedAttributes(ALLOWED_ATTRIBUTES);
+        setAllowedAttributes(ALLOWED_CLAIMS);
     }
 
     @JsonIgnore

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcProfileScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/OidcProfileScopeAttributeReleasePolicy.java
@@ -5,8 +5,6 @@ import org.apereo.cas.oidc.OidcConstants;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This is {@link OidcProfileScopeAttributeReleasePolicy}.
@@ -17,10 +15,9 @@ import java.util.stream.Stream;
 public class OidcProfileScopeAttributeReleasePolicy extends BaseOidcScopeAttributeReleasePolicy {
     private static final long serialVersionUID = 1532960981124784595L;
 
-    private static final List<String> ALLOWED_ATTRIBUTES = Stream.of("name", "family_name", "given_name",
+    public static final List<String> ALLOWED_ATTRIBUTES = List.of("name", "family_name", "given_name",
         "middle_name", "nickname", "preferred_username", "profile", "picture", "website",
-        "gender", "birthdate", "zoneinfo", "locale", "updated_at")
-        .collect(Collectors.toList());
+        "gender", "birthdate", "zoneinfo", "locale", "updated_at");
 
     public OidcProfileScopeAttributeReleasePolicy() {
         super(OidcConstants.StandardScopes.PROFILE.getScope());

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/syncope/authentication/SyncopeAuthenticationHandler.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/syncope/authentication/SyncopeAuthenticationHandler.java
@@ -58,50 +58,43 @@ public class SyncopeAuthenticationHandler extends AbstractUsernamePasswordAuthen
     private static Map<String, List<Object>> buildSyncopeUserAttributes(final JsonNode user) {
         val attributes = new HashMap<String, List<Object>>();
 
+        if (user.has("securityQuestion") && !user.get("securityQuestion").isNull()) {
+            attributes.put("syncopeUserSecurityQuestion", List.of(user.get("securityQuestion").asText()));
+        }
+
+        attributes.put("syncopeUserStatus", List.of(user.get("status").asText()));
+
+        attributes.put("syncopeUserRealm", List.of(user.get("realm").asText()));
+
+        attributes.put("syncopeUserCreator", List.of(user.get("creator").asText()));
+
+        attributes.put("syncopeUserCreationDate", List.of(user.get("creationDate").asText()));
+
+        if (user.has("changePwdDate") && !user.get("changePwdDate").isNull()) {
+            attributes.put("syncopeUserChangePwdDate", List.of(user.get("changePwdDate").asText()));
+        }
+
+        if (user.has("lastLoginDate") && !user.get("lastLoginDate").isNull()) {
+            attributes.put("syncopeUserLastLoginDate", List.of(user.get("lastLoginDate").asText()));
+        }
+
         val roles = user.has("roles")
-            ? MAPPER.convertValue(user.get("roles"), ArrayList.class)
-            : new ArrayList<>(0);
+                ? MAPPER.convertValue(user.get("roles"), ArrayList.class)
+                : new ArrayList<>(0);
         if (!roles.isEmpty()) {
             attributes.put("syncopeUserRoles", roles);
         }
 
-        if (user.has("securityQuestion")) {
-            attributes.put("syncopeUserSecurityQuestion", List.of(user.get("securityQuestion").asText()));
-        }
-
-        if (user.has("status")) {
-            attributes.put("syncopeUserStatus", List.of(user.get("status").asText()));
-        }
-        if (user.has("realm")) {
-            attributes.put("syncopeUserRealm", List.of(user.get("realm").asText()));
-        }
-
-        if (user.has("creator")) {
-            attributes.put("syncopeUserCreator", List.of(user.get("creator").asText()));
-        }
-
-        if (user.has("creationDate")) {
-            attributes.put("syncopeUserCreationDate", List.of(user.get("creationDate").asText()));
-        }
-
-        if (user.has("changePwdDate")) {
-            attributes.put("syncopeUserChangePwdDate", List.of(user.get("changePwdDate").asText()));
-        }
-
-        if (user.has("lastLoginDate")) {
-            attributes.put("syncopeUserLastLoginDate", List.of(user.get("lastLoginDate").asText()));
-        }
-
         val dynRoles = user.has("dynRoles")
-            ? MAPPER.convertValue(user.get("dynRoles"), ArrayList.class)
-            : new ArrayList<>(0);
+                ? MAPPER.convertValue(user.get("dynRoles"), ArrayList.class)
+                : new ArrayList<>(0);
         if (!dynRoles.isEmpty()) {
             attributes.put("syncopeUserDynRoles", dynRoles);
         }
 
         val dynRealms = user.has("dynRealms")
-            ? MAPPER.convertValue(user.get("dynRealms"), ArrayList.class)
-            : new ArrayList<>(0);
+                ? MAPPER.convertValue(user.get("dynRealms"), ArrayList.class)
+                : new ArrayList<>(0);
         if (!dynRealms.isEmpty()) {
             attributes.put("syncopeUserDynRealms", dynRealms);
         }
@@ -124,14 +117,24 @@ public class SyncopeAuthenticationHandler extends AbstractUsernamePasswordAuthen
 
         if (user.has("relationships")) {
             user.get("relationships").forEach(r -> attributes.put(
-                "syncopeUserRelationships" + r.get("type").asText(),
-                List.of(r.get("otherEndName").asText())));
+                    "syncopeUserRelationships" + r.get("type").asText(),
+                    List.of(r.get("otherEndName").asText())));
         }
 
         if (user.has("plainAttrs")) {
             user.get("plainAttrs").forEach(a -> attributes.put(
-                "syncopeUserAttr" + a.get("schema").asText(),
-                MAPPER.convertValue(a.get("values"), ArrayList.class)));
+                    "syncopeUserAttr_" + a.get("schema").asText(),
+                    MAPPER.convertValue(a.get("values"), ArrayList.class)));
+        }
+        if (user.has("derAttrs")) {
+            user.get("derAttrs").forEach(a -> attributes.put(
+                    "syncopeUserAttr_" + a.get("schema").asText(),
+                    MAPPER.convertValue(a.get("values"), ArrayList.class)));
+        }
+        if (user.has("virAttrs")) {
+            user.get("virAttrs").forEach(a -> attributes.put(
+                    "syncopeUserAttr_" + a.get("schema").asText(),
+                    MAPPER.convertValue(a.get("values"), ArrayList.class)));
         }
 
         return attributes;

--- a/support/cas-server-support-syncope-authentication/src/test/java/org/apereo/cas/syncope/authentication/SyncopeAuthenticationHandlerTests.java
+++ b/support/cas-server-support-syncope-authentication/src/test/java/org/apereo/cas/syncope/authentication/SyncopeAuthenticationHandlerTests.java
@@ -96,10 +96,20 @@ public class SyncopeAuthenticationHandlerTests {
         user.putArray("relationships").add(MAPPER.createObjectNode()
             .put("type", "T1").put("otherEndName", "Other1"));
 
-        val attrs = MAPPER.createObjectNode();
-        attrs.put("schema", "S1");
-        attrs.putArray("values").add("V1");
-        user.putArray("plainAttrs").add(attrs);
+        val plainAttrs = MAPPER.createObjectNode();
+        plainAttrs.put("schema", "S1");
+        plainAttrs.putArray("values").add("V1");
+        user.putArray("plainAttrs").add(plainAttrs);
+
+        val derAttrs = MAPPER.createObjectNode();
+        derAttrs.put("schema", "S2");
+        derAttrs.putArray("values").add("V2");
+        user.putArray("derAttrs").add(derAttrs);
+
+        val virAttrs = MAPPER.createObjectNode();
+        virAttrs.put("schema", "S3");
+        virAttrs.putArray("values").add("V3");
+        user.putArray("virAttrs").add(virAttrs);
 
         user.put("securityQuestion", "Q1");
         user.put("status", "OK");


### PR DESCRIPTION
* more thorough check for `null` values
* add derived and virtual attributes, not just plain
* generate attribute names as `syncopeUserAttr_userId` rather than `syncopeUserAttruserId`.