### PR TITLE
Fix problem with SP metadata that defines multiple ACS endpoints

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/SamlIdPUtils.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/SamlIdPUtils.java
@@ -103,9 +103,9 @@ public class SamlIdPUtils {
                     endpoint = acsEndpointFromReq;
                 } else {
                     if (acsEndpointFromMetadata == null
-                        || !acsEndpointFromReq.getLocation().equals(adaptor.getAssertionConsumerService(binding).getLocation())) {
-                        throw new SamlException(String.format("Assertion consumer service from unsigned request [%s], does not match ACS from SP metadata [%s]",
-                            acsEndpointFromReq.getLocation(), adaptor.getAssertionConsumerService(binding).getLocation()));
+                        || !adaptor.getAssertionConsumerServiceLocations(binding).contains(acsEndpointFromReq.getLocation())) {
+                          throw new SamlException(String.format("Assertion consumer service from unsigned request [%s], does not match ACS from SP metadata [%s]",
+                            acsEndpointFromReq.getLocation(), adaptor.getAssertionConsumerServiceLocations(binding)));
                     }
                     endpoint = acsEndpointFromReq;
                 }

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
@@ -245,6 +245,20 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
     }
 
     /**
+     * Get locations of all assertion consumer services for the given binding
+     *
+     * @param binding the binding
+     * @return the assertion consumer service
+     */
+    public List<String> getAssertionConsumerServiceLocations(final String binding) {
+      return getAssertionConsumerServices()
+            .stream()
+            .filter(acs -> acs.getBinding().equalsIgnoreCase(binding))
+            .map(acs -> acs.getLocation())
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Gets assertion consumer service for paos binding.
      *
      * @return the assertion consumer service for paos binding

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacadeTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacadeTests.java
@@ -50,6 +50,7 @@ public class SamlRegisteredServiceServiceProviderMetadataFacadeTests extends Bas
         assertFalse(adaptor.isAuthnRequestsSigned());
         assertFalse(adaptor.isSupportedProtocol("example"));
         assertFalse(adaptor.isSupportedProtocol("example"));
+        assertTrue(adaptor.getAssertionConsumerServiceLocations(SAMLConstants.SAML2_POST_BINDING_URI).size() > 1);
     }
 
     @Test

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/util/SamlIdPUtilsTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/util/SamlIdPUtilsTests.java
@@ -135,4 +135,22 @@ public class SamlIdPUtilsTests extends BaseSamlIdPConfigurationTests {
         assertNotNull(acs);
         assertEquals(acsUrl, acs.getLocation());
     }
+
+    @Test
+    public void verifyUnsignedRequestWithAssertionConsumerServiceUrlMatchingAlternateMetadataAcsUrl() {
+        val service = getSamlRegisteredServiceForTestShib();
+        servicesManager.save(service);
+        val authnRequest = mock(AuthnRequest.class);
+        val issuer = mock(Issuer.class);
+        when(issuer.getValue()).thenReturn(service.getServiceId());
+        when(authnRequest.getIssuer()).thenReturn(issuer);
+        when(authnRequest.getProtocolBinding()).thenReturn(SAMLConstants.SAML2_POST_BINDING_URI);
+        val acsUrl = "https://www.testshib.org/Shibboleth.sso/SAML2/POST";
+        when(authnRequest.getAssertionConsumerServiceURL()).thenReturn(acsUrl);
+
+        val adapter = SamlRegisteredServiceServiceProviderMetadataFacade.get(samlRegisteredServiceCachingMetadataResolver, service, service.getServiceId());
+        val acs = SamlIdPUtils.determineEndpointForRequest(authnRequest, adapter.get(), SAMLConstants.SAML2_POST_BINDING_URI);
+        assertNotNull(acs);
+        assertEquals(acsUrl, acs.getLocation());
+    }
 }


### PR DESCRIPTION
The code that validates that the AssertionConsumerService location in an unsigned SAML request matches the location specified in the SP metadata is checking only the first ACS location defined in the metadata. This fails to handle the case of SPs that define multiple ACS locations (for example https://www.testshib.org/Shibboleth.sso/SAML2/POST vs. https://sp.testshib.org/Shibboleth.sso/SAML2/POST). Result is that valid requests are rejected.

Added a getAssertionConsumerServiceLocations() method to facilitate checking against all defined ACS locations.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
