### PR TITLE
Backport : Fix Password Reset Request Verification

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -42,40 +42,40 @@ public class VerifyPasswordResetRequestAction extends AbstractAction {
             return error();
         }
 
-        val tst = this.centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
-        if (tst == null) {
-            LOGGER.error("Unable to locate token [{}] in the ticket registry", transientTicket);
-            return error();
-        }
-
-        val token = tst.getProperties().get(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN).toString();
-        val username = passwordManagementService.parseToken(token);
-        if (StringUtils.isBlank(username)) {
-            LOGGER.error("Password reset token could not be verified");
-            return error();
-        }
-        this.centralAuthenticationService.deleteTicket(tst.getId());
-
-        PasswordManagementWebflowUtils.putPasswordResetToken(requestContext, token);
-        val pm = casProperties.getAuthn().getPm();
-        if (pm.getReset().isSecurityQuestionsEnabled()) {
-            val questions = BasePasswordManagementService
-                .canonicalizeSecurityQuestions(passwordManagementService.getSecurityQuestions(username));
-            if (questions.isEmpty()) {
-                LOGGER.warn("No security questions could be found for [{}]", username);
+        try {
+            val tst = this.centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
+            val token = tst.getProperties().get(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN).toString();
+            val username = passwordManagementService.parseToken(token);
+            if (StringUtils.isBlank(username)) {
+                LOGGER.error("Password reset token could not be verified");
                 return error();
             }
-            PasswordManagementWebflowUtils.putPasswordResetSecurityQuestions(requestContext, questions);
-        } else {
-            LOGGER.debug("Security questions are not enabled");
-        }
+            this.centralAuthenticationService.deleteTicket(tst.getId());
 
-        PasswordManagementWebflowUtils.putPasswordResetUsername(requestContext, username);
-        PasswordManagementWebflowUtils.putPasswordResetSecurityQuestionsEnabled(requestContext, pm.getReset().isSecurityQuestionsEnabled());
+            PasswordManagementWebflowUtils.putPasswordResetToken(requestContext, token);
+            val pm = casProperties.getAuthn().getPm();
+            if (pm.getReset().isSecurityQuestionsEnabled()) {
+                val questions = BasePasswordManagementService
+                    .canonicalizeSecurityQuestions(passwordManagementService.getSecurityQuestions(username));
+                if (questions.isEmpty()) {
+                    LOGGER.warn("No security questions could be found for [{}]", username);
+                    return error();
+                }
+                PasswordManagementWebflowUtils.putPasswordResetSecurityQuestions(requestContext, questions);
+            } else {
+                LOGGER.debug("Security questions are not enabled");
+            }
 
-        if (pm.getReset().isSecurityQuestionsEnabled()) {
-            return success();
+            PasswordManagementWebflowUtils.putPasswordResetUsername(requestContext, username);
+            PasswordManagementWebflowUtils.putPasswordResetSecurityQuestionsEnabled(requestContext, pm.getReset().isSecurityQuestionsEnabled());
+
+            if (pm.getReset().isSecurityQuestionsEnabled()) {
+                return success();
+            }
+            return new EventFactorySupport().event(this, "questionsDisabled");
+        } catch (final Exception e) {
+            LOGGER.error("Unable to locate token [{}] in the ticket registry", transientTicket);
         }
-        return new EventFactorySupport().event(this, "questionsDisabled");
+        return error();
     }
 }

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -26,6 +26,11 @@ import org.springframework.webflow.execution.RequestContext;
 @Slf4j
 @RequiredArgsConstructor
 public class VerifyPasswordResetRequestAction extends AbstractAction {
+    /**
+     * Event id to signal security questions are disabled.
+     */
+    public static final String EVENT_ID_SECURITY_QUESTIONS_DISABLED = "questionsDisabled";
+
     private final CasConfigurationProperties casProperties;
 
     private final PasswordManagementService passwordManagementService;
@@ -43,14 +48,10 @@ public class VerifyPasswordResetRequestAction extends AbstractAction {
         }
 
         try {
-            val tst = this.centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
+            val tst = centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
             val token = tst.getProperties().get(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN).toString();
             val username = passwordManagementService.parseToken(token);
-            if (StringUtils.isBlank(username)) {
-                LOGGER.error("Password reset token could not be verified");
-                return error();
-            }
-            this.centralAuthenticationService.deleteTicket(tst.getId());
+            centralAuthenticationService.deleteTicket(tst.getId());
 
             PasswordManagementWebflowUtils.putPasswordResetToken(requestContext, token);
             val pm = casProperties.getAuthn().getPm();
@@ -67,15 +68,16 @@ public class VerifyPasswordResetRequestAction extends AbstractAction {
             }
 
             PasswordManagementWebflowUtils.putPasswordResetUsername(requestContext, username);
-            PasswordManagementWebflowUtils.putPasswordResetSecurityQuestionsEnabled(requestContext, pm.getReset().isSecurityQuestionsEnabled());
+            PasswordManagementWebflowUtils.putPasswordResetSecurityQuestionsEnabled(requestContext,
+                pm.getReset().isSecurityQuestionsEnabled());
 
             if (pm.getReset().isSecurityQuestionsEnabled()) {
                 return success();
             }
-            return new EventFactorySupport().event(this, "questionsDisabled");
+            return new EventFactorySupport().event(this, EVENT_ID_SECURITY_QUESTIONS_DISABLED);
         } catch (final Exception e) {
-            LOGGER.error("Unable to locate token [{}] in the ticket registry", transientTicket);
+            LOGGER.error("Password reset token could not be verified: [{}]", e.getMessage());
+            return error();
         }
-        return error();
     }
 }


### PR DESCRIPTION
Hello Misagh,

When you're using the password reset feature in CAS, you will receive a mail or a sms with a reset link associated with a token in the registry.

Unfortunately, in the versions 6.2 and 6.3, if the link has already been used or has expired and doesn't appears in the registry, you'll have the following error in the web page:

```
Error: Exception thrown executing org.apereo.cas.pm.web.flow.actions.VerifyPasswordResetRequestAction@4af8ff3 in state 'verifyPasswordResetRequest' of flow 'pswdreset' -- action execution attributes were 'map[[empty]]'
```
It's because the method "getTicket" from "centralAuthenticationService" raise an exception if the ticket doesn't exists instead of provide a null response.

Here a little fix to solve the problem.

Regards,
Julien

