### PR TITLE
Reject invalid oauth/oidc Authentication Requests.

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
@@ -3,6 +3,7 @@ package org.apereo.cas.config;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.oauth.authenticator.Authenticators;
+import org.apereo.cas.support.oauth.validator.authorization.OAuth20AuthorizationRequestValidator;
 import org.apereo.cas.support.oauth.web.OAuth20HandlerInterceptorAdapter;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenGrantRequestExtractor;
 import org.apereo.cas.throttle.AuthenticationThrottlingExecutionPlan;
@@ -29,6 +30,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apereo.cas.support.oauth.OAuth20Constants.BASE_OAUTH20_URL;
@@ -54,6 +56,10 @@ public class CasOAuth20ThrottleConfiguration {
     @Autowired
     @Qualifier("accessTokenGrantRequestExtractors")
     private Collection<AccessTokenGrantRequestExtractor> accessTokenGrantRequestExtractors;
+
+    @Autowired
+    @Qualifier("oauthAuthorizationRequestValidators")
+    private Set<OAuth20AuthorizationRequestValidator> oauthAuthorizationRequestValidators;
 
     @ConditionalOnMissingBean(name = "requiresAuthenticationAuthorizeInterceptor")
     @Bean
@@ -88,7 +94,8 @@ public class CasOAuth20ThrottleConfiguration {
             requiresAuthenticationAuthorizeInterceptor(),
             accessTokenGrantRequestExtractors,
             servicesManager.getObject(),
-            oauthSecConfig.getObject().getSessionStore());
+            oauthSecConfig.getObject().getSessionStore(),
+            oauthAuthorizationRequestValidators);
     }
 
     @Bean

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20HandlerInterceptorAdapterTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/OAuth20HandlerInterceptorAdapterTests.java
@@ -13,7 +13,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is {@link OAuth20HandlerInterceptorAdapterTests}.
@@ -23,6 +24,24 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @Tag("OAuth")
 public class OAuth20HandlerInterceptorAdapterTests extends AbstractOAuth20Tests {
+    @Test
+    public void verifyAuthorizationAuth() throws Exception {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        request.setRequestURI('/' + OAuth20Constants.AUTHORIZE_URL);
+        request.setParameter(OAuth20Constants.CLIENT_ID, CLIENT_ID);
+        request.setParameter(OAuth20Constants.REDIRECT_URI, "https://oauth.example.org");
+        request.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.getType());
+
+        val service = getRegisteredService(CLIENT_ID, CLIENT_SECRET);
+        servicesManager.save(service);
+        assertFalse(oauthHandlerInterceptorAdapter.preHandle(request, response, new Object()));
+
+        request.removeAllParameters();
+        assertTrue(oauthHandlerInterceptorAdapter.preHandle(request, response, new Object()));
+    }
+
     @Test
     public void verifyRevocationAuth() throws Exception {
         val request = new MockHttpServletRequest();

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcHandlerInterceptorAdapter.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcHandlerInterceptorAdapter.java
@@ -2,6 +2,7 @@ package org.apereo.cas.oidc.web;
 
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.support.oauth.validator.authorization.OAuth20AuthorizationRequestValidator;
 import org.apereo.cas.support.oauth.web.OAuth20HandlerInterceptorAdapter;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenGrantRequestExtractor;
 
@@ -13,6 +14,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * This is {@link OidcHandlerInterceptorAdapter}.
@@ -35,8 +37,10 @@ public class OidcHandlerInterceptorAdapter extends OAuth20HandlerInterceptorAdap
                                          final OidcConstants.DynamicClientRegistrationMode dynamicClientRegistrationMode,
                                          final Collection<AccessTokenGrantRequestExtractor> accessTokenGrantRequestExtractors,
                                          final ServicesManager servicesManager,
-                                         final SessionStore<JEEContext> sessionStore) {
-        super(requiresAuthenticationAccessTokenInterceptor, requiresAuthenticationAuthorizeInterceptor, accessTokenGrantRequestExtractors, servicesManager, sessionStore);
+                                         final SessionStore<JEEContext> sessionStore,
+                                         final Set<OAuth20AuthorizationRequestValidator> oauthAuthorizationRequestValidators) {
+        super(requiresAuthenticationAccessTokenInterceptor, requiresAuthenticationAuthorizeInterceptor,
+              accessTokenGrantRequestExtractors, servicesManager, sessionStore, oauthAuthorizationRequestValidators);
         this.requiresAuthenticationDynamicRegistrationInterceptor = requiresAuthenticationDynamicRegistrationInterceptor;
         this.dynamicClientRegistrationMode = dynamicClientRegistrationMode;
         this.requiresAuthenticationClientConfigurationInterceptor = requiresAuthenticationClientConfigurationInterceptor;

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -735,7 +735,8 @@ public class OidcConfiguration implements WebMvcConfigurer {
             mode,
             accessTokenGrantRequestExtractors.getObject(),
             servicesManager.getObject(),
-            oauthDistributedSessionStore.getObject());
+            oauthDistributedSessionStore.getObject(),
+            oauthRequestValidators.getObject());
     }
 
     @RefreshScope


### PR DESCRIPTION
Hello Misagh,

When you're trying to do an invalid OAuth 2.0/OIDC Authorization request against the CAS server, for instance a request without or with invalid response_type and client_id parameters, you don't have any error.

Instead, you're redirected to the login page for the "OAuth Authentication Callback Request URL" service.

Authorization Requests validators exist in the code but they are not used because of the OAuth20HandlerInterceptorAdapter who is requesting authentication even for invalid requests.

This PR fix the problem and adds tests to avoid any future problem.

Another PR will be made later to adds OIDC Authorization Requests Validators to ensure the scope parameter exists in the OIDC Authorization request because it's a required parameter.

Regards,
Julien