### PR TITLE
Fix error pages ignoring the default theme in cas.properties

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeClassLoaderTemplateResolver.java
+++ b/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeClassLoaderTemplateResolver.java
@@ -52,16 +52,28 @@ public class ThemeClassLoaderTemplateResolver extends ClassLoaderTemplateResolve
      * @return the current theme
      */
     protected String getCurrentTheme() {
+        return getCurrentTheme(casProperties);
+    }
+
+    static String getCurrentTheme(CasConfigurationProperties casProperties) {
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext();
+        String theme = null;
         if (request != null) {
             val session = request.getSession(false);
             val paramName = casProperties.getTheme().getParamName();
             if (session != null) {
-                return (String) session.getAttribute(paramName);
+                theme = (String) session.getAttribute(paramName);
+                if (theme != null) {
+                    return theme;
+                }
             }
-            return (String) request.getAttribute(paramName);
+            theme = (String) request.getAttribute(paramName);
+            if (theme != null) {
+                return theme;
+            }
         }
-        return null;
+
+        return casProperties.getTheme().getDefaultThemeName();
     }
 }
 

--- a/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeClassLoaderTemplateResolver.java
+++ b/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeClassLoaderTemplateResolver.java
@@ -55,7 +55,7 @@ public class ThemeClassLoaderTemplateResolver extends ClassLoaderTemplateResolve
         return getCurrentTheme(casProperties);
     }
 
-    static String getCurrentTheme(CasConfigurationProperties casProperties) {
+    static String getCurrentTheme(final CasConfigurationProperties casProperties) {
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext();
         String theme = null;
         if (request != null) {

--- a/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeFileTemplateResolver.java
+++ b/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeFileTemplateResolver.java
@@ -42,21 +42,7 @@ public class ThemeFileTemplateResolver extends FileTemplateResolver {
         return super.computeTemplateResource(configuration, ownerTemplate, template, resourceName, characterEncoding, templateResolutionAttributes);
     }
 
-    /**
-     * Gets current theme.
-     *
-     * @return the current theme
-     */
     protected String getCurrentTheme() {
-        val request = WebUtils.getHttpServletRequestFromExternalWebflowContext();
-        if (request != null) {
-            val session = request.getSession(false);
-            val paramName = casProperties.getTheme().getParamName();
-            if (session != null) {
-                return (String) session.getAttribute(paramName);
-            }
-            return (String) request.getAttribute(paramName);
-        }
-        return null;
+        return ThemeClassLoaderTemplateResolver.getCurrentTheme(casProperties);
     }
 }

--- a/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeFileTemplateResolver.java
+++ b/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/web/view/ThemeFileTemplateResolver.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.web.view;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.web.support.WebUtils;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/support/cas-server-support-thymeleaf/src/test/java/org/apereo/cas/web/view/ThemeClassLoaderTemplateResolverTests.java
+++ b/support/cas-server-support-thymeleaf/src/test/java/org/apereo/cas/web/view/ThemeClassLoaderTemplateResolverTests.java
@@ -58,7 +58,13 @@ public class ThemeClassLoaderTemplateResolverTests {
         ExternalContextHolder.setExternalContext(mock);
         verifyThemeFile();
     }
-    
+
+    @Test
+    public void verifyOperationByDefaultValue() throws Exception {
+        casProperties.getTheme().setDefaultThemeName("test");
+        verifyThemeFile();
+    }
+
     private void verifyThemeFile() {
         val resolver = new ThemeClassLoaderTemplateResolver(casProperties);
         resolver.setSuffix(".html");

--- a/support/cas-server-support-thymeleaf/src/test/java/org/apereo/cas/web/view/ThemeFileTemplateResolverTests.java
+++ b/support/cas-server-support-thymeleaf/src/test/java/org/apereo/cas/web/view/ThemeFileTemplateResolverTests.java
@@ -64,6 +64,12 @@ public class ThemeFileTemplateResolverTests {
         verifyThemeFile();
     }
 
+    @Test
+    public void verifyOperationByDefaultValue() throws Exception {
+        casProperties.getTheme().setDefaultThemeName("test");
+        verifyThemeFile();
+    }
+
     private void verifyThemeFile() throws IOException {
         val themeDir = new File(FileUtils.getTempDirectory(), "test");
         if (!themeDir.exists() && !themeDir.mkdir()) {


### PR DESCRIPTION
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test
- [x] Any possible limitations, side effects, etc
- [n/a] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test
- [x] Any possible limitations, side effects, etc
- [n/a] Reference any other pull requests that might be related

We noticed a bug that error pages (404, 500) wouldn't honor the default theme [set in cas.properties](https://apereo.github.io/cas/6.2.x/configuration/Configuration-Properties.html#themes). You can verify this by running a custom theme (even just a different CSS background color) and then trying to visit `login2` instead of `login`. 

This MR fixes that issue along with test cases to prove it. I'll follow up with a master version as well.

We also noticed that error page handling falls through to `SpringTemplateResolver` instead of using `ChainingTemplateViewResolver` which then caches the resulting view. This prevents custom theme views from ever appearing again (specifically the header). I spent a little time trying to determine why only the error pages would exhibit that behavior but came up empty (though, admittedly I didn't spend a _ton_ of time since we only use a simple theme and fixing the error page 'solves' it for us). Future work may want to investigate that behavior.
