### PR TITLE
Fix Hazelcast Cluster shutdown when configuration is reloaded

### DIFF
--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastTicketRegistryConfiguration.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastTicketRegistryConfiguration.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastTicketRegistryConfiguration.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/HazelcastTicketRegistryConfiguration.java
@@ -49,7 +49,6 @@ public class HazelcastTicketRegistryConfiguration {
     private ObjectProvider<TicketCatalog> ticketCatalog;
 
     @Bean
-    @RefreshScope
     public TicketRegistry ticketRegistry() {
         val hz = casProperties.getTicket().getRegistry().getHazelcast();
         val hazelcastInstance = casTicketRegistryHazelcastInstance();


### PR DESCRIPTION
See this group post: https://groups.google.com/a/apereo.org/g/cas-user/c/xix3So1Hsrg

## Brief description of changes applied

I encountered an issue with  **reload configuration dynamically** features shutting down **Hazelcast ticket cluster** hence impacting login during my testing. This PR is intended to fix the issue.

## Steps to reproduce the issue:
1. Follow this article to setup dynamic configuration reload: https://fawnoos.com/2020/05/02/cas62x-reloadable-configuration/
2. Add Hazelcast Ticekt Registry feature to `build.gradle`
3. Go to `/cas/login` able to login
4. Edit `/etc/cas/config/cas.properties` , hence trigger a reload
5. Seeing `shutting down 127.0.0.1 hazelcast cluster` INFO message
6.  Go to `/cas/login` not able to login, see `Hazelcast cluster is not active` ERROR message

## Solution

Remove the `@RefreshScope` as suggested in the above will fix this issue

## Analyze on why the issue and solution works:

I think the issue is related to the `casTicketRegistryHazelcastInstance` having `@Bean(destroyMethod = "shutdown")` tag, which trigger the shutdown of Hazelcast cluster when reload.

However, instead of starting Hazelcast back up after `shutdown` is initialized, instead I think for Hazelcast Ticket Registry, it doesn't make too much sense giving it `@RefreshScope`.

For people with Hazelcast Ticket Registry with only 1 node, changing the Hazelcast ticket registry properties means stopping the ticket registry and starting it again, which **destroy all ticket inside**, which is no good.

For people with Hazelcast Ticket Registry with 2 nodes, changing the Hazelcast ticket registry also put it momentary into single node mode. Issue being this will happen for every CAS properties reload, making reloading a relative dangerous operation.

Therefore, I suggest the removal of `@RefreshScope` on Hazelcast Ticket Registry, see if my point is across and make sense.

This will need to be back ported `6.2.x` (issue starts with `6.1.x` , however I think no need backport to it anymore due to soon EOL)

Many thanks, hopefully I explain this clearly, thanks.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
