### PR TITLE
avoid logging null messages if nested message available

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
@@ -1,7 +1,9 @@
 package org.apereo.cas.util;
 
 import lombok.experimental.UtilityClass;
+import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 
 /**
@@ -31,7 +33,8 @@ public class LoggingUtils {
      * @param throwable the throwable
      */
     public static void error(final Logger logger, final Throwable throwable) {
-        error(logger, StringUtils.defaultIfEmpty(throwable.getMessage(), throwable.getClass().getSimpleName()), throwable);
+
+        error(logger, getMessage(throwable), throwable);
     }
 
     /**
@@ -41,7 +44,7 @@ public class LoggingUtils {
      * @param throwable the throwable
      */
     public static void warn(final Logger logger, final Throwable throwable) {
-        warn(logger, StringUtils.defaultIfEmpty(throwable.getMessage(), throwable.getClass().getSimpleName()), throwable);
+        warn(logger, getMessage(throwable), throwable);
     }
 
     /**
@@ -53,6 +56,22 @@ public class LoggingUtils {
      */
     public static void warn(final Logger logger, final String message, final Throwable throwable) {
         logger.warn(message, throwable);
+    }
+
+    /**
+     * Get first non-null exception message, and return classname if all messages null.
+     * @param throwable Top level throwable
+     * @return String containing first non-null exception message, or Throwable simple classname
+     */
+    protected static String getMessage(final Throwable throwable) {
+        if (throwable.getMessage() == null) {
+            val throwableList = ExceptionUtils.getThrowableList(throwable);
+            val message = throwableList.stream().map(t -> t.getMessage()).filter(m -> m != null).findFirst();
+            if (message.isPresent()) {
+                return message.get();
+            }
+        }
+        return StringUtils.defaultIfEmpty(throwable.getMessage(), throwable.getClass().getSimpleName());
     }
 
 }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
@@ -64,9 +64,9 @@ public class LoggingUtils {
      * @return String containing first non-null exception message, or Throwable simple classname
      */
     protected static String getMessage(final Throwable throwable) {
-        if (throwable.getMessage() == null) {
-            val throwableList = ExceptionUtils.getThrowableList(throwable);
-            val message = throwableList.stream().map(t -> t.getMessage()).filter(m -> m != null).findFirst();
+        if (StringUtils.isEmpty(throwable.getMessage())) {
+            val message = ExceptionUtils.getThrowableList(throwable)
+                    .stream().map(t -> t.getMessage()).filter(m -> m != null).findFirst();
             if (message.isPresent()) {
                 return message.get();
             }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
@@ -63,7 +63,7 @@ public class LoggingUtils {
      * @param throwable Top level throwable
      * @return String containing first non-null exception message, or Throwable simple class name
      */
-    protected static String getMessage(final Throwable throwable) {
+    static String getMessage(final Throwable throwable) {
         if (StringUtils.isEmpty(throwable.getMessage())) {
             val message = ExceptionUtils.getThrowableList(throwable)
                     .stream().map(t -> t.getMessage()).filter(m -> m != null).findFirst();

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
@@ -59,9 +59,9 @@ public class LoggingUtils {
     }
 
     /**
-     * Get first non-null exception message, and return classname if all messages null.
+     * Get first non-null exception message, and return class name if all messages null.
      * @param throwable Top level throwable
-     * @return String containing first non-null exception message, or Throwable simple classname
+     * @return String containing first non-null exception message, or Throwable simple class name
      */
     protected static String getMessage(final Throwable throwable) {
         if (StringUtils.isEmpty(throwable.getMessage())) {

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/LoggingUtilsTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/LoggingUtilsTests.java
@@ -1,8 +1,11 @@
 package org.apereo.cas.util;
 
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.UndeclaredThrowableException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -23,5 +26,15 @@ public class LoggingUtilsTests {
             LoggingUtils.warn(LOGGER, "error", new RuntimeException("error"));
             LoggingUtils.warn(LOGGER, new RuntimeException("error"));
         });
+    }
+
+    @Test
+    public void verifyGetNonNullMessage() {
+        val exception = new UndeclaredThrowableException(new Exception("nested"));
+        assertEquals("nested", LoggingUtils.getMessage(exception));
+        val exception2 = new Exception("first", new Exception("second"));
+        assertEquals("first", LoggingUtils.getMessage(exception2));
+        val exception3 = new UndeclaredThrowableException(new Exception(new RuntimeException()));
+        assertEquals("java.lang.RuntimeException", LoggingUtils.getMessage(exception3));
     }
 }


### PR DESCRIPTION
This seeks to log a better exception message if the top level throwable's message is null, as is the case with an UndeclaredThrowableException used by SneakyThrows. This looks for the first non-null message but still results in the top level exception's stack trace being logged (as it may have useful information). Here is an example where the top level exception provides details on where the exception occurred but the nested exception message is more useful as to the cause of the problem. This shouldn't add any extra overhead in the case where the top level message is not null. 

```
2021-01-20 15:00:59,880 WARN [org.apereo.cas.services.GitServiceRegistry] - <UndeclaredThrowableException>
java.lang.reflect.UndeclaredThrowableException: null
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:767) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.apereo.cas.git.GitRepository$$EnhancerBySpringCGLIB$$cbd09dc3.pull(<generated>) ~[cas-server-support-git-core-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at org.apereo.cas.services.GitServiceRegistry.load(GitServiceRegistry.java:100) ~[cas-server-support-git-service-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor187.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282) ~[spring-core-5.3.3.jar!/:5.3.3]
	at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:490) ~[spring-cloud-context-3.0.0.jar!/:3.0.0]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at com.sun.proxy.$Proxy158.load(Unknown Source) ~[?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
	at org.apereo.cas.services.DefaultChainingServiceRegistry.load(DefaultChainingServiceRegistry.java:63) ~[cas-server-core-services-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor187.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282) ~[spring-core-5.3.3.jar!/:5.3.3]
	at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:490) ~[spring-cloud-context-3.0.0.jar!/:3.0.0]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at com.sun.proxy.$Proxy273.load(Unknown Source) ~[?:?]
	at org.apereo.cas.services.AbstractServicesManager.load(AbstractServicesManager.java:226) ~[cas-server-core-services-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at org.apereo.cas.services.ChainingServicesManager.lambda$load$12(ChainingServicesManager.java:143) ~[cas-server-core-services-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
	at org.apereo.cas.services.ChainingServicesManager.load(ChainingServicesManager.java:144) ~[cas-server-core-services-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at org.apereo.cas.services.ChainingServicesManager$$FastClassBySpringCGLIB$$d1902915.invoke(<generated>) ~[cas-server-core-services-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:779) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.apereo.cas.services.ChainingServicesManager$$EnhancerBySpringCGLIB$$2d737530.load(<generated>) ~[cas-server-core-services-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor193.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282) ~[spring-core-5.3.3.jar!/:5.3.3]
	at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:490) ~[spring-cloud-context-3.0.0.jar!/:3.0.0]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at com.sun.proxy.$Proxy155.load(Unknown Source) ~[?:?]
	at org.apereo.cas.services.ServicesManagerScheduledLoader.run(ServicesManagerScheduledLoader.java:32) ~[cas-server-core-services-registry-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor202.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[spring-context-5.3.3.jar!/:5.3.3]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-5.3.3.jar!/:5.3.3]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: org.eclipse.jgit.api.errors.RefNotAdvertisedException: Remote origin did not advertise Ref for branch awsdev-saml. This Ref may not exist in the remote or may be hidden by permission settings.
	at org.eclipse.jgit.api.PullCommand.call(PullCommand.java:291) ~[org.eclipse.jgit-5.10.0.202012080955-r.jar!/:5.10.0.202012080955-r]
	at org.apereo.cas.git.GitRepository.pull(GitRepository.java:175) ~[cas-server-support-git-core-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
	at jdk.internal.reflect.GeneratedMethodAccessor192.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282) ~[spring-core-5.3.3.jar!/:5.3.3]
	at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:490) ~[spring-cloud-context-3.0.0.jar!/:3.0.0]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.3.jar!/:5.3.3]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.3.jar!/:5.3.3]
	... 67 more
```
