### PR TITLE
MFA:Gauth: Fix potential TOTP secret key leakage due to HTTP request logging

### DIFF
--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/util/QRUtils.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/util/QRUtils.java
@@ -1,6 +1,8 @@
 package org.apereo.cas.otp.util;
 
 import com.google.zxing.BarcodeFormat;
+import java.io.ByteArrayOutputStream;
+import org.apereo.cas.util.EncodingUtils;
 import com.google.zxing.EncodeHintType;
 import com.google.zxing.qrcode.QRCodeWriter;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
@@ -66,7 +68,13 @@ public class QRUtils {
                 .filter(j -> byteMatrix.get(i, j))
                 .forEach(j -> graphics.fillRect(i, j, 1, 1)));
 
-        ImageIO.write(image, "png", stream);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageIO.write(image, "PNG", out);
+        byte[] bytes = out.toByteArray();
+
+        String base64bytes = EncodingUtils.encodeBase64(bytes);
+        String src = "data:image/png;base64," + base64bytes;
+        stream.write(src.getBytes("UTF-8"));
     }
 
 }

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/OneTimeTokenAccountCheckRegistrationAction.java
@@ -11,6 +11,9 @@ import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.action.EventFactorySupport;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
+import org.apereo.cas.otp.util.QRUtils;
+import java.io.ByteArrayOutputStream;
+
 
 /**
  * This is {@link OneTimeTokenAccountCheckRegistrationAction}.
@@ -33,9 +36,11 @@ public class OneTimeTokenAccountCheckRegistrationAction extends AbstractAction {
         if (acct == null || StringUtils.isBlank(acct.getSecretKey())) {
             val keyAccount = this.repository.create(uid);
             val keyUri = "otpauth://totp/" + this.label + ':' + uid + "?secret=" + keyAccount.getSecretKey() + "&issuer=" + this.issuer;
+
+            ByteArrayOutputStream o = new ByteArrayOutputStream();
+            QRUtils.generateQRCode(o, keyUri, QRUtils.WIDTH_LARGE, QRUtils.WIDTH_LARGE);
             requestContext.getFlowScope().put("key", keyAccount);
-            requestContext.getFlowScope().put("keyUri", keyUri);
-            LOGGER.debug("Registration key URI is [{}]", keyUri);
+            requestContext.getFlowScope().put("QRcode", o.toString());
             return new EventFactorySupport().event(this, "register");
         }
         return success();

--- a/webapp/cas-server-webapp-resources/src/main/resources/templates/casGoogleAuthenticatorRegistrationView.html
+++ b/webapp/cas-server-webapp-resources/src/main/resources/templates/casGoogleAuthenticatorRegistrationView.html
@@ -17,7 +17,7 @@
 
         <form method="post" id="fm1" class="fm-v clearfix" th:action="@{/login}">
             <div class="form-group">
-                <img th:src="@{/otp/qrgen(key=${keyUri})}"/>
+                <img th:src="{QRcode}"/>
                 <br/>
                 <div>
                     <p th:utext="#{screen.authentication.gauth.key(${key.getSecretKey()})}">Secret key to register is


### PR DESCRIPTION

# Details
While deploying CAS for my [employer](https://www.skroutz.gr/), I skimmed through the load balancer's
logs and that's how I stumbled upon the issue described below. In short, the user's
TOTP secret key is logged as it's sent as a GET parameter during the registration
process. Most of the times every middleware that terminates TLS (such as reverse proxies,
load balancers and so on) tend to also log GET parameters. CAS users could unknowingly
writing TOTP secret keys to disk, and probably ship those logs to other machines (ELK stacks and so on).
An adversary could potentially steal those just by having access to logs somewhere
other than the CAS hosts themselves.
 
## Brief description of changes applied
An HTTP endpoint [0] currently serves the purpose of grabbing the user's
TOTP secret key and produce the required QR code that in turn gets
scanned by the user's phone, as shown below:
https://github.com/apereo/cas/blob/acdc6cfd9e919e7feb54ad1ad0cbea44db88733d/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/web/flow/rest/OneTimeTokenQRGeneratorController.java#L28-L33

A security issue arises in the Google Authenticator registration
template (below) because the aforementioned HTTP endpoint is sourced in an
`img` tag, passing the user's secret key as a GET parameter. This poses
an immediate threat to the confidentiality of the key.
GET parameters get logged in proxies (e.g. Load balancers, reverse
proxies etc), hence CAS users might be unknowingly logging these.
https://github.com/apereo/cas/blob/c839b62772078bf347c45e67bb2b51d0aa622ff0/support/cas-server-support-thymeleaf/src/main/resources/templates/casGoogleAuthenticatorRegistrationView.html#L108

This PR attempts to provide the registration template with the QR code image, base64 encode
it and embed it using the `base64:image/png` scheme.

NOTE: This is a first draft to discuss the matter, see if you're interested in me merging this one.
Nevertheless, this PR is working as-is, despite lacking the two points below.
There are certainly two things missing here:
- Cleaning up the existing `/otp/qrgen` endpoint
- Potentially add more tests

##  Any possible limitations, side effects, etc
I've verified that this endpoint is only used there, so the shouldn't be any side-effects.



