### PR TITLE
SAML Attribute Definition should support "urn" 

### DIFF
--- a/docs/cas-server-documentation/installation/Configuring-SAML2-Attribute-Release.md
+++ b/docs/cas-server-documentation/installation/Configuring-SAML2-Attribute-Release.md
@@ -303,3 +303,32 @@ This attribute release policy authorizes the release of defined attributes, base
 ```
 
 The `useFriendlyName` allows the filter to compare the requested attribute's friendly name with the resolved attribute.
+
+### SAML IdP Attribute Definition
+
+SAML attributes can be defined as part of the [Attribute Definition Store](../integration/Attribute-Definitions.md).
+The `SamlIdPAtrributeDefinition` inherits all the properties form `DefaultAttributeDefinition` and adds two optional properties specific to 
+SAML attributes.  Defining an attribute with this definition does not prevent it from being released by other protocols.
+
+```json
+{
+  "@class": "java.util.TreeMap",
+  "eduPersonPrincipalName": {
+    "@class": "org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlIdPAttributeDefinition",
+    "key": "eduPersonPrincipalName",
+    "name": "eduPersonPrincipalName",
+    "urn": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
+    "scoped": true,
+    "encrypted": false,
+    "attribute": "uid",
+    "friendlyName": "eduPersonPrincipalName"
+  }
+}
+```
+
+The following additional settings can be specified for a Saml IdP attribute definition:
+
+| Name                    | Description
+|-------------------------|--------------------------------------------------------------------------------------------------------
+| `friendlyName`          | (Optional) Friendly name of the attribute shared with the target application during attribute release.
+| `urn`                   | (Optional) Defined Universal Resource name for an attribute (i.e. urn:oid:1.3.6.1.4.1.5923.1.1.1.6).

--- a/docs/cas-server-documentation/integration/Attribute-Definitions.md
+++ b/docs/cas-server-documentation/integration/Attribute-Definitions.md
@@ -92,35 +92,6 @@ as usual with the following definition:
 ...
 ```
 
-### SAML IdP Attribute Definition
-
-Attribute definitions that specifically apply to the release of attributes as part of SAML response can be defined using the `SamlIdPAtrributeDefinition` that inherits
-all the properties form `DefaultAttributeDefinition` and adds two optional properties specific to SAML attributes.  Defining an attribute with this definition does not 
-prevent it from being released by other protocols.
-
-```json
-{
-  "@class": "java.util.TreeMap",
-  "eduPersonPrincipalName": {
-    "@class": "org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlIdPAttributeDefinition",
-    "key": "eduPersonPrincipalName",
-    "name": "eduPersonPrincipalName",
-    "urn": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
-    "scoped": true,
-    "encrypted": false,
-    "attribute": "uid",
-    "friendlyName": "eduPersonPrincipalName"
-  }
-}
-```
-
-The following additional settings can be specified for a Saml IdP attribute definition:
-
-| Name                    | Description
-|-------------------------|--------------------------------------------------------------------------------------------------------
-| `friendlyName`          | (Optional) Friendly name of the attribute shared with the target application during attribute release.
-| `urn`                   | (Oprional) Defined Universal Resource name for an attribute (i.e. urn:oid:1.3.6.1.4.1.5923.1.1.1.6).
-
 ### Encrypted Attribute
 
 Same use case as above, except the attribute value will be encrypted and encoded using the service definition's public key:

--- a/docs/cas-server-documentation/integration/Attribute-Definitions.md
+++ b/docs/cas-server-documentation/integration/Attribute-Definitions.md
@@ -29,14 +29,11 @@ may match the following:
 ```json 
 {
     "@class" : "java.util.TreeMap",
-    "eduPersonPrincipalName" : {
+    "employeeId" : {
       "@class" : "org.apereo.cas.authentication.attribute.DefaultAttributeDefinition",
-      "key" : "eduPersonPrincipalName",
-      "name" : "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
-      "friendlyName" : "eduPersonPrincipalName",
+      "key" : "employeeId",
       "scoped" : true,
-      "encrypted" : false,
-      "attribute" : "uid"
+      "attribute" : "empl_identifier"
     }
 }
 ```         
@@ -50,7 +47,6 @@ The following settings can be specified by an attribute definition:
 |-------------------------|--------------------------------------------------------------------------------------------------------
 | `key`                   | Attribute name, as resolved by the CAS [attribute resolution engine](Attribute-Resolution.html)
 | `name`                  | Attribute name to be used and shared with the target application during attribute release.
-| `friendlyName`          | (Optional) Friendly name of the attribute shared with the target application during attribute release. 
 | `scoped`                | (Optional) If `true`, the attribute value be scoped to the scope of the CAS server deployment defined in settings.
 | `encrypted`             | (Optional) If `true`, the attribute value will be encrypted and encoded in base-64 using the service definition's defined public key.
 | `attribute`             | (Optional) The source attribute to provide values for the attribute definition itself, replacing that of the original source.
@@ -95,6 +91,35 @@ as usual with the following definition:
   }
 ...
 ```
+
+### SAML IdP Attribute Definition
+
+Attribute definitions that specifically apply to the release of attributes as part of SAML response can be defined using the `SamlIdPAtrributeDefinition` that inherits
+all the properties form `DefaultAttributeDefinition` and adds two optional properties specific to SAML attributes.  Defining an attribute with this definition does not 
+prevent it from being released by other protocols.
+
+```json
+{
+  "@class": "java.util.TreeMap",
+  "eduPersonPrincipalName": {
+    "@class": "org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlIdPAttributeDefinition",
+    "key": "eduPersonPrincipalName",
+    "name": "eduPersonPrincipalName",
+    "urn": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
+    "scoped": true,
+    "encrypted": false,
+    "attribute": "uid",
+    "friendlyName": "eduPersonPrincipalName"
+  }
+}
+```
+
+The following additional settings can be specified for a Saml IdP attribute definition:
+
+| Name                    | Description
+|-------------------------|--------------------------------------------------------------------------------------------------------
+| `friendlyName`          | (Optional) Friendly name of the attribute shared with the target application during attribute release.
+| `urn`                   | (Oprional) Defined Universal Resource name for an attribute (i.e. urn:oid:1.3.6.1.4.1.5923.1.1.1.6).
 
 ### Encrypted Attribute
 

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/attr/SamlIdPAttributeDefinition.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/attr/SamlIdPAttributeDefinition.java
@@ -27,4 +27,6 @@ public class SamlIdPAttributeDefinition extends DefaultAttributeDefinition {
     private static final long serialVersionUID = -144152003366303322L;
 
     private String friendlyName;
+
+    private String urn;
 }

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/attr/SamlProfileSamlAttributeStatementBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/attr/SamlProfileSamlAttributeStatementBuilder.java
@@ -31,9 +31,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-
 /**
  * This is {@link SamlProfileSamlAttributeStatementBuilder}.
  *
@@ -128,11 +125,11 @@ public class SamlProfileSamlAttributeStatementBuilder extends AbstractSaml20Obje
             val friendlyName = friendlyNames.getOrDefault(e.getKey(), null);
 
             val name = urns.containsKey(e.getKey())
-                    ? urns.get(e.getKey())
-                    : attributeDefinitionStore.locateAttributeDefinition(e.getKey())
-                        .map(AttributeDefinition::getName)
-                        .filter(StringUtils::isNotBlank)
-                        .orElseGet(e::getKey);
+                ? urns.get(e.getKey())
+                : attributeDefinitionStore.locateAttributeDefinition(e.getKey())
+                    .map(AttributeDefinition::getName)
+                    .filter(StringUtils::isNotBlank)
+                    .orElseGet(e::getKey);
 
             LOGGER.trace("Creating SAML attribute [{}] with value [{}], friendlyName [{}]", name, e.getValue(), friendlyName);
             val attribute = newAttribute(friendlyName, name, e.getValue(),

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/AllSamlIdPTestsSuite.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/AllSamlIdPTestsSuite.java
@@ -28,6 +28,7 @@ import org.apereo.cas.support.saml.web.idp.metadata.SamlRegisteredServiceCachedM
 import org.apereo.cas.support.saml.web.idp.profile.SamlIdPInitiatedProfileHandlerControllerTests;
 import org.apereo.cas.support.saml.web.idp.profile.artifact.CasSamlArtifactMapTests;
 import org.apereo.cas.support.saml.web.idp.profile.artifact.SamlIdPSaml1ArtifactResolutionProfileHandlerControllerTests;
+import org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlProfileSamlAttributeStatementBuilderTests;
 import org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlProfileSamlRegisteredServiceAttributeBuilderTests;
 import org.apereo.cas.support.saml.web.idp.profile.builders.authn.DefaultAuthnContextClassRefBuilderTests;
 import org.apereo.cas.support.saml.web.idp.profile.builders.conditions.SamlProfileSamlConditionsBuilderTests;
@@ -115,6 +116,7 @@ import org.junit.runner.RunWith;
     SamlIdPMetadataUIActionTests.class,
     SamlIdPObjectSignerTests.class,
     SamlIdPObjectEncrypterTests.class,
+    SamlProfileSamlAttributeStatementBuilderTests.class,
     SamlProfileSamlConditionsBuilderTests.class,
     SamlProfileSamlSubjectBuilderTests.class,
     DefaultSamlArtifactTicketFactoryTests.class,

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/builders/attr/SamlProfileSamlAttributeStatementBuilderTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/builders/attr/SamlProfileSamlAttributeStatementBuilderTests.java
@@ -1,0 +1,47 @@
+package org.apereo.cas.support.saml.web.idp.profile.builders.attr;
+
+import org.apereo.cas.support.saml.BaseSamlIdPConfigurationTests;
+import org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade;
+import org.apereo.cas.support.saml.web.idp.profile.builders.SamlProfileObjectBuilder;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link SamlProfileSamlAttributeStatementBuilderTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.4.0
+ */
+@Tag("SAML")
+@TestPropertySource(properties = "cas.authn.attribute-repository.attribute-definition-store.json.location=classpath:/basic-definitions.json")
+public class SamlProfileSamlAttributeStatementBuilderTests extends BaseSamlIdPConfigurationTests {
+
+    @Autowired
+    @Qualifier("samlProfileSamlAttributeStatementBuilder")
+    private SamlProfileObjectBuilder<AttributeStatement> samlProfileSamlAttributeStatementBuilder;
+
+    @Test
+    public void verifyTestAttributeDefns() {
+        val service = getSamlRegisteredServiceForTestShib();
+
+        val adaptor = SamlRegisteredServiceServiceProviderMetadataFacade.get(samlRegisteredServiceCachingMetadataResolver, service, service.getServiceId()).get();
+        val statement = samlProfileSamlAttributeStatementBuilder.build(getAuthnRequestFor(service), new MockHttpServletRequest(),
+            new MockHttpServletResponse(), getAssertion(), service, adaptor, SAMLConstants.SAML2_POST_BINDING_URI,
+            new MessageContext());
+
+        assertFalse(statement.getAttributes().isEmpty());
+    }
+
+}

--- a/support/cas-server-support-saml-idp/src/test/resources/basic-definitions.json
+++ b/support/cas-server-support-saml-idp/src/test/resources/basic-definitions.json
@@ -6,5 +6,13 @@
     "name": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6",
     "friendlyName": "eduPersonPrincipalName-FriendlyName",
     "scoped": true
+  },
+  "mail": {
+    "@class": "org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlIdPAttributeDefinition",
+    "key": "mail",
+    "name": "mail",
+    "urn": "urn:oid:0.9.2342.19200300.100.1.3",
+    "attribute": "mail",
+    "friendlyName": "email"
   }
 }


### PR DESCRIPTION
This PR adds a new `urn` property to `SamlIdPAttributeDefinition`.  This allows defining `key` and `name` with more friendly names that are likely to match what is pulled form attribute repositories and still assign the attributes published urn to be used as the `Name` attribute for a SAML response. If `urn` is not defined the `name` property will be used as it currently is in the SAML response. 

Documentation has also been updated to reflect the two types of attribute definitions available.