### PR TITLE
restrict SAML service lookups to matching entityIDs

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
@@ -16,8 +16,8 @@ import org.springframework.core.Ordered;
 public class SamlIdPServicesManagerRegisteredServiceLocator extends DefaultServicesManagerRegisteredServiceLocator {
     public SamlIdPServicesManagerRegisteredServiceLocator(final SamlRegisteredServiceCachingMetadataResolver resolver) {
         setOrder(Ordered.HIGHEST_PRECEDENCE);
-        setRegisteredServiceFilter((registeredService, service) -> {
-            if (registeredService.getClass().equals(SamlRegisteredService.class)) {
+        setRegisteredServiceFilter((registeredService, serviceId) -> {
+            if (registeredService.getClass().equals(SamlRegisteredService.class) && registeredService.matches(serviceId)) {
                 val samlService = SamlRegisteredService.class.cast(registeredService);
                 val adaptor = SamlRegisteredServiceServiceProviderMetadataFacade.get(resolver, samlService, service.getId());
                 return adaptor.isPresent();

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
@@ -16,8 +16,8 @@ import org.springframework.core.Ordered;
 public class SamlIdPServicesManagerRegisteredServiceLocator extends DefaultServicesManagerRegisteredServiceLocator {
     public SamlIdPServicesManagerRegisteredServiceLocator(final SamlRegisteredServiceCachingMetadataResolver resolver) {
         setOrder(Ordered.HIGHEST_PRECEDENCE);
-        setRegisteredServiceFilter((registeredService, serviceId) -> {
-            if (registeredService.getClass().equals(SamlRegisteredService.class) && registeredService.matches(serviceId)) {
+        setRegisteredServiceFilter((registeredService, service) -> {
+            if (registeredService.getClass().equals(SamlRegisteredService.class) && registeredService.matches(service.getId())) {
                 val samlService = SamlRegisteredService.class.cast(registeredService);
                 val adaptor = SamlRegisteredServiceServiceProviderMetadataFacade.get(resolver, samlService, service.getId());
                 return adaptor.isPresent();

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocatorTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocatorTests.java
@@ -4,12 +4,16 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManagerRegisteredServiceLocator;
 import org.apereo.cas.support.saml.BaseSamlIdPConfigurationTests;
 import org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade;
+import org.apereo.cas.support.saml.services.idp.metadata.cache.SamlRegisteredServiceCachingMetadataResolver;
 import org.apereo.cas.util.CollectionUtils;
 
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.Ordered;
@@ -18,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * This is {@link SamlIdPServicesManagerRegisteredServiceLocatorTests}.
@@ -75,36 +78,33 @@ public class SamlIdPServicesManagerRegisteredServiceLocatorTests extends BaseSam
     /**
      * serviceLocator should not trigger metadata lookups when requested entityID does not match pattern for service in question.
      *
-     * This test first verifies that, in the case of one service entry that does not match the requested entityID, no
-     * metadata lookups are performed. It then verifies that, in the case of two service entries, one matching the
-     * requested entityID, exactly one metadata lookup is performed.
+     * This test verifies that, in the case of one service entry that does not match the requested entityID, no
+     * metadata lookups are performed.
      *
      * @author Hayden Sartoris
      */
     @Test
     public void verifyEntityIDFilter() {
+        SamlRegisteredServiceCachingMetadataResolver resolver = new BrokenMetadataResolver();
+        SamlIdPServicesManagerRegisteredServiceLocator locator = new SamlIdPServicesManagerRegisteredServiceLocator(resolver);
+
         val service1 = RegisteredServiceTestUtils.getRegisteredService("urn:abc:def.+");
         service1.setEvaluationOrder(9);
+        val entityID = "https://sp.testshib.org/shibboleth-sp";
+        val service = webApplicationServiceFactory.createService(entityID);
 
-        val service2 = getSamlRegisteredServiceFor(false, false, false, ".+");
-        service2.setEvaluationOrder(10);
+        locator.locate(List.of(service1), service, r -> r.matches(entityID));
+    }
 
-        servicesManager.save(service1);
+    private static class BrokenMetadataResolver implements SamlRegisteredServiceCachingMetadataResolver {
+        public MetadataResolver resolve(SamlRegisteredService service, CriteriaSet criteriaSet) {
+            throw new IllegalStateException("This method shouldn't have been called");
+        }
 
-        val service = webApplicationServiceFactory.createService("https://sp.testshib.org/shibboleth-sp");
+        public void invalidate() {
+        }
 
-        try (MockedStatic mockedFacade = mockStatic(SamlRegisteredServiceServiceProviderMetadataFacade.class)) {
-            //mockedFacade.when(SamlRegisteredServiceServiceProviderMetadataFacade::get)
-                //.thenThrow(new IllegalStateException("SamlRegisteredServiceServiceProviderMetadataFacade.get should not be called when requested entityID does not match configured pattern"));
-            val res1 = servicesManager.findServiceBy(service);
-            assertNull(res1);
-            mockedFacade.verify(never(), SamlRegisteredServiceServiceProviderMetadataFacade::get);
-
-            servicesManager.save(service2);
-
-            val res2 = servicesManager.findServiceBy(service);
-            assertNotNull(res2);
-            mockedFacade.verify(times(1), SamlRegisteredServiceServiceProviderMetadataFacade::get);
+        public void invalidate(SamlRegisteredService s, CriteriaSet c) {
         }
     }
 }

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocatorTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocatorTests.java
@@ -4,16 +4,12 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManagerRegisteredServiceLocator;
 import org.apereo.cas.support.saml.BaseSamlIdPConfigurationTests;
 import org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade;
-import org.apereo.cas.support.saml.services.idp.metadata.cache.SamlRegisteredServiceCachingMetadataResolver;
 import org.apereo.cas.util.CollectionUtils;
 
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
-import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.Ordered;
@@ -22,11 +18,13 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * This is {@link SamlIdPServicesManagerRegisteredServiceLocatorTests}.
  *
  * @author Misagh Moayyed
+ * @author Hayden Sartoris
  * @since 6.3.0
  */
 @Tag("SAML")
@@ -78,33 +76,35 @@ public class SamlIdPServicesManagerRegisteredServiceLocatorTests extends BaseSam
     /**
      * serviceLocator should not trigger metadata lookups when requested entityID does not match pattern for service in question.
      *
-     * This test verifies that, in the case of one service entry that does not match the requested entityID, no
-     * metadata lookups are performed.
-     *
-     * @author Hayden Sartoris
+     * This test first verifies that, in the case of one service entry that does not match the requested entityID, no
+     * metadata lookups are performed. It then verifies that, in the case of two service entries, one matching the
+     * requested entityID, exactly one metadata lookup is performed.
      */
     @Test
     public void verifyEntityIDFilter() {
-        SamlRegisteredServiceCachingMetadataResolver resolver = new BrokenMetadataResolver();
-        SamlIdPServicesManagerRegisteredServiceLocator locator = new SamlIdPServicesManagerRegisteredServiceLocator(resolver);
+        try (val mockFacade = mockStatic(SamlRegisteredServiceServiceProviderMetadataFacade.class)) {
+            val service1 = getSamlRegisteredServiceFor(false, false, false, "urn:abc:def.+");
+            service1.setEvaluationOrder(9);
+            servicesManager.save(service1);
+            mockFacade.when(() -> SamlRegisteredServiceServiceProviderMetadataFacade.get(any(), any(), anyString()))
+                .thenCallRealMethod();
 
-        val service1 = RegisteredServiceTestUtils.getRegisteredService("urn:abc:def.+");
-        service1.setEvaluationOrder(9);
-        val entityID = "https://sp.testshib.org/shibboleth-sp";
-        val service = webApplicationServiceFactory.createService(entityID);
+            val entityID = "https://sp.testshib.org/shibboleth-sp";
+            val service = webApplicationServiceFactory.createService(entityID);
+            val res1 = servicesManager.findServiceBy(service);
+            assertNull(res1);
 
-        locator.locate(List.of(service1), service, r -> r.matches(entityID));
-    }
+            mockFacade.verify(never(), () -> SamlRegisteredServiceServiceProviderMetadataFacade.get(any(), service1, anyString()));
 
-    private static class BrokenMetadataResolver implements SamlRegisteredServiceCachingMetadataResolver {
-        public MetadataResolver resolve(SamlRegisteredService service, CriteriaSet criteriaSet) {
-            throw new IllegalStateException("This method shouldn't have been called");
+            val service2 = getSamlRegisteredServiceFor(false, false, false, ".+");
+            service2.setEvaluationOrder(10);
+            servicesManager.save(service2);
+
+            val res2 = servicesManager.findServiceBy(service);
+            assertNotNull(res2);
+
+            mockFacade.verify(() -> SamlRegisteredServiceServiceProviderMetadataFacade.get(any(), service2, entityID));
         }
 
-        public void invalidate() {
-        }
-
-        public void invalidate(SamlRegisteredService s, CriteriaSet c) {
-        }
     }
 }


### PR DESCRIPTION
Following the addition of `SamlIdPServicesManagerRegisteredServiceLocator`, unidentified service IDs are evaluated as possible SAML entityIDs against known SAML services, in addition to regular service ID matching as performed by `DefaultServicesManagerRegisteredServiceLocator`. This introduces an interesting failure case.

First, we need a SAML registered service that retrieves its metadata over MDQ, but it has not yet been retrieved, or the cached copy has expired. Now, we fire a request bearing a service ID not related to the SAML service; let's say it's not an entityID at all but a regular CAS service ID. What will happen is that, at some point, a call to `locate()` on `SamlIdPServicesManagerRegisteredServiceLocator` will fire in [`AbstractServicesManager`](https://github.com/apereo/cas/blob/0b3a7641e7e96a931c7a5577cd38ce0d1b106540/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java#L97), providing a predicate `entry -> entry.matches(serviceId)`. Before that predicate is evaluated, the candidates will be filtered by the BiPredicate on the extending class, which will dispatch a call to `SamlRegisteredServiceServiceProviderMetadataFacade.get`. After a series of attempted lookups, this will throw as no metadata is found - performing an MDQ lookup with the provided service ID is useless as it is not a SAML service. This will be logged as a failure to locate metadata for the *candidate* service, not the service ID being queried. 

This also extends into misconfigured SAML services - if one uses filesystem metadata, for example, that does not exist, it will fail every service (other than SAML services with higher precedence, I believe), which is not ideal.

There are a couple of ways to deal with this. The code I've changed here performs a check with `matches()` before actually doing any attempt to resolve the metadata. Another option would be to change the [filter order](https://github.com/apereo/cas/blob/0b3a7641e7e96a931c7a5577cd38ce0d1b106540/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultServicesManagerRegisteredServiceLocator.java#L34-L35) on `DefaultServicesManagerRegisteredServiceLocator` to evaluate the provided Predicate first, but I feel this is making implicit in the usage pattern something that should be explicit: the server ought not to perform a costly metadata lookup if the entityID of the registered service does not even match the provided service ID. 

I believe this could be tested for by using Mockito in [SamlIdPServiceManagerRegisteredServiceLocatorTests](support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocatorTests.java) to ensure that `get` is not called on the metadataFacade, but haven't gotten that far yet.