### PR TITLE
Check for null client info from thread local to avoid NPE

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/mgmr/DefaultCasCookieValueManager.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/mgmr/DefaultCasCookieValueManager.java
@@ -19,6 +19,10 @@ import java.util.stream.Stream;
  * The {@link DefaultCasCookieValueManager} is responsible for creating
  * the CAS SSO cookie and encrypting and signing its value.
  *
+ * This class by default ({@code CookieProperties.isPinToSession=true}) ensures the cookie is used on a
+ * request from same IP and with the same user-agent as when cookie was created.
+ * The client info (with original client ip) may be null if cluster failover occurs and session replication not working.
+ *
  * @author Misagh Moayyed
  * @since 4.1
  */
@@ -56,11 +60,6 @@ public class DefaultCasCookieValueManager extends EncryptedCookieValueManager {
         return builder.toString();
     }
 
-
-    /**
-     * Make sure cookie is used from same IP and with same user-agent as when cookie created.
-     * Client info (with original client ip) may be null if cluster failover occurs and session replication not working.
-     */
     @Override
     protected String obtainValueFromCompoundCookie(final String cookieValue, final HttpServletRequest request) {
         val cookieParts = Splitter.on(String.valueOf(COOKIE_FIELD_SEPARATOR)).splitToList(cookieValue);
@@ -83,7 +82,7 @@ public class DefaultCasCookieValueManager extends EncryptedCookieValueManager {
         val clientInfo = ClientInfoHolder.getClientInfo();
         if (clientInfo == null) {
             throw new InvalidCookieException("Unable to match required remote address "
-                    + remoteAddr + " because client ip at time of cookie creation unknown");
+                    + remoteAddr + " because client ip at time of cookie creation is unknown");
         }
 
         if (!remoteAddr.equals(clientInfo.getClientIpAddress())) {

--- a/core/cas-server-core-cookie-api/src/test/java/org/apereo/cas/web/support/DefaultCasCookieValueManagerTests.java
+++ b/core/cas-server-core-cookie-api/src/test/java/org/apereo/cas/web/support/DefaultCasCookieValueManagerTests.java
@@ -105,4 +105,14 @@ public class DefaultCasCookieValueManagerTests {
         assertThrows(InvalidCookieException.class, () -> mgr.obtainCookieValue("something@"
             + ClientInfoHolder.getClientInfo().getClientIpAddress() + "@agent", new MockHttpServletRequest()));
     }
+
+    @Test
+    public void verifyMissingClientInfo() {
+        val props = new TicketGrantingCookieProperties();
+        val mgr = new DefaultCasCookieValueManager(CipherExecutor.noOp(), props);
+        ClientInfoHolder.clear();
+        assertThrows(InvalidCookieException.class, () -> mgr.obtainCookieValue("something@"
+                + CLIENT_IP + "@" + USER_AGENT, new MockHttpServletRequest()));
+    }
+
 }


### PR DESCRIPTION
This tries to address error observed during deployment when users bounced to new server and session info containing original client ip of session was lost. Indicates session replication probably not working but might as well get exception with message rather than NPE. One could make case that this is not user's fault and we should just let them use the cookie without the IP check if the server no longer knows what it was, but that is not what this change does. 

