### PR TITLE
x509 documentation update

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -2647,7 +2647,9 @@ Principal resolution and Person Directory settings for this feature are availabl
 
 ### X509 LDAP Integration
 
-LDAP settings for this feature are available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.authn.x509.ldap`.
+LDAP settings for the X509 feature (used if fetching CRLs from LDAP) are available [here](Configuration-Properties-Common.html#ldap-connection-settings) under the configuration key `cas.authn.x509.ldap`.
+
+See LDAP attribute repositories [here](Configuration-Properties.html#ldap) to fetch additional LDAP attributes using the principal extracted from the X509 certificate. 
 
 ## Syncope Authentication
 


### PR DESCRIPTION
Added some more verbiage under X509 LDAP section since most of the X509 LDAP usage is probably retrieving attributes from LDAP using X509 principal rather than fetching CRLs from LDAP.