### PR TITLE
Put jmeter CAS logs in file

### DIFF
--- a/ci/tests/perf/EvalJMeterTestResults.java
+++ b/ci/tests/perf/EvalJMeterTestResults.java
@@ -5,6 +5,7 @@ import java.util.regex.*;
 public class EvalJMeterTestResults {
     public static void main(String[] args) throws Exception {
         var content = new String(Files.readAllBytes(Paths.get(args[0])), StandardCharsets.UTF_8);
+        System.out.format("JMeter results from %s: ", args[0]);
         System.out.println(content);
 
         var pattern = Pattern.compile("summary\\s=.+Err:\\s*(\\d+)");
@@ -13,7 +14,7 @@ public class EvalJMeterTestResults {
         if (matcher.find()) {
             var count = Integer.parseInt(matcher.group(1));
             if (count > 0) {
-                System.out.println("JMeter tests contain errors.");
+                System.out.format("JMeter tests contain %d errors.", count);
                 System.exit(1);
             }
         }

--- a/ci/tests/perf/perftests-jmeter.sh
+++ b/ci/tests/perf/perftests-jmeter.sh
@@ -32,12 +32,13 @@ if [ $retVal == 0 ]; then
     casOutput="/tmp/logs/cas.log"
     cmd="java -jar webapp/cas-server-webapp-${webAppServerType}/build/libs/cas.war \\
       --server.ssl.key-store=${keystore} --cas.service-registry.init-from-json=true --logging.level.org.apereo.cas=info"
-#    exec $cmd > ${casOutput} 2>&1 &
-    exec $cmd &
+    exec $cmd > ${casOutput} 2>&1 &
     pid=$!
     echo "Launched CAS with pid ${pid}. Waiting for CAS server to come online..."
     sleep 60
-    
+    echo "CAS server output before tests have started:"
+    cat ${casOutput}
+
     sudo mkdir -p /etc/cas/config/loadtests/jmeter/
     sudo cp etc/loadtests/jmeter/cas-users.csv /etc/cas/config/loadtests/jmeter/
     sudo chmod -R ugo+r /etc/cas/config/loadtests
@@ -51,7 +52,9 @@ if [ $retVal == 0 ]; then
     echo "Running JMeter tests..."
     apache-jmeter-${jmeterVersion}/bin/jmeter -n -t etc/loadtests/jmeter/CAS_CAS.jmx > results.log
 #    ~/Workspace/Portal/apache-jmeter/bin/jmeter -n -t etc/loadtests/jmeter/CAS_CAS.jmx > results.log
-    cat ./results.log
+    echo CAS server warnings and errors:
+    grep -E WARN\|ERROR\|FATAL ${casOutput}
+
     java ci/tests/perf/EvalJMeterTestResults.java ./results.log
 
     retVal=$?

--- a/ci/tests/perf/perftests-jmeter.sh
+++ b/ci/tests/perf/perftests-jmeter.sh
@@ -29,7 +29,7 @@ if [ $retVal == 0 ]; then
     keytool -genkey -noprompt -alias cas -keyalg RSA -keypass changeit -storepass changeit \
       -keystore "${keystore}" -dname "${dname}" -ext SAN="${subjectAltName}"
     echo "Launching CAS web application ${webAppServerType} server..."
-    casOutput="/tmp/logs/cas.log"
+    casOutput="/tmp/cas.log"
     cmd="java -jar webapp/cas-server-webapp-${webAppServerType}/build/libs/cas.war \\
       --server.ssl.key-store=${keystore} --cas.service-registry.init-from-json=true --logging.level.org.apereo.cas=info"
     exec $cmd > ${casOutput} 2>&1 &


### PR DESCRIPTION
The CAS output from JMeter tests was > 200MB so this dumps log after startup and before tests, then greps for WARN|ERROR|FATAL after running tests.
Also not sure if the results were being processed so added some more output

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
