### PR TITLE
Update Configuration-Properties-Common.md - remove file: prefix from git clone-directory 

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -482,7 +482,7 @@ The following options related to Git integration support in CAS when it attempts
 # ${configurationKey}.git.sign-commits=false
 # ${configurationKey}.git.username=
 # ${configurationKey}.git.password=
-# ${configurationKey}.git.clone-directory=file:/tmp/cas-service-registry
+# ${configurationKey}.git.clone-directory=/tmp/cas-service-registry
 # ${configurationKey}.git.push-changes=false
 # ${configurationKey}.git.private-key-passphrase=
 # ${configurationKey}.git.private-key-path=


### PR DESCRIPTION
Removing the file: prefix from the git clone directory, it is treated a literal part of the path, at least in the git service registry. If file: should be supported (or is supported for other uses of the git properties), disregard this and I can look into fixing the code in git service registry. 

