### PR TITLE
Fix code comment typo in CasWebflowConstants

### DIFF
--- a/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
+++ b/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
@@ -330,7 +330,7 @@ public interface CasWebflowConstants {
     String STATE_ID_GATEWAY_REQUEST_CHECK = "gatewayRequestCheck";
 
     /**
-     * The state 'gatewayRequestCheck'.
+     * The state 'generateServiceTicket'.
      */
     String STATE_ID_GENERATE_SERVICE_TICKET = "generateServiceTicket";
 


### PR DESCRIPTION
`The state 'gatewayRequestCheck'.` should be  `The state 'generateServiceTicket'.`, thanks

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
