### PR TITLE
Amazon Cognito Authentication: fix adminGetUser

### DIFF
--- a/support/cas-server-support-aws-cognito-authentication/src/main/java/org/apereo/cas/authentication/AmazonCognitoAuthenticationAuthenticationHandler.java
+++ b/support/cas-server-support-aws-cognito-authentication/src/main/java/org/apereo/cas/authentication/AmazonCognitoAuthenticationAuthenticationHandler.java
@@ -82,8 +82,8 @@ public class AmazonCognitoAuthenticationAuthenticationHandler extends AbstractUs
             }
 
             val userResult = cognitoIdentityProvider.adminGetUser(AdminGetUserRequest.builder()
-                .userPoolId(credential.getUsername())
-                .userPoolId(properties.getUserPoolId()).build());
+                .userPoolId(properties.getUserPoolId())
+                .username(credential.getUsername()).build());
 
             val attributes = new LinkedHashMap<String, List<Object>>();
             attributes.put("userStatus", CollectionUtils.wrap(userResult.userStatusAsString()));


### PR DESCRIPTION
username in AdminGetUserRequest object appears null in adminGetUser method call and gives ''userName' failed to satisfy constraint: Member must not be null' error. This is a minor fix to address that issue. Looks like this bug was introduced in 6.3.0 release.
