### PR TITLE
Support one way hash for OAuth2 client secrets

### DIFF
--- a/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
+++ b/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
@@ -187,6 +187,8 @@ Client secrets for OAuth relying parties may be defined as encrypted values pref
 
 Client secrets may be encrypted using CAS-provided cipher operations either manually or via the [CAS Command-line shell](Configuring-Commandline-Shell.html).
 
+Client secrets may also be defined as hash values prefixed with `{id}` supported by [Spring Security's password storage formats](https://docs.spring.io/spring-security/site/docs/current/reference/html5/#authentication-password-storage-dpe-format)
+
 {% include {{ version }}/oauth2-configuration.md %}
 
 ### Attribute Release

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.pac4j.core.context.JEEContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 
 import java.util.HashSet;
 import java.util.List;
@@ -122,6 +123,18 @@ public class OAuth20UtilsTests {
         val registeredService = new OAuthRegisteredService();
         registeredService.setClientId("clientid");
         registeredService.setClientSecret(secret);
+        val result = OAuth20Utils.checkClientSecret(registeredService, secret, cipher);
+        assertTrue(result);
+    }
+
+    @Test
+    public void verifyClientSecretCheckWithOneWayHash() {
+        val cipher = new OAuth20RegisteredServiceCipherExecutor();
+        val secret = RandomUtils.randomAlphanumeric(12);
+        val encodedSecret = PasswordEncoderFactories.createDelegatingPasswordEncoder().encode(secret);
+        val registeredService = new OAuthRegisteredService();
+        registeredService.setClientId("clientid");
+        registeredService.setClientSecret(encodedSecret);
         val result = OAuth20Utils.checkClientSecret(registeredService, secret, cipher);
         assertTrue(result);
     }


### PR DESCRIPTION
Add one way hash function support for OAuth2 `clientSecret `storage mechanism as recommended by [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#hashing-vs-encryption)