### PR TITLE
Fix to permit saml custom service definition by overriding SamlRegisteredService

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -147,7 +147,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
             return null;
         }
         val service = findServiceBy(serviceId);
-        if (service != null && service.getClass().equals(clazz)) {
+        if (service != null && clazz.isAssignableFrom(service.getClass())) {
             return (T) service;
         }
         return null;


### PR DESCRIPTION
By using class equals method won't be possible to define a custom saml registered service by overriding the existing SamlRegisteredService class.