### PR TITLE
Proposal: Allow multiple JDBC Source Monitoring

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/monitor/MonitorProperties.java
@@ -71,7 +71,7 @@ public class MonitorProperties implements Serializable {
     /**
      * Options for monitoring JDBC resources.
      */
-    private Jdbc jdbc = new Jdbc();
+    private List<Jdbc> jdbc = new ArrayList<>(0);
 
     /**
      * Options for monitoring LDAP resources.


### PR DESCRIPTION
This is just to initialize a proposal, the main code should work but needs style check, test case and document.

## Brief description of changes applied

Change JDBC Monitoring to support multiple source (Instead of the single source that currently support)

### Reason

We use multiple database implementation for our CAS, some for attribute some for authentication. 

However, only single database can be monitor as of CAS 6.2.x, see: https://apereo.github.io/cas/development/configuration/Configuration-Properties.html#database-monitoring

Hence, I would like to propose if possible, to expand the number of JDBC monitor target. Just like LDAP monitoring as seen here: https://apereo.github.io/cas/development/configuration/Configuration-Properties.html#ldap-server-monitoring


## Any possible limitations, side effects, etc

**Breaking changes**:
`cas.monitor.jdbc.xxxx` properties needs to change to `cas.monitor.jdbc[0].xxx`

## Test cases and follow up

Will update test cases & update document if this proposal is ok

I understand that it is near 6.3.x launch. Therefore if the idea is accepted but schedule is tight, then this feature can be push back to next release.

Many thanks!

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
