### PR TITLE
CAS Initializr - update CI for helm

### DIFF
--- a/ci/validate-helm.sh
+++ b/ci/validate-helm.sh
@@ -29,14 +29,19 @@ sudo k3s ctr images import build/jib-image.tar
 cd helm
 chmod +x *.sh
 
+export NAMESPACE=${1:-default}
+if [[ $NAMESPACE != "default" ]]; then
+  kubectl create namespace $NAMESPACE || true
+fi
+
 echo "Creating Keystore and secret for keystore"
-./create-cas-server-keystore-secret.sh
+./create-cas-server-keystore-secret.sh $NAMESPACE
 
 echo "Creating tls secret for ingress to use"
-./create-ingress-tls.sh
+./create-ingress-tls.sh $NAMESPACE
 
 echo "Creating truststore with server/ingress certs and put in configmap"
-./create-truststore.sh
+./create-truststore.sh $NAMESPACE
 
 # Set KUBECONFIG for helm
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
@@ -57,28 +62,31 @@ kubectl wait --namespace ingress-nginx \
 
 echo "Install cas-server helm chart"
 echo "Using local jib image imported into k3s"
-helm upgrade --install cas-server --set image.pullPolicy=Never --set image.tag="${imageTag}" ./cas-server
-sleep 15
+helm upgrade --install cas-server --namespace $NAMESPACE --set image.pullPolicy=Never --set image.tag="${imageTag}" ./cas-server
+
+echo "Waiting for startup"
+kubectl wait --for=condition=ready --timeout=150s --namespace $NAMESPACE pod cas-server-0 || true
+kubectl wait --for=condition=available --timeout=150s --namespace $NAMESPACE deployment cas-server-boot-admin || true
+
 echo "Describing cas-server pod"
-kubectl describe pod cas-server-0
+kubectl describe pod --namespace $NAMESPACE cas-server-0
 echo "Describing cas bootadmin pod"
-kubectl describe pod -l cas.server-type=bootadmin
-sleep 75
+kubectl describe pod --namespace $NAMESPACE -l cas.server-type=bootadmin
 
 echo "Pod Status:"
-kubectl get pods
+kubectl get pods --namespace $NAMESPACE
 
 echo "CAS Server Logs..."
-kubectl logs cas-server-0 | tee cas.out
+kubectl logs cas-server-0 --namespace $NAMESPACE | tee cas.out
 echo "CAS Boot Admin Server Logs..."
-kubectl logs -l cas.server-type=bootadmin --tail=-1 | tee cas-bootadmin.out
+kubectl logs -l cas.server-type=bootadmin --tail=-1 --namespace $NAMESPACE | tee cas-bootadmin.out
 echo "Checking cas server log for startup message"
 grep "Started CasWebApplication" cas.out
 echo "Checking bootadmin server log for startup message"
 grep "Started CasSpringBootAdminServerWebApplication" cas-bootadmin.out
 
 echo "Running chart built-in test"
-helm test cas-server
+helm test --namespace $NAMESPACE cas-server
 
 echo "Checking login page"
 curl -k -H "Host: cas.example.org" https://127.0.0.1/cas/login > login.txt

--- a/ci/validate.sh
+++ b/ci/validate.sh
@@ -35,6 +35,7 @@ echo "Configuration Metadata Export"
 echo "Exploding WAR"
 ./gradlew explodeWar
 
+
 echo "Building Container Image via Spring Boot"
 ./gradlew bootBuildImage
 


### PR DESCRIPTION
This allows validate-helm.sh script to run locally on linux (when k3s is installed) and should make it more reliable by using kubectl wait instead of sleep. 