### PR TITLE
Allow PairwiseOidcRegisteredServiceUsernameAttributeProvider to be extended

### DIFF
--- a/support/cas-server-support-oidc-services/src/main/java/org/apereo/cas/services/PairwiseOidcRegisteredServiceUsernameAttributeProvider.java
+++ b/support/cas-server-support-oidc-services/src/main/java/org/apereo/cas/services/PairwiseOidcRegisteredServiceUsernameAttributeProvider.java
@@ -44,7 +44,7 @@ public class PairwiseOidcRegisteredServiceUsernameAttributeProvider extends Base
 
     private static final long serialVersionUID = 469929103943101717L;
 
-    private PersistentIdGenerator persistentIdGenerator = new OidcPairwisePersistentIdGenerator();
+    protected PersistentIdGenerator persistentIdGenerator = new OidcPairwisePersistentIdGenerator();
 
     @Override
     public String resolveUsernameInternal(final Principal principal, final Service service, final RegisteredService registeredService) {
@@ -64,7 +64,7 @@ public class PairwiseOidcRegisteredServiceUsernameAttributeProvider extends Base
         return id;
     }
 
-    private static String getSectorIdentifier(final OidcRegisteredService client) {
+    protected String getSectorIdentifier(final OidcRegisteredService client) {
         if (!StringUtils.isBlank(client.getSectorIdentifierUri())) {
             val uri = UriComponentsBuilder.fromUriString(client.getSectorIdentifierUri()).build();
             return uri.getHost();


### PR DESCRIPTION
Hello,

I would like to provide a custom sector identifier algorithm for my OIDC services.
So I have changed the visibility of private inner methods to allow them to be overridden.

If you agree with this, I'll propose the same for 6.2.x branch