### PR TITLE
Allowing to specify LDAP TrustManager

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapProperties.java
@@ -246,6 +246,12 @@ public abstract class AbstractLdapProperties implements Serializable {
     private LdapHostnameVerifierOptions hostnameVerifier = LdapHostnameVerifierOptions.DEFAULT;
 
     /**
+     * Trust Manager options.
+     * Accepted values are {@link LdapTrustManagerOptions#DEFAULT} and {@link LdapTrustManagerOptions#ANY}.
+     */
+    private LdapTrustManagerOptions trustManager = LdapTrustManagerOptions.DEFAULT;
+
+    /**
      * Name of the LDAP handler.
      */
     private String name;
@@ -337,6 +343,17 @@ public abstract class AbstractLdapProperties implements Serializable {
         DEFAULT,
         /**
          * Skip hostname verification and allow all.
+         */
+        ANY
+    }
+
+    public enum LdapTrustManagerOptions {
+        /**
+         * Default option, loads the trust managers from the default {@link TrustManagerFactory} and delegates to those.
+         */
+        DEFAULT,
+        /**
+         * Trusts any client or server.
          */
         ANY
     }

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -81,7 +81,9 @@ import org.ldaptive.sasl.QualityOfProtection;
 import org.ldaptive.sasl.SaslConfig;
 import org.ldaptive.sasl.SecurityStrength;
 import org.ldaptive.ssl.AllowAnyHostnameVerifier;
+import org.ldaptive.ssl.AllowAnyTrustManager;
 import org.ldaptive.ssl.DefaultHostnameVerifier;
+import org.ldaptive.ssl.DefaultTrustManager;
 import org.ldaptive.ssl.KeyStoreCredentialConfig;
 import org.ldaptive.ssl.SslConfig;
 import org.ldaptive.ssl.X509CredentialConfig;
@@ -793,7 +795,15 @@ public class LdapUtils {
                 case DEFAULT:
                 default:
                     sslConfig.setHostnameVerifier(new DefaultHostnameVerifier());
+            }
+
+            switch (l.getTrustManager()) {
+                case ANY:
+                    sslConfig.setTrustManagers(new AllowAnyTrustManager());
                     break;
+                case DEFAULT:
+                default:
+                    sslConfig.setTrustManagers(new DefaultTrustManager());
             }
         }
 


### PR DESCRIPTION
Easy switch to trust (only during development!) self-signed TLS certificates for LDAPS.