### PR TITLE
Fix session replication autoconfigure

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/replication/SessionReplicationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/replication/SessionReplicationProperties.java
@@ -43,8 +43,6 @@ public class SessionReplicationProperties implements Serializable {
 
         public Cookie() {
             setName("DISSESSION");
-            setPath("/cas/");
         }
     }
-
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20ConfigurationContext.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20ConfigurationContext.java
@@ -125,4 +125,5 @@ public class OAuth20ConfigurationContext {
 
     private OAuth20TokenSigningAndEncryptionService idTokenSigningAndEncryptionService;
 
+    private final CasCookieBuilder oauthDistributedSessionCookieGenerator;
 }

--- a/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
+++ b/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
@@ -42,6 +42,7 @@ import org.apereo.cas.uma.web.controllers.rpt.UmaRequestingPartyTokenJwksEndpoin
 import org.apereo.cas.util.DefaultUniqueTicketIdGenerator;
 
 import lombok.val;
+import org.apereo.cas.web.cookie.CasCookieBuilder;
 import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
@@ -93,6 +94,10 @@ public class CasOAuthUmaConfiguration implements WebMvcConfigurer {
     private ObjectProvider<TicketRegistry> ticketRegistry;
 
     @Autowired
+    @Qualifier("oauthDistributedSessionCookieGenerator")
+    private ObjectProvider<CasCookieBuilder> oauthDistributedSessionCookieGenerator;
+
+    @Autowired
     @Qualifier("oauthDistributedSessionStore")
     private ObjectProvider<SessionStore> oauthDistributedSessionStore;
 
@@ -127,6 +132,7 @@ public class CasOAuthUmaConfiguration implements WebMvcConfigurer {
             .ticketRegistry(ticketRegistry.getObject())
             .servicesManager(servicesManager.getObject())
             .idTokenSigningAndEncryptionService(signingService)
+            .oauthDistributedSessionCookieGenerator(oauthDistributedSessionCookieGenerator.getObject())
             .sessionStore(oauthDistributedSessionStore.getObject())
             .casProperties(casProperties)
             .accessTokenJwtBuilder(accessTokenJwtBuilder.getObject())

--- a/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
+++ b/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
@@ -40,9 +40,9 @@ import org.apereo.cas.uma.web.controllers.resource.UmaFindResourceSetRegistratio
 import org.apereo.cas.uma.web.controllers.resource.UmaUpdateResourceSetRegistrationEndpointController;
 import org.apereo.cas.uma.web.controllers.rpt.UmaRequestingPartyTokenJwksEndpointController;
 import org.apereo.cas.util.DefaultUniqueTicketIdGenerator;
+import org.apereo.cas.web.cookie.CasCookieBuilder;
 
 import lombok.val;
-import org.apereo.cas.web.cookie.CasCookieBuilder;
 import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
@@ -156,7 +156,13 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
+        mockRequest.setContextPath("");
         val mockResponse = new MockHttpServletResponse();
+
+        val casProperties = oAuth20AuthorizeEndpointController.getOAuthConfigurationContext().getCasProperties();
+        casProperties.getSessionReplication().getCookie().setAutoConfigureCookiePath(true);
+        casProperties.getAuthn().getOauth().setReplicateSessions(true);
+        oAuth20AuthorizeEndpointController.getOAuthConfigurationContext().getOauthDistributedSessionCookieGenerator().setCookiePath("");
 
         val service = getRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
@@ -186,6 +192,8 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         assertNotNull(redirectUrl);
         assertEquals(redirectUrl, REDIRECT_URI);
 
+        assertEquals("/", oAuth20AuthorizeEndpointController.getOAuthConfigurationContext()
+                .getOauthDistributedSessionCookieGenerator().getCookiePath());
         val code = modelAndView.getModelMap().get("code");
         val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(String.valueOf(code));
         assertNotNull(oAuthCode);
@@ -207,7 +215,12 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
+        mockRequest.setContextPath("");
         val mockResponse = new MockHttpServletResponse();
+
+        val oauthContext = oAuth20AuthorizeEndpointController.getOAuthConfigurationContext();
+        oauthContext.getCasProperties().getSessionReplication().getCookie().setAutoConfigureCookiePath(false);
+        oauthContext.getOauthDistributedSessionCookieGenerator().setCookiePath("");
 
         val service = getRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
@@ -235,6 +248,8 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         assertNotNull(redirectUrl);
         assertTrue(redirectUrl.startsWith(REDIRECT_URI + "#access_token="));
 
+        assertEquals("", oAuth20AuthorizeEndpointController.getOAuthConfigurationContext()
+                .getOauthDistributedSessionCookieGenerator().getCookiePath());
         val code = StringUtils.substringBetween(redirectUrl, "#access_token=", "&token_type=bearer");
         val accessToken = (OAuth20AccessToken) this.ticketRegistry.getTicket(code);
         assertNotNull(accessToken);

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
@@ -156,13 +156,14 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
-        mockRequest.setContextPath("");
+        mockRequest.setContextPath(StringUtils.EMPTY);
         val mockResponse = new MockHttpServletResponse();
 
         val casProperties = oAuth20AuthorizeEndpointController.getOAuthConfigurationContext().getCasProperties();
         casProperties.getSessionReplication().getCookie().setAutoConfigureCookiePath(true);
         casProperties.getAuthn().getOauth().setReplicateSessions(true);
-        oAuth20AuthorizeEndpointController.getOAuthConfigurationContext().getOauthDistributedSessionCookieGenerator().setCookiePath("");
+        oAuth20AuthorizeEndpointController.getOAuthConfigurationContext()
+                .getOauthDistributedSessionCookieGenerator().setCookiePath(StringUtils.EMPTY);
 
         val service = getRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
@@ -215,12 +216,12 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
-        mockRequest.setContextPath("");
+        mockRequest.setContextPath(StringUtils.EMPTY);
         val mockResponse = new MockHttpServletResponse();
 
         val oauthContext = oAuth20AuthorizeEndpointController.getOAuthConfigurationContext();
         oauthContext.getCasProperties().getSessionReplication().getCookie().setAutoConfigureCookiePath(false);
-        oauthContext.getOauthDistributedSessionCookieGenerator().setCookiePath("");
+        oauthContext.getOauthDistributedSessionCookieGenerator().setCookiePath(StringUtils.EMPTY);
 
         val service = getRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
@@ -248,7 +249,7 @@ public class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Test
         assertNotNull(redirectUrl);
         assertTrue(redirectUrl.startsWith(REDIRECT_URI + "#access_token="));
 
-        assertEquals("", oAuth20AuthorizeEndpointController.getOAuthConfigurationContext()
+        assertEquals(StringUtils.EMPTY, oAuth20AuthorizeEndpointController.getOAuthConfigurationContext()
                 .getOauthDistributedSessionCookieGenerator().getCookiePath());
         val code = StringUtils.substringBetween(redirectUrl, "#access_token=", "&token_type=bearer");
         val accessToken = (OAuth20AccessToken) this.ticketRegistry.getTicket(code);

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -364,6 +364,10 @@ public class OidcConfiguration implements WebMvcConfigurer {
     @Qualifier("defaultRefreshTokenFactory")
     private ObjectProvider<OAuth20RefreshTokenFactory> defaultRefreshTokenFactory;
 
+    @Autowired
+    @Qualifier("oauthDistributedSessionCookieGenerator")
+    private ObjectProvider<CasCookieBuilder> oauthDistributedSessionCookieGenerator;
+
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(oauthInterceptor()).addPathPatterns('/' + OidcConstants.BASE_OIDC_URL.concat("/").concat("*"));
@@ -985,6 +989,7 @@ public class OidcConfiguration implements WebMvcConfigurer {
             .webApplicationServiceServiceFactory(webApplicationServiceFactory.getObject())
             .casProperties(casProperties)
             .ticketGrantingTicketCookieGenerator(ticketGrantingTicketCookieGenerator.getObject())
+            .oauthDistributedSessionCookieGenerator(oauthDistributedSessionCookieGenerator.getObject())
             .oauthConfig(oauthSecConfig.getObject())
             .registeredServiceAccessStrategyEnforcer(registeredServiceAccessStrategyEnforcer.getObject())
             .centralAuthenticationService(centralAuthenticationService.getObject())


### PR DESCRIPTION
There are currently two issues with session replication autoconfiguration. I tested it with master, but I think it's the same for the 6.2.x branch.

1) The `SessionReplicationProperties` sets its cookies `DISSESSION` on the `/cas/` path. Though, in the `doPreExecute` method of the `DelegatedClientAuthenticationAction`, this path is compared to blank if the `autoConfigureCookiePath` property is set to `true` (by default). Thus, it is never auto-configured.

2) The `SessionReplicationProperties` is shared between authentication and OAuth server support. Though, it is only auto-configured for authentication delegation in the `DelegatedClientAuthenticationAction`. It must also be auto-configured for OAuth server support when replication is enabled `cas.authn.oauth.replicate-sessions: true`.

This PR fixes both issues. I chose to remove the default `/cas/` path for the session replication cookie, which could be a breaking change in 6.2 in some edge use cases.
