### PR TITLE
Make git repository support file: URI prefix for clone-directory and private-key-path

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -73,7 +73,7 @@ public abstract class BaseGitProperties implements Serializable {
      * Must be a resource that can resolve to an absolute file on disk due to Jsch library needing String path.
      * Classpath resource would work if file on disk rather than inside archive.
      */
-    private Resource privateKeyPath;
+    private transient Resource privateKeyPath;
 
     /**
      * As with using SSH with public keys, an SSH session

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -64,14 +64,16 @@ public abstract class BaseGitProperties implements Serializable {
     private boolean signCommits;
 
     /**
-     * Path to the SSH private key identity.
+     * Password for the SSH private key.
      */
     private String privateKeyPassphrase;
 
     /**
-     * Password for the SSH private key.
+     * Path to the SSH private key identity.
+     * Must be a resource that can resolve to an absolute file on disk due to Jsch library needing String path.
+     * Classpath resource would work if file on disk rather than inside archive.
      */
-    private File privateKeyPath;
+    private Resource privateKeyPath;
 
     /**
      * As with using SSH with public keys, an SSH session
@@ -82,7 +84,7 @@ public abstract class BaseGitProperties implements Serializable {
 
     /**
      * Whether on not to turn on strict host key checking.
-     * true will be "yes", false will be "no", "ask" not supported
+     * true will be "yes", false will be "no", "ask" not supported.
      */
     private boolean strictHostKeyChecking = true;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -1,13 +1,14 @@
 package org.apereo.cas.configuration.model.support.git.services;
 
+import org.apereo.cas.configuration.model.SpringResourceProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.commons.io.FileUtils;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 
 import java.io.File;
 import java.io.Serializable;
@@ -73,7 +74,8 @@ public abstract class BaseGitProperties implements Serializable {
      * Must be a resource that can resolve to an absolute file on disk due to Jsch library needing String path.
      * Classpath resource would work if file on disk rather than inside archive.
      */
-    private transient Resource privateKeyPath;
+    @NestedConfigurationProperty
+    private SpringResourceProperties privateKey = new SpringResourceProperties();
 
     /**
      * As with using SSH with public keys, an SSH session
@@ -96,5 +98,18 @@ public abstract class BaseGitProperties implements Serializable {
     /**
      * Directory into which the repository would be cloned.
      */
-    private transient Resource cloneDirectory = new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-git-clone"));
+    @NestedConfigurationProperty
+    private CloneDirectory cloneDirectory = new CloneDirectory();
+
+    @Getter
+    @Setter
+    @Accessors(chain = true)
+    public static class CloneDirectory extends SpringResourceProperties {
+
+        private static final long serialVersionUID = 2070414250350989144L;
+
+        public CloneDirectory() {
+            setLocation(new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-git-clone")));
+        }
+    }
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.commons.io.FileUtils;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 
 import java.io.File;
 import java.io.Serializable;
@@ -86,5 +88,5 @@ public abstract class BaseGitProperties implements Serializable {
     /**
      * Directory into which the repository would be cloned.
      */
-    private File cloneDirectory = new File(FileUtils.getTempDirectory(), "cas-git-clone");
+    private Resource cloneDirectory = new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-git-clone"));
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -88,5 +88,5 @@ public abstract class BaseGitProperties implements Serializable {
     /**
      * Directory into which the repository would be cloned.
      */
-    private Resource cloneDirectory = new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-git-clone"));
+    private transient Resource cloneDirectory = new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-git-clone"));
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -81,6 +81,12 @@ public abstract class BaseGitProperties implements Serializable {
     private String sshSessionPassword;
 
     /**
+     * Whether on not to turn on strict host key checking.
+     * true will be "yes", false will be "no", "ask" not supported
+     */
+    private boolean strictHostKeyChecking = true;
+
+    /**
      * Timeout for git operations such as push and pull in seconds.
      */
     private String timeout = "PT10S";

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/GitServiceRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/GitServiceRegistryProperties.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.commons.io.FileUtils;
+import org.springframework.core.io.FileSystemResource;
 
 import java.io.File;
 
@@ -20,6 +21,12 @@ import java.io.File;
 @Setter
 @Accessors(chain = true)
 public class GitServiceRegistryProperties extends BaseGitProperties {
+
+    /**
+     * Default name used for git service registry clone directory.
+     */
+    public static final String DEFAULT_CAS_SERVICE_REGISTRY_NAME = "cas-service-registry2";
+
     private static final long serialVersionUID = 4194689836396653458L;
 
     /**
@@ -44,6 +51,6 @@ public class GitServiceRegistryProperties extends BaseGitProperties {
     private boolean groupByType = true;
 
     public GitServiceRegistryProperties() {
-        setCloneDirectory(new File(FileUtils.getTempDirectory(), "cas-service-registry"));
+        setCloneDirectory(new FileSystemResource(new File(FileUtils.getTempDirectory(), DEFAULT_CAS_SERVICE_REGISTRY_NAME)));
     }
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/GitServiceRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/GitServiceRegistryProperties.java
@@ -25,7 +25,7 @@ public class GitServiceRegistryProperties extends BaseGitProperties {
     /**
      * Default name used for git service registry clone directory.
      */
-    public static final String DEFAULT_CAS_SERVICE_REGISTRY_NAME = "cas-service-registry2";
+    public static final String DEFAULT_CAS_SERVICE_REGISTRY_NAME = "cas-service-registry";
 
     private static final long serialVersionUID = 4194689836396653458L;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/GitServiceRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/GitServiceRegistryProperties.java
@@ -5,6 +5,7 @@ import org.apereo.cas.configuration.support.RequiresModule;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.springframework.core.io.FileSystemResource;
 
@@ -51,6 +52,8 @@ public class GitServiceRegistryProperties extends BaseGitProperties {
     private boolean groupByType = true;
 
     public GitServiceRegistryProperties() {
-        setCloneDirectory(new FileSystemResource(new File(FileUtils.getTempDirectory(), DEFAULT_CAS_SERVICE_REGISTRY_NAME)));
+        val cloneDirectory = new CloneDirectory();
+        cloneDirectory.setLocation(
+                new FileSystemResource(new File(FileUtils.getTempDirectory(), DEFAULT_CAS_SERVICE_REGISTRY_NAME)));
     }
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/GitSamlMetadataProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/GitSamlMetadataProperties.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.commons.io.FileUtils;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.core.io.FileSystemResource;
 
 import java.io.File;
 
@@ -33,7 +34,7 @@ public class GitSamlMetadataProperties extends BaseGitProperties {
     private EncryptionJwtSigningJwtCryptographyProperties crypto = new EncryptionJwtSigningJwtCryptographyProperties();
 
     public GitSamlMetadataProperties() {
-        setCloneDirectory(new File(FileUtils.getTempDirectory(), "cas-saml-metadata"));
+        setCloneDirectory(new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-saml-metadata")));
         crypto.getEncryption().setKeySize(CipherExecutor.DEFAULT_STRINGABLE_ENCRYPTION_KEY_SIZE);
         crypto.getSigning().setKeySize(CipherExecutor.DEFAULT_STRINGABLE_SIGNING_KEY_SIZE);
     }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/GitSamlMetadataProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/GitSamlMetadataProperties.java
@@ -3,7 +3,7 @@ package org.apereo.cas.configuration.model.support.saml.idp.metadata;
 import org.apereo.cas.configuration.model.core.util.EncryptionJwtSigningJwtCryptographyProperties;
 import org.apereo.cas.configuration.model.support.git.services.BaseGitProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
-import org.apereo.cas.util.crypto.CipherExecutor;B
+import org.apereo.cas.util.crypto.CipherExecutor;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/GitSamlMetadataProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/metadata/GitSamlMetadataProperties.java
@@ -3,11 +3,12 @@ package org.apereo.cas.configuration.model.support.saml.idp.metadata;
 import org.apereo.cas.configuration.model.core.util.EncryptionJwtSigningJwtCryptographyProperties;
 import org.apereo.cas.configuration.model.support.git.services.BaseGitProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
-import org.apereo.cas.util.crypto.CipherExecutor;
+import org.apereo.cas.util.crypto.CipherExecutor;B
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.core.io.FileSystemResource;
@@ -34,7 +35,9 @@ public class GitSamlMetadataProperties extends BaseGitProperties {
     private EncryptionJwtSigningJwtCryptographyProperties crypto = new EncryptionJwtSigningJwtCryptographyProperties();
 
     public GitSamlMetadataProperties() {
-        setCloneDirectory(new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-saml-metadata")));
+        val cloneDirectory = new CloneDirectory();
+        cloneDirectory.setLocation(new FileSystemResource(new File(FileUtils.getTempDirectory(), "cas-saml-metadata")));
+        setCloneDirectory(cloneDirectory);
         crypto.getEncryption().setKeySize(CipherExecutor.DEFAULT_STRINGABLE_ENCRYPTION_KEY_SIZE);
         crypto.getSigning().setKeySize(CipherExecutor.DEFAULT_STRINGABLE_SIGNING_KEY_SIZE);
     }

--- a/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api/cas-server-core-api-configuration-model/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -200,6 +200,50 @@
         "reason": "It is a duplication of cas.authn.pac4j.saml[0].sign-service-provider-logout-request.",
         "level": "error"
       }
+    },
+    {
+      "name": "cas.service-registry.git.private-key-path",
+      "type": "java.lang.String",
+      "description": "Set private key path for git service registry.",
+      "defaultValue": false,
+      "deprecation": {
+        "replacement": "cas.service-registry.git.private-key.location",
+        "reason": "Type changed from File to Resource, but still needs to resolve to File.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.service-registry.git.clone-directory",
+      "type": "java.lang.String",
+      "description": "Set the target directory for cloning the git service registry.",
+      "defaultValue": true,
+      "deprecation": {
+        "replacement": "cas.service-registry.git.clone-directory.location",
+        "reason": "Type changed from String to Resource.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.authn.saml-idp.metadata.git.private-key-path",
+      "type": "java.lang.String",
+      "description": "Set private key path for git SAML IDP metadata.",
+      "defaultValue": false,
+      "deprecation": {
+        "replacement": "cas.authn.saml-idp.metadata.git.private-key.location",
+        "reason": "Type changed from File to Resource, but still needs to resolve to File.",
+        "level": "error"
+      }
+    },
+    {
+      "name": "cas.authn.saml-idp.metadata.git.clone-directory",
+      "type": "java.lang.String",
+      "description": "Set the target directory for cloning the git SAML IDP metadata.",
+      "defaultValue": true,
+      "deprecation": {
+        "replacement": "cas.authn.saml-idp.metadata.git.clone-directory.location",
+        "reason": "Type changed from String to Resource.",
+        "level": "error"
+      }
     }
   ]
 }

--- a/ci/tests/webapp/validate-external-webapp.sh
+++ b/ci/tests/webapp/validate-external-webapp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-tomcatVersion="9.0.40"
+tomcatVersion="9.0.41"
 tomcatVersionTag="v${tomcatVersion}"
 tomcatUrl="https://downloads.apache.org/tomcat/tomcat-9/${tomcatVersionTag}/bin/apache-tomcat-${tomcatVersion}.zip"
 

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -482,10 +482,10 @@ The following options related to Git integration support in CAS when it attempts
 # ${configurationKey}.git.sign-commits=false
 # ${configurationKey}.git.username=
 # ${configurationKey}.git.password=
-# ${configurationKey}.git.clone-directory=file:/tmp/cas-service-registry
+# ${configurationKey}.git.clone-directory.location=file:/tmp/cas-service-registry
 # ${configurationKey}.git.push-changes=false
 # ${configurationKey}.git.private-key-passphrase=
-# ${configurationKey}.git.private-key-path=file:/tmp/privkey.pem
+# ${configurationKey}.git.private-key.location=file:/tmp/privkey.pem
 # ${configurationKey}.git.ssh-session-password=
 # ${configurationKey}.git.timeout=PT10S
 # ${configurationKey}.git.strict-host-key-checking=true

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -488,6 +488,7 @@ The following options related to Git integration support in CAS when it attempts
 # ${configurationKey}.git.private-key-path=
 # ${configurationKey}.git.ssh-session-password=
 # ${configurationKey}.git.timeout=PT10S
+# ${configurationKey}.git.strict-host-key-checking=true
 ```
 
 ## InfluxDb Configuration

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -485,7 +485,7 @@ The following options related to Git integration support in CAS when it attempts
 # ${configurationKey}.git.clone-directory=file:/tmp/cas-service-registry
 # ${configurationKey}.git.push-changes=false
 # ${configurationKey}.git.private-key-passphrase=
-# ${configurationKey}.git.private-key-path=
+# ${configurationKey}.git.private-key-path=file:/tmp/privkey.pem
 # ${configurationKey}.git.ssh-session-password=
 # ${configurationKey}.git.timeout=PT10S
 # ${configurationKey}.git.strict-host-key-checking=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -402,7 +402,7 @@ openidVersion=1.0.0
 ###############################
 # Tomcat versions
 ###############################
-tomcatVersion=9.0.40
+tomcatVersion=9.0.41
 
 ###############################
 # SCIM versions

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -92,7 +92,7 @@ public class GitRepositoryBuilder {
             builder.credentialsProviders(providers);
         }
         if (props.getPrivateKeyPath() != null) {
-            builder.privateKeyPath(props.getPrivateKeyPath().getCanonicalPath());
+            builder.privateKeyPath(props.getPrivateKeyPath().getFile().getCanonicalPath());
         }
         return builder.build();
     }

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -60,6 +60,8 @@ public class GitRepositoryBuilder {
 
     private final boolean signCommits;
 
+    private final boolean strictHostKeyChecking;
+
     private static String getBranchPath(final String branchName) {
         return "refs/heads/" + branchName;
     }
@@ -81,7 +83,8 @@ public class GitRepositoryBuilder {
             .privateKeyPassphrase(props.getPrivateKeyPassphrase())
             .sshSessionPassword(props.getSshSessionPassword())
             .timeoutInSeconds(Beans.newDuration(props.getTimeout()).toSeconds())
-            .signCommits(props.isSignCommits());
+            .signCommits(props.isSignCommits())
+            .strictHostKeyChecking(props.isStrictHostKeyChecking());
         if (StringUtils.hasText(props.getUsername())) {
             val providers = CollectionUtils.wrapList(
                 new UsernamePasswordCredentialsProvider(props.getUsername(), props.getPassword()),
@@ -105,6 +108,9 @@ public class GitRepositoryBuilder {
             protected void configure(final OpenSshConfig.Host host, final Session session) {
                 if (StringUtils.hasText(sshSessionPassword)) {
                     session.setPassword(sshSessionPassword);
+                }
+                if (!strictHostKeyChecking) {
+                    session.setConfig("StrictHostKeyChecking", "no");
                 }
             }
 

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -26,6 +26,7 @@ import org.eclipse.jgit.util.FS;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,7 +80,7 @@ public class GitRepositoryBuilder {
             .repositoryUri(resolver.resolve(props.getRepositoryUrl()))
             .activeBranch(resolver.resolve(props.getActiveBranch()))
             .branchesToClone(props.getBranchesToClone())
-            .repositoryDirectory(props.getCloneDirectory())
+            .repositoryDirectory(props.getCloneDirectory().getLocation())
             .privateKeyPassphrase(props.getPrivateKeyPassphrase())
             .sshSessionPassword(props.getSshSessionPassword())
             .timeoutInSeconds(Beans.newDuration(props.getTimeout()).toSeconds())
@@ -91,8 +92,12 @@ public class GitRepositoryBuilder {
                 new NetRCCredentialsProvider());
             builder.credentialsProviders(providers);
         }
-        if (props.getPrivateKeyPath() != null) {
-            builder.privateKeyPath(props.getPrivateKeyPath().getFile().getCanonicalPath());
+        if (props.getPrivateKey().getLocation() != null) {
+            try {
+                builder.privateKeyPath(props.getPrivateKey().getLocation().getFile().getCanonicalPath());
+            } catch (final IOException e) {
+                LOGGER.warn("Error reading private key for git repository: {}", e.getMessage());
+            }
         }
         return builder.build();
     }

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -6,7 +6,6 @@ import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.LoggingUtils;
 import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolver;
 
-
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
@@ -24,9 +23,9 @@ import org.eclipse.jgit.transport.OpenSshConfig;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.util.FS;
+import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,7 +44,7 @@ public class GitRepositoryBuilder {
 
     private final String repositoryUri;
 
-    private final File repositoryDirectory;
+    private final Resource repositoryDirectory;
 
     private final String branchesToClone;
 
@@ -90,7 +89,7 @@ public class GitRepositoryBuilder {
             builder.credentialsProviders(providers);
         }
         if (props.getPrivateKeyPath() != null) {
-            builder.privateKeyPath(props.getPrivateKeyPath().getCanonicalPath());
+            builder.privateKeyPath(props.getPrivateKeyPath());
         }
         return builder.build();
     }
@@ -152,7 +151,7 @@ public class GitRepositoryBuilder {
         val cloneCommand = Git.cloneRepository()
             .setProgressMonitor(new LoggingGitProgressMonitor())
             .setURI(this.repositoryUri)
-            .setDirectory(this.repositoryDirectory)
+            .setDirectory(this.repositoryDirectory.getFile())
             .setBranch(this.activeBranch)
             .setTimeout((int) this.timeoutInSeconds)
             .setTransportConfigCallback(transportCallback)
@@ -173,7 +172,7 @@ public class GitRepositoryBuilder {
 
 
     private GitRepository getExistingGitRepository(final TransportConfigCallback transportCallback) throws Exception {
-        val git = Git.open(this.repositoryDirectory);
+        val git = Git.open(this.repositoryDirectory.getFile());
         LOGGER.debug("Checking out the branch [{}] at [{}]", this.activeBranch, this.repositoryDirectory);
         git.checkout()
             .setName(this.activeBranch)

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -89,7 +89,7 @@ public class GitRepositoryBuilder {
             builder.credentialsProviders(providers);
         }
         if (props.getPrivateKeyPath() != null) {
-            builder.privateKeyPath(props.getPrivateKeyPath());
+            builder.privateKeyPath(props.getPrivateKeyPath().getCanonicalPath());
         }
         return builder.build();
     }

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -33,7 +33,6 @@ public class GitRepositoryBuilderTests {
     @Autowired
     private CasConfigurationProperties casProperties;
 
-    @Test
     /**
      * Verify GitRepositoryBuilder.
      * Build method throws IllegalArgumentException due to authentication failure since key is invalid.
@@ -41,17 +40,18 @@ public class GitRepositoryBuilderTests {
      * The underlying ssh library will use .ssh/known_hosts and use .ssh/config to find keys and .ssh/id_rsa,
      * etc when connecting.
      */
+    @Test
     public void verifyBuild() throws Exception {
         val props = casProperties.getServiceRegistry().getGit();
         props.setRepositoryUrl("git@github.com:mmoayyed/sample-data.git");
         props.setUsername("casuser");
         props.setPassword("password");
         props.setBranchesToClone("master");
-        props.setCloneDirectory(ResourceUtils.getRawResourceFrom(
+        props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
                 FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
         props.setPrivateKeyPassphrase("something");
         props.setSshSessionPassword("more-password");
-        props.setPrivateKeyPath(new ClassPathResource("priv.key"));
+        props.getPrivateKey().setLocation(new ClassPathResource("priv.key"));
         props.setStrictHostKeyChecking(true);
         val builder = GitRepositoryBuilder.newInstance(props);
         val e = assertThrows(IllegalArgumentException.class, builder::build);
@@ -64,18 +64,18 @@ public class GitRepositoryBuilderTests {
                 "[" + e2.getMessage() + "] doesn't contain auth fail");
     }
 
-    @Test
     /**
      * Test that clone directory works with file: prefix.
      * Uses the file:// prefix rather than file: because it should work on windows or linux.
      */
+    @Test
     public void verifyBuildWithFilePrefix() throws Exception {
         val props = casProperties.getServiceRegistry().getGit();
         props.setRepositoryUrl("https://github.com/mmoayyed/sample-data.git");
         props.setUsername("casuser");
         props.setPassword("password");
         props.setBranchesToClone("master");
-        props.setCloneDirectory(ResourceUtils.getRawResourceFrom(
+        props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
                 "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
         val builder = GitRepositoryBuilder.newInstance(props);
         assertDoesNotThrow(builder::build);

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -47,7 +47,7 @@ public class GitRepositoryBuilderTests {
                 FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
         props.setPrivateKeyPassphrase("something");
         props.setSshSessionPassword("more-password");
-        props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());
+        props.setPrivateKeyPath(new ClassPathResource("priv.key"));
         props.setStrictHostKeyChecking(false);
         val builder = GitRepositoryBuilder.newInstance(props);
         assertThrows(IllegalArgumentException.class, builder::build);

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -1,10 +1,10 @@
 package org.apereo.cas.git;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.util.ResourceUtils;
 
 import lombok.val;
 import org.apache.commons.io.FileUtils;
-import org.apereo.cas.util.ResourceUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.File;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,7 +40,7 @@ public class GitRepositoryBuilderTests {
         props.setPassword("password");
         props.setBranchesToClone("master");
         props.setCloneDirectory(ResourceUtils.getRawResourceFrom(
-                FileUtils.getTempDirectoryPath() + UUID.randomUUID().toString()));
+                FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
         props.setPrivateKeyPassphrase("something");
         props.setSshSessionPassword("more-password");
         props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());
@@ -59,7 +60,7 @@ public class GitRepositoryBuilderTests {
         props.setPassword("password");
         props.setBranchesToClone("master");
         props.setCloneDirectory(ResourceUtils.getRawResourceFrom(
-                "file://" + FileUtils.getTempDirectoryPath() + UUID.randomUUID().toString()));
+                "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
         props.setPrivateKeyPassphrase("something");
         props.setSshSessionPassword("more-password");
         props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -46,7 +46,7 @@ public class GitRepositoryBuilderTests {
         props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());
         props.setStrictHostKeyChecking(false);
         val builder = GitRepositoryBuilder.newInstance(props);
-        assertThrows(IllegalAccessException.class, builder::build);
+        assertThrows(IllegalArgumentException.class, builder::build);
     }
 
     @Test

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -44,6 +44,7 @@ public class GitRepositoryBuilderTests {
         props.setPrivateKeyPassphrase("something");
         props.setSshSessionPassword("more-password");
         props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());
+        props.setStrictHostKeyChecking(false);
         val builder = GitRepositoryBuilder.newInstance(props);
         assertDoesNotThrow(builder::build);
     }
@@ -64,6 +65,7 @@ public class GitRepositoryBuilderTests {
         props.setPrivateKeyPassphrase("something");
         props.setSshSessionPassword("more-password");
         props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());
+        props.setStrictHostKeyChecking(false);
         val builder = GitRepositoryBuilder.newInstance(props);
         assertDoesNotThrow(builder::build);
     }

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -33,6 +33,10 @@ public class GitRepositoryBuilderTests {
     private CasConfigurationProperties casProperties;
 
     @Test
+    /**
+     * Verify GitRepositoryBuilder.
+     * Build method throws IllegalArgumentException due to authentication failure since key is invalid.
+     */
     public void verifyBuild() throws Exception {
         val props = casProperties.getServiceRegistry().getGit();
         props.setRepositoryUrl("git@github.com:mmoayyed/sample-data.git");
@@ -52,7 +56,7 @@ public class GitRepositoryBuilderTests {
     @Test
     /**
      * Test that clone directory works with file: prefix.
-     * Uses the file:// prefix because it should work on windows or linux.
+     * Uses the file:// prefix rather than file: because it should work on windows or linux.
      */
     public void verifyBuildWithFilePrefix() throws Exception {
         val props = casProperties.getServiceRegistry().getGit();

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -46,7 +46,7 @@ public class GitRepositoryBuilderTests {
         props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());
         props.setStrictHostKeyChecking(false);
         val builder = GitRepositoryBuilder.newInstance(props);
-        assertDoesNotThrow(builder::build);
+        assertThrows(IllegalAccessException.class, builder::build);
     }
 
     @Test
@@ -56,16 +56,12 @@ public class GitRepositoryBuilderTests {
      */
     public void verifyBuildWithFilePrefix() throws Exception {
         val props = casProperties.getServiceRegistry().getGit();
-        props.setRepositoryUrl("git@github.com:mmoayyed/sample-data.git");
+        props.setRepositoryUrl("https://github.com/mmoayyed/sample-data.git");
         props.setUsername("casuser");
         props.setPassword("password");
         props.setBranchesToClone("master");
         props.setCloneDirectory(ResourceUtils.getRawResourceFrom(
                 "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
-        props.setPrivateKeyPassphrase("something");
-        props.setSshSessionPassword("more-password");
-        props.setPrivateKeyPath(new ClassPathResource("priv.key").getFile());
-        props.setStrictHostKeyChecking(false);
         val builder = GitRepositoryBuilder.newInstance(props);
         assertDoesNotThrow(builder::build);
     }

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/locator/DefaultGitRepositoryRegisteredServiceLocatorTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/locator/DefaultGitRepositoryRegisteredServiceLocatorTests.java
@@ -10,6 +10,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -28,7 +30,7 @@ public class DefaultGitRepositoryRegisteredServiceLocatorTests {
             FileUtils.getTempDirectory(), new GitServiceRegistryProperties().setRootDirectory("sample-root"));
         val service = RegisteredServiceTestUtils.getRegisteredService();
         val file = locator.determine(service, "json");
-        assertTrue(file.getCanonicalPath().endsWith("sample-root/" + strategy.build(service, "json")));
+        assertTrue(file.getCanonicalPath().endsWith("sample-root" + File.separator + strategy.build(service, "json")));
     }
 
 }

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/locator/TypeAwareGitRepositoryRegisteredServiceLocatorTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/locator/TypeAwareGitRepositoryRegisteredServiceLocatorTests.java
@@ -10,6 +10,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -27,6 +29,6 @@ public class TypeAwareGitRepositoryRegisteredServiceLocatorTests {
             FileUtils.getTempDirectory(), new GitServiceRegistryProperties().setRootDirectory("sample-root"));
         val service = RegisteredServiceTestUtils.getRegisteredService();
         val file = locator.determine(service, "json");
-        assertTrue(file.getCanonicalPath().endsWith("sample-root/" + service.getFriendlyName() + '/' + strategy.build(service, "json")));
+        assertTrue(file.getCanonicalPath().endsWith("sample-root" + File.separator + service.getFriendlyName() + File.separator + strategy.build(service, "json")));
     }
 }

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
@@ -53,8 +52,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Getter
 public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
 
-    @Value("${tmpdir:/tmp}")
-    private static String TMPDIR;
+    private static String TMPDIR = "/tmp";
 
     @Autowired
     @Qualifier("serviceRegistry")
@@ -73,8 +71,8 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
                 deleteDirectory(gitDir);
                 FileUtils.deleteDirectory(gitDir);
             }
-            val gitSampleRepo = Git.init().setDirectory(gitDir).setBare(false).call();
-            FileUtils.write(new File(gitDir, "readme.txt"), "text", StandardCharsets.UTF_8);
+            val gitSampleRepo = Git.init().setDirectory(gitRepoSampleDir).setBare(false).call();
+            FileUtils.write(new File(gitRepoSampleDir, "readme.txt"), "text", StandardCharsets.UTF_8);
             gitSampleRepo.commit().setSign(false).setMessage("Initial commit").call();
 
             val git = Git.init().setDirectory(gitDir).setBare(false).call();
@@ -99,7 +97,7 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
     /**
      * Extra deleteDirectory method b/c FileUtils.deleteDirectory wasn't working reliably on Windows.
      * @param path path to folder to be recursively deleted
-     * @return <code>true</code> if the file or directory is successfully deleted; <code>false</code> otherwise
+     * @return {@code true} if the file or directory is successfully deleted; {@code false} otherwise
      */
     private static boolean deleteDirectory(final File path) {
         if (path.exists()) {

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -63,12 +63,10 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
         try {
             val gitRepoSampleDir = new File(TMPDIR +"/cas-sample-data");
             if (gitRepoSampleDir.exists()) {
-                deleteDirectory(gitRepoSampleDir);
                 FileUtils.deleteDirectory(gitRepoSampleDir);
             }
             val gitDir = new File(FileUtils.getTempDirectory(), GitServiceRegistryProperties.DEFAULT_CAS_SERVICE_REGISTRY_NAME);
             if (gitDir.exists()) {
-                deleteDirectory(gitDir);
                 FileUtils.deleteDirectory(gitDir);
             }
             val gitSampleRepo = Git.init().setDirectory(gitRepoSampleDir).setBare(false).call();
@@ -89,27 +87,7 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
         FileUtils.deleteDirectory(new File(TMPDIR +"/cas-sample-data"));
         val gitDir = new File(FileUtils.getTempDirectory(), GitServiceRegistryProperties.DEFAULT_CAS_SERVICE_REGISTRY_NAME);
         if (gitDir.exists()) {
-            deleteDirectory(gitDir);
             FileUtils.deleteDirectory(gitDir);
         }
-    }
-
-    /**
-     * Extra deleteDirectory method b/c FileUtils.deleteDirectory wasn't working reliably on Windows.
-     * @param path path to folder to be recursively deleted
-     * @return {@code true} if the file or directory is successfully deleted; {@code false} otherwise
-     */
-    private static boolean deleteDirectory(final File path) {
-        if (path.exists()) {
-            File[] files = path.listFiles();
-            for (int i = 0; i < files.length; i++) {
-                if (files[i].isDirectory()) {
-                    deleteDirectory(files[i]);
-                } else {
-                    files[i].delete();
-                }
-            }
-        }
-        return path.delete();
     }
 }

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -99,7 +99,7 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
     /**
      * Extra deleteDirectory method b/c FileUtils.deleteDirectory wasn't working reliably on Windows.
      * @param path path to folder to be recursively deleted
-     * @return
+     * @return <code>true</code> if the file or directory is successfully deleted; <code>false</code> otherwise
      */
     private static boolean deleteDirectory(final File path) {
         if (path.exists()) {

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.config.CasCoreNotificationsConfiguration;
 import org.apereo.cas.config.CasCoreServicesConfiguration;
 import org.apereo.cas.config.CasCoreUtilConfiguration;
 import org.apereo.cas.config.GitServiceRegistryConfiguration;
+import org.apereo.cas.configuration.model.support.git.services.GitServiceRegistryProperties;
 import org.apereo.cas.util.LoggingUtils;
 
 import lombok.Getter;
@@ -59,7 +60,7 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
     public static void setup() {
         try {
             FileUtils.deleteDirectory(new File("/tmp/cas-sample-data"));
-            val gitDir = new File(FileUtils.getTempDirectory(), "cas-service-registry");
+            val gitDir = new File(FileUtils.getTempDirectory(), GitServiceRegistryProperties.DEFAULT_CAS_SERVICE_REGISTRY_NAME);
             if (gitDir.exists()) {
                 FileUtils.deleteDirectory(gitDir);
             }
@@ -75,7 +76,7 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
     @AfterAll
     public static void cleanUp() throws Exception {
         FileUtils.deleteDirectory(new File("/tmp/cas-sample-data"));
-        val gitDir = new File(FileUtils.getTempDirectory(), "cas-service-registry");
+        val gitDir = new File(FileUtils.getTempDirectory(), GitServiceRegistryProperties.DEFAULT_CAS_SERVICE_REGISTRY_NAME);
         if (gitDir.exists()) {
             FileUtils.deleteDirectory(gitDir);
         }

--- a/support/cas-server-support-saml-idp-metadata-git/src/main/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/main/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolver.java
@@ -79,7 +79,9 @@ public class GitSamlRegisteredServiceMetadataResolver extends BaseSamlRegistered
                 return false;
             }
             val metadataLocation = service.getMetadataLocation();
-            return metadataLocation != null && metadataLocation.trim().startsWith("git://");
+            return metadataLocation != null
+                    && (metadataLocation.trim().startsWith("git://")
+                            || (metadataLocation.trim().startsWith("http") && metadataLocation.trim().endsWith(".git")));
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         }

--- a/support/cas-server-support-saml-idp-metadata-git/src/main/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/main/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolver.java
@@ -75,8 +75,9 @@ public class GitSamlRegisteredServiceMetadataResolver extends BaseSamlRegistered
     @Override
     public boolean supports(final SamlRegisteredService service) {
         try {
+            if (service == null) { return false; }
             val metadataLocation = service.getMetadataLocation();
-            return metadataLocation.trim().startsWith("git://");
+            return metadataLocation != null && metadataLocation.trim().startsWith("git://");
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         }

--- a/support/cas-server-support-saml-idp-metadata-git/src/main/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/main/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolver.java
@@ -75,7 +75,9 @@ public class GitSamlRegisteredServiceMetadataResolver extends BaseSamlRegistered
     @Override
     public boolean supports(final SamlRegisteredService service) {
         try {
-            if (service == null) { return false; }
+            if (service == null) {
+                return false;
+            }
             val metadataLocation = service.getMetadataLocation();
             return metadataLocation != null && metadataLocation.trim().startsWith("git://");
         } catch (final Exception e) {

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolverTests.java
@@ -84,5 +84,7 @@ public class GitSamlRegisteredServiceMetadataResolverTests extends BaseGitSamlMe
         assertFalse(resolver.supports(null));
         val resolvers = resolver.resolve(service);
         assertFalse(resolvers.isEmpty());
+        service.setMetadataLocation("https://example.com/endswith.git");
+        assertTrue(resolver.supports(service));
     }
 }


### PR DESCRIPTION
This adds support for the git clone-directory property to access file path with the file resource prefix, to match documentation. The  privateKeyPath also take a Resource now but the underlying JSch library eventually wants a String path so it would only take a file: type of resource or classpath: type if in file in classpath but not in an archive. File type of resource also only makes sense for clone-directory but that should be obvious.  

I don't understand what is going on with GitServiceRegistryTests.java - There is a ```"cas.service-registry.git.repository-url=file:/tmp/cas-sample-data.git"``` and it deletes "/tmp/cas-sample-data" but I don't think it uses either one? Is that supposed to be a git repo that it clones from and pushes to because it is making the git repo in ```cas-service-registry``` and it tries to push somewhere but there is nowhere to push (the tests pass).  

I added a test to GitRepositoryBuilderTests.java to test the Resource usage via file: prefix. The existing test with ssh is doing an assertThrows(IllegalArgumentException... because of an authentication failure but that Exception would be thrown for any type of error so I am not clear on what is being tested. It's also an odd test because it works locally (which means assertThrows fails), presumably b/c the ssh library is using my ssh key (with no password) to authenticate to github. 

I added a new property to turn off host key verification but it defaults to being on as before. I think this could be useful when cloning from internal git repos from CAS running in a container that may not have the host key installed (scenarios where you aren't worried about MITM or DNS hijacking, etc). 