### PR TITLE
Fix `cas.events.track-configuration-modifications` not set to true by…

### DIFF
--- a/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/config/CasCoreBootstrapStandaloneWatchConfiguration.java
+++ b/core/cas-server-core-configuration/src/main/java/org/apereo/cas/configuration/config/CasCoreBootstrapStandaloneWatchConfiguration.java
@@ -33,7 +33,7 @@ public class CasCoreBootstrapStandaloneWatchConfiguration {
     @Qualifier("configurationPropertiesEnvironmentManager")
     private ObjectProvider<CasConfigurationPropertiesEnvironmentManager> configurationPropertiesEnvironmentManager;
 
-    @ConditionalOnProperty(value = "cas.events.track-configuration-modifications", havingValue = "true")
+    @ConditionalOnProperty(prefix = "cas.events", name = "track-configuration-modifications", havingValue = "true", matchIfMissing = true)
     @Bean
     public CasConfigurationWatchService casConfigurationWatchService() {
         return new CasConfigurationWatchService(configurationPropertiesEnvironmentManager.getObject(), applicationContext);


### PR DESCRIPTION

## What this PR does

Fix `cas.events.track-configuration-modifications` not set to true by default issue, by applying `matchIfMissing = true` on the relevant bean.

## Issue

* Dynamic reload not possible unless specifying  `cas.events.track-configuration-modifications` to `true`. 
* However,  `cas.events.track-configuration-modifications`  is seemingly intended to be set to `true` by default (below for more elaboration)
* Hence this PR to fix this issue.

## Detail
By default , `cas.events.track-configuration-modifications` seems intended to be set as true, see:
https://github.com/apereo/cas/blob/master/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/events/EventsProperties.java#L43

However, we find out that the value actually is not applied, and we need to manually add `cas.events.track-configuration-modifications` back in.

See this discussion: https://github.com/apereo/cas/pull/4988#issuecomment-737750615

## Solution

This PR will add back the `matchIfMissing = true` for the `casConfigurationWatchService` bean. I have tested this will fix the issue.

I have also change the style from `value = xxx` to `prefix = xx, name = xx`, to align with other syntax in CAS project.
See: https://github.com/apereo/cas/search?q=havingValue, will see the general syntax for `@ConditionalOnProperty`

See if this PR makes sense, many thanks!

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
