### PR TITLE
Changed design for casLoginMessageView.html

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casLoginMessageView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casLoginMessageView.html
@@ -1,55 +1,43 @@
 <!DOCTYPE html>
 <html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+   <head>
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      <title th:text="#{screen.authentication.warning}">CAS Login Message View</title>
+      <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
+   </head>
 
-<head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-
-    <title th:text="#{screen.authentication.warning}">CAS Login Message View</title>
-    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag" />
-</head>
-
-<body>
-    <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="loginMessageView">
-            <div class="row">
-                <div class="col-lg-8 offset-lg-2 col-xs-12">
-                    <div class="mdc-card warning">
-                        <div class="mdc-card-content">
-                            <h2 class="m-0" th:text="#{screen.authentication.warning}">Authentication Succeeded with Warnings</h2>
-                        </div>
-                        <ul class="mdc-list">
-                            <li class="mdc-list-item text-warn" tabindex="0" th:each="message : ${messages}">
-                                <span class="mdc-list-item__text" th:utext="${message.text}">Lorem ipsum dolor sit amet, consectetur
-                                    adipiscing elit.</span>
-                            </li>
-                        </ul>
-            
-                        <div class="mdc-card__actions">
-                            <form method="post" id="form" class="mr-2" th:action="@{/login}">
-                                <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
-                                <input type="hidden" name="_eventId" value="proceed" />
-                                <button class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button"
-                                    name="continue" accesskey="l" th:value="#{screen.button.continue}" value="Continue">
-                                    <span class="mdc-button__label" th:text="#{screen.button.continue}">Continue</span>
-                                </button>
-                            </form>
-                            <form method="post" id="changePasswordForm" class="fm-v" th:action="@{/login}"
-                                th:if="${passwordManagementEnabled} AND ${passwordExpirationWarningFound}">
-                                <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
-                                <input type="hidden" name="_eventId" value="changePassword" />
-                                <button class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button"
-                                    name="changePassword" accesskey="l" th:value="#{screen.button.changePassword}"
-                                    value="Change Password">
-                                    <span class="mdc-button__label" th:text="#{screen.button.changePassword}">Change Password</span>
-                                </button>
-                            </form>
-                        </div>
-                    </div>
-                </div>
+   <body>
+      <main role="main" class="container mt-3 mb-3">
+         <div layout:fragment="content" class="loginMessageView mdc-card p-4 w-lg-66 m-auto">
+            <h3 class="m-0" th:text="#{screen.authentication.warning}">Authentication Succeeded with Warnings</h3>
+            <ul class="mdc-list">
+               <li class="mdc-list-item text-warn" tabindex="0" th:each="message : ${messages}">
+                  <span class="mdc-list-item__text" th:utext="${message.text}">Lorem ipsum dolor sit amet, consectetur
+                  adipiscing elit.</span>
+               </li>
+            </ul>
+            <div class="cas-field d-flex">
+               <form method="post" id="form" class="mr-2" th:action="@{/login}">
+                  <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
+                  <input type="hidden" name="_eventId" value="proceed" />
+                  <button class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button"
+                     name="continue" accesskey="l" th:value="#{screen.button.continue}" value="Continue">
+                  <span class="mdc-button__label" th:text="#{screen.button.continue}">Continue</span>
+                  </button>
+               </form>
+               <form method="post" id="changePasswordForm" class="fm-v" th:action="@{/login}"
+                  th:if="${passwordManagementEnabled} AND ${passwordExpirationWarningFound}">
+                  <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
+                  <input type="hidden" name="_eventId" value="changePassword" />
+                  <button class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button"
+                     name="changePassword" accesskey="l" th:value="#{screen.button.changePassword}"
+                     value="Change Password">
+                  <span class="mdc-button__label" th:text="#{screen.button.changePassword}">Change Password</span>
+                  </button>
+               </form>
             </div>
-        </div>
-    </main>
-</body>
-
+         </div>
+      </main>
+   </body>
 </html>


### PR DESCRIPTION
Changed design structure for casLoginMessageView.html

First image is Before, second image is after change.

The new layout more corresponds with layout for pwdupdateform.html

![befafter](https://user-images.githubusercontent.com/4963819/89895189-a8879500-dbdb-11ea-9eae-9adff2f141e1.png)
