### PR TITLE
Cannot resend token in casSimpleMfaLoginView

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casSimpleMfaLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casSimpleMfaLoginView.html
@@ -35,7 +35,7 @@
                                        id="token"
                                        th:field="*{token}"
                                        size="25"
-                                       autocomplete="one-time-code" />
+                                       autocomplete="one-time-code" required />
 
                                 <span class="mdc-notched-outline">
                                     <span class="mdc-notched-outline__leading"></span>
@@ -63,7 +63,7 @@
                     <button class="mdc-button mdc-button--raised mr-2" accesskey="s">
                         <span class="mdc-button__label" th:text="#{screen.welcome.button.login}">Login</span>
                     </button>
-                    <button class="mdc-button mdc-button--raised" name="resend" onclick="$('#eventId').val('resend');">
+                    <button class="mdc-button mdc-button--raised" name="resend" formnovalidate onclick="$('#eventId').val('resend');">
                         <span class="mdc-button__label" th:text="#{cas.mfa.simple.label.resend}">Resend</span>
                     </button>
                 </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casSimpleMfaLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casSimpleMfaLoginView.html
@@ -35,7 +35,7 @@
                                        id="token"
                                        th:field="*{token}"
                                        size="25"
-                                       autocomplete="off" required />
+                                       autocomplete="one-time-code" />
 
                                 <span class="mdc-notched-outline">
                                     <span class="mdc-notched-outline__leading"></span>


### PR DESCRIPTION
Token should not be required in casSimpleMfaLoginView. Otherwise clicking on resend button would be not possible if the token input is empty.
