### PR TITLE
[backport] Password Management : Allow an authenticated user to reset his password.

### DIFF
--- a/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
+++ b/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
@@ -199,6 +199,10 @@ public interface CasWebflowConstants {
      * Transition id 'resetPassword'.
      */
     String TRANSITION_ID_RESET_PASSWORD = "resetPassword";
+    /**
+     * Transition id 'invalidPasswordResetToken'.
+     */
+    String TRANSITION_ID_INVALID_PASSWORD_RESET_TOKEN = "invalidPasswordResetToken";
 
     /**
      * Transition id 'forgotUsername'.
@@ -559,6 +563,11 @@ public interface CasWebflowConstants {
      */
     String STATE_ID_PASSWORD_CHANGE_ACTION = "passwordChangeAction";
 
+    /**
+     * The view state 'passwordResetErrorView'.
+     */
+    String STATE_ID_PASSWORD_RESET_ERROR_VIEW = "passwordResetErrorView";
+    
     /*
      ****************************************
      * Views.

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -102,7 +102,7 @@ public class PasswordManagementWebflowConfiguration {
     @RefreshScope
     @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategy")
     public SingleSignOnParticipationStrategy passwordManagementSingleSignOnParticipationStrategy() {
-        return new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry.getObject());
+        return new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService.getObject());
     }
 
     @Bean

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -102,7 +102,7 @@ public class PasswordManagementWebflowConfiguration {
     @RefreshScope
     @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategy")
     public SingleSignOnParticipationStrategy passwordManagementSingleSignOnParticipationStrategy() {
-        return new PasswordManagementSingleSignOnParticipationStrategy();
+        return new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry.getObject());
     }
 
     @Bean

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -5,6 +5,7 @@ import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.pm.PasswordValidationService;
 import org.apereo.cas.pm.web.flow.PasswordManagementCaptchaWebflowConfigurer;
+import org.apereo.cas.pm.web.flow.PasswordManagementSingleSignOnParticipationStrategy;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowConfigurer;
 import org.apereo.cas.pm.web.flow.actions.HandlePasswordExpirationWarningMessagesAction;
 import org.apereo.cas.pm.web.flow.actions.InitPasswordChangeAction;
@@ -20,6 +21,8 @@ import org.apereo.cas.util.io.CommunicationsManager;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
 import org.apereo.cas.web.flow.CasWebflowExecutionPlanConfigurer;
 import org.apereo.cas.web.flow.InitializeCaptchaAction;
+import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
+import org.apereo.cas.web.flow.SingleSignOnParticipationStrategyConfigurer;
 import org.apereo.cas.web.flow.ValidateCaptchaAction;
 import org.apereo.cas.web.flow.actions.StaticEventExecutionAction;
 
@@ -94,6 +97,20 @@ public class PasswordManagementWebflowConfiguration {
     @Autowired
     @Qualifier("passwordChangeService")
     private ObjectProvider<PasswordManagementService> passwordManagementService;
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategy")
+    public SingleSignOnParticipationStrategy passwordManagementSingleSignOnParticipationStrategy() {
+        return new PasswordManagementSingleSignOnParticipationStrategy();
+    }
+
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean(name = "passwordManagementSingleSignOnParticipationStrategyConfigurer")
+    public SingleSignOnParticipationStrategyConfigurer passwordManagementSingleSignOnParticipationStrategyConfigurer() {
+        return chain -> chain.addStrategy(passwordManagementSingleSignOnParticipationStrategy());
+    }
 
     @RefreshScope
     @Bean
@@ -225,6 +242,3 @@ public class PasswordManagementWebflowConfiguration {
         }
     }
 }
-
-
-

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -13,6 +13,7 @@ import org.apereo.cas.pm.web.flow.actions.InitPasswordResetAction;
 import org.apereo.cas.pm.web.flow.actions.PasswordChangeAction;
 import org.apereo.cas.pm.web.flow.actions.SendForgotUsernameInstructionsAction;
 import org.apereo.cas.pm.web.flow.actions.SendPasswordResetInstructionsAction;
+import org.apereo.cas.pm.web.flow.actions.ValidatePasswordResetTokenAction;
 import org.apereo.cas.pm.web.flow.actions.VerifyPasswordResetRequestAction;
 import org.apereo.cas.pm.web.flow.actions.VerifySecurityQuestionsAction;
 import org.apereo.cas.ticket.TicketFactory;
@@ -189,6 +190,14 @@ public class PasswordManagementWebflowConfiguration {
         return new VerifySecurityQuestionsAction(passwordManagementService.getObject());
     }
 
+    @ConditionalOnMissingBean(name = "validatePasswordResetTokenAction")
+    @Bean
+    @RefreshScope
+    public Action validatePasswordResetTokenAction() {
+        return new ValidatePasswordResetTokenAction(passwordManagementService.getObject(),
+            centralAuthenticationService.getObject());
+    }
+
     @ConditionalOnMissingBean(name = "passwordManagementWebflowConfigurer")
     @RefreshScope
     @Bean
@@ -196,7 +205,7 @@ public class PasswordManagementWebflowConfiguration {
     public CasWebflowConfigurer passwordManagementWebflowConfigurer() {
         return new PasswordManagementWebflowConfigurer(flowBuilderServices.getObject(),
             loginFlowDefinitionRegistry.getObject(),
-            applicationContext, casProperties, initPasswordChangeAction());
+            applicationContext, casProperties);
     }
 
     @Bean
@@ -234,7 +243,7 @@ public class PasswordManagementWebflowConfiguration {
         public Action passwordResetInitializeCaptchaAction() {
             return new InitializeCaptchaAction(casProperties);
         }
-        
+
         @Bean
         @ConditionalOnMissingBean(name = "passwordManagementCaptchaWebflowExecutionPlanConfigurer")
         public CasWebflowExecutionPlanConfigurer passwordManagementCaptchaWebflowExecutionPlanConfigurer() {

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -3,6 +3,8 @@ package org.apereo.cas.pm.web.flow;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.webflow.execution.RequestContext;
 
@@ -18,7 +20,15 @@ public class PasswordManagementSingleSignOnParticipationStrategy implements Sing
 
     @Override
     public boolean supports(final RequestContext requestContext) {
-        return PasswordManagementWebflowUtils.isPasswordResetRequestIsValid(requestContext, ticketRegistry);
+        val transientTicket = requestContext
+            .getRequestParameters()
+            .get(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+
+        if (StringUtils.isBlank(transientTicket)) {
+            return false;
+        }
+
+        return ticketRegistry.getTicket(transientTicket) != null;
     }
 
     @Override

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -2,6 +2,7 @@ package org.apereo.cas.pm.web.flow;
 
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
+import lombok.val;
 import org.springframework.webflow.execution.RequestContext;
 
 /**
@@ -11,6 +12,12 @@ import org.springframework.webflow.execution.RequestContext;
  * @since 6.3.0
  */
 public class PasswordManagementSingleSignOnParticipationStrategy implements SingleSignOnParticipationStrategy {
+
+    @Override
+    public boolean supports(final RequestContext requestContext) {
+        val params = requestContext.getRequestParameters();
+        return params.contains(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+    }
 
     @Override
     public boolean isParticipating(final RequestContext requestContext) {

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -1,0 +1,19 @@
+package org.apereo.cas.pm.web.flow;
+
+import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
+
+import org.springframework.webflow.execution.RequestContext;
+
+/**
+ * This is {@link PasswordManagementSingleSignOnParticipationStrategy}.
+ *
+ * @author Julien Huon
+ * @since 6.3.0
+ */
+public class PasswordManagementSingleSignOnParticipationStrategy implements SingleSignOnParticipationStrategy {
+
+    @Override
+    public boolean isParticipating(final RequestContext requestContext) {
+        return false;
+    }
+}

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -34,11 +34,10 @@ public class PasswordManagementSingleSignOnParticipationStrategy implements Sing
         }
 
         try {
-            val ticket = centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
-            if (ticket != null || !ticket.isExpired()) {
-                LOGGER.trace("Token ticket [{}] is valid, SSO will be disabled", transientTicket);
-                return true;
-            }
+            centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
+
+            LOGGER.trace("Token ticket [{}] is valid, SSO will be disabled", transientTicket);
+            return true;
         } catch (final Exception e) {
             LOGGER.trace("Token ticket [{}] is not found or has expired, SSO will not be disabled", transientTicket);
         }

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -1,8 +1,9 @@
 package org.apereo.cas.pm.web.flow;
 
+import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
-import lombok.val;
+import lombok.RequiredArgsConstructor;
 import org.springframework.webflow.execution.RequestContext;
 
 /**
@@ -11,12 +12,13 @@ import org.springframework.webflow.execution.RequestContext;
  * @author Julien Huon
  * @since 6.3.0
  */
+@RequiredArgsConstructor
 public class PasswordManagementSingleSignOnParticipationStrategy implements SingleSignOnParticipationStrategy {
+    private final TicketRegistry ticketRegistry;
 
     @Override
     public boolean supports(final RequestContext requestContext) {
-        val params = requestContext.getRequestParameters();
-        return params.contains(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+        return PasswordManagementWebflowUtils.isPasswordResetRequestIsValid(requestContext, ticketRegistry);
     }
 
     @Override

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategy.java
@@ -3,9 +3,9 @@ package org.apereo.cas.pm.web.flow;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.web.flow.SingleSignOnParticipationStrategy;
 
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import lombok.RequiredArgsConstructor;
 import org.springframework.webflow.execution.RequestContext;
 
 /**

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
@@ -1,11 +1,7 @@
 package org.apereo.cas.pm.web.flow;
 
-import org.apereo.cas.ticket.TransientSessionTicket;
-import org.apereo.cas.ticket.registry.TicketRegistry;
-
 import lombok.experimental.UtilityClass;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.execution.RequestContext;
 
 import java.util.List;
@@ -27,25 +23,6 @@ public class PasswordManagementWebflowUtils {
      * Flowscope param name for token.
      */
     public static final String FLOWSCOPE_PARAMETER_NAME_TOKEN = "token";
-
-    /**
-     * Is reset request submited is valid? Does it contain a valid tst token?
-     *
-     * @param requestContext the request context
-     * @param ticketRegistry the ticket registry
-     * @return true/false
-     */
-    public boolean isPasswordResetRequestIsValid(final RequestContext requestContext, final TicketRegistry ticketRegistry) {
-        val transientTicket = requestContext
-            .getRequestParameters()
-            .get(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
-
-        if (StringUtils.isBlank(transientTicket)) {
-            return false;
-        }
-
-        return ticketRegistry.getTicket(transientTicket, TransientSessionTicket.class) != null;
-    }
 
     /**
      * Put password reset token.

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowUtils.java
@@ -1,7 +1,11 @@
 package org.apereo.cas.pm.web.flow;
 
+import org.apereo.cas.ticket.TransientSessionTicket;
+import org.apereo.cas.ticket.registry.TicketRegistry;
+
 import lombok.experimental.UtilityClass;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.execution.RequestContext;
 
 import java.util.List;
@@ -23,6 +27,25 @@ public class PasswordManagementWebflowUtils {
      * Flowscope param name for token.
      */
     public static final String FLOWSCOPE_PARAMETER_NAME_TOKEN = "token";
+
+    /**
+     * Is reset request submited is valid? Does it contain a valid tst token?
+     *
+     * @param requestContext the request context
+     * @param ticketRegistry the ticket registry
+     * @return true/false
+     */
+    public boolean isPasswordResetRequestIsValid(final RequestContext requestContext, final TicketRegistry ticketRegistry) {
+        val transientTicket = requestContext
+            .getRequestParameters()
+            .get(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+
+        if (StringUtils.isBlank(transientTicket)) {
+            return false;
+        }
+
+        return ticketRegistry.getTicket(transientTicket, TransientSessionTicket.class) != null;
+    }
 
     /**
      * Put password reset token.

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
@@ -90,7 +90,7 @@ public class SendPasswordResetInstructionsAction extends AbstractAction {
                 ExpirationPolicy.class.getName(), HardTimeoutExpirationPolicy.builder().timeToKillInSeconds(expirationSeconds).build());
             val ticket = transientFactory.create(service, properties);
             this.ticketRegistry.addTicket(ticket);
-            
+
             StringBuilder resetUrl = new StringBuilder(casProperties.getServer().getPrefix())
                 .append('/').append(CasWebflowConfigurer.FLOW_ID_LOGIN).append('?')
                 .append(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN).append('=').append(ticket.getId());

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/ValidatePasswordResetTokenAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/ValidatePasswordResetTokenAction.java
@@ -1,0 +1,50 @@
+package org.apereo.cas.pm.web.flow.actions;
+
+import org.apereo.cas.CentralAuthenticationService;
+import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.web.flow.PasswordManagementWebflowUtils;
+import org.apereo.cas.ticket.TransientSessionTicket;
+import org.apereo.cas.web.flow.CasWebflowConstants;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.webflow.action.AbstractAction;
+import org.springframework.webflow.action.EventFactorySupport;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+
+/**
+ * This is {@link ValidatePasswordResetTokenAction}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.3.0
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class ValidatePasswordResetTokenAction extends AbstractAction {
+    private final PasswordManagementService passwordManagementService;
+
+    private final CentralAuthenticationService centralAuthenticationService;
+
+    @Override
+    protected Event doExecute(final RequestContext requestContext) {
+        try {
+            val transientTicket = requestContext.getRequestParameters()
+                .get(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN);
+            if (StringUtils.isNotBlank(transientTicket)) {
+                val tst = centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
+                val token = tst.getProperties().get(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN).toString();
+                val username = passwordManagementService.parseToken(token);
+                if (StringUtils.isBlank(username)) {
+                    throw new IllegalArgumentException("Password reset token could not be verified to determine username");
+                }
+            }
+            return null;
+        } catch (final Exception e) {
+            LOGGER.warn("Password reset token could not be verified: [{}]");
+            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_INVALID_PASSWORD_RESET_TOKEN);
+        }
+    }
+}

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -1,6 +1,7 @@
 
 package org.apereo.cas;
 
+import org.apereo.cas.pm.web.flow.PasswordManagementSingleSignOnParticipationStrategyTests;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowConfigurerDisabledTests;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowConfigurerEnabledTests;
 import org.apereo.cas.pm.web.flow.actions.HandlePasswordExpirationWarningMessagesActionTests;
@@ -23,6 +24,7 @@ import org.junit.runner.RunWith;
     VerifySecurityQuestionsActionTests.class,
     SendPasswordResetInstructionsActionTests.class,
     InitPasswordResetActionTests.class,
+    PasswordManagementSingleSignOnParticipationStrategyTests.class,
     PasswordManagementWebflowConfigurerEnabledTests.class,
     PasswordManagementWebflowConfigurerDisabledTests.class,
     VerifyPasswordResetRequestActionTests.class,

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -7,6 +7,7 @@ import org.apereo.cas.pm.web.flow.PasswordManagementWebflowConfigurerEnabledTest
 import org.apereo.cas.pm.web.flow.actions.HandlePasswordExpirationWarningMessagesActionTests;
 import org.apereo.cas.pm.web.flow.actions.InitPasswordResetActionTests;
 import org.apereo.cas.pm.web.flow.actions.SendPasswordResetInstructionsActionTests;
+import org.apereo.cas.pm.web.flow.actions.ValidatePasswordResetTokenActionTests;
 import org.apereo.cas.pm.web.flow.actions.VerifyPasswordResetRequestActionTests;
 import org.apereo.cas.pm.web.flow.actions.VerifySecurityQuestionsActionTests;
 
@@ -27,6 +28,7 @@ import org.junit.runner.RunWith;
     PasswordManagementSingleSignOnParticipationStrategyTests.class,
     PasswordManagementWebflowConfigurerEnabledTests.class,
     PasswordManagementWebflowConfigurerDisabledTests.class,
+    ValidatePasswordResetTokenActionTests.class,
     VerifyPasswordResetRequestActionTests.class,
     HandlePasswordExpirationWarningMessagesActionTests.class
 })

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.webflow.test.MockRequestContext;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is {@link PasswordManagementSingleSignOnParticipationStrategyTests}.

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.pm.web.flow;
 
+import org.apereo.cas.pm.web.flow.actions.BasePasswordManagementActionTests;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
@@ -29,26 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 6.3.0
  */
 @Tag("Webflow")
-public class PasswordManagementSingleSignOnParticipationStrategyTests {
-
-    @Autowired
-    @Qualifier("ticketRegistry")
-    protected TicketRegistry ticketRegistry;
-
-    @Autowired
-    @Qualifier("defaulticketFactory")
-    protected TicketFactory ticketFactory;
-
-    @Autowired
-    protected CasConfigurationProperties casProperties;
-
-    @Autowired
-    @Qualifier("passwordChangeService")
-    protected PasswordManagementService passwordManagementService;
-
-    @Autowired
-    @Qualifier("webApplicationServiceFactory")
-    protected ServiceFactory<WebApplicationService> webApplicationServiceFactory;
+public class PasswordManagementSingleSignOnParticipationStrategyTests extends BasePasswordManagementActionTests {
 
     @Test
     public void verifyStrategyWithANonPmRequest() {
@@ -57,7 +39,7 @@ public class PasswordManagementSingleSignOnParticipationStrategyTests {
     }
 
     @Test
-    public void verifyStrategyWithAInvalidPmRequest() {
+    public void verifyStrategyWithAnInvalidPmRequest() {
         val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
         val ctx = new MockRequestContext();
         ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "invalidResetToken");

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -1,21 +1,13 @@
 package org.apereo.cas.pm.web.flow;
 
 import org.apereo.cas.pm.web.flow.actions.BasePasswordManagementActionTests;
-import org.apereo.cas.authentication.principal.ServiceFactory;
-import org.apereo.cas.authentication.principal.WebApplicationService;
-import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.pm.PasswordManagementService;
-import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.ticket.TransientSessionTicket;
 import org.apereo.cas.ticket.TransientSessionTicketFactory;
-import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.util.CollectionUtils;
 
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.webflow.test.MockRequestContext;
 
 import java.io.Serializable;

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -1,0 +1,34 @@
+package org.apereo.cas.pm.web.flow;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.webflow.test.MockRequestContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link PasswordManagementSingleSignOnParticipationStrategyTests}.
+ *
+ * @author Julien Huon
+ * @since 6.3.0
+ */
+@Tag("Webflow")
+public class PasswordManagementSingleSignOnParticipationStrategyTests {
+
+    @Test
+    public void verifyStrategyWithANonPmRequest() {
+        val s = new PasswordManagementSingleSignOnParticipationStrategy();
+        assertFalse(s.supports(new MockRequestContext()));
+    }
+
+    @Test
+    public void verifyStrategyWithAPmRequest() {
+        val s = new PasswordManagementSingleSignOnParticipationStrategy();
+        val ctx = new MockRequestContext();
+        ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "resetToken");
+
+        assertTrue(s.supports(ctx));
+        assertFalse(s.isParticipating(ctx));
+    }
+}

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementSingleSignOnParticipationStrategyTests.java
@@ -26,13 +26,13 @@ public class PasswordManagementSingleSignOnParticipationStrategyTests extends Ba
 
     @Test
     public void verifyStrategyWithANonPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService);
         assertFalse(s.supports(new MockRequestContext()));
     }
 
     @Test
     public void verifyStrategyWithAnInvalidPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService);
         val ctx = new MockRequestContext();
         ctx.putRequestParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, "invalidResetToken");
 
@@ -41,7 +41,7 @@ public class PasswordManagementSingleSignOnParticipationStrategyTests extends Ba
 
     @Test
     public void verifyStrategyWithAValidPmRequest() {
-        val s = new PasswordManagementSingleSignOnParticipationStrategy(ticketRegistry);
+        val s = new PasswordManagementSingleSignOnParticipationStrategy(centralAuthenticationService);
         val ctx = new MockRequestContext();
 
         val token = passwordManagementService.createToken("casuser");

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.pm.web.flow.actions;
 
+import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.principal.ServiceFactory;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.config.CasCoreAuthenticationConfiguration;
@@ -75,7 +76,7 @@ import org.springframework.webflow.execution.Action;
 }, properties = {
     "spring.mail.host=localhost",
     "spring.mail.port=25000",
-    
+
     "cas.authn.pm.enabled=true",
     "cas.authn.pm.groovy.location=classpath:PasswordManagementService.groovy",
     "cas.authn.pm.reset.mail.from=cas@example.org",
@@ -90,6 +91,10 @@ public class BasePasswordManagementActionTests {
     @Autowired
     @Qualifier("ticketRegistry")
     protected TicketRegistry ticketRegistry;
+
+    @Autowired
+    @Qualifier("centralAuthenticationService")
+    protected CentralAuthenticationService centralAuthenticationService;
 
     @Autowired
     @Qualifier("passwordChangeService")

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/BasePasswordManagementActionTests.java
@@ -113,6 +113,10 @@ public class BasePasswordManagementActionTests {
     protected Action verifyPasswordResetRequestAction;
 
     @Autowired
+    @Qualifier("validatePasswordResetTokenAction")
+    protected Action validatePasswordResetTokenAction;
+
+    @Autowired
     @Qualifier("sendPasswordResetInstructionsAction")
     protected Action sendPasswordResetInstructionsAction;
 

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/ValidatePasswordResetTokenActionTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/ValidatePasswordResetTokenActionTests.java
@@ -1,0 +1,67 @@
+package org.apereo.cas.pm.web.flow.actions;
+
+import org.apereo.cas.pm.web.flow.PasswordManagementWebflowUtils;
+import org.apereo.cas.ticket.TransientSessionTicket;
+import org.apereo.cas.util.junit.EnabledIfPortOpen;
+import org.apereo.cas.web.flow.CasWebflowConstants;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.webflow.context.servlet.ServletExternalContext;
+import org.springframework.webflow.test.MockRequestContext;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * This is {@link ValidatePasswordResetTokenActionTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.3.0
+ */
+@EnabledIfPortOpen(port = 25000)
+@Tag("Mail")
+public class ValidatePasswordResetTokenActionTests extends BasePasswordManagementActionTests {
+    @Test
+    public void verifyInvalidTicket() throws Exception {
+        val context = new MockRequestContext();
+        val request = new MockHttpServletRequest();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
+        request.addParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, UUID.randomUUID().toString());
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
+        assertEquals(CasWebflowConstants.TRANSITION_ID_INVALID_PASSWORD_RESET_TOKEN, validatePasswordResetTokenAction.execute(context).getId());
+    }
+
+    @Test
+    public void verifyNoParam() throws Exception {
+        val context = new MockRequestContext();
+        val request = new MockHttpServletRequest();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
+        assertNull(validatePasswordResetTokenAction.execute(context));
+    }
+
+    @Test
+    public void verifyInvalidToken() throws Exception {
+        val context = new MockRequestContext();
+        val request = new MockHttpServletRequest();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
+
+        val ticketId = UUID.randomUUID().toString();
+        val sts = mock(TransientSessionTicket.class);
+        when(sts.getProperties()).thenReturn(Map.of(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN, "invalid"));
+        when(sts.getId()).thenReturn(ticketId);
+        ticketRegistry.addTicket(sts);
+
+        request.addParameter(PasswordManagementWebflowUtils.REQUEST_PARAMETER_NAME_PASSWORD_RESET_TOKEN, ticketId);
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
+        assertEquals(CasWebflowConstants.TRANSITION_ID_INVALID_PASSWORD_RESET_TOKEN, validatePasswordResetTokenAction.execute(context).getId());
+    }
+}


### PR DESCRIPTION
Hello,

When you're using the password reset link received by Mail or SMS when you're already connected, you'll have a 500 error and it's impossible to reset the password.

Access logs:

```
192.168.176.1 - - [01/Nov/2020:12:22:09 +0000] "GET /login?pswdrst=TST-1-******************************&service=https%3A%2F%2Fcasserver%3A8443%2Foauth2.0%2FcallbackAuthorize%3Fclient_id%3Dclient%26redirect_uri%3Dhttps%253A%252F%252Fwww.client.com%26response_type%3Dcode%26client_name%3DCasOAuthClient HTTP/1.1" 302 -

192.168.176.1 - - [01/Nov/2020:12:22:09 +0000] "GET /oauth2.0/callbackAuthorize?client_id=client&redirect_uri=https%3A%2F%2Fwww.client.com&response_type=code&client_name=CasOAuthClient&ticket=ST-2-**************** HTTP/1.1" 302 -

192.168.176.1 - - [01/Nov/2020:12:22:09 +0000] "GET /oauth2.0/callbackAuthorize?client_id=client&redirect_uri=https%3A%2F%2Fwww.client.com&response_type=code&client_name=CasOAuthClient&ticket=ST-2-X************** HTTP/1.1" 500 14379
```

Cas logs:

```
2020-11-01 12:22:09,691 DEBUG [org.apereo.cas.web.FlowExecutionExceptionResolver] - <Ignoring the received exception [org.apereo.cas.ticket.InvalidTicketException] due to a type mismatch with handler [org.apereo.cas.support.oauth.web.endpoints.OAuth20CallbackAuthorizeEndpointController#handleRequest(HttpServletRequest, HttpServletResponse)]>
2020-11-01 12:22:09,691 DEBUG [org.apereo.cas.web.FlowExecutionExceptionResolver] - <Ignoring the received exception [org.apereo.cas.ticket.InvalidTicketException] due to a type mismatch with handler [org.apereo.cas.support.oauth.web.endpoints.OAuth20CallbackAuthorizeEndpointController#handleRequest(HttpServletRequest, HttpServletResponse)]>
2020-11-01 12:22:09,699 ERROR [org.springframework.boot.web.servlet.support.ErrorPageFilter] - <Forwarding to error page from request [/oauth2.0/callbackAuthorize] due to exception [null]>
```

When you're using the CAS Protocol and not oauth or oidc, the link is redirecting you to the service without error.

Backport of #4967 

Regards,
Julien