### PR TITLE
GitServiceRepository:  settings branchesToClone fix

### DIFF
--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -158,7 +158,7 @@ public class GitRepositoryBuilder {
             .setTransportConfigCallback(transportCallback)
             .setCredentialsProvider(new ChainingCredentialsProvider(providers));
 
-        if (StringUtils.hasText(this.branchesToClone) || "*".equals(branchesToClone)) {
+        if (StringUtils.isEmpty(this.branchesToClone) || "*".equals(branchesToClone)) {
             cloneCommand.setCloneAllBranches(true);
         } else {
             cloneCommand.setBranchesToClone(StringUtils.commaDelimitedListToSet(this.branchesToClone)


### PR DESCRIPTION
There isn't possible to set branchesToClone.I found what is the problem.