### PR TITLE
Fix profiles missing SESSION_CLIENT_ID throws NullPointerException

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/OAuth20ClientIdAwareProfileManager.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/OAuth20ClientIdAwareProfileManager.java
@@ -41,7 +41,7 @@ public class OAuth20ClientIdAwareProfileManager<U extends CommonProfile> extends
         val clientId = getClientIdFromRequest();
         val results = profiles
             .stream()
-            .filter(it -> it.getValue().getAuthenticationAttribute(SESSION_CLIENT_ID).equals(clientId))
+            .filter(it -> StringUtils.equals((String) it.getValue().getAuthenticationAttribute(SESSION_CLIENT_ID), clientId))
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
                 Map.Entry::getValue,

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
@@ -9,6 +9,7 @@ import org.apereo.cas.support.oauth.authenticator.OAuth20UsernamePasswordAuthent
 import org.apereo.cas.support.oauth.profile.CasServerApiBasedTicketValidatorTests;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20ProfileScopeToAttributesFilterTests;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20UserProfileDataCreatorTests;
+import org.apereo.cas.support.oauth.profile.OAuth20ClientIdAwareProfileManagerTests;
 import org.apereo.cas.support.oauth.services.OAuth20AuthenticationServiceSelectionStrategyTests;
 import org.apereo.cas.support.oauth.services.OAuth20RegisteredServiceCipherExecutorTests;
 import org.apereo.cas.support.oauth.services.OAuth20ServicesManagerRegisteredServiceLocatorTests;
@@ -128,6 +129,7 @@ import org.junit.runner.RunWith;
     UnapprovedOAuth20DeviceUserCodeExceptionTests.class,
     InvalidOAuth20DeviceTokenExceptionTests.class,
     DefaultOAuth20UserProfileDataCreatorTests.class,
+    OAuth20ClientIdAwareProfileManagerTests.class,
     CasServerApiBasedTicketValidatorTests.class,
     DefaultOAuth20ProfileScopeToAttributesFilterTests.class,
     OAuth20AuthenticationServiceSelectionStrategyTests.class,

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/profile/OAuth20ClientIdAwareProfileManagerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/profile/OAuth20ClientIdAwareProfileManagerTests.java
@@ -1,0 +1,65 @@
+package org.apereo.cas.support.oauth.profile;
+
+import org.apereo.cas.AbstractOAuth20Tests;
+import org.apereo.cas.support.oauth.OAuth20ClientIdAwareProfileManager;
+
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.pac4j.core.context.JEEContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.util.Pac4jConstants;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * This is {@link OAuth20ClientIdAwareProfileManagerTests}.
+ *
+ * @author Charley Wu
+ * @since 6.3.0
+ */
+@Tag("OAuth")
+public class OAuth20ClientIdAwareProfileManagerTests extends AbstractOAuth20Tests {
+
+    protected OAuth20ClientIdAwareProfileManager<CommonProfile> profileManager;
+    protected WebContext context;
+
+    @BeforeEach
+    public void init() {
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+        context = new JEEContext(request, response);
+        profileManager = new OAuth20ClientIdAwareProfileManager<>(context, context.getSessionStore(), servicesManager);
+    }
+
+    @Test
+    public void verifyGetProfiles() {
+        val profile = new CommonProfile();
+        profile.setId(ID);
+        profile.setClientName(CLIENT_ID);
+        profileManager.save(true, profile, false);
+        val profiles = profileManager.getAll(true);
+        assertNotNull(profiles);
+        assertEquals(1, profiles.size());
+    }
+
+    @Test
+    public void verifyGetProfilesWithoutSavedClientId() {
+        val profile = new CommonProfile();
+        profile.setId(ID);
+        profile.setClientName(CLIENT_ID);
+        val sessionProfiles = new HashMap<String, CommonProfile>(1);
+        sessionProfiles.put(CLIENT_ID, profile);
+        context.getSessionStore().set(context, Pac4jConstants.USER_PROFILES, sessionProfiles);
+        val profiles = profileManager.getAll(true);
+        assertNotNull(profiles);
+        assertEquals(0, profiles.size());
+    }
+}


### PR DESCRIPTION
## Problem 

When user signed in by [Delegated Authentication](https://apereo.github.io/cas/development/integration/Delegate-Authentication.html), it will cause `NullPointerException` in OAuth 2.0 callback authorize flow.

```
Exception: Servlet.service() for servlet [dispatcherServlet] in context with path [/cas] threw exception [Request processing failed; nested exception is java.lang.NullPointerException] with root cause
java.lang.NullPointerException
        at org.apereo.cas.support.oauth.profile.ClientIdAwareProfileManager.lambda$retrieveAll$0(ClientIdAwareProfileManager.java:47) ~[cas-server-support-oauth-5.3.16.jar!/:5.3.16]
```

## Solution

Use `StringUtils.equals` instead of `Object.equals` to compare `clientId` that may not exists in `AuthenticationAttribute`

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
