### PR TITLE
Accept simple MFA tokens without prefix

### DIFF
--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
@@ -50,30 +50,34 @@ public class CasSimpleMultifactorAuthenticationHandler extends AbstractPreAndPos
     @Override
     protected AuthenticationHandlerExecutionResult doAuthentication(final Credential credential) throws GeneralSecurityException {
         val tokenCredential = (CasSimpleMultifactorTokenCredential) credential;
-        LOGGER.debug("Received token [{}]", tokenCredential.getId());
+        String tokenId = tokenCredential.getId();
+        if (!tokenId.startsWith(CasSimpleMultifactorAuthenticationTicket.PREFIX)) {
+            tokenId = CasSimpleMultifactorAuthenticationTicket.PREFIX + CasSimpleMultifactorAuthenticationUniqueTicketIdGenerator.SEPARATOR + tokenId;
+        }
+        LOGGER.debug("Received token [{}]", tokenId);
 
         val authentication = WebUtils.getInProgressAuthentication();
         val uid = authentication.getPrincipal().getId();
 
         try {
             LOGGER.debug("Received principal id [{}]. Attempting to locate token in registry...", uid);
-            val acct = centralAuthenticationService.getTicket(tokenCredential.getId(), CasSimpleMultifactorAuthenticationTicket.class);
+            val acct = centralAuthenticationService.getTicket(tokenId, CasSimpleMultifactorAuthenticationTicket.class);
             val properties = acct.getProperties();
             if (!properties.containsKey(CasSimpleMultifactorAuthenticationConstants.PROPERTY_PRINCIPAL)) {
-                LOGGER.warn("Unable to locate principal for token [{}]", tokenCredential.getId());
+                LOGGER.warn("Unable to locate principal for token [{}]", tokenId);
                 deleteToken(acct);
-                throw new FailedLoginException("Failed to authenticate code " + tokenCredential.getId());
+                throw new FailedLoginException("Failed to authenticate code " + tokenId);
             }
             val principal = Principal.class.cast(properties.get(CasSimpleMultifactorAuthenticationConstants.PROPERTY_PRINCIPAL));
             if (!principal.equals(authentication.getPrincipal())) {
-                LOGGER.warn("Principal assigned to token [{}] is unauthorized for of token [{}]", principal.getId(), tokenCredential.getId());
+                LOGGER.warn("Principal assigned to token [{}] is unauthorized for of token [{}]", principal.getId(), tokenId);
                 deleteToken(acct);
-                throw new FailedLoginException("Failed to authenticate code " + tokenCredential.getId());
+                throw new FailedLoginException("Failed to authenticate code " + tokenId);
             }
             deleteToken(acct);
 
             LOGGER.debug("Validated token [{}] successfully for [{}]. Creating authentication result and building principal...",
-                tokenCredential.getId(), uid);
+                tokenId, uid);
             return createHandlerResult(tokenCredential, this.principalFactory.createPrincipal(uid));
         } catch (final AbstractTicketException e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
@@ -7,6 +7,7 @@ import org.apereo.cas.authentication.handler.support.AbstractPreAndPostProcessin
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.mfa.simple.ticket.CasSimpleMultifactorAuthenticationTicket;
+import org.apereo.cas.mfa.simple.ticket.CasSimpleMultifactorAuthenticationUniqueTicketIdGenerator;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.AbstractTicketException;
 import org.apereo.cas.util.LoggingUtils;

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
@@ -51,7 +51,7 @@ public class CasSimpleMultifactorAuthenticationHandler extends AbstractPreAndPos
     @Override
     protected AuthenticationHandlerExecutionResult doAuthentication(final Credential credential) throws GeneralSecurityException {
         val tokenCredential = (CasSimpleMultifactorTokenCredential) credential;
-        String tokenId = tokenCredential.getId();
+        var tokenId = tokenCredential.getId();
         if (!tokenId.startsWith(CasSimpleMultifactorAuthenticationTicket.PREFIX)) {
             tokenId = CasSimpleMultifactorAuthenticationTicket.PREFIX + CasSimpleMultifactorAuthenticationUniqueTicketIdGenerator.SEPARATOR + tokenId;
         }

--- a/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
+++ b/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
@@ -137,9 +137,9 @@ public class CasSimpleMultifactorAuthenticationHandlerTests {
         val factory = (CasSimpleMultifactorAuthenticationTicketFactory) defaultTicketFactory.get(CasSimpleMultifactorAuthenticationTicket.class);
         val ticket = factory.create(RegisteredServiceTestUtils.getService(), Map.of());
         ticketRegistry.addTicket(ticket);
-        val ticketWithoutPrefix = ticket.getId().substring(CasSimpleMultifactorAuthenticationTicket.PREFIX.length()
+        String ticketIdWithoutPrefix = ticket.getId().substring(CasSimpleMultifactorAuthenticationTicket.PREFIX.length()
             + CasSimpleMultifactorAuthenticationUniqueTicketIdGenerator.SEPARATOR.length());
-        val credential = new CasSimpleMultifactorTokenCredential(ticket.getId());
+        val credential = new CasSimpleMultifactorTokenCredential(ticketIdWithoutPrefix);
         assertNotNull(casSimpleMultifactorAuthenticationHandler.authenticate(credential).getPrincipal());
     }
 }

--- a/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
+++ b/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
@@ -6,7 +6,6 @@ import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.mfa.simple.ticket.CasSimpleMultifactorAuthenticationTicket;
 import org.apereo.cas.mfa.simple.ticket.CasSimpleMultifactorAuthenticationTicketFactory;
-import org.apereo.cas.mfa.simple.ticket.CasSimpleMultifactorAuthenticationUniqueTicketIdGenerator;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.TicketFactory;
@@ -137,8 +136,7 @@ public class CasSimpleMultifactorAuthenticationHandlerTests {
         val factory = (CasSimpleMultifactorAuthenticationTicketFactory) defaultTicketFactory.get(CasSimpleMultifactorAuthenticationTicket.class);
         val ticket = factory.create(RegisteredServiceTestUtils.getService(), Map.of());
         ticketRegistry.addTicket(ticket);
-        String ticketIdWithoutPrefix = ticket.getId().substring(CasSimpleMultifactorAuthenticationTicket.PREFIX.length()
-            + CasSimpleMultifactorAuthenticationUniqueTicketIdGenerator.SEPARATOR.length());
+        String ticketIdWithoutPrefix = ticket.getId().substring(CasSimpleMultifactorAuthenticationTicket.PREFIX.length() + 1);
         val credential = new CasSimpleMultifactorTokenCredential(ticketIdWithoutPrefix);
         assertNotNull(casSimpleMultifactorAuthenticationHandler.authenticate(credential).getPrincipal());
     }

--- a/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
+++ b/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
@@ -131,10 +131,12 @@ public class CasSimpleMultifactorAuthenticationHandlerTests {
         RequestContextHolder.setRequestContext(context);
         ExternalContextHolder.setExternalContext(context.getExternalContext());
 
-        WebUtils.putAuthentication(RegisteredServiceTestUtils.getAuthentication(), context);
+        val principal = RegisteredServiceTestUtils.getPrincipal();
+        WebUtils.putAuthentication(RegisteredServiceTestUtils.getAuthentication(principal), context);
 
         val factory = (CasSimpleMultifactorAuthenticationTicketFactory) defaultTicketFactory.get(CasSimpleMultifactorAuthenticationTicket.class);
-        val ticket = factory.create(RegisteredServiceTestUtils.getService(), Map.of());
+        val ticket = factory.create(RegisteredServiceTestUtils.getService(),
+            Map.of(CasSimpleMultifactorAuthenticationConstants.PROPERTY_PRINCIPAL, principal));
         ticketRegistry.addTicket(ticket);
         val ticketIdWithoutPrefix = ticket.getId().substring(CasSimpleMultifactorAuthenticationTicket.PREFIX.length() + 1);
         val credential = new CasSimpleMultifactorTokenCredential(ticketIdWithoutPrefix);

--- a/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
+++ b/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
@@ -123,7 +123,7 @@ public class CasSimpleMultifactorAuthenticationHandlerTests {
     }
     
     @Test
-    public void verifySuccessfulAuthenticationWithTokenWithoutPrefix() {
+    public void verifySuccessfulAuthenticationWithTokenWithoutPrefix() throws Exception {
         val context = new MockRequestContext();
         val request = new MockHttpServletRequest();
         val response = new MockHttpServletResponse();

--- a/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
+++ b/support/cas-server-support-simple-mfa/src/test/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandlerTests.java
@@ -136,7 +136,7 @@ public class CasSimpleMultifactorAuthenticationHandlerTests {
         val factory = (CasSimpleMultifactorAuthenticationTicketFactory) defaultTicketFactory.get(CasSimpleMultifactorAuthenticationTicket.class);
         val ticket = factory.create(RegisteredServiceTestUtils.getService(), Map.of());
         ticketRegistry.addTicket(ticket);
-        String ticketIdWithoutPrefix = ticket.getId().substring(CasSimpleMultifactorAuthenticationTicket.PREFIX.length() + 1);
+        val ticketIdWithoutPrefix = ticket.getId().substring(CasSimpleMultifactorAuthenticationTicket.PREFIX.length() + 1);
         val credential = new CasSimpleMultifactorTokenCredential(ticketIdWithoutPrefix);
         assertNotNull(casSimpleMultifactorAuthenticationHandler.authenticate(credential).getPrincipal());
     }


### PR DESCRIPTION
I propose to accept Simple MFA tokens without prefix. This way users won't have to type the additional first 7 characters.