### PR TITLE
Added padding for .mdc-card-content

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -72,6 +72,10 @@ aside, section, main {
     z-index: 7;
 }
 
+.mdc-card-content {
+    padding: 8px;
+}
+
 /* widgets */
 
 .notifications-count {


### PR DESCRIPTION
Added padding class (.mdc-card-content) for title in cas.css.
This class is used on view [cas/support/cas-server-support-thymeleaf/src/main/resources/templates/casLoginMessageView.html](https://github.com/apereo/cas/blob/master/support/cas-server-support-thymeleaf/src/main/resources/templates/casLoginMessageView.html)

