### PR TITLE
docs: Correct the per-SP metadata overrides guide

### DIFF
--- a/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
@@ -89,9 +89,10 @@ SAML2 identity provider metadata can be managed in dynamics ways as well. To lea
 
 Identity provider metadata, certificates and keys can also be defined on a per-service basis to override the global defaults.
 Metadata artifacts that would be applicable to a specific service definition and managed via the file system need to be stored
-in a directory location named after the service definition's name inside the canonical metadata directory. For example,
-if global metadata artifacts are managed on disk at `/etc/cas/config/saml/metadata`, then metadata applicable to a service definition
-whose name is configured as `SampleService` are expected to be found at `/etc/cas/config/saml/metadata/SampleService`.
+in a directory location named using the following pattern `<service_name>-<service_numeric_identifier>`
+inside the canonical metadata directory. For example, if global metadata artifacts are managed on disk at `/etc/cas/config/saml/metadata`,
+then metadata applicable to a service definition whose name is configured as `SampleService` and its numeric identifier is `1`,
+are expected to be found at `/etc/cas/config/saml/metadata/SampleService-1`.
 
 SAML2 identity provider metadata can be managed in dynamics ways as well. To learn more, please [review this guide](Configuring-SAML2-DynamicMetadata.html).
 


### PR DESCRIPTION
In order to override the SAML2 idP's metadata and/or keys, one needs to
provide the folder structure described in this commit, e.g.
`<service_name>-<service_id>`

The official guide on CAS' blog is [already changed](https://github.com/apereo/apereo.github.io/commit/c2d15ab84cd8b3b9f7a6c90e184808502b21dc5f) to reflect this
issue [0].



<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
