### PR TITLE
capture better error message on startup for BeanDefinitionStoreException

### DIFF
--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/BeanDefinitionStoreFailureAnalyzer.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/BeanDefinitionStoreFailureAnalyzer.java
@@ -1,0 +1,54 @@
+package org.apereo.cas.web;
+
+import org.apereo.cas.util.LoggingUtils;
+
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Failure analyzer for spring boot startup exceptions from BeanDefinitionStoreException.
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@Slf4j
+public class BeanDefinitionStoreFailureAnalyzer extends AbstractFailureAnalyzer<BeanDefinitionStoreException> {
+
+    private static String ANALYSIS = "Review the properties available for the configuration. Enable debug logging on "
+            + BeanDefinitionStoreFailureAnalyzer.class.getName() + " to see exception stack trace";
+
+    @Override
+    protected FailureAnalysis analyze(final Throwable rootFailure, final BeanDefinitionStoreException cause) {
+        if (LOGGER.isDebugEnabled()) {
+            LoggingUtils.error(LOGGER, getDescription(cause), cause);
+        }
+        return new FailureAnalysis(getDescription(cause), ANALYSIS, cause);
+    }
+
+    private String getDescription(final BeanDefinitionStoreException ex) {
+        val causedMsg = ExceptionUtils.getRootCauseMessage(ex);
+        val description = new StringWriter();
+        val printer = new PrintWriter(description);
+
+        printer.printf("Error creating bean");
+        if (ex.getBeanName() != null) {
+            printer.printf(" named %s", ex.getBeanName());
+        }
+        if (ex.getResourceDescription() != null) {
+            printer.printf(", with resource description %s,", ex.getResourceDescription());
+        }
+        printer.printf(" due to: %s ", ex.getMessage());
+        if (StringUtils.isNotBlank(causedMsg)) {
+            printer.printf(" caused by %s ", causedMsg);
+        }
+        return description.toString();
+    }
+}

--- a/webapp/cas-server-webapp-init/src/main/resources/META-INF/spring.factories
+++ b/webapp/cas-server-webapp-init/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.diagnostics.FailureAnalyzer=org.apereo.cas.web.BeanDefinitionStoreFailureAnalyzer

--- a/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/AllCasWebApplicationTestsSuite.java
+++ b/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/AllCasWebApplicationTestsSuite.java
@@ -10,7 +10,8 @@ import org.junit.runner.RunWith;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-@SelectClasses(CasEmbeddedContainerUtilsTests.class)
+@SelectClasses({CasEmbeddedContainerUtilsTests.class,
+                BeanDefinitionStoreFailureAnalyzerTests.class})
 @RunWith(JUnitPlatform.class)
 public class AllCasWebApplicationTestsSuite {
 }

--- a/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/AllCasWebApplicationTestsSuite.java
+++ b/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/AllCasWebApplicationTestsSuite.java
@@ -10,8 +10,10 @@ import org.junit.runner.RunWith;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-@SelectClasses({CasEmbeddedContainerUtilsTests.class,
-                BeanDefinitionStoreFailureAnalyzerTests.class})
+@SelectClasses({
+    CasEmbeddedContainerUtilsTests.class,
+    BeanDefinitionStoreFailureAnalyzerTests.class
+})
 @RunWith(JUnitPlatform.class)
 public class AllCasWebApplicationTestsSuite {
 }

--- a/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/BeanDefinitionStoreFailureAnalyzerTests.java
+++ b/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/BeanDefinitionStoreFailureAnalyzerTests.java
@@ -4,6 +4,7 @@ import org.apereo.cas.configuration.model.core.CasServerProperties;
 import org.apereo.cas.web.BeanDefinitionStoreFailureAnalyzer;
 
 import lombok.val;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -20,6 +21,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ge
  * @author Hal Deadman
  * @since 6.4.0
  */
+@Tag("Utility")
 public class BeanDefinitionStoreFailureAnalyzerTests {
 
     @Test

--- a/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/BeanDefinitionStoreFailureAnalyzerTests.java
+++ b/webapp/cas-server-webapp-init/src/test/java/org/apereo/cas/BeanDefinitionStoreFailureAnalyzerTests.java
@@ -1,0 +1,71 @@
+package org.apereo.cas;
+
+import org.apereo.cas.configuration.model.core.CasServerProperties;
+import org.apereo.cas.web.BeanDefinitionStoreFailureAnalyzer;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
+
+/**
+ * This is {@link BeanDefinitionStoreFailureAnalyzerTests}.
+ *
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+public class BeanDefinitionStoreFailureAnalyzerTests {
+
+    @Test
+    public void analyzeBeanDefinitionStoreException() {
+        val analysis = performAnalysis();
+        val description = analysis.getDescription();
+        assertThat(description).contains("not.defined");
+    }
+
+    @Test
+    public void analyzeBeanDefinitionStoreExceptionFullMsg() {
+        val analysis = new BeanDefinitionStoreFailureAnalyzer().analyze(
+                new BeanDefinitionStoreException("resourcedesc", "beanname", "themsg"));
+        val description = analysis.getDescription();
+        assertThat(description).contains("resourcedesc");
+        assertThat(description).contains("beanname");
+        assertThat(description).contains("themsg");
+        val analysis2 = new BeanDefinitionStoreFailureAnalyzer().analyze(
+                new BeanDefinitionStoreException("beanname", "themsg", new IllegalStateException("thecause")));
+        val description2 = analysis2.getDescription();
+        assertThat(description2).contains("beanname");
+        assertThat(description2).contains("themsg");
+        assertThat(description2).contains("thecause");
+    }
+
+    private FailureAnalysis performAnalysis() {
+        val failure = createFailure();
+        assertNotNull(failure);
+        return new BeanDefinitionStoreFailureAnalyzer().analyze(failure);
+    }
+
+    private BeanDefinitionStoreException createFailure() {
+        val bf = new DefaultListableBeanFactory();
+        bf.registerBeanDefinition("testBean",
+                genericBeanDefinition(CasServerProperties.class)
+                        .addPropertyValue("name", "${not.defined}")
+                        .getBeanDefinition());
+
+        val ppc = new PropertySourcesPlaceholderConfigurer();
+        try {
+            ppc.postProcessBeanFactory(bf);
+        } catch (final BeanDefinitionStoreException e) {
+            return e;
+        }
+        return null;
+    }
+}
+
+


### PR DESCRIPTION
I had a startup failure caused by a BeanDefinitionStoreException due to an unresolved placeholder and there wasn't a good message logged when the server stopped. This adds a spring boot FailureAnalyzer that prints more information about the error, and you can turn on debug to try to get the stack trace.

Here is the example of what the error message looks like, although I have updated the Action text since this was generated:
```
2021-01-29 10:37:27,250 WARN [org.apereo.cas.web.CasWebApplicationContext] - <Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to process import candidates for configuration class [org.apereo.cas.web.CasWebApplication]; nested exception is java.lang.IllegalStateException: Error processing condition on org.apereo.cas.config.CasPersonDirectoryConfiguration$CasPersonDirectoryLdapConfiguration>
2021-01-29 10:37:27,282 ERROR [org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter] - <

***************************
APPLICATION FAILED TO START
***************************

Description:

Error creating bean  due to: Failed to process import candidates for configuration class [org.apereo.cas.web.CasWebApplication]; nested exception is java.lang.IllegalStateException: Error processing condition on org.apereo.cas.config.CasPersonDirectoryConfiguration$CasPersonDirectoryLdapConfiguration  caused by IllegalArgumentException: Could not resolve placeholder 'ldap-url' in value "${ldap-url}"

Action:

Fix the invalid configuration
>
```