### PR TITLE
Documentation: Cookie maxAge should be max-age

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -224,7 +224,7 @@ The following common properties configure cookie generator support in CAS.
 
 ```properties
 # ${configurationKey}.path=
-# ${configurationKey}.maxAge=-1
+# ${configurationKey}.max-age=-1
 # ${configurationKey}.domain=
 # ${configurationKey}.name=
 # ${configurationKey}.secure=true


### PR DESCRIPTION
As title, camel case `maxAge` spotted, PR change it back to `max-age`, thanks.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
