### PR TITLE
allow redis modules to be disabled via properties

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
@@ -25,6 +25,12 @@ public class BaseRedisProperties implements Serializable {
     private static final long serialVersionUID = -2600996981339638782L;
 
     /**
+     * Whether the module is enabled or not, defaults to true.
+     */
+    @RequiredProperty
+    private boolean enabled = true;
+
+    /**
      * Database index used by the connection factory.
      */
     @RequiredProperty

--- a/support/cas-server-support-audit-redis/src/main/java/org/apereo/cas/config/CasSupportRedisAuditConfiguration.java
+++ b/support/cas-server-support-audit-redis/src/main/java/org/apereo/cas/config/CasSupportRedisAuditConfiguration.java
@@ -9,6 +9,7 @@ import lombok.val;
 import org.apereo.inspektr.audit.AuditTrailManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("casSupportRedisAuditConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.audit.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class CasSupportRedisAuditConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;

--- a/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
+++ b/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("casAcceptableUsagePolicyRedisConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnExpression(value = "${cas.acceptable-usage-policy.core.enabled:true} and ${cas.acceptable-usage-policy.core.redis.enabled:true}")
+@ConditionalOnExpression(value = "${cas.acceptable-usage-policy.core.enabled:true} and ${cas.acceptable-usage-policy.redis.enabled:true}")
 public class CasAcceptableUsagePolicyRedisConfiguration {
 
     @Autowired

--- a/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
+++ b/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
@@ -10,8 +10,8 @@ import lombok.val;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -27,7 +27,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("casAcceptableUsagePolicyRedisConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnProperty(prefix = "cas.acceptable-usage-policy.core", name = { "enabled", "redis.enabled" })
+@ConditionalOnExpression(value = "${cas.acceptable-usage-policy.core.enabled:false} and ${cas.acceptable-usage-policy.core.redis.enabled:true}")
 public class CasAcceptableUsagePolicyRedisConfiguration {
 
     @Autowired

--- a/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
+++ b/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("casAcceptableUsagePolicyRedisConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnExpression(value = "${cas.acceptable-usage-policy.core.enabled:false} and ${cas.acceptable-usage-policy.core.redis.enabled:true}")
+@ConditionalOnExpression(value = "${cas.acceptable-usage-policy.core.enabled:true} and ${cas.acceptable-usage-policy.core.redis.enabled:true}")
 public class CasAcceptableUsagePolicyRedisConfiguration {
 
     @Autowired

--- a/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
+++ b/support/cas-server-support-aup-redis/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyRedisConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("casAcceptableUsagePolicyRedisConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnProperty(prefix = "cas.acceptable-usage-policy.core", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "cas.acceptable-usage-policy.core", name = { "enabled", "redis.enabled" })
 public class CasAcceptableUsagePolicyRedisConfiguration {
 
     @Autowired

--- a/support/cas-server-support-aup-redis/src/test/java/org/apereo/cas/RedisAcceptableUsageTestsSuite.java
+++ b/support/cas-server-support-aup-redis/src/test/java/org/apereo/cas/RedisAcceptableUsageTestsSuite.java
@@ -1,0 +1,21 @@
+package org.apereo.cas;
+
+import org.apereo.cas.aup.ConditionalOnExpressionNegativeTests;
+import org.apereo.cas.aup.RedisAcceptableUsagePolicyRepositoryTests;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.runner.RunWith;
+
+/**
+ * This is {@link RedisAcceptableUsageTestsSuite}.
+ *
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@SelectClasses({
+    ConditionalOnExpressionNegativeTests.class,
+    RedisAcceptableUsagePolicyRepositoryTests.class
+})
+@RunWith(JUnitPlatform.class)
+public class RedisAcceptableUsageTestsSuite {
+}

--- a/support/cas-server-support-aup-redis/src/test/java/org/apereo/cas/aup/ConditionalOnExpressionNegativeTests.java
+++ b/support/cas-server-support-aup-redis/src/test/java/org/apereo/cas/aup/ConditionalOnExpressionNegativeTests.java
@@ -1,6 +1,6 @@
-package org.apereo.cas.support.saml;
+package org.apereo.cas.aup;
 
-import org.apereo.cas.config.SamlIdPRedisIdPMetadataConfiguration;
+import org.apereo.cas.config.CasAcceptableUsagePolicyRedisConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,14 +14,14 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * This class is testing that the conditional expression on the SamlIdPRedisIdPMetadataConfiguration class works.
- * The class should not be created because one of the properties is false.
+ * This class is testing that the conditional expression on the CasAcceptableUsagePolicyRedisConfiguration class works.
+ * The positive test is done implicitly by other tests that use the CasAcceptableUsagePolicyRedisConfiguration class.
  * @since 6.4.0
  */
-@SpringBootTest(classes = SamlIdPRedisIdPMetadataConfiguration.class)
+@SpringBootTest(classes = CasAcceptableUsagePolicyRedisConfiguration.class)
 @TestPropertySource(properties = {
-        "cas.authn.saml-idp.metadata.redis.idp-metadata-enabled=true",
-        "cas.authn.saml-idp.metadata.redis.enabled=false"
+        "cas.acceptable-usage-policy.core.enabled=false",
+        "cas.acceptable-usage-policy.core.redis.enabled=true"
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class ConditionalOnExpressionNegativeTests {
@@ -29,9 +29,10 @@ public class ConditionalOnExpressionNegativeTests {
     private ConfigurableApplicationContext applicationContext;
 
     @Test
-    public void verifyConfigClassNotLoaded() {
+    public void verifyConfigClassLoaded() {
         String[] beans = applicationContext.getBeanDefinitionNames();
-        assertFalse(Arrays.stream(beans).anyMatch("redisSamlIdPMetadataConnectionFactory"::equalsIgnoreCase));
+        assertFalse(Arrays.stream(beans).anyMatch("redisAcceptableUsagePolicyTemplate"::equalsIgnoreCase));
+        assertFalse(Arrays.stream(beans).anyMatch("redisAcceptableUsagePolicyConnectionFactory"::equalsIgnoreCase));
     }
 
 }

--- a/support/cas-server-support-aup-redis/src/test/java/org/apereo/cas/aup/ConditionalOnExpressionNegativeTests.java
+++ b/support/cas-server-support-aup-redis/src/test/java/org/apereo/cas/aup/ConditionalOnExpressionNegativeTests.java
@@ -2,6 +2,9 @@ package org.apereo.cas.aup;
 
 import org.apereo.cas.config.CasAcceptableUsagePolicyRedisConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -18,10 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * The positive test is done implicitly by other tests that use the CasAcceptableUsagePolicyRedisConfiguration class.
  * @since 6.4.0
  */
+@Tag("Redis")
 @SpringBootTest(classes = CasAcceptableUsagePolicyRedisConfiguration.class)
 @TestPropertySource(properties = {
         "cas.acceptable-usage-policy.core.enabled=false",
-        "cas.acceptable-usage-policy.core.redis.enabled=true"
+        "cas.acceptable-usage-policy.redis.enabled=true"
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class ConditionalOnExpressionNegativeTests {
@@ -30,7 +34,7 @@ public class ConditionalOnExpressionNegativeTests {
 
     @Test
     public void verifyConfigClassLoaded() {
-        String[] beans = applicationContext.getBeanDefinitionNames();
+        val beans = applicationContext.getBeanDefinitionNames();
         assertFalse(Arrays.stream(beans).anyMatch("redisAcceptableUsagePolicyTemplate"::equalsIgnoreCase));
         assertFalse(Arrays.stream(beans).anyMatch("redisAcceptableUsagePolicyConnectionFactory"::equalsIgnoreCase));
     }

--- a/support/cas-server-support-consent-redis/src/main/java/org/apereo/cas/config/CasConsentRedisConfiguration.java
+++ b/support/cas-server-support-consent-redis/src/main/java/org/apereo/cas/config/CasConsentRedisConfiguration.java
@@ -8,6 +8,7 @@ import org.apereo.cas.redis.core.RedisObjectFactory;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("casConsentRedisConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.consent.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class CasConsentRedisConfiguration {
 
     @Autowired

--- a/support/cas-server-support-gauth-redis/src/main/java/org/apereo/cas/config/GoogleAuthenticatorRedisConfiguration.java
+++ b/support/cas-server-support-gauth-redis/src/main/java/org/apereo/cas/config/GoogleAuthenticatorRedisConfiguration.java
@@ -13,6 +13,7 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @EnableTransactionManagement(proxyTargetClass = true)
 @EnableScheduling
+@ConditionalOnProperty(prefix = "cas.authn.mfa.gauth.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class GoogleAuthenticatorRedisConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;

--- a/support/cas-server-support-redis-authentication/src/main/java/org/apereo/cas/config/RedisAuthenticationConfiguration.java
+++ b/support/cas-server-support-redis-authentication/src/main/java/org/apereo/cas/config/RedisAuthenticationConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
  */
 @Configuration("redisAuthenticationConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.authn.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisAuthenticationConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;

--- a/support/cas-server-support-redis-service-registry/src/main/java/org/apereo/cas/config/RedisServiceRegistryConfiguration.java
+++ b/support/cas-server-support-redis-service-registry/src/main/java/org/apereo/cas/config/RedisServiceRegistryConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -30,6 +31,7 @@ import java.util.Collection;
  */
 @Configuration("redisServiceRegistryConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.service-registry.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisServiceRegistryConfiguration {
 
     @Autowired

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/RedisTicketRegistryConfiguration.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/RedisTicketRegistryConfiguration.java
@@ -10,6 +10,7 @@ import org.apereo.cas.util.CoreTicketUtils;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +26,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("redisTicketRegistryConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.ticket.registry.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisTicketRegistryConfiguration {
 
     @Autowired

--- a/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("SamlIdPRedisIdPMetadataConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnExpression(value = "${cas.authn.saml-idp.metadata.redis.idp-metadata-enabled:false} and ${cas.authn.saml-idp.metadata.redis:true}")
+@ConditionalOnExpression(value = "${cas.authn.saml-idp.metadata.redis.idp-metadata-enabled:false} and ${cas.authn.saml-idp.metadata.redis.enabled:true}")
 @Slf4j
 public class SamlIdPRedisIdPMetadataConfiguration {
 

--- a/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
@@ -18,8 +18,8 @@ import lombok.val;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -36,7 +36,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("SamlIdPRedisIdPMetadataConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnProperty(prefix = "cas.authn.saml-idp.metadata.redis", name = {"idp-metadata-enabled", "enabled"}, matchIfMissing = true)
+@ConditionalOnExpression(value = "${cas.authn.saml-idp.metadata.redis.idp-metadata-enabled:false} and ${cas.acceptable-usage-policy.core.redis.enabled:true}")
 @Slf4j
 public class SamlIdPRedisIdPMetadataConfiguration {
 

--- a/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("SamlIdPRedisIdPMetadataConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnProperty(prefix = "cas.authn.saml-idp.metadata.redis", name = "idp-metadata-enabled", havingValue = "true")
+@ConditionalOnProperty(prefix = "cas.authn.saml-idp.metadata.redis", name = {"idp-metadata-enabled", "enabled"})
 @Slf4j
 public class SamlIdPRedisIdPMetadataConfiguration {
 

--- a/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("SamlIdPRedisIdPMetadataConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnProperty(prefix = "cas.authn.saml-idp.metadata.redis", name = {"idp-metadata-enabled", "enabled"})
+@ConditionalOnProperty(prefix = "cas.authn.saml-idp.metadata.redis", name = {"idp-metadata-enabled", "enabled"}, matchIfMissing = true)
 @Slf4j
 public class SamlIdPRedisIdPMetadataConfiguration {
 

--- a/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisIdPMetadataConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("SamlIdPRedisIdPMetadataConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnExpression(value = "${cas.authn.saml-idp.metadata.redis.idp-metadata-enabled:false} and ${cas.acceptable-usage-policy.core.redis.enabled:true}")
+@ConditionalOnExpression(value = "${cas.authn.saml-idp.metadata.redis.idp-metadata-enabled:false} and ${cas.authn.saml-idp.metadata.redis:true}")
 @Slf4j
 public class SamlIdPRedisIdPMetadataConfiguration {
 

--- a/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisRegisteredServiceMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/main/java/org/apereo/cas/config/SamlIdPRedisRegisteredServiceMetadataConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("SamlIdPRedisRegisteredServiceMetadataConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.authn.saml-idp.metadata.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class SamlIdPRedisRegisteredServiceMetadataConfiguration {
 
     @Autowired

--- a/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/RedisSamlTestsSuite.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/RedisSamlTestsSuite.java
@@ -1,5 +1,7 @@
 package org.apereo.cas;
 
+import org.apereo.cas.support.saml.ConditionalOnExpressionNegativeTests;
+import org.apereo.cas.support.saml.ConditionalOnExpressionPositiveTests;
 import org.apereo.cas.support.saml.idp.metadata.RedisSamlIdPMetadataGeneratorTests;
 import org.apereo.cas.support.saml.idp.metadata.RedisSamlIdPMetadataLocatorTests;
 import org.apereo.cas.support.saml.metadata.resolver.RedisSamlRegisteredServiceMetadataResolverTests;
@@ -17,7 +19,9 @@ import org.junit.runner.RunWith;
 @SelectClasses({
     RedisSamlIdPMetadataGeneratorTests.class,
     RedisSamlIdPMetadataLocatorTests.class,
-    RedisSamlRegisteredServiceMetadataResolverTests.class
+    RedisSamlRegisteredServiceMetadataResolverTests.class,
+    ConditionalOnExpressionPositiveTests.class,
+    ConditionalOnExpressionNegativeTests.class
 })
 @RunWith(JUnitPlatform.class)
 public class RedisSamlTestsSuite {

--- a/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionNegativeTests.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionNegativeTests.java
@@ -2,6 +2,9 @@ package org.apereo.cas.support.saml;
 
 import org.apereo.cas.config.SamlIdPRedisIdPMetadataConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -18,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * The class should not be created because one of the properties is false.
  * @since 6.4.0
  */
+@Tag("Redis")
 @SpringBootTest(classes = SamlIdPRedisIdPMetadataConfiguration.class)
 @TestPropertySource(properties = {
         "cas.authn.saml-idp.metadata.redis.idp-metadata-enabled=true",
@@ -30,7 +34,7 @@ public class ConditionalOnExpressionNegativeTests {
 
     @Test
     public void verifyConfigClassNotLoaded() {
-        String[] beans = applicationContext.getBeanDefinitionNames();
+        val beans = applicationContext.getBeanDefinitionNames();
         assertFalse(Arrays.stream(beans).anyMatch("redisSamlIdPMetadataConnectionFactory"::equalsIgnoreCase));
     }
 

--- a/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionNegativeTests.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionNegativeTests.java
@@ -1,0 +1,37 @@
+package org.apereo.cas.support.saml;
+
+import org.apereo.cas.config.SamlIdPRedisIdPMetadataConfiguration;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * This class is testing that the conditional expression on the SamlIdPRedisIdPMetadataConfiguration class works.
+ * The class should not be created because one of the properties is false.
+ * @since 6.4.0
+ */
+@SpringBootTest(classes = SamlIdPRedisIdPMetadataConfiguration.class)
+@TestPropertySource(properties = {
+        "cas.authn.saml-idp.metadata.redis.idp-metadata-enabled=true",
+        "cas.acceptable-usage-policy.core.redis.enabled=false"
+})
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class ConditionalOnExpressionNegativeTests {
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
+
+    @Test
+    public void verifyConfigClassNotLoaded() {
+        String[] beans = applicationContext.getBeanDefinitionNames();
+        assertFalse(Arrays.stream(beans).anyMatch("redisSamlIdPMetadataConnectionFactory"::equalsIgnoreCase));
+    }
+
+}

--- a/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionPositiveTests.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionPositiveTests.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(classes = SamlIdPRedisIdPMetadataConfiguration.class)
 @TestPropertySource(properties = {
         "cas.authn.saml-idp.metadata.redis.idp-metadata-enabled=true",
-        "cas.acceptable-usage-policy.core.redis.enabled=true"
+        "cas.authn.saml-idp.metadata.redis.enabled=true"
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class ConditionalOnExpressionPositiveTests {

--- a/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionPositiveTests.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionPositiveTests.java
@@ -1,0 +1,37 @@
+package org.apereo.cas.support.saml;
+
+import org.apereo.cas.config.SamlIdPRedisIdPMetadataConfiguration;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This class is testing that the conditional expression on the SamlIdPRedisIdPMetadataConfiguration class works.
+ * @since 6.4.0
+ */
+@SpringBootTest(classes = SamlIdPRedisIdPMetadataConfiguration.class)
+@TestPropertySource(properties = {
+        "cas.authn.saml-idp.metadata.redis.idp-metadata-enabled=true",
+        "cas.acceptable-usage-policy.core.redis.enabled=true"
+})
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class ConditionalOnExpressionPositiveTests {
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
+
+    @Test
+    public void verifyConfigClassLoaded() {
+        String[] beans = applicationContext.getBeanDefinitionNames();
+        assertTrue(Arrays.stream(beans).anyMatch("redisSamlIdPMetadataConnectionFactory"::equalsIgnoreCase));
+        assertTrue(Arrays.stream(beans).anyMatch("redisSamlIdPMetadataTemplate"::equalsIgnoreCase));
+    }
+
+}

--- a/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionPositiveTests.java
+++ b/support/cas-server-support-saml-idp-metadata-redis/src/test/java/org/apereo/cas/support/saml/ConditionalOnExpressionPositiveTests.java
@@ -2,6 +2,9 @@ package org.apereo.cas.support.saml;
 
 import org.apereo.cas.config.SamlIdPRedisIdPMetadataConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -17,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * This class is testing that the conditional expression on the SamlIdPRedisIdPMetadataConfiguration class works.
  * @since 6.4.0
  */
+@Tag("Redis")
 @SpringBootTest(classes = SamlIdPRedisIdPMetadataConfiguration.class)
 @TestPropertySource(properties = {
         "cas.authn.saml-idp.metadata.redis.idp-metadata-enabled=true",
@@ -29,7 +33,7 @@ public class ConditionalOnExpressionPositiveTests {
 
     @Test
     public void verifyConfigClassLoaded() {
-        String[] beans = applicationContext.getBeanDefinitionNames();
+        val beans = applicationContext.getBeanDefinitionNames();
         assertTrue(Arrays.stream(beans).anyMatch("redisSamlIdPMetadataConnectionFactory"::equalsIgnoreCase));
         assertTrue(Arrays.stream(beans).anyMatch("redisSamlIdPMetadataTemplate"::equalsIgnoreCase));
     }

--- a/support/cas-server-support-throttle-redis/src/main/java/org/apereo/cas/config/CasRedisThrottlingConfiguration.java
+++ b/support/cas-server-support-throttle-redis/src/main/java/org/apereo/cas/config/CasRedisThrottlingConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("casRedisThrottlingConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.audit.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class CasRedisThrottlingConfiguration {
 
     @Autowired

--- a/support/cas-server-support-trusted-mfa-redis/src/main/java/org/apereo/cas/trusted/config/RedisMultifactorAuthenticationTrustConfiguration.java
+++ b/support/cas-server-support-trusted-mfa-redis/src/main/java/org/apereo/cas/trusted/config/RedisMultifactorAuthenticationTrustConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +31,7 @@ import java.util.List;
  */
 @Configuration("RedisMultifactorAuthenticationTrustConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.authn.mfa.trusted.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisMultifactorAuthenticationTrustConfiguration {
 
     @Autowired

--- a/support/cas-server-support-u2f-redis/src/main/java/org/apereo/cas/config/U2FRedisConfiguration.java
+++ b/support/cas-server-support-u2f-redis/src/main/java/org/apereo/cas/config/U2FRedisConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("u2fRedisConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.authn.mfa.u2f.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class U2FRedisConfiguration {
 
     @Autowired

--- a/support/cas-server-support-webauthn-redis/src/main/java/org/apereo/cas/config/RedisWebAuthnConfiguration.java
+++ b/support/cas-server-support-webauthn-redis/src/main/java/org/apereo/cas/config/RedisWebAuthnConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +28,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("RedisWebAuthnConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.authn.mfa.web-authn.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisWebAuthnConfiguration {
 
     @Autowired

--- a/support/cas-server-support-yubikey-redis/src/main/java/org/apereo/cas/config/RedisYubiKeyConfiguration.java
+++ b/support/cas-server-support-yubikey-redis/src/main/java/org/apereo/cas/config/RedisYubiKeyConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +28,7 @@ import org.springframework.data.redis.core.RedisTemplate;
  */
 @Configuration("redisYubiKeyConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnProperty(prefix = "cas.authn.mfa.yubikey.redis", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisYubiKeyConfiguration {
 
     @Autowired


### PR DESCRIPTION
I like to be able to add a module for something like the redis ticket registry but not necessarily use it right away or in every deployment, but I like to use the same image in multiple deployments. This allows me to add the redis module and then disable it via a property. I went ahead and added it to `BaseRedisProperties` so I made the various Configurations that use properties extending from that conditional on enabled being true, which is the default. 