### PR TITLE
Password Reset multiple fixes

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
@@ -738,6 +738,26 @@ public class WebUtils {
     }
 
     /**
+     * Put Password Management Auto-Login enabled.
+     *
+     * @param context the context
+     * @param value the value
+     */
+    public static void putPasswordManagementAutoLoginEnabled(final RequestContext context, final Boolean value) {
+        context.getFlowScope().put("passwordManagementAutoLoginEnabled", value);
+    }
+
+    /**
+     * Put Allow Missing Service Parameter enabled.
+     *
+     * @param context the context
+     * @param value the value
+     */
+    public static void putAllowMissingServiceParameterEnabled(final RequestContext context, final Boolean value) {
+        context.getFlowScope().put("allowMissingServiceParameterEnabled", value);
+    }
+
+    /**
      * Put principal.
      *
      * @param requestContext          the request context
@@ -946,7 +966,7 @@ public class WebUtils {
         request.setAttribute("error", HttpStatus.BAD_REQUEST.name());
         request.setAttribute("message", "Unable to verify registration record");
     }
-    
+
     /**
      * Produce error view model and view.
      *

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
@@ -69,6 +69,8 @@ public class WebUtilsTests {
                 WebUtils.putExistingSingleSignOnSessionPrincipal(context, CoreAuthenticationTestUtils.getPrincipal());
                 WebUtils.putAvailableAuthenticationHandleNames(context, List.of());
                 WebUtils.putPasswordManagementEnabled(context, true);
+                WebUtils.putPasswordManagementAutoLoginEnabled(context, true);
+                WebUtils.putAllowMissingServiceParameterEnabled(context, true);
                 WebUtils.putRecaptchaPropertiesFlowScope(context, new GoogleRecaptchaProperties());
                 WebUtils.putLogoutUrls(context, Map.of());
                 val ac = OneTimeTokenAccount.builder()

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
@@ -40,7 +40,7 @@ public class PasswordManagementWebflowConfigurer extends AbstractCasWebflowConfi
      * Name of parameter that can be supplied to login url to force display of password change during login.
      */
     public static final String DO_CHANGE_PASSWORD_PARAMETER = "doChangePassword";
-    
+
     private final Action initPasswordChangeAction;
 
     public PasswordManagementWebflowConfigurer(final FlowBuilderServices flowBuilderServices,
@@ -139,7 +139,7 @@ public class PasswordManagementWebflowConfigurer extends AbstractCasWebflowConfi
             createTransitionForState(initializeLoginFormState,
                 CasWebflowConstants.STATE_ID_SUCCESS,
                 CasWebflowConstants.DECISION_STATE_CHECK_FOR_PASSWORD_RESET_TOKEN_ACTION, true);
-            
+
             createEndState(flow, CasWebflowConstants.STATE_ID_REDIRECT_TO_LOGIN, '\'' + CasWebflowConfigurer.FLOW_ID_LOGIN + '\'', true);
 
             createTransitionForState(
@@ -175,26 +175,10 @@ public class PasswordManagementWebflowConfigurer extends AbstractCasWebflowConfi
     private void registerPasswordResetFlowDefinition() {
         val pswdFlow = buildFlow("classpath:/webflow/pswdreset/pswdreset-webflow.xml", FLOW_ID_PASSWORD_RESET);
 
-        pswdFlow.getStartActionList().add(createEvaluateAction("initialFlowSetupAction"));
-
-        val initReset = createActionState(pswdFlow, "initPasswordReset", "initPasswordResetAction");
-        createStateDefaultTransition(initReset, CasWebflowConstants.VIEW_ID_MUST_CHANGE_PASSWORD);
-
-        val verifyQuestions = createActionState(pswdFlow, "verifySecurityQuestions", "verifySecurityQuestionsAction");
-        createTransitionForState(verifyQuestions, CasWebflowConstants.TRANSITION_ID_SUCCESS, "initPasswordReset");
-        createTransitionForState(verifyQuestions, CasWebflowConstants.TRANSITION_ID_ERROR, "passwordResetErrorView");
-
-        val verifyRequest = createActionState(pswdFlow, "verifyPasswordResetRequest", "verifyPasswordResetRequestAction");
-        createTransitionForState(verifyRequest, CasWebflowConstants.TRANSITION_ID_SUCCESS, "getSecurityQuestionsView");
-        createTransitionForState(verifyRequest, CasWebflowConstants.TRANSITION_ID_ERROR, "passwordResetErrorView");
-        createTransitionForState(verifyRequest, "questionsDisabled", "initPasswordReset");
-
-        val questionsView = createViewState(pswdFlow, "getSecurityQuestionsView", "casResetPasswordVerifyQuestionsView");
-        createTransitionForState(questionsView, CasWebflowConstants.TRANSITION_ID_SUBMIT,
-            "verifySecurityQuestions", Map.of("bind", Boolean.FALSE, "validate", Boolean.FALSE));
-
         pswdFlow.getStartActionList().add(requestContext -> {
             WebUtils.putPasswordManagementEnabled(requestContext, casProperties.getAuthn().getPm().isEnabled());
+            WebUtils.putPasswordManagementAutoLoginEnabled(requestContext, casProperties.getAuthn().getPm().isAutoLogin());
+            WebUtils.putAllowMissingServiceParameterEnabled(requestContext, casProperties.getSso().isAllowMissingServiceParameter());
             return null;
         });
         createViewState(pswdFlow, "passwordResetErrorView", CasWebflowConstants.VIEW_ID_PASSWORD_RESET_ERROR);

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
@@ -90,10 +90,11 @@ public class SendPasswordResetInstructionsAction extends AbstractAction {
                 ExpirationPolicy.class.getName(), HardTimeoutExpirationPolicy.builder().timeToKillInSeconds(expirationSeconds).build());
             val ticket = transientFactory.create(service, properties);
             this.ticketRegistry.addTicket(ticket);
-            
+
             StringBuilder resetUrl = new StringBuilder(casProperties.getServer().getPrefix())
                 .append('/').append(CasWebflowConfigurer.FLOW_ID_LOGIN).append('?')
-                .append(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN).append('=').append(ticket.getId());
+                .append(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN).append('=').append(ticket.getId())
+                .append('&').append(CasProtocolConstants.PARAMETER_RENEW).append('=').append(true);
 
             if (service != null) {
                 val encodeServiceUrl = UriUtils.encode(service.getOriginalUrl(), StandardCharsets.UTF_8);

--- a/support/cas-server-support-pm-webflow/src/main/resources/webflow/pswdreset/pswdreset-webflow.xml
+++ b/support/cas-server-support-pm-webflow/src/main/resources/webflow/pswdreset/pswdreset-webflow.xml
@@ -3,6 +3,31 @@
       xmlns="http://www.springframework.org/schema/webflow"
       xsi:schemaLocation="http://www.springframework.org/schema/webflow
                           http://www.springframework.org/schema/webflow/spring-webflow.xsd">
-    
-    <end-state id="end" />
+
+
+    <on-start>
+        <evaluate expression="initialFlowSetupAction"/>
+    </on-start>
+
+    <action-state id="verifyPasswordResetRequest">
+        <evaluate expression="verifyPasswordResetRequestAction"/>
+        <transition on="success" to="getSecurityQuestionsView" />
+        <transition on="error" to="passwordResetErrorView" />
+        <transition on="questionsDisabled" to="initPasswordReset" />
+    </action-state>
+
+    <view-state id="getSecurityQuestionsView" view="casResetPasswordVerifyQuestionsView">
+        <transition on="submit" to="verifySecurityQuestions" bind="false" validate="false"/>
+    </view-state>
+
+    <action-state id="verifySecurityQuestions">
+        <evaluate expression="verifySecurityQuestionsAction"/>
+        <transition on="success" to="initPasswordReset" />
+        <transition on="error" to="passwordResetErrorView" />
+    </action-state>
+
+    <action-state id="initPasswordReset">
+        <evaluate expression="initPasswordResetAction" />
+        <transition to="casMustChangePassView" />
+    </action-state>
 </flow>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casPasswordUpdateSuccessView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casPasswordUpdateSuccessView.html
@@ -15,7 +15,7 @@
             <h2 th:utext="#{screen.pm.success.header}">Password Change Successful</h2>
             <p th:utext="#{screen.pm.success.message}">Your account password is successfully updated.</p>
 
-            <form method="post" id="form" class="fm-v clearfix" th:action="@{/login}">
+            <form th:if="${passwordManagementAutoLoginEnabled} or ${not passwordManagementAutoLoginEnabled and allowMissingServiceParameterEnabled}" method="post" id="form" class="fm-v clearfix" th:action="@{/login}">
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
                 <input type="hidden" name="_eventId" value="proceed" />
                 <button class="mdc-button mdc-button--raised mr-2" name="continue" accesskey="l" type="submit"


### PR DESCRIPTION
Hi,

Here a few fixes for the Password Reset feature:

- The reset password feature is not working because of the end-state end definition:

```
[org.springframework.webflow.engine.NoMatchingTransitionException: No transition found on occurence of event 'end' in state 'pswdResetSubflow' of flow 'login' -- valid transitional criteria are array<TransitionCriteria>[pswdResetComplete] -- likely programmer error, check the set of TransitionCriteria for this state] due to a type mismatch with handler [[FlowHandlerMapping.DefaultFlowHandler@42dfa863]]
```
Fixed by removing it, it does not seems to be used anywhere.

- Even when you remove the end-state "end",  the reset password page is always redirecting to the login page and you can't change the password.

Fixed by moving the definitions to the pswdreset-webflow.xml file.

- When you're using the password reset link received by Mail or SMS when you're already connected, you'll have a 500 error and you cannot reset the password.

Fixed by adding the renew parameter to the link.

- When the Password Management Auto Login feature is disabled an the allowMissingServiceParameter is disabled, the casPasswordUpdateSuccessView does have a "Log in" button which does not working because the user is not authorised to use it.

Fixed by removing the "Login Button" when Auto-Login is disabled an the allowMissingServerParameter also.


I'll open another PR for the 6.2 branch which is affected by the last two bugs.


Let me know if you need any further information.

Regards,
Julien