### PR TITLE
ensure SecurityHandler on SamlObjectSignatureValidator is not reused when multiple credentials are present

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/validate/SamlObjectSignatureValidator.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/validate/SamlObjectSignatureValidator.java
@@ -138,12 +138,11 @@ public class SamlObjectSignatureValidator {
                                                           final HttpServletRequest request,
                                                           final MessageContext context,
                                                           final RoleDescriptorResolver roleDescriptorResolver) throws Exception {
-        val handler = new SAML2HTTPRedirectDeflateSignatureSecurityHandler();
         val peer = context.getSubcontext(SAMLPeerEntityContext.class, true);
         peer.setEntityId(SamlIdPUtils.getIssuerFromSamlObject(profileRequest));
 
         val peerEntityId = peer.getEntityId();
-        LOGGER.debug("Validating request signature for [{}] via [{}]...", peerEntityId, handler.getClass().getSimpleName());
+        LOGGER.debug("Validating request signature for [{}]...", peerEntityId);
 
         val roleDescriptor = roleDescriptorResolver.resolveSingle(
             new CriteriaSet(new EntityIdCriterion(peerEntityId),
@@ -175,6 +174,7 @@ public class SamlObjectSignatureValidator {
         var foundValidCredential = false;
         val it = credentials.iterator();
         while (!foundValidCredential && it.hasNext()) {
+            val handler = new SAML2HTTPRedirectDeflateSignatureSecurityHandler();
             try {
                 val c = it.next();
 


### PR DESCRIPTION
The `SAML2HTTPRedirectDeflateSignatureSecurityHandler` used to validate signed SAML authn request in `SamlObjectSignatureValidator` cannot be reused once initialized, evidently even given `destroy` is called. This means that it is impossible to validate the signature on a request that comes from an SP with metadata that includes multiple certificates. As such, this patch ensures that a new instance is used for each potential credential.

Unfortunately, I do not have a functional understanding of how the potential signing credentials are resolved, and thus have no idea how to go about testing for this scenario. I can, however, provide an example of metadata that caused this to become an issue: https://bard.zoom.us/saml/metadata/sp 