### PR TITLE
Bugfix/javascript syntax error

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
@@ -18,7 +18,7 @@
             let selector = document.querySelector('.mdc-select.authn-source');
             if (selector != null) {
                 const select = new material.select.MDCSelect(selector);
-                select.listen('MDCSelect:change', () => {
+                select.listen('MDCSelect:change', function () {
                     $('#source').val(select.value);
                 });
                 $('#source').val(select.value);
@@ -83,7 +83,7 @@ function requestGeoPosition() {
     // console.log('Requesting GeoLocation data from the browser...');
     if (navigator.geolocation) {
         navigator.geolocation.watchPosition(showGeoPosition, logGeoLocationError,
-            {maximumAge: 600000, timeout: 8000, enableHighAccuracy: true});
+            { maximumAge: 600000, timeout: 8000, enableHighAccuracy: true });
     } else {
         console.log('Browser does not support Geo Location');
     }

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
@@ -83,7 +83,7 @@ function requestGeoPosition() {
     // console.log('Requesting GeoLocation data from the browser...');
     if (navigator.geolocation) {
         navigator.geolocation.watchPosition(showGeoPosition, logGeoLocationError,
-            { maximumAge: 600000, timeout: 8000, enableHighAccuracy: true });
+            {maximumAge: 600000, timeout: 8000, enableHighAccuracy: true});
     } else {
         console.log('Browser does not support Geo Location');
     }


### PR DESCRIPTION
Fixes a syntax error breaking forms in IE 11 by changing an 'arrow' function to traditional function call for older browsers.
