### PR TITLE
update kotlin version

### DIFF
--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
@@ -201,7 +201,7 @@ public class MockWebServer implements AutoCloseable {
         }
 
         private static byte[] header(final String name, final Object value) {
-            return String.format("%s: %s\r\n", name, value).getBytes(StandardCharsets.UTF_8);
+            return String.format("%s: %s%s", name, value, SEPARATOR).getBytes(StandardCharsets.UTF_8);
         }
 
         private void writeResponse(final Socket socket) throws IOException {
@@ -209,7 +209,7 @@ public class MockWebServer implements AutoCloseable {
                 LOGGER.debug("Socket response for resource [{}]", resource.getFilename());
                 val out = socket.getOutputStream();
 
-                val statusLine = String.format("HTTP/1.1 %s %s\r\n", status.value(), status.getReasonPhrase());
+                val statusLine = String.format("HTTP/1.1 %s %s%s", status.value(), status.getReasonPhrase(), SEPARATOR);
                 out.write(statusLine.getBytes(StandardCharsets.UTF_8));
                 out.write(header("Content-Length", this.resource.contentLength()));
                 out.write(header("Content-Type", this.contentType));

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
@@ -201,7 +201,7 @@ public class MockWebServer implements AutoCloseable {
         }
 
         private static byte[] header(final String name, final Object value) {
-            return String.format("%s: %s\r%n", name, value).getBytes(StandardCharsets.UTF_8);
+            return String.format("%s: %s\r\n", name, value).getBytes(StandardCharsets.UTF_8);
         }
 
         private void writeResponse(final Socket socket) throws IOException {
@@ -209,7 +209,7 @@ public class MockWebServer implements AutoCloseable {
                 LOGGER.debug("Socket response for resource [{}]", resource.getFilename());
                 val out = socket.getOutputStream();
 
-                val statusLine = String.format("HTTP/1.1 %s %s%n", status.value(), status.getReasonPhrase());
+                val statusLine = String.format("HTTP/1.1 %s %s\r\n", status.value(), status.getReasonPhrase());
                 out.write(statusLine.getBytes(StandardCharsets.UTF_8));
                 out.write(header("Content-Length", this.resource.contentLength()));
                 out.write(header("Content-Type", this.contentType));

--- a/gradle.properties
+++ b/gradle.properties
@@ -337,6 +337,7 @@ hjsonVersion=3.0.0
 jsonSmartVersion=2.3
 jsonassertVersion=1.5.0
 jacksonVersion=2.11.2
+kotlinVersion=1.4.0
 
 ###############################
 # PersonDirectory versions

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1118,20 +1118,11 @@ ext.libraries = [
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-databind")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-core")
                 },
-                dependencies.create("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion") {
-                    exclude(group: "com.fasterxml.jackson.core", module: "jackson-annotations")
-                    exclude(group: "com.fasterxml.jackson.core", module: "jackson-databind")
-                    exclude(group: "com.fasterxml.jackson.core", module: "jackson-core")
-                    exclude(group: "org.jetbrains.kotlin", module: "kotlin-reflect")
-                },
                 dependencies.create("com.fasterxml.jackson.dataformat:jackson-dataformat-properties:$jacksonVersion") {
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-annotations")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-databind")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-core")
-                },
-                dependencies.create("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion") {
-                },
-
+                }
         ],
         couchbase               : dependencies.create("com.couchbase.client:java-client:$couchbaseVersion"),
         ektorp                  : dependencies.create("org.ektorp:org.ektorp:$ektorpVersion"),
@@ -1190,7 +1181,9 @@ ext.libraries = [
                 },
                 dependencies.create("com.squareup.okhttp3:okhttp:$okhttp3Version") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
-                }
+                },
+                dependencies.create("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion") {
+                },
         ],
         oktasdk                 : [
                 dependencies.create("com.okta.authn.sdk:okta-authn-sdk-api:$oktaSdkVersion") {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -134,14 +134,6 @@ ext.libraries = [
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     exclude(group: "com.squareup.retrofit2", module: "retrofit")
                     exclude(group: "com.squareup.okio", module: "okio")
-                },
-                dependencies.create("com.squareup.retrofit2:retrofit:$retrofitVersion") {
-                    exclude(group: "org.slf4j", module: "slf4j-api")
-                    exclude(group: "com.squareup.okhttp3", module: "okhttp")
-                    exclude(group: "com.squareup.okio", module: "okio")
-                },
-                dependencies.create("com.squareup.okhttp3:okhttp:$okhttp3Version") {
-                    exclude(group: "org.slf4j", module: "slf4j-api")
                 }
         ],
         bouncycastle            : [
@@ -1130,12 +1122,16 @@ ext.libraries = [
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-annotations")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-databind")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-core")
+                    exclude(group: "org.jetbrains.kotlin", module: "kotlin-reflect")
                 },
                 dependencies.create("com.fasterxml.jackson.dataformat:jackson-dataformat-properties:$jacksonVersion") {
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-annotations")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-databind")
                     exclude(group: "com.fasterxml.jackson.core", module: "jackson-core")
-                }
+                },
+                dependencies.create("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion") {
+                },
+
         ],
         couchbase               : dependencies.create("com.couchbase.client:java-client:$couchbaseVersion"),
         ektorp                  : dependencies.create("org.ektorp:org.ektorp:$ektorpVersion"),
@@ -1182,6 +1178,16 @@ ext.libraries = [
                 },
                 dependencies.create("com.google.code.gson:gson:$gsonVersion") {
 
+                }
+        ],
+        squareup                : [
+                dependencies.create("com.squareup.retrofit2:retrofit:$retrofitVersion") {
+                    exclude(group: "org.slf4j", module: "slf4j-api")
+                    exclude(group: "com.squareup.okhttp3", module: "okhttp")
+                    exclude(group: "com.squareup.okio", module: "okio")
+                },
+                dependencies.create("com.squareup.okhttp3:okhttp:$okhttp3Version") {
+                    exclude(group: "org.slf4j", module: "slf4j-api")
                 }
         ],
         oktasdk                 : [
@@ -2077,7 +2083,9 @@ ext.libraries = [
             exclude(group: "com.google.guava", module: "guava")
             exclude(group: "commons-io", module: "commons-io")
             exclude(group: "com.sun.xml.bind", module: "jaxb-impl")
-
+            exclude(group: "com.squareup.retrofit2", module: "retrofit")
+            exclude(group: "com.squareup.retrofit2", module: "converter-moshi")
+            exclude(group: "com.squareup.okhttp3", module: "logging-interceptor")
         },
         quartz                  : dependencies.create("org.quartz-scheduler:quartz:$quartzVersion") {
             exclude(group: "org.slf4j", module: "slf4j-api")

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1186,6 +1186,8 @@ ext.libraries = [
                     exclude(group: "com.squareup.okhttp3", module: "okhttp")
                     exclude(group: "com.squareup.okio", module: "okio")
                 },
+                dependencies.create("com.squareup.retrofit2:converter-moshi:$retrofitVersion") {
+                },
                 dependencies.create("com.squareup.okhttp3:okhttp:$okhttp3Version") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 }

--- a/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepositoryTests.java
+++ b/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepositoryTests.java
@@ -9,8 +9,8 @@ import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.web.support.WebUtils;
 
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.val;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,7 +104,7 @@ public class DefaultAcceptableUsagePolicyRepositoryTests extends BaseAcceptableU
         assertTrue(repo.verify(context, c).isAccepted());
     }
 
-    @NotNull
+    @NonNull
     private static MockRequestContext getRequestContext() {
         val context = new MockRequestContext();
         val request = new MockHttpServletRequest();

--- a/support/cas-server-support-azuread-authentication/build.gradle
+++ b/support/cas-server-support-azuread-authentication/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation libraries.nimbus
     implementation libraries.jose4j
     implementation libraries.azuread
+    implementation libraries.squareup
 
     implementation project(":core:cas-server-core-authentication-api")
     implementation project(":core:cas-server-core-webflow-api")

--- a/support/cas-server-support-events-influxdb/build.gradle
+++ b/support/cas-server-support-events-influxdb/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     
     
     implementation libraries.influxdb
+    implementation libraries.squareup
     implementation libraries.okhttp
 
     testImplementation project(path: ":core:cas-server-core-tickets", configuration: "tests")

--- a/support/cas-server-support-influxdb-core/build.gradle
+++ b/support/cas-server-support-influxdb-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     
     implementation libraries.influxdb
+    implementation libraries.squareup
     implementation libraries.okhttp
 }
 

--- a/support/cas-server-support-metrics/build.gradle
+++ b/support/cas-server-support-metrics/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation libraries.redis
     implementation libraries.metrics
     implementation libraries.influxdb
+    implementation libraries.squareup
     implementation libraries.okhttp
 
     implementation project(":support:cas-server-support-redis-core")

--- a/support/cas-server-support-openid/src/test/java/org/apereo/cas/support/openid/authentication/principal/OpenIdServiceTests.java
+++ b/support/cas-server-support-openid/src/test/java/org/apereo/cas/support/openid/authentication/principal/OpenIdServiceTests.java
@@ -11,10 +11,10 @@ import org.apereo.cas.support.openid.OpenIdProtocolConstants;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -176,7 +176,7 @@ public class OpenIdServiceTests extends AbstractOpenIdTests {
         assertFalse(o1.equals(new Object()));
     }
 
-    @NotNull
+    @NonNull
     private DefaultServicesManager getServicesManager() {
         val context = ServicesManagerConfigurationContext.builder()
             .serviceRegistry(mock(ServiceRegistry.class))


### PR DESCRIPTION
I am trying to make sure kotlin dependencies are at > 1.4.0 to make CVE-2020-15824 go away. Kotlin is used by person-directory but only one azure related class:

```
org.jetbrains.kotlin:kotlin-stdlib:1.3.72
+--- com.squareup.okhttp3:okhttp:4.8.0
|    +--- com.squareup.retrofit2:retrofit:2.9.0 (requested com.squareup.okhttp3:okhttp:3.14.9)
|    |    +--- org.apereo.service.persondir:person-directory-impl:2.0.0
|    |    |    \--- runtimeClasspath
```
This PR puts the retrofit2 and okhttp3 into their own library and includes it for the azure module that uses that person-directory class that needs them and it includes that group whereever influxdb library is used (they used to be part of that library but I removed so as not to duplicate that block).

Kotlin is needed by jackson but only because jackson-module-kotlin. Not sure if that is used. I added the kotlin-stdlib (indirectly) to the jackson group with a kotlinVersion so it will be kept up to date. Since most person-directory users don't need kotlin, the jackson library is probably responsible for it being in most deployments. 
```
org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
\--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72
     \--- org.jetbrains.kotlin:kotlin-reflect:1.3.72
          \--- com.fasterxml.jackson.module:jackson-module-kotlin:2.11.2
               \--- runtimeClasspath
```