### PR TITLE
update signalfx version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -316,7 +316,7 @@ acmeClientVersion=2.11
 # Metrics versions
 ###############################
 statsdVersion=3.1.1
-signalFxVersion=1.0.3
+signalFxVersion=1.0.7
 micrometerVersion=1.6.3
 dropwizardVersion=4.1.17
 


### PR DESCRIPTION
Signal shards an older version of jackson databind which has lots of vulnerabilities on scans, this version of signalfx uses newer version of jackson. 
