### PR TITLE
add logging at warn level when response type not supported by service

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
@@ -292,7 +292,6 @@ public class OAuth20Utils {
     public static boolean isAuthorizedResponseTypeForService(final JEEContext context, final OAuthRegisteredService registeredService) {
         if (registeredService.getSupportedResponseTypes() != null && !registeredService.getSupportedResponseTypes().isEmpty()) {
             val responseType = context.getRequestParameter(OAuth20Constants.RESPONSE_TYPE).map(String::valueOf).orElse(StringUtils.EMPTY);
-            LOGGER.debug("Checking response type [{}] against supported response types [{}]", responseType, registeredService.getSupportedResponseTypes());
             if (registeredService.getSupportedResponseTypes().stream().anyMatch(s -> s.equalsIgnoreCase(responseType))) {
                 return true;
             } else {

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
@@ -293,7 +293,13 @@ public class OAuth20Utils {
         if (registeredService.getSupportedResponseTypes() != null && !registeredService.getSupportedResponseTypes().isEmpty()) {
             val responseType = context.getRequestParameter(OAuth20Constants.RESPONSE_TYPE).map(String::valueOf).orElse(StringUtils.EMPTY);
             LOGGER.debug("Checking response type [{}] against supported response types [{}]", responseType, registeredService.getSupportedResponseTypes());
-            return registeredService.getSupportedResponseTypes().stream().anyMatch(s -> s.equalsIgnoreCase(responseType));
+            if (registeredService.getSupportedResponseTypes().stream().anyMatch(s -> s.equalsIgnoreCase(responseType))) {
+                return true;
+            } else {
+                LOGGER.warn("Response type not authorized for service: [{}] not listed in supported response types: [{}]",
+                        responseType, registeredService.getSupportedResponseTypes());
+                return false;
+            }
         }
 
         LOGGER.warn("Registered service [{}] does not define any authorized/supported response types. "

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
@@ -6,6 +6,7 @@ import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.OAuth20GrantTypes;
 import org.apereo.cas.support.oauth.OAuth20ResponseModeTypes;
+import org.apereo.cas.support.oauth.OAuth20ResponseTypes;
 import org.apereo.cas.support.oauth.services.OAuth20RegisteredServiceCipherExecutor;
 import org.apereo.cas.support.oauth.services.OAuthRegisteredService;
 import org.apereo.cas.ticket.OAuth20Token;
@@ -19,6 +20,7 @@ import org.pac4j.core.context.JEEContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -122,5 +124,26 @@ public class OAuth20UtilsTests {
         registeredService.setClientSecret(secret);
         val result = OAuth20Utils.checkClientSecret(registeredService, secret, cipher);
         assertTrue(result);
+    }
+
+    @Test
+    public void verifyIsAuthorizedResponseTypeForService() {
+        val request = new MockHttpServletRequest();
+        request.addParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.ID_TOKEN.getType());
+        val response = new MockHttpServletResponse();
+        val context = new JEEContext(request, response);
+        val registeredService = new OAuthRegisteredService();
+        val supportedResponseTypes = new HashSet<String>();
+
+        registeredService.setSupportedResponseTypes(supportedResponseTypes);
+        assertTrue(OAuth20Utils.isAuthorizedResponseTypeForService(context, registeredService));
+
+        supportedResponseTypes.add(OAuth20ResponseTypes.IDTOKEN_TOKEN.getType());
+        registeredService.setSupportedResponseTypes(supportedResponseTypes);
+        assertFalse(OAuth20Utils.isAuthorizedResponseTypeForService(context, registeredService));
+
+        supportedResponseTypes.add(OAuth20ResponseTypes.ID_TOKEN.getType());
+        registeredService.setSupportedResponseTypes(supportedResponseTypes);
+        assertTrue(OAuth20Utils.isAuthorizedResponseTypeForService(context, registeredService));
     }
 }


### PR DESCRIPTION
When the `OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidator.validate()` method rejects a request, all the various ways that can fail validation result in WARN logging that specifies why it was rejected, with the exception of the call to `OAuth20Utils.isAuthorizedResponseTypeForService()`. This adds a WARN logging inside `isAuthorizedResponseTypeForService` where more details are available. Below is the current logging if debug turned on in OAuth20Utils and someone more observant could probably see why the request was going to fail validation, but it would be better if it were logged at WARN level once problem is identified. The isAuthorizedResponseTypeForService method is only called in two places and neither logs a return of "false" at the WARN level. 

Current Logging:
```
2020-11-11 12:37:35,176 DEBUG [org.apereo.cas.support.oauth.util.OAuth20Utils] - <Checking response type [id_token] against supported response types [[id_token token, code, token]]>
2020-11-11 12:38:16,328 ERROR [org.apereo.cas.support.oauth.web.endpoints.OAuth20AuthorizeEndpointController] - <Authorize request verification failed. Authorization request is missing required parameters, or the request is not authenticated and contains no authenticated profile/principal.>
```
