### PR TITLE
WIP - DelegatedClientID being lost

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java
@@ -104,6 +104,9 @@ public class DelegatedClientWebflowManager {
             config.setStateGenerator(new StaticValueGenerator(ticketId));
         }
         if (client instanceof CasClient) {
+	    // ====Code from 5.3 branch=====
+	    // final CasClient casClient = (CasClient) client;
+            // casClient.getConfiguration().addCustomParam(DelegatedClientWebflowManager.PARAMETER_CLIENT_ID, ticketId);
             sessionStore.set(webContext, CAS_CLIENT_ID_SESSION_KEY, ticket.getId());
         }
         if (client instanceof OAuth10Client) {


### PR DESCRIPTION
I believe this is a bug, but wanted to verify before I create a fix. 

**Issue:**
Cannot get delegatedClientId param added to query string URL when creating customized webflow using Pac4j library.

**Evidence:**
In CAS 5.3.x 
"support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java" the clientId was added to configuration.customParams 
```
        if (client instanceof CasClient) {
            final CasClient casClient = (CasClient) client;
            casClient.getConfiguration().addCustomParam(DelegatedClientWebflowManager.PARAMETER_CLIENT_ID, ticketId);
        }
```
Then "org/pac4j/pac4j-core/3.6.1/pac4j-core-3.6.1.jar!/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolver.class" would pull the value from the same configuration params
```
        Entry entry;
        for(Iterator var6 = this.customParams.entrySet().iterator(); var6.hasNext(); newUrl = CommonHelper.addParameter(newUrl, (String)entry.getKey(), (String)entry.getValue())) {
            entry = (Entry)var6.next();
        }
```

In 6.1.6 and 6.2 
"support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/DelegatedClientWebflowManager.java" saves to the session now
```
        if (client instanceof CasClient) {
            sessionStore.set(webContext, CAS_CLIENT_ID_SESSION_KEY, ticket.getId());
        }
```
but Pac4j is still pulling from the configurations custom params:
```
        for (final Map.Entry<String, String> entry : this.customParams.entrySet()) {
            newUrl = CommonHelper.addParameter(newUrl, entry.getKey(), entry.getValue());
        }
```

If this is truly a bug, I can work on creating the fix. But I am not sure if should go in the CAS repo in the  "DelegatedClientWebflowManager.java" file or should the fix be created in the Pac4j repo for file "QueryParameterCallbackUrlResolver.class"?

Thanks for your input!


