### PR TITLE
Password management: Allow an authenticated user to reset password

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -102,7 +102,7 @@ public class PasswordManagementWebflowConfiguration {
     @RefreshScope
     @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategy")
     public SingleSignOnParticipationStrategy passwordManagementSingleSignOnParticipationStrategy() {
-        return new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry.getObject());
+        return new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService.getObject());
     }
 
     @Bean

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -6,6 +6,7 @@ import org.apereo.cas.notifications.CommunicationsManager;
 import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.pm.PasswordValidationService;
 import org.apereo.cas.pm.web.flow.PasswordManagementCaptchaWebflowConfigurer;
+import org.apereo.cas.pm.web.flow.PasswordManagementSingleSignOnParticipationStrategy;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowConfigurer;
 import org.apereo.cas.pm.web.flow.actions.HandlePasswordExpirationWarningMessagesAction;
 import org.apereo.cas.pm.web.flow.actions.InitPasswordChangeAction;
@@ -20,6 +21,8 @@ import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
 import org.apereo.cas.web.flow.CasWebflowExecutionPlanConfigurer;
 import org.apereo.cas.web.flow.InitializeCaptchaAction;
+import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
+import org.apereo.cas.web.flow.SingleSignOnParticipationStrategyConfigurer;
 import org.apereo.cas.web.flow.ValidateCaptchaAction;
 import org.apereo.cas.web.flow.actions.StaticEventExecutionAction;
 
@@ -94,6 +97,20 @@ public class PasswordManagementWebflowConfiguration {
     @Autowired
     @Qualifier("passwordChangeService")
     private ObjectProvider<PasswordManagementService> passwordManagementService;
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategy")
+    public SingleSignOnParticipationStrategy passwordManagementSingleSignOnParticipationStrategy() {
+        return new PasswordManagementSingleSignOnParticipationStrategy();
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategyConfigurer")
+    public SingleSignOnParticipationStrategyConfigurer passwordManagementSingleSignOnParticipationStrategyConfigurer() {
+        return chain -> chain.addStrategy(passwordManagementSingleSignOnParticipationStrategy());
+    }
 
     @RefreshScope
     @Bean
@@ -227,6 +244,3 @@ public class PasswordManagementWebflowConfiguration {
         }
     }
 }
-
-
-

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -102,7 +102,7 @@ public class PasswordManagementWebflowConfiguration {
     @RefreshScope
     @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategy")
     public SingleSignOnParticipationStrategy passwordManagementSingleSignOnParticipationStrategy() {
-        return new PasswordManagementSingleSignOnParticipationStrategy();
+        return new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry.getObject());
     }
 
     @Bean

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -3,6 +3,8 @@ package org.apereo.cas.pm.web.flow;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.webflow.execution.RequestContext;
 
@@ -18,7 +20,15 @@ public class PasswordManagementSingleSignOnParticipationStrategy implements Sing
 
     @Override
     public boolean supports(final RequestContext requestContext) {
-        return PasswordManagementWebflowUtils.isPasswordResetRequestIsValid(requestContext, ticketRegistry);
+        val transientTicket = requestContext
+            .getRequestParameters()
+            .get(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+
+        if (StringUtils.isBlank(transientTicket)) {
+            return false;
+        }
+
+        return ticketRegistry.getTicket(transientTicket) != null;
     }
 
     @Override

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -2,6 +2,7 @@ package org.apereo.cas.pm.web.flow;
 
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
+import lombok.val;
 import org.springframework.webflow.execution.RequestContext;
 
 /**
@@ -11,6 +12,12 @@ import org.springframework.webflow.execution.RequestContext;
  * @since 6.3.0
  */
 public class PasswordManagementSingleSignOnParticipationStrategy implements SingleSignOnParticipationStrategy {
+
+    @Override
+    public boolean supports(final RequestContext requestContext) {
+        val params = requestContext.getRequestParameters();
+        return params.contains(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+    }
 
     @Override
     public boolean isParticipating(final RequestContext requestContext) {

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -1,0 +1,19 @@
+package org.apereo.cas.pm.web.flow;
+
+import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
+
+import org.springframework.webflow.execution.RequestContext;
+
+/**
+ * This is {@link PasswordManagementSingleSignOnParticipationStrategy}.
+ *
+ * @author Julien Huon
+ * @since 6.3.0
+ */
+public class PasswordManagementSingleSignOnParticipationStrategy implements SingleSignOnParticipationStrategy {
+
+    @Override
+    public boolean isParticipating(final RequestContext requestContext) {
+        return false;
+    }
+}

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -34,11 +34,10 @@ public class PasswordManagementSingleSignOnParticipationStrategy implements Sing
         }
 
         try {
-            val ticket = centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
-            if (ticket != null || !ticket.isExpired()) {
-                LOGGER.trace("Token ticket [{}] is valid, SSO will be disabled", transientTicket);
-                return true;
-            }
+            centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
+
+            LOGGER.trace("Token ticket [{}] is valid, SSO will be disabled", transientTicket);
+            return true;
         } catch (final Exception e) {
             LOGGER.trace("Token ticket [{}] is not found or has expired, SSO will not be disabled", transientTicket);
         }

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -1,8 +1,9 @@
 package org.apereo.cas.pm.web.flow;
 
+import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
-import lombok.val;
+import lombok.RequiredArgsConstructor;
 import org.springframework.webflow.execution.RequestContext;
 
 /**
@@ -11,12 +12,13 @@ import org.springframework.webflow.execution.RequestContext;
  * @author Julien Huon
  * @since 6.3.0
  */
+@RequiredArgsConstructor
 public class PasswordManagementSingleSignOnParticipationStrategy implements SingleSignOnParticipationStrategy {
+    private final TicketRegistry ticketRegistry;
 
     @Override
     public boolean supports(final RequestContext requestContext) {
-        val params = requestContext.getRequestParameters();
-        return params.contains(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+        return PasswordManagementWebflowUtils.isPasswordResetRequestIsValid(requestContext, ticketRegistry);
     }
 
     @Override

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -3,9 +3,9 @@ package org.apereo.cas.pm.web.flow;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import lombok.RequiredArgsConstructor;
 import org.springframework.webflow.execution.RequestContext;
 
 /**

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
@@ -1,11 +1,7 @@
 package org.apereo.cas.pm.web.flow;
 
-import org.apereo.cas.ticket.TransientSessionTicket;
-import org.apereo.cas.ticket.registry.TicketRegistry;
-
 import lombok.experimental.UtilityClass;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.execution.RequestContext;
 
 import java.util.List;
@@ -27,25 +23,6 @@ public class PasswordManagementWebflowUtils {
      * Flowscope param name for token.
      */
     public static final String FLOWSCOPE_PARAMETER_NAME_TOKEN = "token";
-
-    /**
-     * Is reset request submited is valid? Does it contain a valid tst token?
-     *
-     * @param requestContext the request context
-     * @param ticketRegistry the ticket registry
-     * @return true/false
-     */
-    public boolean isPasswordResetRequestIsValid(final RequestContext requestContext, final TicketRegistry ticketRegistry) {
-        val transientTicket = requestContext
-            .getRequestParameters()
-            .get(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
-
-        if (StringUtils.isBlank(transientTicket)) {
-            return false;
-        }
-
-        return ticketRegistry.getTicket(transientTicket, TransientSessionTicket.class) != null;
-    }
 
     /**
      * Put password reset token.

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
@@ -1,7 +1,11 @@
 package org.apereo.cas.pm.web.flow;
 
+import org.apereo.cas.ticket.TransientSessionTicket;
+import org.apereo.cas.ticket.registry.TicketRegistry;
+
 import lombok.experimental.UtilityClass;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.execution.RequestContext;
 
 import java.util.List;
@@ -23,6 +27,25 @@ public class PasswordManagementWebflowUtils {
      * Flowscope param name for token.
      */
     public static final String FLOWSCOPE_PARAMETER_NAME_TOKEN = "token";
+
+    /**
+     * Is reset request submited is valid? Does it contain a valid tst token?
+     *
+     * @param requestContext the request context
+     * @param ticketRegistry the ticket registry
+     * @return true/false
+     */
+    public boolean isPasswordResetRequestIsValid(final RequestContext requestContext, final TicketRegistry ticketRegistry) {
+        val transientTicket = requestContext
+            .getRequestParameters()
+            .get(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+
+        if (StringUtils.isBlank(transientTicket)) {
+            return false;
+        }
+
+        return ticketRegistry.getTicket(transientTicket, TransientSessionTicket.class) != null;
+    }
 
     /**
      * Put password reset token.

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -2,6 +2,7 @@
 package org.apereo.cas;
 
 import org.apereo.cas.pm.web.flow.PasswordManagementCaptchaWebflowConfigurerTests;
+import org.apereo.cas.pm.web.flow.PasswordManagementSingleSignOnParticipationStrategyTests;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowConfigurerDisabledTests;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowConfigurerEnabledTests;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowUtilsTests;
@@ -35,6 +36,7 @@ import org.junit.runner.RunWith;
     PasswordChangeActionTests.class,
     VerifyPasswordResetRequestActionSecurityQuestionsDisabledTests.class,
     PasswordManagementCaptchaWebflowConfigurerTests.class,
+    PasswordManagementSingleSignOnParticipationStrategyTests.class,
     PasswordManagementWebflowConfigurerEnabledTests.class,
     PasswordManagementWebflowConfigurerDisabledTests.class,
     VerifyPasswordResetRequestActionTests.class,

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -1,0 +1,34 @@
+package org.apereo.cas.pm.web.flow;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.webflow.test.MockRequestContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link PasswordManagementSingleSignOnParticipationStrategyTests}.
+ *
+ * @author Julien Huon
+ * @since 6.3.0
+ */
+@Tag("WebflowConfig")
+public class PasswordManagementSingleSignOnParticipationStrategyTests {
+
+    @Test
+    public void verifyStrategyWithANonPmRequest() {
+        val s = new PasswordManagementSingleSignOnParticipationStrategy();
+        assertFalse(s.supports(new MockRequestContext()));
+    }
+
+    @Test
+    public void verifyStrategyWithAPmRequest() {
+        val s = new PasswordManagementSingleSignOnParticipationStrategy();
+        val ctx = new MockRequestContext();
+        ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "resetToken");
+
+        assertTrue(s.supports(ctx));
+        assertFalse(s.isParticipating(ctx));
+    }
+}

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.pm.web.flow;
 
+import org.apereo.cas.pm.web.flow.actions.BasePasswordManagementActionTests;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
@@ -29,26 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 6.3.0
  */
 @Tag("WebflowConfig")
-public class PasswordManagementSingleSignOnParticipationStrategyTests {
-
-    @Autowired
-    @Qualifier("ticketRegistry")
-    protected TicketRegistry ticketRegistry;
-
-    @Autowired
-    @Qualifier("defaulticketFactory")
-    protected TicketFactory ticketFactory;
-
-    @Autowired
-    protected CasConfigurationProperties casProperties;
-
-    @Autowired
-    @Qualifier("passwordChangeService")
-    protected PasswordManagementService passwordManagementService;
-
-    @Autowired
-    @Qualifier("webApplicationServiceFactory")
-    protected ServiceFactory<WebApplicationService> webApplicationServiceFactory;
+public class PasswordManagementSingleSignOnParticipationStrategyTests extends BasePasswordManagementActionTests {
 
     @Test
     public void verifyStrategyWithANonPmRequest() {
@@ -57,7 +39,7 @@ public class PasswordManagementSingleSignOnParticipationStrategyTests {
     }
 
     @Test
-    public void verifyStrategyWithAInvalidPmRequest() {
+    public void verifyStrategyWithAnInvalidPmRequest() {
         val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
         val ctx = new MockRequestContext();
         ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "invalidResetToken");

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.webflow.test.MockRequestContext;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is {@link PasswordManagementSingleSignOnParticipationStrategyTests}.

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -1,21 +1,13 @@
 package org.apereo.cas.pm.web.flow;
 
 import org.apereo.cas.pm.web.flow.actions.BasePasswordManagementActionTests;
-import org.apereo.cas.authentication.principal.ServiceFactory;
-import org.apereo.cas.authentication.principal.WebApplicationService;
-import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.pm.PasswordManagementService;
-import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.ticket.TransientSessionTicket;
 import org.apereo.cas.ticket.TransientSessionTicketFactory;
-import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.util.CollectionUtils;
 
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.webflow.test.MockRequestContext;
 
 import java.io.Serializable;

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -1,9 +1,23 @@
 package org.apereo.cas.pm.web.flow;
 
+import org.apereo.cas.authentication.principal.ServiceFactory;
+import org.apereo.cas.authentication.principal.WebApplicationService;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.ticket.TicketFactory;
+import org.apereo.cas.ticket.TransientSessionTicket;
+import org.apereo.cas.ticket.TransientSessionTicketFactory;
+import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.util.CollectionUtils;
+
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.webflow.test.MockRequestContext;
+
+import java.io.Serializable;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,17 +31,53 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Tag("WebflowConfig")
 public class PasswordManagementSingleSignOnParticipationStrategyTests {
 
+    @Autowired
+    @Qualifier("ticketRegistry")
+    protected TicketRegistry ticketRegistry;
+
+    @Autowired
+    @Qualifier("defaulticketFactory")
+    protected TicketFactory ticketFactory;
+
+    @Autowired
+    protected CasConfigurationProperties casProperties;
+
+    @Autowired
+    @Qualifier("passwordChangeService")
+    protected PasswordManagementService passwordManagementService;
+
+    @Autowired
+    @Qualifier("webApplicationServiceFactory")
+    protected ServiceFactory<WebApplicationService> webApplicationServiceFactory;
+
     @Test
     public void verifyStrategyWithANonPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy();
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
         assertFalse(s.supports(new MockRequestContext()));
     }
 
     @Test
-    public void verifyStrategyWithAPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy();
+    public void verifyStrategyWithAInvalidPmRequest() {
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
         val ctx = new MockRequestContext();
-        ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "resetToken");
+        ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "invalidResetToken");
+
+        assertFalse(s.supports(ctx));
+    }
+
+    @Test
+    public void verifyStrategyWithAValidPmRequest() {
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
+        val ctx = new MockRequestContext();
+
+        val token = passwordManagementService.createToken("casuser");
+        val transientFactory = (TransientSessionTicketFactory) ticketFactory.get(TransientSessionTicket.class);
+        val serverPrefix = casProperties.getServer().getPrefix();
+        val service = webApplicationServiceFactory.createService(serverPrefix);
+        val properties = CollectionUtils.<String, Serializable>wrap(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN, token);
+        val ticket = transientFactory.create(service, properties);
+        ticketRegistry.addTicket(ticket);
+        ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, ticket.getId());
 
         assertTrue(s.supports(ctx));
         assertFalse(s.isParticipating(ctx));

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -26,13 +26,13 @@ public class PasswordManagementSingleSignOnParticipationStrategyTests extends Ba
 
     @Test
     public void verifyStrategyWithANonPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService);
         assertFalse(s.supports(new MockRequestContext()));
     }
 
     @Test
     public void verifyStrategyWithAnInvalidPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService);
         val ctx = new MockRequestContext();
         ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "invalidResetToken");
 
@@ -41,7 +41,7 @@ public class PasswordManagementSingleSignOnParticipationStrategyTests extends Ba
 
     @Test
     public void verifyStrategyWithAValidPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService);
         val ctx = new MockRequestContext();
 
         val token = passwordManagementService.createToken("casuser");

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.pm.web.flow.actions;
 
+import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
@@ -81,7 +82,7 @@ import org.springframework.webflow.execution.Action;
 }, properties = {
     "spring.mail.host=localhost",
     "spring.mail.port=25000",
-    
+
     "cas.authn.pm.enabled=true",
     "cas.authn.pm.groovy.location=classpath:PasswordManagementService.groovy",
     "cas.authn.pm.reset.mail.from=cas@example.org",
@@ -96,6 +97,10 @@ public class BasePasswordManagementActionTests {
     @Autowired
     @Qualifier("ticketRegistry")
     protected TicketRegistry ticketRegistry;
+
+    @Autowired
+    @Qualifier("centralAuthenticationService")
+    protected CentralAuthenticationService centralAuthenticationService;
 
     @Autowired
     @Qualifier("passwordChangeService")


### PR DESCRIPTION
Hello,

When you're using the password reset link received by Mail or SMS when you're already connected, you'll have a 500 error and it's impossible to reset the password.

Access logs:

```
192.168.176.1 - - [01/Nov/2020:12:22:09 +0000] "GET /login?pswdrst=TST-1-******************************&service=https%3A%2F%2Fcasserver%3A8443%2Foauth2.0%2FcallbackAuthorize%3Fclient_id%3Dclient%26redirect_uri%3Dhttps%253A%252F%252Fwww.client.com%26response_type%3Dcode%26client_name%3DCasOAuthClient HTTP/1.1" 302 -

192.168.176.1 - - [01/Nov/2020:12:22:09 +0000] "GET /oauth2.0/callbackAuthorize?client_id=client&redirect_uri=https%3A%2F%2Fwww.client.com&response_type=code&client_name=CasOAuthClient&ticket=ST-2-**************** HTTP/1.1" 302 -

192.168.176.1 - - [01/Nov/2020:12:22:09 +0000] "GET /oauth2.0/callbackAuthorize?client_id=client&redirect_uri=https%3A%2F%2Fwww.client.com&response_type=code&client_name=CasOAuthClient&ticket=ST-2-X************** HTTP/1.1" 500 14379
```

Cas logs:

```
2020-11-01 12:22:09,691 DEBUG [org.apereo.cas.web.FlowExecutionExceptionResolver] - <Ignoring the received exception [org.apereo.cas.ticket.InvalidTicketException] due to a type mismatch with handler [org.apereo.cas.support.oauth.web.endpoints.OAuth20CallbackAuthorizeEndpointController#handleRequest(HttpServletRequest, HttpServletResponse)]>
2020-11-01 12:22:09,691 DEBUG [org.apereo.cas.web.FlowExecutionExceptionResolver] - <Ignoring the received exception [org.apereo.cas.ticket.InvalidTicketException] due to a type mismatch with handler [org.apereo.cas.support.oauth.web.endpoints.OAuth20CallbackAuthorizeEndpointController#handleRequest(HttpServletRequest, HttpServletResponse)]>
2020-11-01 12:22:09,699 ERROR [org.springframework.boot.web.servlet.support.ErrorPageFilter] - <Forwarding to error page from request [/oauth2.0/callbackAuthorize] due to exception [null]>
```

When you're using the CAS Protocol and not oauth or oidc, the link is redirecting you to the service without error.

Fixed by adding the renew parameter to the link.

Regards,
Julien