### PR TITLE
[WIP] Update Cognito Auth Flow

### DIFF
--- a/docs/cas-server-documentation/authentication/AWS-Cognito-Authentication.md
+++ b/docs/cas-server-documentation/authentication/AWS-Cognito-Authentication.md
@@ -18,7 +18,7 @@ Support is enabled by including the following dependency in the WAR overlay:
 
 {% include casproperties.html properties="cas.authn.cognito"  %}
 
-When you create the *app client* entry in the Amazon Cognito management console, make sure the app is able to support the `ADMIN_NO_SRP_AUTH` authentication flow and it is *NOT* assigned a secret key.
+When you create the *app client* entry in the Amazon Cognito management console, ~~make sure the app is able to support the `ADMIN_NO_SRP_AUTH` authentication flow~~ and it is *NOT* assigned a secret key.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Problem
When attempting to use the CAS server support for AWS Cognito, we ran into this error:
```log
Unable to accept the id token with an invalid [sub] claim
```
After a bit of digging we realized AWS has deprecated the ```ADMIN_NO_SRP_AUTH``` for ```ALLOW_ADMIN_USER_PASSWORD_AUTH```.

### Solution
Change the AuthFlowType and make any related changes if it is not backwards compatible.

Looking at:

```java
val request = authRequest.authFlow(AuthFlowType.ADMIN_NO_SRP_AUTH)
    .clientId(properties.getClientId())
    .userPoolId(properties.getUserPoolId())
    .authParameters(authParams).build();
val result = cognitoIdentityProvider.adminInitiateAuth(request);
```

...we can see that this could be a simple change.
