### PR TITLE
Update Configuring-Multifactor-Authentication-Triggers.md

### DIFF
--- a/docs/cas-server-documentation/installation/Configuring-Multifactor-Authentication-Triggers.md
+++ b/docs/cas-server-documentation/installation/Configuring-Multifactor-Authentication-Triggers.md
@@ -242,6 +242,14 @@ The `entityId` parameter may be passed as such:
 https://.../cas/login?service=http://idp.example.org&entityId=the-entity-id-passed
 ```
 
+Alternatively, you can also configure your Shibboleth Identity Provider to embed the entity id into the service string itself, resulting in the following service URL:
+
+```bash
+https://.../cas/login?service=http%3A%2F%2Fidp.example.org%2Fidp%2FAuthn%2FExtCas%3Fconversation%3De2s1%26entityId%3Dthe-entity-id-passed
+```
+
+See [`shibcas.entityIdLocation` setting](https://github.com/Unicon/shib-cas-authn3#cas-service-registry) more details and suggested service matching regex patterns.
+
 ## Custom
 
 While support for triggers may seem extensive, there is always that edge use case that would have you trigger MFA based on a special set of requirements. To learn how to design your own triggers, [please see this guide](Configuring-Multifactor-Authentication-CustomTriggers.html).


### PR DESCRIPTION
Add alternative configuration to rebuilding WAR with `shibcas.entityIdLocation` setting in Shibboleth IdP for MFA trigger (Entity Id Request Parameter)

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
