### PR TITLE
fix illegal underscores in kubernetes names

### DIFF
--- a/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/bootadmin/deployment.yaml
+++ b/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/bootadmin/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         {{- range $.Values.bootAdminContainer.casConfigMounts }}
-          {{- $configMount := printf "%s-%s" "bootadmin-config" . | replace "." "-" }}
+          {{- $configMount := printf "%s-%s" "bootadmin-config" . | replace "." "-" | replace "_" "-" | lower }}
           - name: {{ $configMount | quote }}
             configMap:
               name: {{ include "cas-server.bootadminname" $ }}-config
@@ -55,7 +55,7 @@ spec:
           {{- include "cas-server.tplvalues.render" ( dict "value" .Values.bootAdminContainer.extraVolumes "context" $ ) | nindent 10 }}
           {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: cas-boot-admin
           securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "cas-server.bootadminImageName" . }}
@@ -66,7 +66,7 @@ spec:
               value: {{ .Values.bootAdminContainer.warPath | quote }}
             {{- end }}
             {{- if .Values.bootAdminContainer.profiles }}
-            - name: SPRING_PROFILES
+            - name: CAS_SPRING_PROFILES
               value: {{ .Values.bootAdminContainer.profiles | quote }}
             {{- end }}
             {{- if .Values.bootAdminContainer.jvm.maxHeapOpt }}
@@ -115,7 +115,7 @@ spec:
               protocol: TCP
           volumeMounts:
             {{- range $.Values.bootAdminContainer.casConfigMounts }}
-            {{- $configMount := printf "%s-%s" "bootadmin-config" . | replace "." "-" }}
+            {{- $configMount := printf "%s-%s" "bootadmin-config" . | replace "." "-" | replace "_" "-" | lower }}
             {{- $configMountPath := printf "%s/%s" "/etc/cas/config" . }}
             - name: {{ $configMount | quote }}
               mountPath: {{ $configMountPath }}

--- a/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/script-configmap.yaml
+++ b/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/script-configmap.yaml
@@ -15,8 +15,8 @@ data:
         echo "kubectl port-forward $HOSTNAME ${JAVA_DEBUG_PORT:-5005}:${JAVA_DEBUG_PORT:-5005}"
     fi
     PROFILE_OPT=
-    if [ ! -z $SPRING_PROFILES ]; then
-      PROFILE_OPT="--spring.profiles.active=$SPRING_PROFILES"
+    if [ ! -z $CAS_SPRING_PROFILES ]; then
+      PROFILE_OPT="--spring.profiles.active=$CAS_SPRING_PROFILES"
     fi
     echo java -server -noverify $JAVA_DEBUG_ARGS $MAX_HEAP_OPT $NEW_HEAP_OPT $JVM_EXTRA_OPTS -jar $CAS_WAR $PROFILE_OPT $@
     exec java -server -noverify $JAVA_DEBUG_ARGS $MAX_HEAP_OPT $NEW_HEAP_OPT $JVM_EXTRA_OPTS -jar $CAS_WAR $PROFILE_OPT $@
@@ -31,8 +31,8 @@ data:
         JAVA_DEBUG_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${JAVA_DEBUG_SUSPEND:-n},address=${JAVA_DEBUG_PORT:-5005}"
     fi
     PROFILE_OPT=
-    if [ ! -z $SPRING_PROFILES ]; then
-      PROFILE_OPT="--spring.profiles.active=$SPRING_PROFILES"
+    if [ ! -z $CAS_SPRING_PROFILES ]; then
+      PROFILE_OPT="--spring.profiles.active=$CAS_SPRING_PROFILES"
     fi
     echo java -server -noverify $JAVA_DEBUG_ARGS $MAX_HEAP_OPT $NEW_HEAP_OPT $JVM_EXTRA_OPTS -jar $CAS_BOOTADMIN_WAR $PROFILE_OPT $@
     exec java -server -noverify $JAVA_DEBUG_ARGS $MAX_HEAP_OPT $NEW_HEAP_OPT $JVM_EXTRA_OPTS -jar $CAS_BOOTADMIN_WAR $PROFILE_OPT $@

--- a/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/statefulset.yaml
+++ b/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         {{- range $.Values.casServerContainer.casConfigMounts }}
-        {{- $configMount := printf "%s-%s" "cas-config" . | replace "." "-" }}
+        {{- $configMount := printf "%s-%s" "cas-config" . | replace "." "-" | replace "_" "-" | lower }}
         - name: {{ $configMount | quote }}
           configMap:
             name: {{ include "cas-server.fullname" $ }}-casconfig
@@ -71,7 +71,7 @@ spec:
               value: {{ .Values.casServerContainer.warPath | quote }}
             {{- end }}
             {{- if .Values.casServerContainer.profiles }}
-            - name: SPRING_PROFILES
+            - name: CAS_SPRING_PROFILES
               value: {{ .Values.casServerContainer.profiles | quote }}
             {{- end }}
             {{- if .Values.casServerContainer.jvm.maxHeapOpt }}
@@ -120,7 +120,7 @@ spec:
               protocol: TCP
           volumeMounts:
             {{- range $.Values.casServerContainer.casConfigMounts }}
-            {{- $configMount := printf "%s-%s" "cas-config" . | replace "." "-" }}
+            {{- $configMount := printf "%s-%s" "cas-config" . | replace "." "-" | replace "_" "-" | lower }}
             {{- $configMountPath := printf "%s/%s" "/etc/cas/config" . }}
             - name: {{ $configMount | quote }}
               mountPath: {{ $configMountPath }}


### PR DESCRIPTION
Kubernetes doesn't like underscores in volume mount names. Also SPRING_PROFILES env variable gets interpreted by spring boot 2.4 as spring.profiles property setting and that breaks things in some cases. 