### PR TITLE
Resolve Attribute Definition requested by release policy

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicy.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicy.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.springframework.core.Ordered;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -114,16 +113,5 @@ public interface RegisteredServiceAttributeReleasePolicy extends Serializable, O
     @JsonIgnore
     default String getName() {
         return getClass().getSimpleName();
-    }
-
-    /**
-     * This method should be overridden by release policies that are able to request definitions by listing them as being
-     * released in the policy.  This method should return the list of definitions keys that need to be resolved by the
-     * definition store so the can be resolved and released to the client.
-     *
-     * @return - List of requested definitions to be released.
-     */
-    default List<String> getRequestedDefinitions() {
-        return new ArrayList<>();
     }
 }

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicy.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicy.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.springframework.core.Ordered;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -113,5 +114,16 @@ public interface RegisteredServiceAttributeReleasePolicy extends Serializable, O
     @JsonIgnore
     default String getName() {
         return getClass().getSimpleName();
+    }
+
+    /**
+     * This method should be overridden by release policies that are able to request definitions by listing them as being
+     * released in the policy.  This method should return the list of definitions keys that need to be resolved by the
+     * definition store so the can be resolved and released to the client.
+     *
+     * @return - List of requested definitions to be released.
+     */
+    default List<String> getRequestedDefinitions() {
+        return new ArrayList<>();
     }
 }

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/AbstractRegisteredServiceAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/AbstractRegisteredServiceAttributeReleasePolicy.java
@@ -97,6 +97,9 @@ public abstract class AbstractRegisteredServiceAttributeReleasePolicy implements
         val principalAttributes = resolveAttributesFromPrincipalAttributeRepository(principal, registeredService);
         LOGGER.debug("Found principal attributes [{}] for [{}]", principalAttributes, principal.getId());
 
+        LOGGER.trace("Finding requested attribute definitions");
+        getRequestedDefinitions().forEach(a -> principalAttributes.putIfAbsent(a, List.of()));
+
         val attributesFromDefinitions = resolveAttributesFromAttributeDefinitionStore(principal, principalAttributes, registeredService, selectedService);
         LOGGER.trace("Resolved principal attributes [{}] for [{}] from attribute definition store", attributesFromDefinitions, principal.getId());
 

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/AbstractRegisteredServiceAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/AbstractRegisteredServiceAttributeReleasePolicy.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.PostLoad;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -258,6 +259,17 @@ public abstract class AbstractRegisteredServiceAttributeReleasePolicy implements
             return defaultAttributesToRelease;
         }
         return new TreeMap<>();
+    }
+
+    /**
+     * This method should be overridden by release policies that are able to request definitions by listing them as being
+     * released in the policy.  This method should return the list of definitions keys that need to be resolved by the
+     * definition store so the can be resolved and released to the client.
+     *
+     * @return - List of requested definitions to be released.
+     */
+    public List<String> getRequestedDefinitions() {
+        return new ArrayList<>();
     }
 
     /**

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicy.java
@@ -73,7 +73,7 @@ public class ReturnAllowedAttributeReleasePolicy extends AbstractRegisteredServi
     }
 
     @Override
-    public List<String> getRequestedDefinitions() {
+    protected List<String> getRequestedDefinitions() {
         return getAllowedAttributes();
     }
 }

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicy.java
@@ -72,4 +72,8 @@ public class ReturnAllowedAttributeReleasePolicy extends AbstractRegisteredServi
         return attributesToRelease;
     }
 
+    @Override
+    public List<String> getRequestedDefinitions() {
+        return getAllowedAttributes();
+    }
 }

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnEncryptedAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnEncryptedAttributeReleasePolicy.java
@@ -103,4 +103,8 @@ public class ReturnEncryptedAttributeReleasePolicy extends AbstractRegisteredSer
         return attributesToRelease;
     }
 
+    @Override
+    public List<String> getRequestedDefinitions() {
+        return allowedAttributes;
+    }
 }

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicy.java
@@ -221,4 +221,9 @@ public class ReturnMappedAttributeReleasePolicy extends AbstractRegisteredServic
         });
         return attributesToRelease;
     }
+
+    @Override
+    public List<String> getRequestedDefinitions() {
+        return new ArrayList<>(allowedAttributes.keySet());
+    }
 }

--- a/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicyTests.java
+++ b/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/RegisteredServiceAttributeReleasePolicyTests.java
@@ -83,6 +83,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
             CoreAttributesTestUtils.getRegisteredService());
         assertEquals(1, attr.size());
         assertTrue(attr.containsKey(NEW_ATTR_1_VALUE));
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes().keySet()));
     }
 
     @Test
@@ -106,6 +107,7 @@ public class RegisteredServiceAttributeReleasePolicyTests {
         assertEquals(2, attr.size());
         assertTrue(attr.containsKey(ATTR_1));
         assertTrue(attr.containsKey(ATTR_2));
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes()));
     }
 
     @Test

--- a/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicyTests.java
+++ b/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/ReturnAllowedAttributeReleasePolicyTests.java
@@ -73,6 +73,16 @@ public class ReturnAllowedAttributeReleasePolicyTests {
     }
 
     @Test
+    public void verifyRequestedDefinitions() {
+        val allowedAttributes = new ArrayList<String>();
+        allowedAttributes.add("uid");
+        allowedAttributes.add("cn");
+        allowedAttributes.add("givenName");
+        val policy = new ReturnAllowedAttributeReleasePolicy(allowedAttributes);
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes()));
+    }
+
+    @Test
     public void verifyDefaultAttributes() {
         ApplicationContextProvider.holdApplicationContext(applicationContext);
 

--- a/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicyTests.java
+++ b/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/ReturnMappedAttributeReleasePolicyTests.java
@@ -291,5 +291,13 @@ public class ReturnMappedAttributeReleasePolicyTests {
         assertTrue(result.containsKey("my-userid"));
     }
 
+    @Test
+    @Order(9)
+    public void verifyRequestedDefinitions() {
+        val allowed1 = CollectionUtils.<String, Object>wrap("uid", "my-userid");
+        val policy = new ReturnMappedAttributeReleasePolicy(allowed1);
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes().keySet()));
+    }
+
 
 }

--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
@@ -101,4 +101,9 @@ public abstract class BaseOidcScopeAttributeReleasePolicy extends AbstractRegist
         LOGGER.debug("No mapped attribute is defined for claim [{}]; Used [{}] to locate value [{}]", claim, claim, value);
         return Pair.of(claim, value);
     }
+
+    @Override
+    public List<String> getRequestedDefinitions() {
+        return allowedAttributes;
+    }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcAddressScopeAttributeReleasePolicyTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcAddressScopeAttributeReleasePolicyTests.java
@@ -31,5 +31,6 @@ public class OidcAddressScopeAttributeReleasePolicyTests extends AbstractOidcTes
             CoreAuthenticationTestUtils.getService(),
             CoreAuthenticationTestUtils.getRegisteredService());
         assertTrue(policy.getAllowedAttributes().stream().allMatch(attrs::containsKey));
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes()));
     }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcCustomScopeAttributeReleasePolicyTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcCustomScopeAttributeReleasePolicyTests.java
@@ -42,6 +42,7 @@ public class OidcCustomScopeAttributeReleasePolicyTests extends AbstractOidcTest
             CoreAuthenticationTestUtils.getService(),
             CoreAuthenticationTestUtils.getRegisteredService());
         assertTrue(policy.getAllowedAttributes().stream().allMatch(releaseAttrs::containsKey));
+        assertTrue(policy.getAllowedAttributes().containsAll(policy.getRequestedDefinitions()));
         assertEquals(releaseAttrs.get("groups"), List.of("admin", "user"));
     }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcEmailScopeAttributeReleasePolicyTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcEmailScopeAttributeReleasePolicyTests.java
@@ -37,6 +37,7 @@ public class OidcEmailScopeAttributeReleasePolicyTests extends AbstractOidcTests
             CoreAuthenticationTestUtils.getService(),
             CoreAuthenticationTestUtils.getRegisteredService());
         assertTrue(policy.getAllowedAttributes().stream().allMatch(attrs::containsKey));
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes()));
     }
 
     @Test

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcPhoneScopeAttributeReleasePolicyTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcPhoneScopeAttributeReleasePolicyTests.java
@@ -32,5 +32,6 @@ public class OidcPhoneScopeAttributeReleasePolicyTests extends AbstractOidcTests
             CoreAuthenticationTestUtils.getService(),
             CoreAuthenticationTestUtils.getRegisteredService());
         assertTrue(policy.getAllowedAttributes().stream().allMatch(attrs::containsKey));
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes()));
     }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcProfileScopeAttributeReleasePolicyTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcProfileScopeAttributeReleasePolicyTests.java
@@ -34,5 +34,6 @@ public class OidcProfileScopeAttributeReleasePolicyTests extends AbstractOidcTes
             CoreAuthenticationTestUtils.getService(),
             CoreAuthenticationTestUtils.getRegisteredService());
         assertTrue(policy.getAllowedAttributes().containsAll(attrs.keySet()));
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes()));
     }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/mapping/OidcDefaultAttributeToScopeClaimMapperTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/mapping/OidcDefaultAttributeToScopeClaimMapperTests.java
@@ -46,5 +46,6 @@ public class OidcDefaultAttributeToScopeClaimMapperTests extends AbstractOidcTes
             CoreAuthenticationTestUtils.getService(),
             CoreAuthenticationTestUtils.getRegisteredService());
         assertTrue(policy.getAllowedAttributes().stream().allMatch(attrs::containsKey));
+        assertTrue(policy.getRequestedDefinitions().containsAll(policy.getAllowedAttributes()));
     }
 }

--- a/support/cas-server-support-ws-idp-api/src/main/java/org/apereo/cas/ws/idp/services/CustomNamespaceWSFederationClaimsReleasePolicy.java
+++ b/support/cas-server-support-ws-idp-api/src/main/java/org/apereo/cas/ws/idp/services/CustomNamespaceWSFederationClaimsReleasePolicy.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,5 +61,10 @@ public class CustomNamespaceWSFederationClaimsReleasePolicy extends AbstractRegi
             }
         });
         return attributesToRelease;
+    }
+
+    @Override
+    public List<String> getRequestedDefinitions() {
+        return new ArrayList<>(allowedAttributes.keySet());
     }
 }

--- a/support/cas-server-support-ws-idp-api/src/main/java/org/apereo/cas/ws/idp/services/WSFederationClaimsReleasePolicy.java
+++ b/support/cas-server-support-ws-idp-api/src/main/java/org/apereo/cas/ws/idp/services/WSFederationClaimsReleasePolicy.java
@@ -185,4 +185,9 @@ public class WSFederationClaimsReleasePolicy extends AbstractRegisteredServiceAt
             LOGGER.warn("Groovy-scripted attribute returned no value for [{}]", attributeName);
         }
     }
+
+    @Override
+    public List<String> getRequestedDefinitions() {
+        return new ArrayList<>(allowedAttributes.keySet());
+    }
 }


### PR DESCRIPTION
Currently an attribute definition is only resolved and made available for release if it's key matches an attribute that was resolved by an attribute repository.  This limits attribute definition keys to match a corresponding attribute in a repository.  It also limits that separate definitions could not use the same base attribute for it's definition.  

This PR then adds a requestedAttributeDefinitions() method to policies that allow specifying attributes to be released, such as ReturnAllowed and ReturnMapped policies.  The list of definitions is then processed and added to the attribute list before resolving them from the AttrributeDefinitionStore so that they are available to the release policy.

This approach of only resolving requested definitions is preferable to resolving all definitions regardless of policy since performance could be affected.
