### PR TITLE
Update jmeter perf tests to not use cookies on serviceValidate calls

### DIFF
--- a/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultLogoutExecutionPlan.java
+++ b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultLogoutExecutionPlan.java
@@ -27,35 +27,35 @@ public class DefaultLogoutExecutionPlan implements LogoutExecutionPlan {
     public void registerLogoutPostProcessor(final LogoutPostProcessor handler) {
         LOGGER.debug("Registering logout handler [{}]", handler.getName());
         handlers.add(handler);
+        AnnotationAwareOrderComparator.sort(this.handlers);
     }
 
     @Override
     public void registerSingleLogoutServiceMessageHandler(final SingleLogoutServiceMessageHandler handler) {
         LOGGER.trace("Registering single logout service message handler [{}]", handler.getName());
         singleLogoutServiceMessageHandlers.add(handler);
+        AnnotationAwareOrderComparator.sort(this.singleLogoutServiceMessageHandlers);
     }
 
     @Override
     public void registerLogoutRedirectionStrategy(final LogoutRedirectionStrategy strategy) {
         LOGGER.trace("Registering logout redirection strategy [{}]", strategy.getName());
         logoutRedirectionStrategies.add(strategy);
+        AnnotationAwareOrderComparator.sort(this.logoutRedirectionStrategies);
     }
 
     @Override
     public Collection<LogoutPostProcessor> getLogoutPostProcessors() {
-        AnnotationAwareOrderComparator.sort(this.handlers);
         return this.handlers;
     }
 
     @Override
     public Collection<SingleLogoutServiceMessageHandler> getSingleLogoutServiceMessageHandlers() {
-        AnnotationAwareOrderComparator.sort(this.singleLogoutServiceMessageHandlers);
         return this.singleLogoutServiceMessageHandlers;
     }
 
     @Override
     public Collection<LogoutRedirectionStrategy> getLogoutRedirectionStrategies() {
-        AnnotationAwareOrderComparator.sort(this.logoutRedirectionStrategies);
         return this.logoutRedirectionStrategies;
     }
 }

--- a/etc/loadtests/jmeter/CAS_CAS.jmx
+++ b/etc/loadtests/jmeter/CAS_CAS.jmx
@@ -352,24 +352,35 @@
       </hashTree>
       <TestFragmentController guiclass="TestFragmentControllerGui" testclass="TestFragmentController" testname="GET - User Info with Service Ticket" enabled="true"/>
       <hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="CAS GET Ticket Info" enabled="true">
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-            <collectionProp name="Arguments.arguments"/>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain"></stringProp>
-          <stringProp name="HTTPSampler.port"></stringProp>
-          <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">${IdPHost}/cas/serviceValidate?ticket=${st}&amp;service=${__urlencode(${CasSP})}</stringProp>
-          <stringProp name="HTTPSampler.method">GET</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-        </HTTPSamplerProxy>
+        <JSR223Sampler guiclass="TestBeanGUI" testclass="JSR223Sampler" testname="Out-of-band Validate Service Ticket" enabled="true">
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="script">import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+String host = vars.get(&quot;IdPHost&quot;)
+String st = vars.get(&quot;st&quot;)
+String service = vars.get(&quot;CasSP&quot;)
+
+String urlString = host + &quot;/cas/serviceValidate?ticket=&quot; + st + &quot;&amp;service=&quot; + URLEncoder.encode(service, &quot;UTF-8&quot;)
+URL url = new URL(urlString);
+HttpURLConnection request = (HttpURLConnection) url.openConnection();
+request.connect();
+BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()));
+StringBuilder output = new StringBuilder();
+while ((inputLine = reader.readLine()) != null) {
+	output.append(inputLine)
+	output.append(&quot;\n&quot;)
+}
+reader.close()
+request.disconnect()
+return output.toString()</stringProp>
+          <stringProp name="scriptLanguage">groovy</stringProp>
+        </JSR223Sampler>
         <hashTree/>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Verify User Info Returned" enabled="true">
           <collectionProp name="Asserion.test_strings">

--- a/etc/loadtests/jmeter/CAS_CAS.jmx
+++ b/etc/loadtests/jmeter/CAS_CAS.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="CAS SSO Tests" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -67,6 +67,7 @@
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">true</boolProp>
+        <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
       </CookieManager>
       <hashTree/>
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
@@ -163,6 +164,7 @@
         <boolProp name="ThreadGroup.scheduler">true</boolProp>
         <stringProp name="ThreadGroup.duration">${Duration}</stringProp>
         <stringProp name="ThreadGroup.delay">${StartupDelay}</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <ModuleController guiclass="ModuleControllerGui" testclass="ModuleController" testname="GET - CAS Login Page" enabled="true">
@@ -356,7 +358,17 @@
           <stringProp name="cacheKey">true</stringProp>
           <stringProp name="filename"></stringProp>
           <stringProp name="parameters"></stringProp>
-          <stringProp name="script">import java.io.BufferedReader
+          <stringProp name="script">/**
+ * If running this test against a cluster it is important not to send cookies
+ * when validating the service ticket which is done server-side by an application
+ * (not the browser). The load balancer in front of the CAS cluster
+ * may use sticky session cookies which the application (service) won&apos;t have access to.
+ * If the CAS ticket registry involves replication, handling validation requests
+ * on a different server than the server that created the service ticket
+ * may expose problems.
+ */
+
+import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
@@ -380,6 +392,7 @@ reader.close()
 request.disconnect()
 return output.toString()</stringProp>
           <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="TestPlan.comments">Groovy script to validate the service ticket without sending cookies (in particular, sticky session cookies)</stringProp>
         </JSR223Sampler>
         <hashTree/>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Verify User Info Returned" enabled="true">

--- a/etc/loadtests/jmeter/CAS_CAS.jmx
+++ b/etc/loadtests/jmeter/CAS_CAS.jmx
@@ -356,22 +356,22 @@
           <stringProp name="cacheKey">true</stringProp>
           <stringProp name="filename"></stringProp>
           <stringProp name="parameters"></stringProp>
-          <stringProp name="script">import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
+          <stringProp name="script">import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
 
 String host = vars.get(&quot;IdPHost&quot;)
 String st = vars.get(&quot;st&quot;)
 String service = vars.get(&quot;CasSP&quot;)
 
 String urlString = host + &quot;/cas/serviceValidate?ticket=&quot; + st + &quot;&amp;service=&quot; + URLEncoder.encode(service, &quot;UTF-8&quot;)
-URL url = new URL(urlString);
-HttpURLConnection request = (HttpURLConnection) url.openConnection();
-request.connect();
-BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()));
-StringBuilder output = new StringBuilder();
+URL url = new URL(urlString)
+HttpURLConnection request = (HttpURLConnection) url.openConnection()
+request.connect()
+BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()))
+StringBuilder output = new StringBuilder()
 while ((inputLine = reader.readLine()) != null) {
 	output.append(inputLine)
 	output.append(&quot;\n&quot;)


### PR DESCRIPTION
I was using the JMeter load test against a cluster and I wanted to have the service ticket validation requests not use the same cookies as the other requests so it better simulated an application making the call with CAS client. If it uses cookies then load balancer sticky session cookies will keep ticket validation on the same server that generated the ticket and that might not be the case in an active/active cluster. I tried various ways to make JMeter not send cookies on the request but I was unsuccessful and ended up doing the service validate call in a groovy script. 

During the load test I saw some failures on logout due to ConcurrentModificationException and this tries to fix by moving the collection sort to the register calls instead of the get methods. The two stack traces I saw are below:

```
java.util.ConcurrentModificationException: null
        at java.util.ArrayList.sort(ArrayList.java:1751) ~[?:?]
        at org.springframework.core.annotation.AnnotationAwareOrderComparator.sort(AnnotationAwareOrderComparator.java:111) ~[spring-core-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
        at org.apereo.cas.logout.DefaultLogoutExecutionPlan.getLogoutRedirectionStrategies(DefaultLogoutExecutionPlan.java:58) ~[cas-server-core-logout-api-6.3.0-SNAPSHOT.jar!/:6.3.0-SNAPSHOT]
        at jdk.internal.reflect.GeneratedMethodAccessor411.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282) ~[spring-core-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
        at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:499) ~[spring-cloud-context-2.2.4.RELEASE.jar!/:2.2.4.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
        at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:212) ~[spring-aop-5.2.8.RELEASE.jar!/:5.2.8.RELEASE]
        at com.sun.proxy.$Proxy312.getLogoutRedirectionStrategies(Unknown Source) ~[?:?]
        at org.apereo.cas.web.flow.logout.LogoutAction.doInternalExecute(LogoutAction.java:47) ~[cas-server-support-actions-6.3.0-SNAPSHOT.jar!/:6.3.0-SNAPSHOT]
```

```
java.util.ConcurrentModificationException: null
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1660) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) ~[?:?]
        at org.apereo.cas.web.flow.logout.LogoutAction.doInternalExecute(LogoutAction.java:50) ~[cas-server-support-actions-6.3.0-SNAPSHOT.jar!/:6.3.0-SNAPSHOT]
```