### PR TITLE
Turn off jasypt initialization vector by default

### DIFF
--- a/.github/workflows/cas-build.yml
+++ b/.github/workflows/cas-build.yml
@@ -289,7 +289,13 @@ jobs:
       - name: Validate CAS Command-line Shell
         run: |
           casVersion=$(./gradlew casVersion --no-daemon -q)
-          java -jar support/cas-server-support-shell/build/libs/cas-server-support-shell-${casVersion}.jar @ci/tests/shell/cas-shell-script.sh
+          java -jar support/cas-server-support-shell/build/libs/cas-server-support-shell-${casVersion}.jar @ci/tests/shell/cas-shell-script.sh 2>&1 | tee cas-shell.out
+          # Check for stack traces in output that would indicate an error
+          count=$(grep -c cas-server-support-shell cas-shell.out)
+          if [ $count -ne 0 ]; then
+            echo "Found stacktrace in script output"
+            exit -1
+          fi
 
 ##########################################################################
 

--- a/.github/workflows/cas-build.yml
+++ b/.github/workflows/cas-build.yml
@@ -290,12 +290,9 @@ jobs:
         run: |
           casVersion=$(./gradlew casVersion --no-daemon -q)
           java -jar support/cas-server-support-shell/build/libs/cas-server-support-shell-${casVersion}.jar @ci/tests/shell/cas-shell-script.sh 2>&1 | tee cas-shell.out
-          # Check for stack traces in output that would indicate an error
+          echo "Checking for stack traces in output that would indicate an error"
           count=$(grep -c cas-server-support-shell cas-shell.out)
-          if [ $count -ne 0 ]; then
-            echo "Found stacktrace in script output"
-            exit -1
-          fi
+          test $count -eq 0
 
 ##########################################################################
 

--- a/.github/workflows/cas-build.yml
+++ b/.github/workflows/cas-build.yml
@@ -291,7 +291,7 @@ jobs:
           casVersion=$(./gradlew casVersion --no-daemon -q)
           java -jar support/cas-server-support-shell/build/libs/cas-server-support-shell-${casVersion}.jar @ci/tests/shell/cas-shell-script.sh 2>&1 | tee cas-shell.out
           echo "Checking for stack traces in output that would indicate an error"
-          count=$(grep -c cas-server-support-shell cas-shell.out)
+          count=$(grep -c cas-server-support-shell cas-shell.out || true)
           test $count -eq 0
 
 ##########################################################################

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/config/standalone/StandaloneConfigurationSecurityProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/config/standalone/StandaloneConfigurationSecurityProperties.java
@@ -42,4 +42,16 @@ public class StandaloneConfigurationSecurityProperties implements Serializable {
      * Secret key/password to use when deciphering settings.
      */
     private String psw;
+
+    /**
+     * An initialization vector is required for {@code PBEWithDigestAndAES} algorithms that aren't BouncyCastle.
+     * Enabling an initialization vector will break passwords encrypted without one (e.g. encrypted with version <= 6.3).
+     * Toggling this value will make pre-existing non-{@code PBEWithDigestAndAES} encrypted passwords not work.
+     * For non-BouncyCastle {@code PBEWithDigestAndAES} algorithms that require an initialization vector, one will be used
+     * regardless of this setting since backwards compatibility with existing passwords using those algorithms is not
+     * an issue (since they didn't work in previous CAS versions).
+     * The default value is false so as not to break existing encrypted passwords.
+     * In general the use of an initialization vector will increase the encrypted text's length.
+     */
+    private Boolean initializationVector;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/config/standalone/StandaloneConfigurationSecurityProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/config/standalone/StandaloneConfigurationSecurityProperties.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.jasypt.encryption.pbe.StandardPBEByteEncryptor;
 
 import java.io.Serializable;
 
@@ -24,22 +25,28 @@ public class StandaloneConfigurationSecurityProperties implements Serializable {
     private static final long serialVersionUID = 8571848605614437022L;
 
     /**
-     * Algorithm to use when deciphering settings.
+     * Algorithm to use when deciphering settings. Default algorithm is {@code PBEWithMD5AndTripleDES}.
+     * This property can be set as a Java system property: {@code cas.standalone.configuration-security.alg}.
      */
     private String alg;
 
     /**
      * Security provider to use when deciphering settings.
+     * Leave blank for Java, {@code BC} for BouncyCastle.
+     * This property can be set as a Java system property: {@code cas.standalone.configuration-security.provider}.
      */
     private String provider;
 
     /**
      * Total number of iterations to use when deciphering settings.
+     * Default value comes from Jasypt {@value StandardPBEByteEncryptor#DEFAULT_KEY_OBTENTION_ITERATIONS}
+     * This property can be set as a Java system property: {@code cas.standalone.configuration-security.iterations}.
      */
     private long iteration;
 
     /**
      * Secret key/password to use when deciphering settings.
+     * This property can be set as a Java system property: {@code cas.standalone.configuration-security.psw}.
      */
     private String psw;
 
@@ -52,6 +59,7 @@ public class StandaloneConfigurationSecurityProperties implements Serializable {
      * an issue (since they didn't work in previous CAS versions).
      * The default value is false so as not to break existing encrypted passwords.
      * In general the use of an initialization vector will increase the encrypted text's length.
+     * This property can be set a Java system property: {@code cas.standalone.configuration-security.initialization-vector}.
      */
     private Boolean initializationVector;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/tomcat/CasEmbeddedApacheTomcatBasicAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/tomcat/CasEmbeddedApacheTomcatBasicAuthenticationProperties.java
@@ -29,7 +29,7 @@ public class CasEmbeddedApacheTomcatBasicAuthenticationProperties implements Ser
     private static final long serialVersionUID = 1164446071136700282L;
 
     /**
-     * Enable the SSL valve for apache tomcat.
+     * Enable Basic authentication for Tomcat.
      */
     @RequiredProperty
     private boolean enabled;

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutor.java
@@ -27,6 +27,7 @@ public class CasConfigurationJasyptCipherExecutor implements CipherExecutor<Stri
 
     /**
      * Pattern for algorithms that require an initialization vector.
+     * Regex matches all PBEWITHHMACSHA###ANDAES algorithms that aren't BouncyCastle.
      */
     public static final String ALGS_THAT_REQUIRE_IV_PATTERN = "PBEWITHHMACSHA\\d+ANDAES_.*(?<!-BC)$";
 
@@ -246,11 +247,11 @@ public class CasConfigurationJasyptCipherExecutor implements CipherExecutor<Stri
     public enum JasyptEncryptionParameters {
 
         /**
-         * Jasypt algorithm name to use. Default is PBEWithMD5AndTripleDES.
+         * Jasypt algorithm name to use.
          */
         ALGORITHM("cas.standalone.configuration-security.alg", "PBEWithMD5AndTripleDES"),
         /**
-         * Jasypt provider name to use. None for Java, BC for BouncyCastle.
+         * Jasypt provider name to use. None for Java, {@code BC} for BouncyCastle.
          */
         PROVIDER("cas.standalone.configuration-security.provider", null),
         /**

--- a/ci/tests/shell/cas-shell-script.sh
+++ b/ci/tests/shell/cas-shell-script.sh
@@ -1,7 +1,9 @@
 help
 encrypt-value value SOMEVALUE password JASTYPTPW alg PBEWITHSHAAND256BITAES-CBC-BC provider BC
 encrypt-value --value SOMEVALUE --password JASTYPTPW --alg PBEWITHSHAAND256BITAES-CBC-BC --provider BC
+encrypt-value --value SOMEVALUE --password JASTYPTPW --alg PBEWITHSHAAND256BITAES-CBC-BC --provider BC --initvector
 decrypt-value value {cas-cipher}iARpnWTURDdiAhWdcHXxqJpncj4iRo3w9i2UT33stcs= password JASTYPTPW alg PBEWITHSHAAND256BITAES-CBC-BC provider BC
+decrypt-value value {cas-cipher}Snynjp9UvY1VohHy+L5ig9ydKUw/E3yaEsWsxmS1eiQwxwJMPtjpuCNPaBOyPhQs password JASTYPTPW alg PBEWITHSHAAND256BITAES-CBC-BC provider BC --initvector
 jasypt-test-algorithms
 generate-idp-metadata --metadataLocation "./" --subjectAltNames "cas.example.com,cas.example.io,cas.example.net" --force
 generate-key --key-size 256

--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
@@ -87,20 +87,21 @@ public class CasConfigurationJasyptCipherExecutorTests {
     @Test
     public void verifyOldEncryptedPasswordStillWorks() {
         val jasyptTest = new CasConfigurationJasyptCipherExecutor(this.environment);
-        jasyptTest.setAlgorithmForce("PBEWITHHMACSHA512ANDAES_256");
-        assertEquals(jasyptTest.decode("{cas-cipher}GxXRraiiFRMNDS81OAs6eo6qnhfHdfY1LrggFHRhfQo="), "testing");
+        jasyptTest.setAlgorithmForce("PBEWITHSHAAND256BITAES-CBC-BC");
+        assertEquals("testing", jasyptTest.decode("{cas-cipher}GxXRraiiFRMNDS81OAs6eo6qnhfHdfY1LrggFHRhfQo="));
     }
 
     /**
-     * This seeks to ensure that a password encrypted in a previous version of CAS can still be decrypted.
-     * Password encrypted with 6.3.0 shell and password of "P@$$w0rd".
+     * This seeks to ensure that a password encrypted with an initialization vector still works.
+     * Password encrypted with 6.4.0 and password of "P@$$w0rd".
      */
     @Test
     public void verifyEncryptedPasswordWithInitizializationVectorStillWorks() {
         val jasyptTest = new CasConfigurationJasyptCipherExecutor(this.environment);
         jasyptTest.setProviderName("BC");
         jasyptTest.setAlgorithmForce("PBEWITHSHAAND256BITAES-CBC-BC");
-        assertEquals(jasyptTest.decode("{cas-cipher}GxXRraiiFRMNDS81OAs6eo6qnhfHdfY1LrggFHRhfQo="), "testing");
+        jasyptTest.setInitializationVector();
+        assertEquals("testing", jasyptTest.decode("{cas-cipher}88HKpXCD888/ZP7hMAg7VdxljZD3fho5r5V7c15kPXovYCk4cBdpcxfd5vgcxTit"));
     }
 
     /**

--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/CasConfigurationJasyptCipherExecutorTests.java
@@ -100,7 +100,7 @@ public class CasConfigurationJasyptCipherExecutorTests {
         val jasyptTest = new CasConfigurationJasyptCipherExecutor(this.environment);
         jasyptTest.setProviderName("BC");
         jasyptTest.setAlgorithmForce("PBEWITHSHAAND256BITAES-CBC-BC");
-        jasyptTest.setInitializationVector();
+        jasyptTest.configureInitializationVector();
         assertEquals("testing", jasyptTest.decode("{cas-cipher}88HKpXCD888/ZP7hMAg7VdxljZD3fho5r5V7c15kPXovYCk4cBdpcxfd5vgcxTit"));
     }
 
@@ -132,7 +132,7 @@ public class CasConfigurationJasyptCipherExecutorTests {
         val jasyptTest = new CasConfigurationJasyptCipherExecutor(this.environment);
         jasyptTest.setAlgorithmForce(algorithm);
         if (useInitializationVector) {
-            jasyptTest.setInitializationVector();
+            jasyptTest.configureInitializationVector();
         }
         val testValue = "Testing_" + algorithm;
         val value = jasyptTest.encryptValue(testValue);

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
@@ -35,6 +35,7 @@ public class JasyptDecryptPropertyCommand {
      * @param alg        the alg
      * @param provider   the provider
      * @param password   the password
+     * @param initVector whether to use initialization vector
      * @param iterations the iterations- defaults to {@value StandardPBEByteEncryptor#DEFAULT_KEY_OBTENTION_ITERATIONS}
      */
     @ShellMethod(key = "decrypt-value", value = "Decrypt a CAS property value/setting via Jasypt")
@@ -47,6 +48,8 @@ public class JasyptDecryptPropertyCommand {
             help = "Security provider to use to decrypt") final String provider,
         @ShellOption(value = { "password", "--password" },
             help = "Password (encryption key) to decrypt") final String password,
+        @ShellOption(value = { "initvector", "--initvector", "iv", "--iv" },
+                help = "Use initialization vector to encrypt") final Boolean initVector,
         @ShellOption(value = { "iterations", "--iterations" },
             defaultValue = ShellOption.NULL,
             help = "Key obtention iterations to decrypt, default 1000") final String iterations) {
@@ -59,6 +62,9 @@ public class JasyptDecryptPropertyCommand {
         }
         cipher.setProviderName(provider);
         cipher.setKeyObtentionIterations(iterations);
+        if (initVector || cipher.requiresInitializationVector(alg)) {
+            cipher.setInitializationVector();
+        }
         val decrypted = cipher.decryptValue(value);
         LOGGER.info("==== Decrypted Value ====\n[{}]", decrypted);
 

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommand.java
@@ -62,8 +62,8 @@ public class JasyptDecryptPropertyCommand {
         }
         cipher.setProviderName(provider);
         cipher.setKeyObtentionIterations(iterations);
-        if (initVector || cipher.requiresInitializationVector(alg)) {
-            cipher.setInitializationVector();
+        if (initVector || cipher.isVectorInitializationRequiredFor(alg)) {
+            cipher.configureInitializationVector();
         }
         val decrypted = cipher.decryptValue(value);
         LOGGER.info("==== Decrypted Value ====\n[{}]", decrypted);

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
@@ -35,6 +35,7 @@ public class JasyptEncryptPropertyCommand {
      * @param alg        the alg
      * @param provider   the provider
      * @param password   the password
+     * @param initVector whether to use initialization vector
      * @param iterations the iterations - defaults to {@value StandardPBEByteEncryptor#DEFAULT_KEY_OBTENTION_ITERATIONS}
      */
     @ShellMethod(key = "encrypt-value", value = "Encrypt a CAS property value/setting via Jasypt")
@@ -47,6 +48,8 @@ public class JasyptEncryptPropertyCommand {
             help = "Security provider to use to encrypt") final String provider,
         @ShellOption(value = { "password", "--password" },
             help = "Password (encryption key) to encrypt") final String password,
+        @ShellOption(value = { "initvector", "--initvector", "iv", "--iv" },
+            help = "Use initialization vector to encrypt") final Boolean initVector,
         @ShellOption(value = { "iterations", "--iterations" },
             defaultValue = ShellOption.NULL,
             help = "Key obtention iterations to encrypt, default 1000") final String iterations) {
@@ -59,6 +62,9 @@ public class JasyptEncryptPropertyCommand {
         }
         cipher.setProviderName(provider);
         cipher.setKeyObtentionIterations(iterations);
+        if (initVector || cipher.requiresInitializationVector(alg)) {
+            cipher.setInitializationVector();
+        }
         val encrypted = cipher.encryptValue(value);
         LOGGER.info("==== Encrypted Value ====\n[{}]", encrypted);
     }

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommand.java
@@ -62,8 +62,8 @@ public class JasyptEncryptPropertyCommand {
         }
         cipher.setProviderName(provider);
         cipher.setKeyObtentionIterations(iterations);
-        if (initVector || cipher.requiresInitializationVector(alg)) {
-            cipher.setInitializationVector();
+        if (initVector || cipher.isVectorInitializationRequiredFor(alg)) {
+            cipher.configureInitializationVector();
         }
         val encrypted = cipher.encryptValue(value);
         LOGGER.info("==== Encrypted Value ====\n[{}]", encrypted);

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptTestAlgorithmsCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptTestAlgorithmsCommand.java
@@ -44,20 +44,24 @@ public class JasyptTestAlgorithmsCommand {
             LOGGER.trace("Testing provider [{}]", provider);
             for (val algorithm : pbeAlgos) {
                 val cipher = new CasConfigurationJasyptCipherExecutor(this.environment);
+                val algorithmStr = algorithm.toString();
                 cipher.setPassword(password);
                 cipher.setKeyObtentionIterations("1");
                 cipher.setProviderName(provider);
+                if (cipher.requiresInitializationVector(algorithmStr)) {
+                    cipher.setInitializationVector();
+                }
                 try {
                     var encryptedValue = StringUtils.EMPTY;
                     try {
-                        LOGGER.trace("Testing algorithm [{}]", algorithm.toString());
-                        cipher.setAlgorithm(algorithm.toString());
+                        LOGGER.trace("Testing algorithm [{}]", algorithmStr);
+                        cipher.setAlgorithm(algorithmStr);
                         encryptedValue = cipher.encryptValuePropagateExceptions(value);
                     } catch (final Exception e) {
                         LOGGER.trace(e.getMessage(), e);
                         continue;
                     }
-                    LOGGER.info("Provider: [{}] Algorithm: [{}]", provider, algorithm);
+                    LOGGER.info("Provider: [{}] Algorithm: [{}]", provider, algorithmStr);
                     try {
                         cipher.decryptValuePropagateExceptions(encryptedValue);
                         LOGGER.info("Encrypted Value: [{}] Decryption succeeded", encryptedValue);
@@ -66,9 +70,9 @@ public class JasyptTestAlgorithmsCommand {
                     }
                 } catch (final Exception e) {
                     if (e.getCause() instanceof NoSuchAlgorithmException) {
-                        LOGGER.warn("Provider: [{}] does not support Algorithm: [{}]", provider, algorithm);
+                        LOGGER.warn("Provider: [{}] does not support Algorithm: [{}]", provider, algorithmStr);
                     } else {
-                        LOGGER.warn("Error encrypting using provider: [{}] and algorithm: [{}], Message: [{}]", provider, algorithm, e.getMessage());
+                        LOGGER.warn("Error encrypting using provider: [{}] and algorithm: [{}], Message: [{}]", provider, algorithmStr, e.getMessage());
                     }
                 }
             }

--- a/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptTestAlgorithmsCommand.java
+++ b/support/cas-server-support-shell/src/main/java/org/apereo/cas/shell/commands/jasypt/JasyptTestAlgorithmsCommand.java
@@ -48,8 +48,8 @@ public class JasyptTestAlgorithmsCommand {
                 cipher.setPassword(password);
                 cipher.setKeyObtentionIterations("1");
                 cipher.setProviderName(provider);
-                if (cipher.requiresInitializationVector(algorithmStr)) {
-                    cipher.setInitializationVector();
+                if (cipher.isVectorInitializationRequiredFor(algorithmStr)) {
+                    cipher.configureInitializationVector();
                 }
                 try {
                     var encryptedValue = StringUtils.EMPTY;

--- a/support/cas-server-support-shell/src/test/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommandTests.java
+++ b/support/cas-server-support-shell/src/test/java/org/apereo/cas/shell/commands/jasypt/JasyptDecryptPropertyCommandTests.java
@@ -22,5 +22,12 @@ public class JasyptDecryptPropertyCommandTests extends BaseCasShellCommandTests 
         assertDoesNotThrow(() -> shell.evaluate(() -> "decrypt-value --value {cas-cipher}iARpnWTURDdiAhWdcHXxqJpncj4iRo3w9i2UT33stcs= "
             + "--password JASTYPTPW --alg PBEWITHSHAAND256BITAES-CBC-BC --provider BC"));
     }
+
+    @Test
+    public void verifyOperationWithInitVector() {
+        assertDoesNotThrow(() -> shell.evaluate(() -> "decrypt-value --value {cas-cipher}vGJIJnpRIMoB7cusy2f5ogn9gJI/8n8kBr6D/ce62QjnBLdfe5dcPcNWKL7ypaKp "
+                + "--password JASTYPTPW --alg PBEWITHSHAAND256BITAES-CBC-BC --provider BC --initvector"));
+    }
 }
+
 

--- a/support/cas-server-support-shell/src/test/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommandTests.java
+++ b/support/cas-server-support-shell/src/test/java/org/apereo/cas/shell/commands/jasypt/JasyptEncryptPropertyCommandTests.java
@@ -22,5 +22,11 @@ public class JasyptEncryptPropertyCommandTests extends BaseCasShellCommandTests 
         assertDoesNotThrow(() -> shell.evaluate(() -> "encrypt-value --value SOMEVALUE --password "
             + "JASTYPTPW --alg PBEWITHSHAAND256BITAES-CBC-BC --provider BC"));
     }
+
+    @Test
+    public void verifyOperationWithInitVector() {
+        assertDoesNotThrow(() -> shell.evaluate(() -> "encrypt-value --value SOMEVALUE --password "
+                + "JASTYPTPW --alg PBEWITHSHAAND256BITAES-CBC-BC --provider BC --initvector"));
+    }
 }
 


### PR DESCRIPTION
Having initialization vector used by default breaks passwords encrypted without it (e.g. in existing installations). This turns its use off by default but turns it on automatically for previously blacklisted algorithms that don't work without an initialization vector. Test added to make sure future changes don't break existing encrypted values, although the test only does so for a particular algorithm. 

There was a test already that would have caught this but it doesn't currently do a good job checking for errors:

https://github.com/apereo/cas/runs/1722512587?check_suite_focus=true#step:7:108

That isn't fixed by this PR but I will take a look at it. 