### PR TITLE
exclude transitive dependencies from reflection-util (#5057)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -665,6 +665,12 @@ ext.libraries = [
                 dependencies.create("net.bytebuddy:byte-buddy:$bytebuddyVersion") {
                 },
                 dependencies.create("de.cronn:reflection-util:$reflectionUtilVersion") {
+                    exclude(group: "org.slf4j", module: "slf4j-api")
+                    exclude(group: "net.bytebuddy", module: "byte-buddy")
+                    exclude(group: "com.google.code.findbugs", module: "jsr305")
+                },
+                dependencies.create("org.objenesis:objenesis:$objenesisVersion") {
+                    exclude(group: "org.mockito", module: "mockito-all")
                 }
         ],
         hibernatevalidator      : [


### PR DESCRIPTION
(cherry picked from commit 9d417ab06bd0e6c1e0a93c1d0783fb94e0f0e5a9)

I would like this on 6.3 branch to help with slf4j dependencies in cas-management 6.3.x.

