### PR TITLE
change default branchesToClone to all branches, update javadocs

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -32,18 +32,19 @@ public abstract class BaseGitProperties implements Serializable {
     private String repositoryUrl;
 
     /**
-     * The branch to checkout and activate.
+     * The branch to checkout and activate, defaults to {@code master}.
      */
     @RequiredProperty
     private String activeBranch = "master";
 
     /**
      * If the repository is to be cloned,
-     * this will allow the list of branches to be fetched
-     * separated by commas.
+     * this will allow a select list of branches to be fetched.
+     * List the branch names separated by commas or use {@code *} to clone all branches.
+     * Defaults to all branches.
      */
     @RequiredProperty
-    private String branchesToClone = "master";
+    private String branchesToClone = "*";
 
     /**
      * Username used to access or push to the repository.
@@ -94,7 +95,7 @@ public abstract class BaseGitProperties implements Serializable {
     /**
      * When establishing an ssh session, determine if default
      * identities loaded on the machine should be excluded/removed
-     * and identity should only be limitd to those loaded from given keys.
+     * and identity should only be limited to those loaded from given keys.
      */
     private boolean clearExistingIdentities;
 

--- a/docs/cas-server-documentation/release_notes/RC2.md
+++ b/docs/cas-server-documentation/release_notes/RC2.md
@@ -51,6 +51,10 @@ The following items are new improvements and enhancements presented in this rele
 
 ## Other Stuff
 
+ - The default value for `cas.service-registry.git.branches-to-clone` and `cas.authn.saml-idp.metadata.git.branches-to-clone`
+   changed from `master` to `*` which means all branches will be cloned by default. The properties may contain a list of
+   branches, but the list must include the branch specified in the `cas.service-registry.git.active-branch` 
+   or `cas.authn.saml-idp.metadata.git.active-branch` property. 
 
 ## Library Upgrades
 


### PR DESCRIPTION
This updates the default branches to clone to "all" branches. If it isn't all, and you change the `activeBranch`, you also have to change the `branchesToClone` to include the `activeBranch`. Since most config repositories are probably small, defaulting to cloning all the branches is probably not a big deal. If the default is going to remain as-is, we should probably automatically add the activeBranch to the list of branchesToClone. 