### PR TITLE
Explicitly mention U2F token expiry in U2F docs

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3101,8 +3101,11 @@ To learn more about this topic, [please review this guide](../mfa/FIDO-U2F-Authe
 # cas.authn.mfa.u2f.name=
 # cas.authn.mfa.u2f.order=
 
+# Expiry of U2F device registration requests:
 # cas.authn.mfa.u2f.expire-registrations=30
 # cas.authn.mfa.u2f.expire-registrations-time-unit=SECONDS
+
+# Expiry of U2F devices since registration, independent of last time used:
 # cas.authn.mfa.u2f.expire-devices=30
 # cas.authn.mfa.u2f.expire-devices-time-unit=DAYS
 ```

--- a/docs/cas-server-documentation/mfa/FIDO-U2F-Authentication.md
+++ b/docs/cas-server-documentation/mfa/FIDO-U2F-Authentication.md
@@ -29,7 +29,9 @@ To see the relevant list of CAS properties, please [review this guide](../config
 ## Registration
 
 U2F device registration flows are baked into CAS automatically. A background *cleaner* process is also automatically scheduled to scan the 
-repository periodically and remove expired device registration records based on configured parameters.
+repository periodically and remove expired device registration records based on configured parameters. In the default setting U2F devices
+expire after a fixed period since a user registered the U2F token (independent of the last time the token was used); if you deploy U2F
+MFA for a setup where tokens are centrally distributed and revoked, you may want to [extend the interval](../configuration/Configuration-Properties.html#fido-u2f).
 
 <div class="alert alert-warning"><strong>Cleaner Usage</strong><p>In a clustered CAS deployment, it is best to keep the cleaner running on one designated 
 CAS node only and turn it off on all others via CAS settings. Keeping the cleaner running on all nodes may likely lead to severe performance and locking issues.</p></div>


### PR DESCRIPTION
There's already a note on the cleaner process, but explicitly mention the default interval of 30 days (it's covered in the generic Configuration-Properties doc), but it seems important enough to mention explicitly.