### PR TITLE
Making effective SAML IdP Metadata caching

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/idp/metadata/locator/AbstractSamlIdPMetadataLocator.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/idp/metadata/locator/AbstractSamlIdPMetadataLocator.java
@@ -126,7 +126,7 @@ public abstract class AbstractSamlIdPMetadataLocator implements SamlIdPMetadataL
         val key = buildCacheKey(registeredService);
 
         return metadataCache.get(key, k -> {
-            SamlIdPMetadataDocument metadataDocument = fetchInternal(registeredService);
+            val metadataDocument = fetchInternal(registeredService);
             if (metadataDocument != null && metadataDocument.isValid()) {
                 LOGGER.trace("Fetched and cached SAML IdP metadata document [{}] under key [{}]", metadataDocument, key);
                 return metadataDocument;


### PR DESCRIPTION
This PR is:

1. increasing cache's maximum size from 1 to 100 (otherwise, when having > 1 keys to look up, every get is likely resulting into a miss)

2. applying the advice in https://github.com/ben-manes/caffeine/blob/master/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Cache.java#L133-L134