### PR TITLE
Implement findServiceBy for service id

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultChainingServiceRegistry.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultChainingServiceRegistry.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.authentication.principal.Service;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.ArrayList;

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultChainingServiceRegistry.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultChainingServiceRegistry.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.authentication.principal.Service;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.ArrayList;
@@ -138,4 +139,14 @@ public class DefaultChainingServiceRegistry extends AbstractServiceRegistry impl
             })
             .forEach(serviceRegistry -> serviceRegistry.save(service));
     }
+
+    @Override
+    public RegisteredService findServiceBy(final String id) {
+        return serviceRegistries.stream()
+                .map(registry -> registry.findServiceBy(id))
+                .filter(Objects::nonNull)
+                .findFirst()
+                 .orElse(null);
+    }
+
 }


### PR DESCRIPTION
This PR adds an implemented findServiceBy(String id) to the DefaultChainingServiceRegistry.  Without this implementation the default methods in the interface are called.  The side affect of that is the service registry would be reloaded on every call to this method, resulting in poor performance for registries of any significant size. 