### PR TITLE
setting the pac4j csrf cookie properties

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/LocaleCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/LocaleCookieProperties.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.configuration.model.core.web;
 
-import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+import org.apereo.cas.configuration.model.support.cookie.PinnableCookieProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
@@ -21,6 +21,6 @@ import java.io.Serializable;
 @Setter
 @Accessors(chain = true)
 @JsonFilter("LocaleCookieProperties")
-public class LocaleCookieProperties extends CookieProperties implements Serializable {
+public class LocaleCookieProperties extends PinnableCookieProperties implements Serializable {
     private static final long serialVersionUID = 158577966798914031L;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/analytics/GoogleAnalyticsCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/analytics/GoogleAnalyticsCookieProperties.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.configuration.model.support.analytics;
 
-import org.apereo.cas.configuration.model.support.cookie.PinnableCookieProperties;
+import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import lombok.Getter;
@@ -17,7 +17,7 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(chain = true)
-public class GoogleAnalyticsCookieProperties extends PinnableCookieProperties {
+public class GoogleAnalyticsCookieProperties extends CookieProperties {
     private static final long serialVersionUID = -5432498833437602657L;
 
     /**
@@ -37,6 +37,5 @@ public class GoogleAnalyticsCookieProperties extends PinnableCookieProperties {
 
     public GoogleAnalyticsCookieProperties() {
         setName("CasGoogleAnalytics");
-        setPinToSession(false);
     }
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/analytics/GoogleAnalyticsCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/analytics/GoogleAnalyticsCookieProperties.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.configuration.model.support.analytics;
 
-import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+import org.apereo.cas.configuration.model.support.cookie.PinnableCookieProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import lombok.Getter;
@@ -17,7 +17,7 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(chain = true)
-public class GoogleAnalyticsCookieProperties extends CookieProperties {
+public class GoogleAnalyticsCookieProperties extends PinnableCookieProperties {
     private static final long serialVersionUID = -5432498833437602657L;
 
     /**

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/CookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/CookieProperties.java
@@ -83,13 +83,6 @@ public class CookieProperties implements Serializable {
     private int maxAge = -1;
 
     /**
-     * When generating cookie values, determine whether the value
-     * should be compounded and signed with the properties of
-     * the current session, such as IP address, user-agent, etc.
-     */
-    private boolean pinToSession = true;
-
-    /**
      * If a cookie is only intended to be accessed in a first party context, the
      * developer has the option to apply one of settings
      * {@code SameSite=Lax} or {@code SameSite=Strict} or {@code SameSite=None} to prevent external access.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/PinnableCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/PinnableCookieProperties.java
@@ -1,0 +1,30 @@
+package org.apereo.cas.configuration.model.support.cookie;
+
+import org.apereo.cas.configuration.support.RequiresModule;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Base property class for cookies that can be pinned to the HTTP session.
+ * Pinned cookies are ignored if they arrive on a request with different attributes, such as IP address or user-agent,
+ * than what was present whent the cookie was created.
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@RequiresModule(name = "cas-server-core-cookie", automated = true)
+@Getter
+@Setter
+@Accessors(chain = true)
+@JsonFilter("PinnableCookieProperties")
+public class PinnableCookieProperties extends CookieProperties {
+
+    /**
+     * When generating cookie values, determine whether the value
+     * should be compounded and signed with the properties of
+     * the current session, such as IP address, user-agent, etc.
+     */
+    private boolean pinToSession = true;
+}

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/TicketGrantingCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/TicketGrantingCookieProperties.java
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 @Setter
 @Accessors(chain = true)
 @JsonFilter("TicketGrantingCookieProperties")
-public class TicketGrantingCookieProperties extends CookieProperties {
+public class TicketGrantingCookieProperties extends PinnableCookieProperties {
 
     private static final long serialVersionUID = 7392972818105536350L;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/WarningCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/cookie/WarningCookieProperties.java
@@ -18,7 +18,7 @@ import lombok.experimental.Accessors;
 @Setter
 @Accessors(chain = true)
 @JsonFilter("WarningCookieProperties")
-public class WarningCookieProperties extends CookieProperties {
+public class WarningCookieProperties extends PinnableCookieProperties {
     private static final long serialVersionUID = -266090748600049578L;
 
     /**

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mfa/trusteddevice/DeviceFingerprintProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mfa/trusteddevice/DeviceFingerprintProperties.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.configuration.model.support.mfa.trusteddevice;
 
 import org.apereo.cas.configuration.model.core.util.EncryptionJwtSigningJwtCryptographyProperties;
-import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+import org.apereo.cas.configuration.model.support.cookie.PinnableCookieProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 import org.apereo.cas.util.crypto.CipherExecutor;
 
@@ -70,7 +70,7 @@ public class DeviceFingerprintProperties implements Serializable {
     @Setter
     @Accessors(chain = true)
     @RequiresModule(name = "cas-server-support-trusted-mfa")
-    public static class Cookie extends CookieProperties {
+    public static class Cookie extends PinnableCookieProperties {
         private static final long serialVersionUID = -9022498833437602657L;
 
         /**

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/CsrfCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/CsrfCookieProperties.java
@@ -1,0 +1,21 @@
+package org.apereo.cas.configuration.model.support.oauth;
+
+import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+
+/**
+ * Setting default values to the pac4j defaults.
+ * The pac4j library does not allow for customizing the name or the pinToSession.
+ * Pac4j uses an Integer for maxAge and the default is null. CAS avoids setting the maxAge unless it is set to greater
+ * than -1.
+ * @since 6.4.0
+ */
+public class CsrfCookieProperties extends CookieProperties {
+
+    public CsrfCookieProperties() {
+        setSecure(false);
+        setHttpOnly(false);
+        setSameSitePolicy(null);
+        setPath(null);
+        setDomain(null);
+    }
+}

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/CsrfCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/CsrfCookieProperties.java
@@ -3,14 +3,19 @@ package org.apereo.cas.configuration.model.support.oauth;
 import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
 
 /**
- * Setting default values to the pac4j defaults.
- * The pac4j library does not allow for customizing the name or the pinToSession.
- * Pac4j uses an Integer for maxAge and the default is null. CAS avoids setting the maxAge unless it is set to greater
- * than -1.
+ * Properties for the Cross-Site Request Forgery (CSRF) cookie used in some Oauth flows.
+ *
+ * @author Hal Deadman
  * @since 6.4.0
  */
 public class CsrfCookieProperties extends CookieProperties {
 
+    /**
+     * Setting default values to the pac4j defaults.
+     * Pac4j uses an Integer for maxAge and the default is null.
+     * CAS avoids setting the maxAge unless it is set to greater than -1.
+     * The name of the cookie is not configurable.
+     */
     public CsrfCookieProperties() {
         setSecure(false);
         setHttpOnly(false);

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/CsrfCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/CsrfCookieProperties.java
@@ -1,6 +1,12 @@
 package org.apereo.cas.configuration.model.support.oauth;
 
 import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+import org.apereo.cas.configuration.support.RequiresModule;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 /**
  * Properties for the Cross-Site Request Forgery (CSRF) cookie used in some Oauth flows.
@@ -8,6 +14,11 @@ import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
  * @author Hal Deadman
  * @since 6.4.0
  */
+@RequiresModule(name = "cas-server-core-cookie", automated = true)
+@Getter
+@Setter
+@Accessors(chain = true)
+@JsonFilter("CsrfCookieProperties")
 public class CsrfCookieProperties extends CookieProperties {
 
     /**

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.configuration.model.support.oauth;
 
 import org.apereo.cas.configuration.model.core.util.EncryptionOptionalSigningOptionalJwtCryptographyProperties;
+import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
 import org.apereo.cas.configuration.model.support.uma.UmaProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 
@@ -35,6 +36,13 @@ public class OAuthProperties implements Serializable {
      * via means and libraries outside of CAS.
      */
     private boolean replicateSessions;
+
+    /**
+     * The pac4j framework sets a CSRF cookie as part of its Oauth configuration.
+     * This allows the pac4j cookie property defaults to be overridden but the cookie name, pinToSession, comment and
+     */
+    @NestedConfigurationProperty
+    private CookieProperties csrfCookie = new CsrfCookieProperties();
 
     /**
      * Crypto settings that sign/encrypt secrets.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -39,7 +39,8 @@ public class OAuthProperties implements Serializable {
 
     /**
      * The pac4j framework sets a CSRF cookie as part of its Oauth configuration.
-     * This allows the pac4j cookie property defaults to be overridden but the cookie name, pinToSession, comment and
+     * This allows the pac4j cookie property defaults to be overridden but the cookie name, pinToSession, and comment
+     * do are not used by pac4j. Defaults are set to pac4j defaults.
      */
     @NestedConfigurationProperty
     private CookieProperties csrfCookie = new CsrfCookieProperties();

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.configuration.model.support.oauth;
 
 import org.apereo.cas.configuration.model.core.util.EncryptionOptionalSigningOptionalJwtCryptographyProperties;
-import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
 import org.apereo.cas.configuration.model.support.uma.UmaProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 
@@ -38,12 +37,10 @@ public class OAuthProperties implements Serializable {
     private boolean replicateSessions;
 
     /**
-     * The pac4j framework sets a CSRF cookie as part of its Oauth configuration.
-     * This allows the pac4j cookie property defaults to be overridden but the cookie name, pinToSession, and comment
-     * do are not used by pac4j. Defaults are set to pac4j defaults.
+     * Control the CSRF cookie settings in OAUTH authentication flows.
      */
     @NestedConfigurationProperty
-    private CookieProperties csrfCookie = new CsrfCookieProperties();
+    private CsrfCookieProperties csrfCookie = new CsrfCookieProperties();
 
     /**
      * Crypto settings that sign/encrypt secrets.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/replication/CookieSessionReplicationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/replication/CookieSessionReplicationProperties.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.configuration.model.support.replication;
 
-import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+import org.apereo.cas.configuration.model.support.cookie.PinnableCookieProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
@@ -19,7 +19,7 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 @RequiresModule(name = "cas-server-support-pac4j-api")
 @JsonFilter("CookieSessionReplicationProperties")
-public class CookieSessionReplicationProperties extends CookieProperties {
+public class CookieSessionReplicationProperties extends PinnableCookieProperties {
     private static final long serialVersionUID = 6165162204295764362L;
 
     /**

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/wsfed/WsFederationDelegatedCookieProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/wsfed/WsFederationDelegatedCookieProperties.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.configuration.model.support.wsfed;
 
 import org.apereo.cas.configuration.model.core.util.EncryptionJwtSigningJwtCryptographyProperties;
-import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+import org.apereo.cas.configuration.model.support.cookie.PinnableCookieProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
 import org.apereo.cas.util.crypto.CipherExecutor;
 
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 @Accessors(chain = true)
 @Setter
 @JsonFilter("WsFederationDelegatedCookieProperties")
-public class WsFederationDelegatedCookieProperties extends CookieProperties {
+public class WsFederationDelegatedCookieProperties extends PinnableCookieProperties {
     private static final long serialVersionUID = 7392972818105536350L;
 
     /**

--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/mgmr/DefaultCasCookieValueManager.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/mgmr/DefaultCasCookieValueManager.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.web.support.mgmr;
 
-import org.apereo.cas.configuration.model.support.cookie.CookieProperties;
+import org.apereo.cas.configuration.model.support.cookie.PinnableCookieProperties;
 import org.apereo.cas.util.HttpRequestUtils;
 import org.apereo.cas.util.crypto.CipherExecutor;
 import org.apereo.cas.web.support.InvalidCookieException;
@@ -32,10 +32,10 @@ public class DefaultCasCookieValueManager extends EncryptedCookieValueManager {
     private static final int COOKIE_FIELDS_LENGTH = 3;
     private static final long serialVersionUID = -2696352696382374584L;
 
-    private final CookieProperties cookieProperties;
+    private final PinnableCookieProperties cookieProperties;
 
     public DefaultCasCookieValueManager(final CipherExecutor<Serializable, Serializable> cipherExecutor,
-                                        final CookieProperties cookieProperties) {
+                                        final PinnableCookieProperties cookieProperties) {
         super(cipherExecutor);
         this.cookieProperties = cookieProperties;
     }

--- a/docs/cas-server-documentation/authentication/OAuth-Authentication.md
+++ b/docs/cas-server-documentation/authentication/OAuth-Authentication.md
@@ -204,6 +204,10 @@ mechanism that handles the usual CAS server endpoints for authentication
 and ticket validation, etc is then activated for the OAuth 
 endpoints that are supported for throttling.
 
+## CSRF Cookie Configuration
+
+{% include casproperties.html properties="cas.authn.oauth.csrf-cookie" %}
+
 ## Server Configuration
 
 Remember that OAuth features of CAS require session affinity (and optionally session replication),

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -119,6 +119,8 @@ import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.credentials.extractor.BearerAuthExtractor;
 import org.pac4j.core.http.url.UrlResolver;
+import org.pac4j.core.matching.matcher.csrf.CsrfTokenGeneratorMatcher;
+import org.pac4j.core.matching.matcher.csrf.DefaultCsrfTokenGenerator;
 import org.pac4j.http.client.direct.DirectBasicAuthClient;
 import org.pac4j.http.client.direct.DirectFormClient;
 import org.pac4j.http.client.direct.HeaderClient;
@@ -242,6 +244,17 @@ public class CasOAuth20Configuration {
         val clientList = oauthSecConfigClients();
         val config = new Config(OAuth20Utils.casOAuthCallbackUrl(casProperties.getServer().getPrefix()), clientList);
         config.setSessionStore(oauthDistributedSessionStore());
+        val csrfMatcher = new CsrfTokenGeneratorMatcher(new DefaultCsrfTokenGenerator());
+        val maxAge = casProperties.getAuthn().getOauth().getCsrfCookie().getMaxAge();
+        if (maxAge >= 0) {
+            csrfMatcher.setMaxAge(maxAge);
+        }
+        csrfMatcher.setSameSitePolicy(casProperties.getAuthn().getOauth().getCsrfCookie().getSameSitePolicy());
+        csrfMatcher.setDomain(casProperties.getAuthn().getOauth().getCsrfCookie().getDomain());
+        csrfMatcher.setPath(casProperties.getAuthn().getOauth().getCsrfCookie().getPath());
+        csrfMatcher.setHttpOnly(casProperties.getAuthn().getOauth().getCsrfCookie().isHttpOnly());
+        csrfMatcher.setSecure(casProperties.getAuthn().getOauth().getCsrfCookie().isSecure());
+        config.setMatcher(csrfMatcher);
         Config.setProfileManagerFactory("CASOAuthSecurityProfileManager", (webContext, sessionStore) ->
             new OAuth20ClientIdAwareProfileManager(webContext, config.getSessionStore(), servicesManager.getObject()));
         return config;

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
@@ -27,6 +27,7 @@ import org.apereo.cas.support.oauth.validator.token.OAuth20RefreshTokenGrantType
 import org.apereo.cas.support.oauth.validator.token.OAuth20RevocationRequestValidatorTests;
 import org.apereo.cas.support.oauth.validator.token.device.InvalidOAuth20DeviceTokenExceptionTests;
 import org.apereo.cas.support.oauth.validator.token.device.UnapprovedOAuth20DeviceUserCodeExceptionTests;
+import org.apereo.cas.support.oauth.web.CSRFCookieTests;
 import org.apereo.cas.support.oauth.web.OAuth20CasCallbackUrlResolverTests;
 import org.apereo.cas.support.oauth.web.OAuth20HandlerInterceptorAdapterTests;
 import org.apereo.cas.support.oauth.web.OAuth20RefreshTokenTests;
@@ -149,7 +150,8 @@ import org.junit.runner.RunWith;
     OAuth20AuthorizationCodeAuthorizationResponseBuilderTests.class,
     OAuth20RegisteredServiceCipherExecutorTests.class,
     OAuth20TokenAuthorizationResponseBuilderTests.class,
-    OAuth20InvalidAuthorizationResponseBuilderTests.class
+    OAuth20InvalidAuthorizationResponseBuilderTests.class,
+    CSRFCookieTests.class
 })
 @RunWith(JUnitPlatform.class)
 public class OAuth20TestsSuite {

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/CSRFCookieTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/CSRFCookieTests.java
@@ -1,0 +1,38 @@
+package org.apereo.cas.support.oauth.web;
+
+import org.apereo.cas.AbstractOAuth20Tests;
+import org.apereo.cas.configuration.model.support.oauth.CsrfCookieProperties;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This class tests the {@link CsrfCookieProperties} class.
+ *
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@Tag("OAuth")
+@TestPropertySource(properties = {
+        "cas.authn.oauth.csrf-cookie.max-age=3600",
+        "cas.authn.oauth.csrf-cookie.path=/cas",
+        "cas.authn.oauth.csrf-cookie.same-site-policy=None",
+        "cas.authn.oauth.csrf-cookie.http-only=true",
+        "cas.authn.oauth.csrf-cookie.secure=true",
+        "cas.authn.oauth.csrf-cookie.domain=mellon.edu"
+})
+public class CSRFCookieTests extends AbstractOAuth20Tests {
+
+    @Test
+    public void verifyPropertiesSet() {
+        assertEquals(3600, casProperties.getAuthn().getOauth().getCsrfCookie().getMaxAge());
+        assertEquals("/cas", casProperties.getAuthn().getOauth().getCsrfCookie().getPath());
+        assertEquals("None", casProperties.getAuthn().getOauth().getCsrfCookie().getSameSitePolicy());
+        assertEquals("mellon.edu", casProperties.getAuthn().getOauth().getCsrfCookie().getDomain());
+        assertTrue(casProperties.getAuthn().getOauth().getCsrfCookie().isHttpOnly());
+        assertTrue(casProperties.getAuthn().getOauth().getCsrfCookie().isSecure());
+    }
+}


### PR DESCRIPTION
This is an attempt at configuring the properties of the pac4jCsrfToken cookie. I am trying to leave the defaults to pac4j. There were some people having trouble hitting an app running on localhost that was trying to do CAS OIDC auth to a backend on a different domain. The pac4j cookie was blocked when browsers started defaulting to lax so this lets the same site policy be set to "none". Not sure what type of test would be appropriate for this.