### PR TITLE
Make ehcache3 disk pool persistent

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ehcache/Ehcache3Properties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ehcache/Ehcache3Properties.java
@@ -85,6 +85,11 @@ public class Ehcache3Properties implements Serializable {
     private String rootDirectory = "/tmp/cas/ehcache3";
 
     /**
+     * Persist data on disk when jvm is shut down if not using terracotta cluster.
+     */
+    private boolean persistOnDisk = true;
+
+    /**
      * Timeout when reading or writing to/from Terracotta cluster.
      */
     private long clusterReadWriteTimeout = 5L;

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -4671,6 +4671,7 @@ To learn more about this topic, [please review this guide](../ticketing/Ehcache-
 # cas.ticket.registry.ehcache3.resource-pool-name=cas-ticket-pool
 # cas.ticket.registry.ehcache3.resource-pool-size=15MB
 # cas.ticket.registry.ehcache3.root-directory=/tmp/cas/ehcache3
+# cas.ticket.registry.ehcache3.persist-on-disk=true
 # cas.ticket.registry.ehcache3.cluster-connection-timeout=150
 # cas.ticket.registry.ehcache3.cluster-read-write-timeout=5
 # cas.ticket.registry.ehcache3.clustered-cache-consistency=STRONG

--- a/docs/cas-server-documentation/ticketing/Ehcache-Ticket-Registry.md
+++ b/docs/cas-server-documentation/ticketing/Ehcache-Ticket-Registry.md
@@ -22,8 +22,9 @@ and [an optional Terracotta cluster](https://www.ehcache.org/documentation/3.3/c
 ## In-memory store with disk persistence
 
 Ehcache 3.x doesn't support distributing caching without Terracotta so using it without pointing at a Terracotta 
-server or cluster doesn't support using more than one CAS server at a time, but the registry should survive restarts due 
-to the disk persistence.
+server or cluster doesn't support using more than one CAS server at a time. The location and size of the disk caches 
+can be configured using the root-directory and per-cache-size-on-disk properties. If the persist-on-disk property
+is set to true then the caches will survive a restart. 
 
 ### Terracotta Clustering
 

--- a/support/cas-server-support-ehcache3-ticket-registry/src/main/java/org/apereo/cas/config/Ehcache3TicketRegistryConfiguration.java
+++ b/support/cas-server-support-ehcache3-ticket-registry/src/main/java/org/apereo/cas/config/Ehcache3TicketRegistryConfiguration.java
@@ -135,8 +135,9 @@ public class Ehcache3TicketRegistryConfiguration {
 
         if (StringUtils.isBlank(terracottaClusterUri)) {
             val perCacheCapacity = Capacity.parse(ehcacheProperties.getPerCacheSizeOnDisk());
+            val persistOnDisk = ehcacheProperties.isPersistOnDisk();
             resourcePools = resourcePools.disk(perCacheCapacity.getSize().longValue(),
-                MemoryUnit.valueOf(perCacheCapacity.getUnitOfMeasure().name()), true);
+                MemoryUnit.valueOf(perCacheCapacity.getUnitOfMeasure().name()), persistOnDisk);
         }
 
         var cacheConfigBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(

--- a/support/cas-server-support-ehcache3-ticket-registry/src/main/java/org/apereo/cas/config/Ehcache3TicketRegistryConfiguration.java
+++ b/support/cas-server-support-ehcache3-ticket-registry/src/main/java/org/apereo/cas/config/Ehcache3TicketRegistryConfiguration.java
@@ -136,7 +136,7 @@ public class Ehcache3TicketRegistryConfiguration {
         if (StringUtils.isBlank(terracottaClusterUri)) {
             val perCacheCapacity = Capacity.parse(ehcacheProperties.getPerCacheSizeOnDisk());
             resourcePools = resourcePools.disk(perCacheCapacity.getSize().longValue(),
-                MemoryUnit.valueOf(perCacheCapacity.getUnitOfMeasure().name()));
+                MemoryUnit.valueOf(perCacheCapacity.getUnitOfMeasure().name()), true);
         }
 
         var cacheConfigBuilder = CacheConfigurationBuilder.newCacheConfigurationBuilder(


### PR DESCRIPTION
Docs say that if using Ehcache3 without terracotta "the registry should survive restarts due to the disk persistence"
However as the persistent option is not set on the disk resource pool the disk files are deleted on shutdown.
This pull request just sets the persistent option to true
