### PR TITLE
exclude transitive dependencies from reflection-util

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -680,6 +680,12 @@ ext.libraries = [
                 dependencies.create("net.bytebuddy:byte-buddy:$bytebuddyVersion") {
                 },
                 dependencies.create("de.cronn:reflection-util:$reflectionUtilVersion") {
+                    exclude(group: "org.slf4j", module: "slf4j-api")
+                    exclude(group: "net.bytebuddy", module: "byte-buddy")
+                    exclude(group: "com.google.code.findbugs", module: "jsr305")
+                },
+                dependencies.create("org.objenesis:objenesis:$objenesisVersion") {
+                    exclude(group: "org.mockito", module: "mockito-all")
                 }
         ],
         hibernatevalidator      : [


### PR DESCRIPTION
I was looking into how cas-management was getting slf4j since it wasn't declaring and it appeared to be getting from reflection-util dependency. This excludes it so it can be managed directly (easier). 