### PR TITLE
Allow OAuth2 clientid-secret to apply attribute release policy

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
@@ -29,6 +29,7 @@ import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.profile.CommonProfile;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * Authenticator for client credentials authentication.
@@ -82,6 +83,9 @@ public class OAuth20ClientIdClientSecretAuthenticator implements Authenticator {
             val profile = new CommonProfile();
             profile.setId(id);
             principal.getAttributes().forEach(profile::addAttribute);
+
+            val attributes = registeredService.getAttributeReleasePolicy().getAttributes(principal, service, registeredService);
+            profile.addAttributes((Map) attributes);
 
             credentials.setUserProfile(profile);
             LOGGER.debug("Authenticated user profile [{}]", profile);


### PR DESCRIPTION
Allow OAuth2 clientid-secret to apply attribute release policy for "Client Credentials" clients.

It's usefull when you want to add custom attributes in this OAuth2 use case.

eg :
```
"attributeReleasePolicy" : {
	"@class" : "org.apereo.cas.services.ReturnMappedAttributeReleasePolicy",
	"allowedAttributes" : {
	  "@class" : "java.util.TreeMap",
	  "mycustomattribute" : "groovy { return 'a value' }"
	}
}
```
