### PR TITLE
add support for overlay casmodules property

### DIFF
--- a/gradle/webapp.gradle
+++ b/gradle/webapp.gradle
@@ -53,8 +53,8 @@ dependencies {
     implementation project(":webapp:cas-server-webapp-resources")
 
     // add modules in format compatible with overlay casmodules property
-    if (project.hasProperty("casmodules")) {
-        def dependencies = project.getProperty("casmodules").split(",")
+    if (project.hasProperty("casModules")) {
+        def dependencies = project.getProperty("casModules").split(",")
         dependencies.each {
             if (it.startsWith("core")) {
                 implementation project(":core:cas-server-${it}")

--- a/gradle/webapp.gradle
+++ b/gradle/webapp.gradle
@@ -52,6 +52,19 @@ dependencies {
     implementation project(":webapp:cas-server-webapp-init")
     implementation project(":webapp:cas-server-webapp-resources")
 
+    // add modules in format compatible with overlay casmodules property
+    if (project.hasProperty("casmodules")) {
+        def dependencies = project.getProperty("casmodules").split(",")
+        dependencies.each {
+            if (it.startsWith("core")) {
+                implementation project(":core:cas-server-${it}")
+            }
+            if (it.startsWith("support")) {
+                implementation project(":support:cas-server-${it}")
+            }
+        }
+    }
+
     implementation libraries.springcloudconfigclient
     if (!rootProject.publishReleases && !rootProject.publishSnapshots) {
         runtimeClasspath libraries.springbootdevtools


### PR DESCRIPTION
This change allows using the same casmodules property between the recent cas-template-overlay and when running cas from this project, e.g. with `bc`.

```
casmodules=core-monitor,\
    support-ldap,\
    support-aup-webflow,\
    support-x509,\
    support-x509-core,\
    support-x509-webflow,\
    support-saml-idp,\
    support-saml-sp-integrations,\
    support-oidc,\
    support-oauth-webflow,\
    support-rest-x509,\
    support-ehcache-ticket-registry,\
    support-ehcache3-ticket-registry,\
    support-ldap-monitor,\
    support-metrics,\
    support-reports,\
    support-pm-webflow,\
    support-pm-ldap,\
    support-pm,\
    support-swagger,\
    support-events-memory,\
    core-configuration-metadata-repository,\
    support-bootadmin-client
```