### PR TITLE
Service ticket as JWT without TGT and gateway=true

### DIFF
--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -43,9 +43,9 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
 
         if (!tokenAsResponse || !ticketIdAvailable) {
             if (ticketIdAvailable) {
-                LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "
+                LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. " 
                              + "Make sure the service property [{}] is defined and set to true", 
-                             registeredService,RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName());
+                             registeredService,RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName()); 
             }
             return super.buildInternal(service, parameters);
         }

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -44,7 +44,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val tokenAsResponse = RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.isAssignedTo(registeredService);
         val ticketIdAvailable=isTicketIdAvailable(parameters);
 
-        if ((!tokenAsResponse)||(!ticketIdAvailable)) {
+        if (!tokenAsResponse||!ticketIdAvailable) {
             if(ticketIdAvailable) {
                 LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "
                                 + "Make sure the service property [{}] is defined and set to true", registeredService,

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -10,10 +10,10 @@ import org.apereo.cas.services.RegisteredServiceProperty;
 import org.apereo.cas.services.RegisteredServiceProperty.RegisteredServiceProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.token.TokenTicketBuilder;
-import org.apache.commons.lang3.StringUtils;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
 
 /**
@@ -42,7 +42,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val ticketIdAvailable=isTicketIdAvailable(parameters);
 
         if (!tokenAsResponse||!ticketIdAvailable) {
-            if(ticketIdAvailable) {
+            if (ticketIdAvailable) {
                 LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "
                                 + "Make sure the service property [{}] is defined and set to true", registeredService,
                         RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName());
@@ -64,7 +64,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
     private boolean isTicketIdAvailable(final Map<String, String> parameters){
         final String ticketId=parameters.get(CasProtocolConstants.PARAMETER_TICKET);
 
-        if(StringUtils.isBlank(ticketId)){
+        if (StringUtils.isBlank(ticketId)){
             return false;
         }
 

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -41,11 +41,11 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val tokenAsResponse = RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.isAssignedTo(registeredService);
         val ticketIdAvailable=isTicketIdAvailable(parameters);
 
-        if (!tokenAsResponse||!ticketIdAvailable) {
+        if (!tokenAsResponse || !ticketIdAvailable) {
             if (ticketIdAvailable) {
                 LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "
-                                + "Make sure the service property [{}] is defined and set to true", registeredService,
-                        RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName());
+                             + "Make sure the service property [{}] is defined and set to true", 
+                             registeredService,RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName());
             }
             return super.buildInternal(service, parameters);
         }
@@ -62,13 +62,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
     }
     
     private boolean isTicketIdAvailable(final Map<String, String> parameters){
-        final String ticketId=parameters.get(CasProtocolConstants.PARAMETER_TICKET);
-
-        if (StringUtils.isBlank(ticketId)){
-            return false;
-        }
-
-        return true;
+        return StringUtils.isNotBlank(parameters.get(CasProtocolConstants.PARAMETER_TICKET));
     }
 
     /**

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -43,9 +43,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
 
         if (!tokenAsResponse || !ticketIdAvailable) {
             if (ticketIdAvailable) {
-                LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. " 
-                             + "Make sure the service property [{}] is defined and set to true", 
-                             registeredService,RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName()); 
+                LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "+"Make sure the service property [{}] is defined and set to true", registeredService,RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName()); 
             }
             return super.buildInternal(service, parameters);
         }

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -39,7 +39,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val registeredService = this.servicesManager.findServiceBy(service);
         RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);
         val tokenAsResponse = RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.isAssignedTo(registeredService);
-        val ticketIdAvailable =isTicketIdAvailable(parameters);
+        val ticketIdAvailable = isTicketIdAvailable(parameters);
 
         if (!tokenAsResponse || !ticketIdAvailable) {
             if (ticketIdAvailable) {

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -11,11 +11,9 @@ import org.apereo.cas.services.RegisteredServiceProperty.RegisteredServiceProper
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.token.TokenTicketBuilder;
 import org.apache.commons.lang3.StringUtils;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-
 import java.util.Map;
 
 /**

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -42,9 +42,9 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val registeredService = this.servicesManager.findServiceBy(service);
         RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);
         val tokenAsResponse = RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.isAssignedTo(registeredService);
-        final boolean ticketIdAvaiable=isTicketIdAvailable(parameters);
+        final boolean ticketIdAvailable=isTicketIdAvailable(parameters);
 
-        if ((!tokenAsResponse)||(!ticketIdAvaiable)) {
+        if ((!tokenAsResponse)||(!ticketIdAvailable)) {
             if(ticketIdAvaiable) {
                 LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "
                                 + "Make sure the service property [{}] is defined and set to true", registeredService,

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -45,7 +45,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val ticketIdAvailable=isTicketIdAvailable(parameters);
 
         if ((!tokenAsResponse)||(!ticketIdAvailable)) {
-            if(ticketIdAvaiable) {
+            if(ticketIdAvailable) {
                 LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "
                                 + "Make sure the service property [{}] is defined and set to true", registeredService,
                         RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName());

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -39,7 +39,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val registeredService = this.servicesManager.findServiceBy(service);
         RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);
         val tokenAsResponse = RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.isAssignedTo(registeredService);
-        val ticketIdAvailable = isTicketIdAvailable(parameters);
+        val ticketIdAvailable =isTicketIdAvailable(parameters);
 
         if (!tokenAsResponse || !ticketIdAvailable) {
             if (ticketIdAvailable) {

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -43,7 +43,10 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
 
         if (!tokenAsResponse || !ticketIdAvailable) {
             if (ticketIdAvailable) {
-                LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "+"Make sure the service property [{}] is defined and set to true", registeredService,RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName()); 
+                LOGGER.debug("Registered service [{}] is not configured to issue JWTs for service tickets. "
+                             +"Make sure the service property [{}] is defined and set to true", 
+                             registeredService,
+                             RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.getPropertyName()); 
             }
             return super.buildInternal(service, parameters);
         }

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -39,7 +39,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val registeredService = this.servicesManager.findServiceBy(service);
         RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);
         val tokenAsResponse = RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.isAssignedTo(registeredService);
-        val ticketIdAvailable=isTicketIdAvailable(parameters);
+        val ticketIdAvailable = isTicketIdAvailable(parameters);
 
         if (!tokenAsResponse || !ticketIdAvailable) {
             if (ticketIdAvailable) {

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -10,7 +10,6 @@ import org.apereo.cas.services.RegisteredServiceProperty;
 import org.apereo.cas.services.RegisteredServiceProperty.RegisteredServiceProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.token.TokenTicketBuilder;
-
 import org.apache.commons.lang3.StringUtils;
 
 import lombok.SneakyThrows;

--- a/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
+++ b/support/cas-server-support-token-tickets/src/main/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilder.java
@@ -42,7 +42,7 @@ public class TokenWebApplicationServiceResponseBuilder extends WebApplicationSer
         val registeredService = this.servicesManager.findServiceBy(service);
         RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(service, registeredService);
         val tokenAsResponse = RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET.isAssignedTo(registeredService);
-        final boolean ticketIdAvailable=isTicketIdAvailable(parameters);
+        val ticketIdAvailable=isTicketIdAvailable(parameters);
 
         if ((!tokenAsResponse)||(!ticketIdAvailable)) {
             if(ticketIdAvaiable) {

--- a/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
+++ b/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
@@ -139,4 +139,19 @@ public class TokenWebApplicationServiceResponseBuilderTests {
             assertNotNull(JWTParser.parse(ticket));
         }
     }
+    
+    @Test
+    public void verifyTokenBuilderWhenGatewayIsTrue() throws Exception {
+        val data = "yes\ncasuser";
+        try (val webServer = new MockWebServer(8281,
+            new ByteArrayResource(data.getBytes(StandardCharsets.UTF_8), "REST Output"), MediaType.APPLICATION_JSON_VALUE)) {
+            webServer.start();
+
+            val result = responseBuilder.build(CoreAuthenticationTestUtils.getWebApplicationService("jwtservice"),
+                "",
+                CoreAuthenticationTestUtils.getAuthentication());
+            assertNotNull(result);
+            assertFalse(result.getAttributes().containsKey(CasProtocolConstants.PARAMETER_TICKET));
+        }
+    }
 }

--- a/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
+++ b/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
@@ -142,7 +142,7 @@ public class TokenWebApplicationServiceResponseBuilderTests {
     }
     
     @Test
-    public void verifyTokenBuilderWhenGatewayIsTrue() throws Exception {
+    public void verifyTokenBuilderWithoutServiceTicket() throws Exception {
         val data = "yes\ncasuser";
         try (val webServer = new MockWebServer(8281,
             new ByteArrayResource(data.getBytes(StandardCharsets.UTF_8), "REST Output"), MediaType.APPLICATION_JSON_VALUE)) {

--- a/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
+++ b/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
@@ -49,9 +49,9 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.apache.commons.lang3.StringUtils;
 
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.lang3.StringUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
+++ b/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
@@ -51,6 +51,7 @@ import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.nio.charset.StandardCharsets;
+import org.apache.commons.lang3.StringUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -148,7 +149,7 @@ public class TokenWebApplicationServiceResponseBuilderTests {
             webServer.start();
 
             val result = responseBuilder.build(CoreAuthenticationTestUtils.getWebApplicationService("jwtservice"),
-                "",
+                StringUtils.EMPTY,
                 CoreAuthenticationTestUtils.getAuthentication());
             assertNotNull(result);
             assertFalse(result.getAttributes().containsKey(CasProtocolConstants.PARAMETER_TICKET));

--- a/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
+++ b/support/cas-server-support-token-tickets/src/test/java/org/apereo/cas/token/authentication/principal/TokenWebApplicationServiceResponseBuilderTests.java
@@ -38,6 +38,7 @@ import org.apereo.cas.web.flow.config.CasWebflowContextConfiguration;
 
 import com.nimbusds.jwt.JWTParser;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +50,6 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.apache.commons.lang3.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 


### PR DESCRIPTION
Fix the following issue:
Given the service xxx is configured to allow service ticket as JWT
And the user has no TGT session

When the user tries to go on the url /cas/login?service=xxx&gateway=true

Expected behaviour: 302 Redirect on the requested service
Found behaviour: The following exception

`org.jasig.cas.client.validation.TicketValidationException: service and ticket parameters are both required
        at org.jasig.cas.client.validation.Cas20ServiceTicketValidator.parseResponseFromServer(Cas20ServiceTicketValidator.java:84) ~[cas-client-core-3.5.1.jar!/:3.5.1]
        at org.jasig.cas.client.validation.AbstractUrlBasedTicketValidator.validate(AbstractUrlBasedTicketValidator.java:198) ~[cas-client-core-3.5.1.jar!/:3.5.1]
        at org.apereo.cas.token.JWTTokenTicketBuilder.build(JWTTokenTicketBuilder.java:52) ~[cas-server-support-token-core-5.3.15.1.jar!/:5.3.15.1]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_92]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_92]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_92]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_92]
        at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:215) ~[spring-core-4.3.25.RELEASE.jar!/:4.3.25.RELEASE]
        at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:470) ~[spring-cloud-context-1.3.0.RELEASE.jar!/:1.3.0.RELEASE]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179) ~[spring-aop-4.3.25.RELEASE.jar!/:4.3.25.RELEASE]
        at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213) ~[spring-aop-4.3.25.RELEASE.jar!/:4.3.25.RELEASE]
        at com.sun.proxy.$Proxy134.build(Unknown Source) ~[?:?]
        at org.apereo.cas.token.authentication.principal.TokenWebApplicationServiceResponseBuilder.generateToken(TokenWebApplicationServiceResponseBuilder.java:70) ~[cas-server-support-token-tickets-5.3.15.1.jar!/:5.3.15.1]
        at org.apereo.cas.token.authentication.principal.TokenWebApplicationServiceResponseBuilder.buildInternal(TokenWebApplicationServiceResponseBuilder.java:49) ~[cas-server-support-token-tickets-5.3.15.1.jar!/:5.3.15.1]
        at org.apereo.cas.authentication.principal.WebApplicationServiceResponseBuilder.build(WebApplicationServiceResponseBuilder.java:43) ~[cas-server-core-services-authentication-5.3.15.1.jar!/:5.3.15.1]
        at org.apereo.cas.web.flow.actions.RedirectToServiceAction.doExecute(RedirectToServiceAction.java:41) ~[cas-server-core-webflow-api-5.3.15.1.jar!/:5.3.15.1]`