### PR TITLE
Enable Management Center scripting through property

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/hazelcast/BaseHazelcastProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/hazelcast/BaseHazelcastProperties.java
@@ -76,7 +76,7 @@ public class BaseHazelcastProperties implements Serializable {
     private boolean enableCompression;
 
     /**
-     * Enables scripting from Management Center
+     * Enables scripting from Management Center.
      */
     private boolean enableManagementCenterScripting = true;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/hazelcast/BaseHazelcastProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/hazelcast/BaseHazelcastProperties.java
@@ -76,6 +76,11 @@ public class BaseHazelcastProperties implements Serializable {
     private boolean enableCompression;
 
     /**
+     * Enables scripting from Management Center
+     */
+    private boolean enableManagementCenterScripting = true;
+
+    /**
      * Hazelcast cluster settings if CAS is able to auto-create caches.
      */
     @NestedConfigurationProperty

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -536,6 +536,7 @@ The following options related to Hazelcast support in CAS apply equally to a num
 
 # ${configurationKey}.license-key=
 # ${configurationKey}.enable-compression=false
+# ${configurationKey}.enable-management-center-scripting=true
 ```
 
 More advanced Hazelcast configuration settings are listed below, given the component's *configuration key*:

--- a/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
+++ b/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
@@ -144,7 +144,7 @@ public class HazelcastConfigurationFactory {
      * @param hz the hz
      * @param config the config
      */
-        private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
+    private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
         val managementCenter = new ManagementCenterConfig();
         managementCenter.setScriptingEnabled(hz.isEnableManagementCenterScripting());
         config.setManagementCenterConfig(managementCenter);

--- a/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
+++ b/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
@@ -137,13 +137,6 @@ public class HazelcastConfigurationFactory {
             .setProperty(BaseHazelcastProperties.MAX_HEARTBEAT_SECONDS_PROP, String.valueOf(cluster.getMaxNoHeartbeatSeconds()));
     }
 
-    /**
-     * Build Management Center config.
-     * Enables scripting. For more on scripting config see {@link com.hazelcast.config.ManagementCenterConfig#setScriptingEnabled(boolean)}
-     *
-     * @param hz the hz
-     * @param config the config
-     */
     private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
         val managementCenter = new ManagementCenterConfig();
 

--- a/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
+++ b/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
@@ -147,7 +147,7 @@ public class HazelcastConfigurationFactory {
     private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
         val managementCenter = new ManagementCenterConfig();
 
-        LOGGER.trace("Enables management center scripting: {}", hz.isEnableManagementCenterScripting());
+        LOGGER.trace("Enables management center scripting: [{}]", hz.isEnableManagementCenterScripting());
         managementCenter.setScriptingEnabled(hz.isEnableManagementCenterScripting());
 
         config.setManagementCenterConfig(managementCenter);

--- a/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
+++ b/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
@@ -137,7 +137,14 @@ public class HazelcastConfigurationFactory {
             .setProperty(BaseHazelcastProperties.MAX_HEARTBEAT_SECONDS_PROP, String.valueOf(cluster.getMaxNoHeartbeatSeconds()));
     }
 
-    private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
+    /**
+     * Build Management Center config.
+     * Enables scripting. For more on scripting config see {@link com.hazelcast.config.ManagementCenterConfig#setScriptingEnabled(boolean)}
+     *
+     * @param hz the hz
+     * @param config the config
+     */
+        private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
         val managementCenter = new ManagementCenterConfig();
         managementCenter.setScriptingEnabled(hz.isEnableManagementCenterScripting());
         config.setManagementCenterConfig(managementCenter);

--- a/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
+++ b/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
@@ -89,7 +89,7 @@ public class HazelcastConfigurationFactory {
 
         config.setLicenseKey(hz.getLicenseKey());
 
-        buildManagementCenterConfig(config);
+        buildManagementCenterConfig(hz, config);
 
         val networkConfig = new NetworkConfig()
             .setPort(cluster.getPort())
@@ -137,9 +137,9 @@ public class HazelcastConfigurationFactory {
             .setProperty(BaseHazelcastProperties.MAX_HEARTBEAT_SECONDS_PROP, String.valueOf(cluster.getMaxNoHeartbeatSeconds()));
     }
 
-    private static void buildManagementCenterConfig(final Config config) {
+    private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
         val managementCenter = new ManagementCenterConfig();
-        managementCenter.setScriptingEnabled(true);
+        managementCenter.setScriptingEnabled(hz.isEnableManagementCenterScripting());
         config.setManagementCenterConfig(managementCenter);
     }
 

--- a/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
+++ b/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
@@ -146,7 +146,10 @@ public class HazelcastConfigurationFactory {
      */
     private static void buildManagementCenterConfig(final BaseHazelcastProperties hz, final Config config) {
         val managementCenter = new ManagementCenterConfig();
+
+        LOGGER.trace("Enables management center scripting: {}", hz.isEnableManagementCenterScripting());
         managementCenter.setScriptingEnabled(hz.isEnableManagementCenterScripting());
+
         config.setManagementCenterConfig(managementCenter);
     }
 

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DefaultHazelcastInstanceConfigurationTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/DefaultHazelcastInstanceConfigurationTests.java
@@ -89,6 +89,7 @@ public class DefaultHazelcastInstanceConfigurationTests {
         assertFalse(config.getNetworkConfig().getJoin().getMulticastConfig().isEnabled());
         assertEquals(List.of("localhost"), config.getNetworkConfig().getJoin().getTcpIpConfig().getMembers());
         assertTrue(config.getNetworkConfig().isPortAutoIncrement());
+        assertTrue(config.getManagementCenterConfig().isScriptingEnabled());
         assertEquals(5701, config.getNetworkConfig().getPort());
         assertEquals(5, config.getMapConfigs().size());
     }


### PR DESCRIPTION
Use `cas.ticket.registry.hazelcast.enable-management-center-scripting` property to enable/disable scripting from Management Center.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
