### PR TITLE
update xml-apis to 1.4.01, 2.0.2 is redirected to 1.0.b2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,8 @@
     "net.jradius:jradius-extended",
     "net.jradius:jradius-core",
     "net.jradius:jradius-server",
-    "com.mebigfatguy.fb-contrib:fb-contrib"
+    "com.mebigfatguy.fb-contrib:fb-contrib",
+    "xml-apis:xml-apis"
   ],
   "packageRules": [
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -450,7 +450,7 @@ oktaSdkVersion=2.0.0
 ###############################
 opensamlVersion=4.0.1
 xercesVersion=2.12.0
-xmlapisVersion=2.0.2
+xmlapisVersion=1.4.01
 bouncyCastleVersion=1.66
 shibbolethUtilJavaSupportVersion=8.0.0
 jdomVersion=2.0.6


### PR DESCRIPTION
I noticed the following message during a build:
```
> Task :support:cas-server-support-saml-core-api:compileJava UP-TO-DATE
POM relocation to an other version number is not fully supported in Gradle : xml-apis:xml-apis:2.0.2 relocated to xml-apis:xml-apis:1.0.b2.
Please update your dependency to directly use the correct version 'xml-apis:xml-apis:1.0.b2'.
Resolution will only pick dependencies of the relocated element.  Artifacts and other metadata will be ignored.
```
It looks like xml-apis 2.0.2 is from 2005 and maps to 1.0.b2, but 1.4.01 is from 2011 so this updates version to newest version.