### PR TITLE
WIP for feedback: optionally refresh TGT on 'Renew' requests

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/sso/SingleSignOnProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/sso/SingleSignOnProperties.java
@@ -26,6 +26,11 @@ public class SingleSignOnProperties implements Serializable {
      * Flag that indicates whether to create SSO session on re-newed authentication event.
      */
     private boolean createSsoCookieOnRenewAuthn = true;
+    
+    /**
+     * Flag that indicates whether Authentication attributes should be updated on re-newed authentication event
+     */
+    private boolean createNewTgtOnRenewAuthn = false;
 
     /**
      * Flag that indicates whether to allow SSO session with a missing target service.

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/ServiceTicketRequestWebflowEventResolver.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/ServiceTicketRequestWebflowEventResolver.java
@@ -25,14 +25,17 @@ import java.util.Set;
  * @since 5.0.0
  */
 @Slf4j
+
 public class ServiceTicketRequestWebflowEventResolver extends AbstractCasWebflowEventResolver {
     public ServiceTicketRequestWebflowEventResolver(final CasWebflowEventResolutionConfigurationContext configContext) {
         super(configContext);
+        isCreateNewTgtOnRenewAuthn = configContext.getCasProperties().getSso().isCreateNewTgtOnRenewAuthn();
     }
 
+    private boolean isCreateNewTgtOnRenewAuthn = true;
     @Override
     public Set<Event> resolveInternal(final RequestContext context) {
-        if (isRequestAskingForServiceTicket(context)) {
+        if (!isCreateNewTgtOnRenewAuthn && isRequestAskingForServiceTicket(context)) {
             LOGGER.debug("Authentication request is asking for service tickets");
             val source = grantServiceTicket(context);
             return source != null ? CollectionUtils.wrapSet(source) : null;

--- a/docs/cas-server-documentation/configuration/Configuration-Properties.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties.md
@@ -3913,6 +3913,7 @@ If the user changes the language, a special cookie is created by CAS to contain 
 ```properties
 # cas.sso.allow-missing-service-parameter=true
 # cas.sso.create-sso-cookie-on-renew-authn=true
+# cas.sso.create-new-tgt-on-renew-authn=false
 # cas.sso.proxy-authn-enabled=true
 # cas.sso.renew-authn-enabled=true
 # cas.sso.required-service-pattern=


### PR DESCRIPTION
Our CAS implementation has a requirement that we update the authentication metadata to the last credential verified when a user re-authenticates via renew.  This allows a user who perhaps logged in with username and password to choose a different method (e.g. smartcard) and have their TGT updated to reflect this to the new app.  (Our apps don't always ask for particular authn methods up front.)  The default behavior on a "renew" request is to short-circuit updating attributes and go directly to issuing a service ticket after the credentials are verified.  In our implementation, we override the ServiceTicketRequestWebflowEventResolver to always return null, which has the effect of generating a new TGT on all renew requests. This PR creates a new property that will implement our override behavior (the default is false, so deployers will have to explicitly opt-in).

This is meant to be a conversation starter -- I'm open to on different approaches to tackling this requirement, especially if this approach seems a little ... hackish ... and there's a more robust way to handle it.

- [] Test cases for all modified changes, where applicable (TODO)
- [] The same pull request targeted at the master branch, if applicable (TODO)
