### PR TITLE
Set Event `trackConfigurationModifications` to `false` by default

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/events/EventsProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/events/EventsProperties.java
@@ -40,7 +40,7 @@ public class EventsProperties implements Serializable {
      * When running in standalone mode, this typically translates to CAS monitoring
      * configuration files and reloading context conditionally if there are any changes.
      */
-    private boolean trackConfigurationModifications = true;
+    private boolean trackConfigurationModifications = false;
 
     /**
      * Track authentication events inside a database.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/events/EventsProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/events/EventsProperties.java
@@ -40,7 +40,7 @@ public class EventsProperties implements Serializable {
      * When running in standalone mode, this typically translates to CAS monitoring
      * configuration files and reloading context conditionally if there are any changes.
      */
-    private boolean trackConfigurationModifications = false;
+    private boolean trackConfigurationModifications;
 
     /**
      * Track authentication events inside a database.


### PR DESCRIPTION
See: https://github.com/apereo/cas/pull/5004

Set `trackConfigurationModifications` to `false` by default.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
