### PR TITLE
Improve registered service locator

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
@@ -5,6 +5,8 @@ import org.apereo.cas.support.oauth.OAuth20Constants;
 
 import org.springframework.core.Ordered;
 
+import java.util.Objects;
+
 /**
  * This is {@link OAuth20ServicesManagerRegisteredServiceLocator}.
  *
@@ -14,8 +16,13 @@ import org.springframework.core.Ordered;
 public class OAuth20ServicesManagerRegisteredServiceLocator extends DefaultServicesManagerRegisteredServiceLocator {
     public OAuth20ServicesManagerRegisteredServiceLocator() {
         setOrder(Ordered.HIGHEST_PRECEDENCE);
-        setRegisteredServiceFilter((registeredService, service) -> service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
-            && registeredService instanceof OAuthRegisteredService);
+        setRegisteredServiceFilter((registeredService, service) -> registeredService instanceof OAuthRegisteredService
+                && service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
+                && service.getAttributes().get(OAuth20Constants.CLIENT_ID)
+                .stream()
+                .filter(Objects::nonNull)
+                .map(String.class::cast)
+                .anyMatch(clientId -> clientId.equals(((OAuthRegisteredService) registeredService).getClientId())));
     }
 }
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 public class OAuth20ServicesManagerRegisteredServiceLocator extends DefaultServicesManagerRegisteredServiceLocator {
     public OAuth20ServicesManagerRegisteredServiceLocator() {
         setOrder(Ordered.HIGHEST_PRECEDENCE);
-        setRegisteredServiceFilter((registeredService, service) -> registeredService instanceof OAuthRegisteredService
+        setRegisteredServiceFilter((registeredService, service) -> OAuthRegisteredService.class.isAssignableFrom(registeredService.getClass())
                 && service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
                 && service.getAttributes().get(OAuth20Constants.CLIENT_ID)
                 .stream()

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointController.java
@@ -164,7 +164,7 @@ public class OAuth20AuthorizeEndpointController extends BaseOAuth20Controller {
 
         val authentication = getOAuthConfigurationContext().getAuthenticationBuilder()
             .build(profile, registeredService, context, service);
-        LOGGER.trace("Created OAuth authentication [{}] for service [{}]", service, authentication);
+        LOGGER.trace("Created OAuth authentication [{}] for service [{}]", authentication, service);
 
         try {
             AuthenticationCredentialsThreadLocalBinder.bindCurrent(authentication);

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocatorTests.java
@@ -33,12 +33,14 @@ public class OAuth20ServicesManagerRegisteredServiceLocatorTests extends Abstrac
     public void verifyOperation() {
         assertNotNull(oauthServicesManagerRegisteredServiceLocator);
         assertEquals(Ordered.HIGHEST_PRECEDENCE, oauthServicesManagerRegisteredServiceLocator.getOrder());
-        val service = getRegisteredService("clientid123456", UUID.randomUUID().toString());
+        val service = getRegisteredService(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         service.setMatchingStrategy(new PartialRegexRegisteredServiceMatchingStrategy());
+        val service2 = getRegisteredService(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        service2.setMatchingStrategy(new PartialRegexRegisteredServiceMatchingStrategy());
         val svc = serviceFactory.createService(
-            String.format("https://oauth.example.org/whatever?%s=clientid", OAuth20Constants.CLIENT_ID));
-        val result = oauthServicesManagerRegisteredServiceLocator.locate(List.of(service),
-            svc, r -> r.matches("https://oauth.example.org"));
+                String.format("https://oauth.example.org/whatever?%s=%s", OAuth20Constants.CLIENT_ID, service.getClientId()));
+        val result = oauthServicesManagerRegisteredServiceLocator.locate(List.of(service, service2),
+                svc, r -> r.matches("https://oauth.example.org"));
         assertNotNull(result);
     }
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
@@ -6,6 +6,8 @@ import org.apereo.cas.support.oauth.OAuth20Constants;
 
 import org.springframework.core.Ordered;
 
+import java.util.Objects;
+
 /**
  * This is {@link OidcServicesManagerRegisteredServiceLocator}.
  *
@@ -16,8 +18,13 @@ public class OidcServicesManagerRegisteredServiceLocator extends DefaultServices
     public OidcServicesManagerRegisteredServiceLocator() {
         setOrder(Ordered.HIGHEST_PRECEDENCE);
         setRegisteredServiceFilter(
-            (registeredService, service) -> service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
-                && registeredService instanceof OidcRegisteredService);
+            (registeredService, service) -> registeredService instanceof OidcRegisteredService
+                && service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
+                && service.getAttributes().get(OAuth20Constants.CLIENT_ID)
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .map(String.class::cast)
+                    .anyMatch(clientId -> clientId.equals(((OidcRegisteredService) registeredService).getClientId())));
     }
 }
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
@@ -18,7 +18,7 @@ public class OidcServicesManagerRegisteredServiceLocator extends DefaultServices
     public OidcServicesManagerRegisteredServiceLocator() {
         setOrder(Ordered.HIGHEST_PRECEDENCE);
         setRegisteredServiceFilter(
-            (registeredService, service) -> registeredService instanceof OidcRegisteredService
+            (registeredService, service) -> OidcRegisteredService.class.isAssignableFrom(registeredService.getClass())
                 && service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
                 && service.getAttributes().get(OAuth20Constants.CLIENT_ID)
                     .stream()

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
@@ -47,7 +47,7 @@ public class SamlIdPServicesManagerRegisteredServiceLocator extends DefaultServi
                 .stream()
                 .anyMatch(entityId -> {
                     LOGGER.trace("Attempting to resolve metadata for service [{}] based on entity id [{}]", registeredService.getName(), entityId);
-                    val samlService = SamlRegisteredService.class.cast(registeredService);
+                    val samlService = (SamlRegisteredService) registeredService;
                     val adaptor = SamlRegisteredServiceServiceProviderMetadataFacade.get(resolver, samlService, entityId);
                     return adaptor.isPresent();
                 });

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
@@ -63,7 +63,7 @@ public class SamlIdPServicesManagerRegisteredServiceLocator extends DefaultServi
      */
     protected Optional<Pair<SamlProtocolServiceAttribute, String>> getSamlParameterValue(final RegisteredService registeredService,
                                                                                          final Service service) {
-        if (registeredService instanceof SamlRegisteredService) {
+        if (SamlRegisteredService.class.isAssignableFrom(registeredService.getClass())) {
             val attributes = service.getAttributes();
             LOGGER.trace("Reviewing service attributes [{}] for service id [{}] to match registered service [{}]",
                 attributes, service.getId(), registeredService.getName());


### PR DESCRIPTION
## Problem

1. We have extended registered service (ex: I18nRegisteredService) cannot be filtered via class name comparison. 
2. We have some OAuth registered services matches same serviceId (ex: http://localhost) 

## Solution

Use `clientId` attribute to find OAuth/ODIC registered service

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
