### PR TITLE
check if the client id is same - get code and at

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
@@ -48,7 +48,8 @@ public class AccessTokenAuthorizationCodeGrantRequestExtractor extends BaseAcces
 
         val requestedScopes = OAuth20Utils.parseRequestScopes(request);
         val token = getOAuthTokenFromRequest(request);
-        if (token == null || token.isExpired()) {
+        String clientId = request.getParameter(OAuth20Constants.CLIENT_ID);
+        if (token == null || token.isExpired() || !StringUtils.equals(clientId, token.getService().getId())) {
             throw new InvalidTicketException(getOAuthParameter(request));
         }
         val scopes = extractRequestedScopesByToken(requestedScopes, token, request);


### PR DESCRIPTION
check if the client id is the same when getting code and change token, if it's not the same, we should not allow access token to be given to the application, as the later client id owner can intercept other application's code and get the access token which can access to other application's resource.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
