### PR TITLE
redirect from /oidc/authorize contains duplicate parameters (code and sometimes state)

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
@@ -15,7 +15,6 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.inspektr.audit.annotation.Audit;
 import org.pac4j.core.context.JEEContext;
-import org.pac4j.core.util.CommonHelper;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.LinkedHashMap;

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
@@ -83,11 +83,14 @@ public class OAuth20AuthorizationCodeAuthorizationResponseBuilder implements OAu
             .orElse(StringUtils.EMPTY);
         LOGGER.debug("Authorize request successful for client [{}] with redirect uri [{}]", clientId, redirectUri);
 
-
         val params = new LinkedHashMap<String, String>();
         params.put(OAuth20Constants.CODE, code.getId());
-        params.put(OAuth20Constants.STATE, state);
-        params.put(OAuth20Constants.NONCE, nonce);
+        if (StringUtils.isNotBlank(state)) {
+            params.put(OAuth20Constants.STATE, state);
+        }
+        if (StringUtils.isNotBlank(nonce)) {
+            params.put(OAuth20Constants.NONCE, nonce);
+        }
         params.put(OAuth20Constants.CLIENT_ID, clientId);
         LOGGER.debug("Redirecting to URL [{}] with params [{}] for clientId [{}]", redirectUri, params.keySet(), clientId);
         return buildResponseModelAndView(context, servicesManager, clientId, redirectUri, params);

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
@@ -83,20 +83,13 @@ public class OAuth20AuthorizationCodeAuthorizationResponseBuilder implements OAu
             .orElse(StringUtils.EMPTY);
         LOGGER.debug("Authorize request successful for client [{}] with redirect uri [{}]", clientId, redirectUri);
 
-        var callbackUrl = redirectUri;
-        callbackUrl = CommonHelper.addParameter(callbackUrl, OAuth20Constants.CODE, code.getId());
-        if (StringUtils.isNotBlank(state)) {
-            callbackUrl = CommonHelper.addParameter(callbackUrl, OAuth20Constants.STATE, state);
-        }
-        if (StringUtils.isNotBlank(nonce)) {
-            callbackUrl = CommonHelper.addParameter(callbackUrl, OAuth20Constants.NONCE, nonce);
-        }
-        LOGGER.debug("Redirecting to URL [{}]", callbackUrl);
+
         val params = new LinkedHashMap<String, String>();
         params.put(OAuth20Constants.CODE, code.getId());
         params.put(OAuth20Constants.STATE, state);
         params.put(OAuth20Constants.NONCE, nonce);
         params.put(OAuth20Constants.CLIENT_ID, clientId);
-        return buildResponseModelAndView(context, servicesManager, clientId, callbackUrl, params);
+        LOGGER.debug("Redirecting to URL [{}] with params [{}] for clientId [{}]", redirectUri, params.keySet(), clientId);
+        return buildResponseModelAndView(context, servicesManager, clientId, redirectUri, params);
     }
 }

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
@@ -13,7 +13,6 @@ import org.apereo.cas.web.flow.CasWebflowConstants;
 
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.utils.URIBuilder;
 import org.jose4j.jwt.JwtClaims;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -188,14 +187,10 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         val redirectView = (RedirectView) view;
         val redirectUrl = redirectView.getUrl();
         assertNotNull(redirectUrl);
-        assertTrue(redirectUrl.startsWith(REDIRECT_URI + "?code=" + OAuth20Code.PREFIX));
+        assertEquals(redirectUrl, REDIRECT_URI);
 
-        val builder = new URIBuilder(redirectUrl);
-        val code = builder.getQueryParams()
-            .stream()
-            .filter(a -> a.getName().equalsIgnoreCase("code"))
-            .findFirst().get().getValue();
-        val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(code);
+        val code = modelAndView.getModelMap().get("code");
+        val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(String.valueOf(code));
         assertNotNull(oAuthCode);
         val principal = oAuthCode.getAuthentication().getPrincipal();
         assertEquals(ID, principal.getId());
@@ -354,17 +349,11 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         val redirectView = (RedirectView) view;
         val redirectUrl = redirectView.getUrl();
         assertNotNull(redirectUrl);
-        assertTrue(redirectUrl.startsWith(REDIRECT_URI + "?code=" + OAuth20Code.PREFIX));
+        assertEquals(redirectUrl, REDIRECT_URI);
 
-        val builder = new URIBuilder(redirectUrl);
-        val code = builder.getQueryParams()
-            .stream()
-            .filter(a -> a.getName().equalsIgnoreCase("code"))
-            .findFirst()
-            .get()
-            .getValue();
+        val code = modelAndView.getModelMap().getAttribute("code");
 
-        val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(code);
+        val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(String.valueOf(code));
         assertNotNull(oAuthCode);
         val principal = oAuthCode.getAuthentication().getPrincipal();
         assertEquals(ID, principal.getId());
@@ -463,16 +452,10 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         val redirectView = (RedirectView) view;
         val redirectUrl = redirectView.getUrl();
         assertNotNull(redirectUrl);
-        assertTrue(redirectUrl.startsWith(REDIRECT_URI + "?code=OC-"));
+        assertEquals(redirectUrl, REDIRECT_URI);
 
-        val builder = new URIBuilder(redirectUrl);
-        val code = builder.getQueryParams()
-            .stream()
-            .filter(a -> a.getName().equalsIgnoreCase("code"))
-            .findFirst()
-            .get()
-            .getValue();
-        val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(code);
+        val code = modelAndView.getModelMap().get("code");
+        val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(String.valueOf(code));
         assertNotNull(oAuthCode);
         val principal = oAuthCode.getAuthentication().getPrincipal();
         assertEquals(ID, principal.getId());


### PR DESCRIPTION
It looked like the newer code was passing all the parameters in a map to the ModelAndView, so this keeps that code but also avoids adding blank state or nonce parameters like the older code did. The previous code was adding multiple `code` parameters in all cases and multiple `state` parameters if it was not blank. It was also adding a single blank `nonce` parameter and a single blank `state` parameter if it was blank. 
