### PR TITLE
Docs: Fix CAS 1.0 Validation Response Format

### DIFF
--- a/docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md
+++ b/docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md
@@ -490,8 +490,7 @@ case sensitive and MUST all be handled by `/validate`.
 
 On ticket validation success:
 
-yes&lt;LF&gt;
-username&lt;LF&gt;
+yes&lt;LF&gt;username&lt;LF&gt;
 
 On ticket validation failure:
 


### PR DESCRIPTION
A new line will be rendered as a whitespace.

I've checked [the demo](https://casserver.herokuapp.com/cas) and there's no additional whitespace after the first \<LF\>.

```python3
>>> url = 'https://casserver.herokuapp.com/cas/validate?service={}&ticket={}'.format(service, ticket)
>>> validation = requests.get(url)
>>> validation.text
'yes\ncasuser\n'
```

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
