### PR TITLE
fix casModules docs

### DIFF
--- a/docs/cas-server-documentation/developer/Build-Process.md
+++ b/docs/cas-server-documentation/developer/Build-Process.md
@@ -70,7 +70,7 @@ The following commandline boolean flags are supported by the build and can be pa
 | `ignoreJavadocFailures`           | Ignore javadoc failures and let the build resume.
 | `ignoreFindbugsFailures`          | Ignore Findbugs failures and let the build resume.
 | `ignoreTestFailures`              | Ignore test failures and let the build resume.
-| `casModules`                      | Comma separated list of modules without the `cas-server-` prefix.
+| `casModules`                      | Comma separated list of modules without the `cas-server-[support|core]` prefix.
 
 - You can use `-x <task>` to entirely skip/ignore a phase in the build. (i.e. `-x test`, `-x check`).
 - If you have no need to let Gradle resolve/update dependencies and new module versions for you, you can take advantage of the `--offline` flag when you build which tends to make the build go a lot faster.

--- a/docs/cas-server-documentation/developer/Test-Process.md
+++ b/docs/cas-server-documentation/developer/Test-Process.md
@@ -25,16 +25,16 @@ comma separated list of modules without the `cas-server-` prefix:
 For example:
 
 ```properties
-casModules=core-monitor,\
-    support-ldap,\
-    support-x509,\
-    support-bootadmin-client
+casModules=monitor,\
+    ldap,\
+    x509,\
+    bootadmin-client
 ```
 
 Or set the property on the command-line:
 
 ```bash
-bc -PcasModules=support-ldap,support-x509
+bc -PcasModules=ldap,x509
 ```
 
 ...where `bc` is an [alias for building CAS](Build-Process.html#sample-build-aliases).

--- a/gradle/webapp.gradle
+++ b/gradle/webapp.gradle
@@ -58,7 +58,7 @@ dependencies {
         def dependencies = project.getProperty("casModules").split(",")
         dependencies.each {
             def projectsToAdd = rootProject.subprojects.findAll {project ->
-                project.name == "cas-server-core-${it}" || project.name == "cas-server-support-${it}"
+                project.name == "cas-server-${it}" || "cas-server-core-${it}" || project.name == "cas-server-support-${it}"
             }
             projectsToAdd.each {
                 println "Adding CAS module ${it.path}"


### PR DESCRIPTION
This fixes some docs related to casModules, but I also figured it doesn't cost anything to support the casModules being specified with the support- or core- prefix, since it is looking for two things already, might as well look for the fully qualified module suffix and prefer that since it is more specific. At least the docs should be merged before 6.3 release, but I can back out the webapp.gradle if you prefer. 