### PR TITLE
Fix attributes released to InCommon and RefedsRS

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/InCommonRSAttributeReleasePolicy.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/InCommonRSAttributeReleasePolicy.java
@@ -18,7 +18,7 @@ public class InCommonRSAttributeReleasePolicy extends MetadataEntityAttributesAt
     private static final long serialVersionUID = 1532960981124784595L;
 
     private static final List<String> ALLOWED_ATTRIBUTES = CollectionUtils.wrapList("eduPersonPrincipalName",
-        "eduPersonTargetedID", "email", "displayName", "givenName", "surname", "eduPersonScopedAffiliation");
+        "eduPersonTargetedID", "mail", "displayName", "givenName", "sn", "eduPersonScopedAffiliation");
 
     public InCommonRSAttributeReleasePolicy() {
         setAllowedAttributes(ALLOWED_ATTRIBUTES);


### PR DESCRIPTION
According to: https://refeds.org/category/research-and-scholarship and https://spaces.at.internet2.edu/display/federation/Identity+provider+-+support+Research+and+Scholarship the mail and sn attributes are expected instead of email and surname.