### PR TITLE
support cors allowed origin patterns

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/security/HttpCorsRequestProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/security/HttpCorsRequestProperties.java
@@ -49,9 +49,18 @@ public class HttpCorsRequestProperties implements Serializable {
     /**
      * The Origin header indicates the origin of the cross-site access request or preflight request.
      * The origin is a URI indicating the server from which the request initiated.
+     * When credentials are allowed, '*' cannot be used and origin patterns should be configured instead.
      * It does not include any path information, but only the server name.
      */
     private List<String> allowOrigins = new ArrayList<>(0);
+
+    /**
+     * Comma-separated list of origin patterns to allow. Unlike allowed origins which only
+     * supports '*', origin patterns are more flexible (for example
+     * 'https://*.example.com') and can be used when credentials are allowed. When no
+     * allowed origin patterns or allowed origins are set, CORS support is disabled.
+     */
+    private List<String> allowOriginPatterns = new ArrayList<>(0);
 
     /**
      * The Access-Control-Allow-Methods header specifies the method or methods allowed when accessing the resource.

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
@@ -193,9 +193,14 @@ public interface RegisteredServiceProperty extends Serializable {
          */
         CORS_MAX_AGE("corsMaxAge", StringUtils.EMPTY),
         /**
-         * Define allowed origins for CORS requests.
+         * Define allowed origins for CORS requests. Cannot use * when credentials are allowed.
          */
         CORS_ALLOWED_ORIGINS("corsAllowedOrigins", StringUtils.EMPTY),
+        /**
+         * Define patterns of allowed origins for CORS requests. (e.g.
+         * 'https://*.example.com') Patterns can be used when credentials are allowed.
+         */
+        CORS_ALLOWED_ORIGIN_PATTERNS("corsAllowedOriginPatterns", StringUtils.EMPTY),
         /**
          * Define allowed methods for CORS requests.
          */

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceCorsConfigurationSource.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/support/RegisteredServiceCorsConfigurationSource.java
@@ -41,6 +41,7 @@ public class RegisteredServiceCorsConfigurationSource implements CorsConfigurati
         config.setAllowCredentials(cors.isAllowCredentials());
         config.setMaxAge(cors.getMaxAge());
         config.setAllowedOrigins(cors.getAllowOrigins());
+        config.setAllowedOriginPatterns(cors.getAllowOriginPatterns());
         config.setAllowedMethods(cors.getAllowMethods());
         config.setAllowedHeaders(cors.getAllowHeaders());
         config.setExposedHeaders(cors.getExposedHeaders());
@@ -59,6 +60,12 @@ public class RegisteredServiceCorsConfigurationSource implements CorsConfigurati
                 val result = RegisteredServiceProperties.CORS_ALLOWED_ORIGINS.getPropertyValues(registeredService, Set.class);
                 if (result != null) {
                     config.setAllowedOrigins(new ArrayList<>(result));
+                }
+            }
+            if (RegisteredServiceProperties.CORS_ALLOWED_ORIGIN_PATTERNS.isAssignedTo(registeredService)) {
+                val result = RegisteredServiceProperties.CORS_ALLOWED_ORIGIN_PATTERNS.getPropertyValues(registeredService, Set.class);
+                if (result != null) {
+                    config.setAllowedOriginPatterns(new ArrayList<>(result));
                 }
             }
             if (RegisteredServiceProperties.CORS_ALLOWED_METHODS.isAssignedTo(registeredService)) {

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceCorsConfigurationSourceTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceCorsConfigurationSourceTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.*;
 @SpringBootTest(classes = RefreshAutoConfiguration.class, properties = {
     "cas.http-web-request.cors.allow-credentials=true",
     "cas.http-web-request.cors.allow-origins[0]=*",
+    "cas.http-web-request.cors.allow-origin-patterns[0]=https://*.example.com",
     "cas.http-web-request.cors.allow-methods[0]=*",
     "cas.http-web-request.cors.allow-headers[0]=*",
     "cas.http-web-request.cors.max-age=1600",
@@ -62,6 +63,7 @@ public class RegisteredServiceCorsConfigurationSourceTests {
         assertEquals(cors.getMaxAge(), config.getMaxAge().intValue());
         assertEquals(cors.getAllowHeaders(), config.getAllowedHeaders());
         assertEquals(cors.getAllowOrigins(), config.getAllowedOrigins());
+        assertEquals(cors.getAllowOriginPatterns(), config.getAllowedOriginPatterns());
         assertEquals(cors.getAllowMethods(), config.getAllowedMethods());
         assertEquals(cors.getExposedHeaders(), config.getExposedHeaders());
         assertTrue(config.getAllowCredentials().booleanValue());
@@ -78,6 +80,8 @@ public class RegisteredServiceCorsConfigurationSourceTests {
             new DefaultRegisteredServiceProperty(Set.of("12345")));
         props.put(RegisteredServiceProperty.RegisteredServiceProperties.CORS_ALLOWED_ORIGINS.getPropertyName(),
             new DefaultRegisteredServiceProperty(Set.of("12345")));
+        props.put(RegisteredServiceProperty.RegisteredServiceProperties.CORS_ALLOWED_ORIGIN_PATTERNS.getPropertyName(),
+                new DefaultRegisteredServiceProperty(Set.of("12345")));
         props.put(RegisteredServiceProperty.RegisteredServiceProperties.CORS_ALLOWED_METHODS.getPropertyName(),
             new DefaultRegisteredServiceProperty(Set.of("12345")));
         props.put(RegisteredServiceProperty.RegisteredServiceProperties.CORS_EXPOSED_HEADERS.getPropertyName(),
@@ -104,5 +108,6 @@ public class RegisteredServiceCorsConfigurationSourceTests {
         assertEquals(List.of("12345"), config.getAllowedOrigins());
         assertEquals(List.of("12345"), config.getAllowedMethods());
         assertEquals(List.of("12345"), config.getExposedHeaders());
+        assertEquals(List.of("12345"), config.getAllowedOriginPatterns());
     }
 }

--- a/docs/cas-server-documentation/services/Configuring-Service-Http-Security-Headers.md
+++ b/docs/cas-server-documentation/services/Configuring-Service-Http-Security-Headers.md
@@ -55,12 +55,13 @@ following properties are supported:
 
 | Name                                      | Description
 |-----------------------|-----------------------------------------------------------------------
-| `corsAllowCredentials`    | Whether user credentials are supported. 
-| `corsMaxAge`              | Configure how long, as a duration, the response from a pre-flight request can be cached by clients. 
-| `corsAllowedOrigins`      | Set the origins to allow. The special value `*` allows all domains.
-| `corsAllowedMethods`      | Set the HTTP methods to allow, e.g. `GET`, etc. The special value `*` allows all methods.
-| `corsAllowedHeaders`      | Set the list of headers that a pre-flight request can list as allowed for use during an actual request. The special value `*` allows actual requests to send any header. 
-| `corsExposedHeaders`      | List of response headers that a response might have and can be exposed. The special value `*` allows all headers to be exposed for non-credentialed requests.
+| `corsAllowCredentials`      | Whether user credentials are supported. 
+| `corsMaxAge`                | Configure how long, as a duration, the response from a pre-flight request can be cached by clients. 
+| `corsAllowedOrigins`        | Set the origins to allow. The special value `*` allows all domains but cannot be used when credentials allowed.
+| `corsAllowedOriginPatterns` | Set the origins patterns to allow. Patterns may be used when credentials allowed, e.g. https://*.example.com.
+| `corsAllowedMethods`        | Set the HTTP methods to allow, e.g. `GET`, etc. The special value `*` allows all methods.
+| `corsAllowedHeaders`        | Set the list of headers that a pre-flight request can list as allowed for use during an actual request. The special value `*` allows actual requests to send any header. 
+| `corsExposedHeaders`        | List of response headers that a response might have and can be exposed. The special value `*` allows all headers to be exposed for non-credentialed requests.
 
 A sample JSON file follows:
 


### PR DESCRIPTION
Spring 5.3 has started throwing this exception when you use * as an allowed origin and credentials are allowed:
```
java.lang.IllegalArgumentException: When allowCredentials is true, allowedOrigins cannot contain the special value "*"since that cannot be set on the "Access-Control-Allow-Origin" response header. To allow credentials to a set of origins,
list them explicitly or consider using "allowedOriginPatterns" instead.
```
Previously Spring would echo back the requested origin for the allowed origin if * was configured with allow credentials true.

This adds support for the new Spring `allowedOriginPatterns` setting. 
