### PR TITLE
Fixed an error in building urlRedirect

### DIFF
--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/DefaultResponse.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/DefaultResponse.java
@@ -86,7 +86,7 @@ public class DefaultResponse implements Response {
             })
             .collect(Collectors.joining("&"));
         if (!(params == null || params.isEmpty())) {
-            builder.append(url.contains("?") ? "&" : "?");
+            builder.append(fragmentSplit.get(0).contains("?") ? "&" : "?");
             builder.append(params);
         }
         if (fragmentSplit.size() > 1) {

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/ResponseTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/authentication/principal/ResponseTests.java
@@ -55,6 +55,15 @@ public class ResponseTests {
     }
 
     @Test
+    public void verifyConstructionWithFragmentAndNoQueryString2() {
+        val url = "http://localhost:8080/foo#hello?test=boo";
+        val attributes = new HashMap<String, String>();
+        attributes.put(TICKET_PARAM, TICKET_VALUE);
+        val response = DefaultResponse.getRedirectResponse(url, attributes);
+        assertEquals("http://localhost:8080/foo?ticket=foobar#hello?test=boo", response.getUrl());
+    }
+
+    @Test
     public void verifyUrlSanitization() {
         val url = "https://www.example.com\r\nLocation: javascript:\r\n\r\n<script>alert(document.cookie)</script>";
         val attributes = new HashMap<String, String>();


### PR DESCRIPTION
Fixed an error in building urlRedirect.
When url like "http://localhost:8080/foo#hello?test=boo", we expect "http://localhost:8080/foo?ticket=foobar#hello?test=boo".