### PR TITLE
[OIDC] Fix OIDC Prompt=login when user is unauthenticated

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCasClientRedirectActionBuilder.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCasClientRedirectActionBuilder.java
@@ -28,12 +28,14 @@ public class OidcCasClientRedirectActionBuilder extends OAuth20DefaultCasClientR
     public Optional<RedirectionAction> build(final CasClient casClient, final WebContext context) {
         var renew = casClient.getConfiguration().isRenew();
         var gateway = casClient.getConfiguration().isGateway();
+        val authentication = oidcAuthorizationRequestSupport.isCasAuthenticationAvailable(context);
 
         val prompts = OidcAuthorizationRequestSupport.getOidcPromptFromAuthorizationRequest(context);
         if (prompts.contains(OidcConstants.PROMPT_NONE)) {
             renew = false;
             gateway = true;
-        } else if (prompts.contains(OidcConstants.PROMPT_LOGIN)
+        } else if ((prompts.contains(OidcConstants.PROMPT_LOGIN)
+            && !authentication.isEmpty())
             || oidcAuthorizationRequestSupport.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context)) {
             renew = true;
         }


### PR DESCRIPTION
Hi Misagh,

In the 6.2 version of CAS, if you're not connected and you're trying to use the `prompt=login` parameter in an authorization request you'll be prompted for login/password two times.

Steps to reproduce:

The origin authorization request here:

```
https://cas.example.org:8443/cas/oidc/authorize?redirect_uri=http://redirecturi&client_id=clientid&response_type=code&scope=openid&prompt=login
```

will redirect you to:

```
https://cas.example.org:8443/cas/login?service=https%3A%2F%2Fcas.example.org%3A8443%2Fcas%2Foauth2.0%2FcallbackAuthorize%3Fclient_id%3Dclientid%26redirect_uri%3Dhttp%3A%2F%2Fredirecturi%26response_type%3Dcode%26client_name%3DCasOAuthClient&renew=true
```

You'll login with your user/password. Since the renew parameter is here you'll not get a TGC cookie. After the login, you're redirect to:

```
https://cas.example.org:8443/cas/oauth2.0/callbackAuthorize?client_id=clientid&redirect_uri=http%3A%2F%2Fredirecturi&response_type=code&client_name=CasOAuthClient&ticket=ST-**********************
```

Wich will redirect you to the oidc authorize endpoint:

```
https://cas.example.org:8443/cas/oidc/authorize?redirect_uri=http://redirecturi&client_id=clientid&response_type=code&scope=openid
```

Because you do not have a TGC cookie, you'll be redirected again to:

```
https://cas.example.org:8443/cas/login?service=https%3A%2F%2Fcas.example.org%3A8443%2Fcas%2Foauth2.0%2FcallbackAuthorize%3Fclient_id%3Dclientid%26redirect_uri%3Dhttp%3A%2F%2Fredirecturi%26response_type%3Dcode%26client_name%3DCasOAuthClient
```

And after another login/password steps you'll finaly get authenticated and redirected to the callback url.


In this fix I just set the renew parameter if the user is already authenticated.


I could not produce the same little fix for the 6.3 branch right now because the `prompt=login` (and the max_age) parameter is no longer working in this version since [this commit](https://github.com/apereo/cas/commit/308002469d98d0ec566ddff0a85633b63260a5b6#diff-c9860d1fead70de2837523032ec0b01d11ef5f1d2a1e9fcde6a9ddc0f87870c3) which has removed the dedicated OIDC Interceptor.

I don't known the exact reason of the removal, so I prefer to discuss this with you before work on a fix for this version.

But the 6.3 version is not affected by this particular bug right now.

Regards,
Julien