### PR TITLE
Disable the "Log in" button in the casPasswordUpdateSuccessView when …

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
@@ -738,6 +738,26 @@ public class WebUtils {
     }
 
     /**
+     * Put Password Management Auto-Login enabled.
+     *
+     * @param context the context
+     * @param value the value
+     */
+    public static void putPasswordManagementAutoLoginEnabled(final RequestContext context, final Boolean value) {
+        context.getFlowScope().put("passwordManagementAutoLoginEnabled", value);
+    }
+
+    /**
+     * Put Allow Missing Service Parameter enabled.
+     *
+     * @param context the context
+     * @param value the value
+     */
+    public static void putAllowMissingServiceParameterEnabled(final RequestContext context, final Boolean value) {
+        context.getFlowScope().put("allowMissingServiceParameterEnabled", value);
+    }
+
+    /**
      * Put principal.
      *
      * @param requestContext          the request context
@@ -946,7 +966,7 @@ public class WebUtils {
         request.setAttribute("error", HttpStatus.BAD_REQUEST.name());
         request.setAttribute("message", "Unable to verify registration record");
     }
-    
+
     /**
      * Produce error view model and view.
      *

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
@@ -69,6 +69,8 @@ public class WebUtilsTests {
                 WebUtils.putExistingSingleSignOnSessionPrincipal(context, CoreAuthenticationTestUtils.getPrincipal());
                 WebUtils.putAvailableAuthenticationHandleNames(context, List.of());
                 WebUtils.putPasswordManagementEnabled(context, true);
+                WebUtils.putPasswordManagementAutoLoginEnabled(context, true);
+                WebUtils.putAllowMissingServiceParameterEnabled(context, true);
                 WebUtils.putRecaptchaPropertiesFlowScope(context, new GoogleRecaptchaProperties());
                 WebUtils.putLogoutUrls(context, Map.of());
                 val ac = OneTimeTokenAccount.builder()

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casPasswordUpdateSuccessView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casPasswordUpdateSuccessView.html
@@ -15,7 +15,7 @@
             <h2 th:utext="#{screen.pm.success.header}">Password Change Successful</h2>
             <p th:utext="#{screen.pm.success.message}">Your account password is successfully updated.</p>
 
-            <form method="post" id="form" class="fm-v clearfix" th:action="@{/login}">
+            <form th:if="${passwordManagementAutoLoginEnabled} or ${not passwordManagementAutoLoginEnabled and allowMissingServiceParameterEnabled}" method="post" id="form" class="fm-v clearfix" th:action="@{/login}">
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
                 <input type="hidden" name="_eventId" value="proceed" />
                 <button class="mdc-button mdc-button--raised mr-2" name="continue" accesskey="l" type="submit"


### PR DESCRIPTION
Hello,

When the Password Management Auto Login feature is disabled:

```
cas.authn.pm.autoLogin=false
```


And the allowMissingServiceParameter is disabled also:

```
cas.sso.allowMissingServiceParameter=false
```


The casPasswordUpdateSuccess View does have a "Log in" button which does not working because the user is not authorised to use it.


Fixed by removing the "Login Button" when Auto-Login is disabled and the allowMissingServerParameter also.

Regards,
Julien