### PR TITLE
x509 extract edipi as attribute, make attribute extractor a bean

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/x509/CnEdipiPrincipalResolverProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/x509/CnEdipiPrincipalResolverProperties.java
@@ -16,4 +16,9 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class CnEdipiPrincipalResolverProperties extends BaseAlternativePrincipalResolverProperties {
     private static final long serialVersionUID = 2622326703782668141L;
+
+    /**
+     * Whether to extract EDIPI as an attribute, regardless of principal resolver type.
+     */
+    private boolean extractEdipiAsAttribute;
 }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/AbstractX509PrincipalResolver.java
@@ -32,6 +32,8 @@ public abstract class AbstractX509PrincipalResolver extends PersonDirectoryPrinc
 
     private String alternatePrincipalAttribute;
 
+    private X509AttributeExtractor x509AttributeExtractor;
+
     protected AbstractX509PrincipalResolver(final PrincipalResolutionContext context) {
         super(context);
     }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/DefaultX509AttributeExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/DefaultX509AttributeExtractor.java
@@ -1,0 +1,75 @@
+package org.apereo.cas.adaptors.x509.authentication.principal;
+
+import org.apereo.cas.util.CollectionUtils;
+import org.apereo.cas.util.LoggingUtils;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Hal Deadman
+ * @since 6.4
+ */
+@Slf4j
+public class DefaultX509AttributeExtractor implements X509AttributeExtractor {
+
+    /**
+     * Get additional attributes from the certificate.
+     *
+     * @param certificate X509 Certificate of user
+     * @return map of attributes
+     */
+    public Map<String, List<Object>> extractPersonAttributes(final X509Certificate certificate) {
+        val attributes = new LinkedHashMap<String, List<Object>>();
+
+        if (certificate != null) {
+            if (StringUtils.isNotBlank(certificate.getSigAlgOID())) {
+                attributes.put("sigAlgOid", CollectionUtils.wrapList(certificate.getSigAlgOID()));
+            }
+            val subjectDn = certificate.getSubjectDN();
+            if (subjectDn != null) {
+                attributes.put("subjectDn", CollectionUtils.wrapList(subjectDn.getName()));
+            }
+            val subjectPrincipal = certificate.getSubjectX500Principal();
+            if (subjectPrincipal != null) {
+                attributes.put("subjectX500Principal", CollectionUtils.wrapList(subjectPrincipal.getName()));
+            }
+            val issuerDn = certificate.getIssuerDN();
+            if (issuerDn != null) {
+                attributes.put("issuerDn", CollectionUtils.wrapList(issuerDn.getName()));
+            }
+            val issuerPrincipal = certificate.getIssuerX500Principal();
+            if (issuerPrincipal != null) {
+                attributes.put("issuerX500Principal", CollectionUtils.wrapList(issuerPrincipal.getName()));
+            }
+            try {
+                val rfc822Email = X509ExtractorUtils.getRFC822EmailAddress(certificate.getSubjectAlternativeNames());
+                if (rfc822Email != null) {
+                    attributes.put("x509Rfc822Email", CollectionUtils.wrapList(rfc822Email));
+                }
+            } catch (final CertificateParsingException e) {
+                if (LOGGER.isDebugEnabled()) {
+                    LoggingUtils.warn(LOGGER, "Error parsing subject alternative names to get rfc822 email", e);
+                }
+                LOGGER.warn("Error parsing subject alternative names to get rfc822 email [{}]", e.getMessage());
+            }
+            try {
+                val x509subjectUPN = X509UPNExtractorUtils.extractUPNString(certificate);
+                if (x509subjectUPN != null) {
+                    attributes.put("x509subjectUPN", CollectionUtils.wrapList(x509subjectUPN));
+                }
+            } catch (final CertificateParsingException e) {
+                LoggingUtils.warn(LOGGER, e);
+            }
+        }
+        return attributes;
+    }
+
+
+}

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/DefaultX509AttributeExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/DefaultX509AttributeExtractor.java
@@ -13,18 +13,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * Get the default set of attributes from an X509 certificate.
  * @author Hal Deadman
  * @since 6.4
  */
 @Slf4j
 public class DefaultX509AttributeExtractor implements X509AttributeExtractor {
 
-    /**
-     * Get additional attributes from the certificate.
-     *
-     * @param certificate X509 Certificate of user
-     * @return map of attributes
-     */
+    @Override
     public Map<String, List<Object>> extractPersonAttributes(final X509Certificate certificate) {
         val attributes = new LinkedHashMap<String, List<Object>>();
 

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractor.java
@@ -19,14 +19,9 @@ import java.util.Map;
 @Slf4j
 public class EDIPIX509AttributeExtractor extends DefaultX509AttributeExtractor {
 
-    /**
-     * Get additional attributes from the certificate.
-     *
-     * @param certificate X509 Certificate of user
-     * @return map of attributes
-     */
+    @Override
     public Map<String, List<Object>> extractPersonAttributes(final X509Certificate certificate) {
-        var personAttributes = super.extractPersonAttributes(certificate);
+        val personAttributes = super.extractPersonAttributes(certificate);
         val subjectPrincipal = certificate.getSubjectX500Principal();
         val commonName = X509ExtractorUtils.retrieveTheCommonName(subjectPrincipal.getName());
         val edipi = X509ExtractorUtils.retrieveTheEDIPI(commonName);

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractor.java
@@ -1,0 +1,40 @@
+package org.apereo.cas.adaptors.x509.authentication.principal;
+
+import org.apereo.cas.util.CollectionUtils;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Extracts EDIPI as an attribute in addition to default attributes.
+ * Only certain types of certificates have EDIPI numbers so users of those certificates
+ * must choose to use this extractor if they want the value extracted.
+ * @author Hal Deadman
+ * @since 6.4
+ */
+@Slf4j
+public class EDIPIX509AttributeExtractor extends DefaultX509AttributeExtractor {
+
+    /**
+     * Get additional attributes from the certificate.
+     *
+     * @param certificate X509 Certificate of user
+     * @return map of attributes
+     */
+    public Map<String, List<Object>> extractPersonAttributes(final X509Certificate certificate) {
+        var personAttributes = super.extractPersonAttributes(certificate);
+        val subjectPrincipal = certificate.getSubjectX500Principal();
+        val commonName = X509ExtractorUtils.retrieveTheCommonName(subjectPrincipal.getName());
+        val edipi = X509ExtractorUtils.retrieveTheEDIPI(commonName);
+        if (StringUtils.isNotEmpty(edipi)) {
+            personAttributes.put("x509EDIPI", CollectionUtils.wrapList(edipi));
+        } else {
+            LOGGER.debug("EDIPI not found in certificate common name: [{}]", commonName);
+        }
+        return personAttributes;
+    }
+}

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractor.java
@@ -4,7 +4,6 @@ import org.apereo.cas.util.CollectionUtils;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
@@ -25,10 +24,10 @@ public class EDIPIX509AttributeExtractor extends DefaultX509AttributeExtractor {
         val subjectPrincipal = certificate.getSubjectX500Principal();
         val commonName = X509ExtractorUtils.retrieveTheCommonName(subjectPrincipal.getName());
         val edipi = X509ExtractorUtils.retrieveTheEDIPI(commonName);
-        if (StringUtils.isNotEmpty(edipi)) {
-            personAttributes.put("x509EDIPI", CollectionUtils.wrapList(edipi));
+        if (edipi.isPresent()) {
+            personAttributes.put("x509EDIPI", CollectionUtils.wrapList(edipi.get()));
         } else {
-            LOGGER.debug("EDIPI not found in certificate common name: [{}]", commonName);
+            LOGGER.trace("EDIPI not found in certificate common name: [{}]", commonName);
         }
         return personAttributes;
     }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509AttributeExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509AttributeExtractor.java
@@ -1,0 +1,20 @@
+package org.apereo.cas.adaptors.x509.authentication.principal;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Hal Deadman
+ * @since 6.4
+ */
+public interface X509AttributeExtractor {
+
+    /**
+     * Extract various attributes from the certificate about the person.
+     * @param certificate X509 Certificate
+     * @return Map of the attributes
+     */
+    Map<String, List<Object>> extractPersonAttributes(X509Certificate certificate);
+
+}

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509AttributeExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509AttributeExtractor.java
@@ -8,6 +8,7 @@ import java.util.Map;
  * @author Hal Deadman
  * @since 6.4
  */
+@FunctionalInterface
 public interface X509AttributeExtractor {
 
     /**

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509CommonNameEDIPIPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509CommonNameEDIPIPrincipalResolver.java
@@ -25,10 +25,6 @@ import java.security.cert.X509Certificate;
 @ToString(callSuper = true)
 public class X509CommonNameEDIPIPrincipalResolver extends AbstractX509PrincipalResolver {
 
-    private static final String COMMON_NAME_VAR = "CN";
-
-    private static final int EDIPI_LENGTH = 10;
-
     public X509CommonNameEDIPIPrincipalResolver(final PrincipalResolutionContext context) {
         super(context);
     }
@@ -45,12 +41,10 @@ public class X509CommonNameEDIPIPrincipalResolver extends AbstractX509PrincipalR
             return getAlternatePrincipal(certificate);
         }
         val result = X509ExtractorUtils.retrieveTheEDIPI(commonName);
-        if (StringUtils.isBlank(result)) {
+        if (result.isEmpty()) {
             return getAlternatePrincipal(certificate);
         }
-        LOGGER.debug("Final principal id extracted from [{}] is [{}]", subjectDn, result);
-        return result;
+        LOGGER.debug("Final principal id extracted from [{}] is [{}]", subjectDn, result.get());
+        return result.get();
     }
-
-
 }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509CommonNameEDIPIPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509CommonNameEDIPIPrincipalResolver.java
@@ -6,10 +6,8 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 
 import java.security.cert.X509Certificate;
-import java.util.StringTokenizer;
 
 /**
  * This is {@link X509CommonNameEDIPIPrincipalResolver}.
@@ -42,11 +40,11 @@ public class X509CommonNameEDIPIPrincipalResolver extends AbstractX509PrincipalR
         if (StringUtils.isBlank(subjectDn)) {
             return getAlternatePrincipal(certificate);
         }
-        val commonName = retrieveTheCommonName(subjectDn);
+        val commonName = X509ExtractorUtils.retrieveTheCommonName(subjectDn);
         if (StringUtils.isBlank(commonName)) {
             return getAlternatePrincipal(certificate);
         }
-        val result = retrieveTheEDIPI(commonName);
+        val result = X509ExtractorUtils.retrieveTheEDIPI(commonName);
         if (StringUtils.isBlank(result)) {
             return getAlternatePrincipal(certificate);
         }
@@ -54,46 +52,5 @@ public class X509CommonNameEDIPIPrincipalResolver extends AbstractX509PrincipalR
         return result;
     }
 
-    private static String retrieveTheCommonName(final String inSubjectDN) {
-        var commonNameFound = false;
-        var tempCommonName = StringUtils.EMPTY;
-        val st = new StringTokenizer(inSubjectDN, ",");
-        while (!commonNameFound && st.hasMoreTokens()) {
-            val token = st.nextToken();
-            if (isTokenCommonName(token)) {
-                commonNameFound = true;
-                tempCommonName = token;
-            }
-        }
-        return StringUtils.remove(tempCommonName, COMMON_NAME_VAR + '=');
-    }
 
-    private static String retrieveTheEDIPI(final String commonName) {
-        var found = false;
-        var tempEDIPI = StringUtils.EMPTY;
-        val st = new StringTokenizer(commonName, ".");
-        while (!found && st.hasMoreTokens()) {
-            val token = st.nextToken();
-            if (isTokenEDIPI(token)) {
-                found = true;
-                tempEDIPI = token;
-            }
-        }
-        return tempEDIPI;
-    }
-
-    /**
-     * This method determines whether or not the input token is the Common Name (CN).
-     *
-     * @param inToken The input token to be tested
-     * @return Returns boolean value indicating whether or not the token string is the Common Name (CN) number
-     */
-    private static boolean isTokenCommonName(final String inToken) {
-        val st = new StringTokenizer(inToken, "=");
-        return st.nextToken().equals(COMMON_NAME_VAR);
-    }
-
-    private static boolean isTokenEDIPI(final String inToken) {
-        return inToken.length() == EDIPI_LENGTH && NumberUtils.isCreatable(inToken);
-    }
 }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509ExtractorUtils.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509ExtractorUtils.java
@@ -92,7 +92,7 @@ public class X509ExtractorUtils {
      * X509Certificate#getSubjectAlternativeNames</a>
      */
     public String getRFC822EmailAddress(final Collection<List<?>> subjectAltNames) {
-        if (subjectAltNames == null) {
+        if (subjectAltNames == null || subjectAltNames.isEmpty()) {
             return null;
         }
         val email = subjectAltNames

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509ExtractorUtils.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509ExtractorUtils.java
@@ -1,0 +1,104 @@
+package org.apereo.cas.adaptors.x509.authentication.principal;
+
+import lombok.experimental.UtilityClass;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * Methods for extracting values from certificates to use as principal IDs or person attributes.
+ *
+ * @author Misagh Moayyed
+ * @author Dmitriy Kopylenko
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@UtilityClass
+public class X509ExtractorUtils {
+
+    private static final String COMMON_NAME_VAR = "CN";
+
+    private static final int EDIPI_LENGTH = 10;
+
+    /**
+     * Subject Alternative Name field id for RFC822 Email Type.
+     */
+    private static int SAN_RFC822_EMAIL_TYPE = 1;
+
+    /**
+     * Extract common name (CN) from subject DN.
+     * @param inSubjectDN subject distinguished name
+     * @return common name string
+     */
+    public String retrieveTheCommonName(final String inSubjectDN) {
+        var commonNameFound = false;
+        var tempCommonName = StringUtils.EMPTY;
+        val st = new StringTokenizer(inSubjectDN, ",");
+        while (!commonNameFound && st.hasMoreTokens()) {
+            val token = st.nextToken();
+            if (isTokenCommonName(token)) {
+                commonNameFound = true;
+                tempCommonName = token;
+            }
+        }
+        return StringUtils.remove(tempCommonName, COMMON_NAME_VAR + '=');
+    }
+
+    /**
+     * Retrieve EDIPI number from common name.
+     * @param commonName Value of CN field.
+     * @return EDIPI number if found or empty string.
+     */
+    public String retrieveTheEDIPI(final String commonName) {
+        var found = false;
+        var tempEDIPI = StringUtils.EMPTY;
+        val st = new StringTokenizer(commonName, ".");
+        while (!found && st.hasMoreTokens()) {
+            val token = st.nextToken();
+            if (isTokenEDIPI(token)) {
+                found = true;
+                tempEDIPI = token;
+            }
+        }
+        return tempEDIPI;
+    }
+
+    /**
+     * This method determines whether or not the input token is the Common Name (CN).
+     *
+     * @param inToken The input token to be tested
+     * @return Returns boolean value indicating whether or not the token string is the Common Name (CN) number
+     */
+    private boolean isTokenCommonName(final String inToken) {
+        val st = new StringTokenizer(inToken, "=");
+        return st.nextToken().equals(COMMON_NAME_VAR);
+    }
+
+    private boolean isTokenEDIPI(final String inToken) {
+        return inToken.length() == EDIPI_LENGTH && NumberUtils.isCreatable(inToken);
+    }
+
+    /**
+     * Get Email Address.
+     *
+     * @param subjectAltNames list of subject alternative name values encoded as collection of Lists with two elements in each List containing type and value.
+     * @return String email address or null if the item passed in is not type 1 (rfc822Name)
+     * as expected to be returned by implementation of {@code X509Certificate.html#getSubjectAlternativeNames}
+     * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/security/cert/X509Certificate.html#getSubjectAlternativeNames()">
+     * X509Certificate#getSubjectAlternativeNames</a>
+     */
+    public String getRFC822EmailAddress(final Collection<List<?>> subjectAltNames) {
+        if (subjectAltNames == null) {
+            return null;
+        }
+        val email = subjectAltNames
+                .stream()
+                .filter(s -> s.size() == 2 && (Integer) s.get(0) == SAN_RFC822_EMAIL_TYPE)
+                .findFirst();
+        return email.map(objects -> (String) objects.get(1)).orElse(null);
+    }
+}

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolver.java
@@ -32,8 +32,8 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolver extends Abst
         try {
             val subjectAltNames = certificate.getSubjectAlternativeNames();
             val email = X509ExtractorUtils.getRFC822EmailAddress(subjectAltNames);
-            if (email != null) {
-                return email;
+            if (email.isPresent()) {
+                return email.get();
             }
         } catch (final CertificateParsingException e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolver.java
@@ -31,7 +31,7 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolver extends Abst
         LOGGER.debug("Resolving principal from Subject Alternative Name RFC8222 type (email) for [{}]", certificate);
         try {
             val subjectAltNames = certificate.getSubjectAlternativeNames();
-            val email = getRFC822EmailAddress(subjectAltNames);
+            val email = X509ExtractorUtils.getRFC822EmailAddress(subjectAltNames);
             if (email != null) {
                 return email;
             }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolver.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolver.java
@@ -1,14 +1,11 @@
 package org.apereo.cas.adaptors.x509.authentication.principal;
 
 import org.apereo.cas.authentication.principal.resolvers.PrincipalResolutionContext;
-import org.apereo.cas.util.LoggingUtils;
 
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 
-import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 
 /**
@@ -29,12 +26,8 @@ public class X509SubjectAlternativeNameUPNPrincipalResolver extends AbstractX509
     @Override
     protected String resolvePrincipalInternal(final X509Certificate certificate) {
         LOGGER.debug("Resolving principal from Subject Alternative Name UPN for [{}]", certificate);
-        try {
-            val upnString = X509UPNExtractorUtils.extractUPNString(certificate);
-            return StringUtils.isNotBlank(upnString) ? upnString : getAlternatePrincipal(certificate);
-        } catch (final CertificateParsingException e) {
-            LoggingUtils.error(LOGGER, e);
-            return getAlternatePrincipal(certificate);
-        }
+        val subjectAltNames = X509ExtractorUtils.getSubjectAltNames(certificate);
+        val upnString = X509UPNExtractorUtils.extractUPNString(subjectAltNames);
+        return upnString.orElse(getAlternatePrincipal(certificate));
     }
 }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509UPNExtractorUtils.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509UPNExtractorUtils.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.adaptors.x509.authentication.principal;
 
+
 import org.apereo.cas.util.LoggingUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 
@@ -7,6 +8,7 @@ import com.google.common.base.Predicates;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
@@ -17,9 +19,9 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.cert.CertificateParsingException;
-import java.security.cert.X509Certificate;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Credential to principal resolver that extracts Subject Alternative Name UPN extension
@@ -119,31 +121,27 @@ public class X509UPNExtractorUtils {
 
     /**
      * Return the first {@code X509UPNExtractorUtils.UPN_OBJECTID} found in the subject alternative names (SAN) extension field of the certificate.
-     * @param certificate X509 certificate
+     * @param subjectAltNames X509 certificate subject alt names
      * @return User principal name, or null if no SAN found matching UPN type.
-     * @throws CertificateParsingException if Java retrieval of subject alt names fails.
      */
-    public String extractUPNString(final X509Certificate certificate) throws CertificateParsingException {
-        val subjectAltNames = certificate.getSubjectAlternativeNames();
-        if (subjectAltNames != null) {
-            for (val sanItem : subjectAltNames) {
-                if (LOGGER.isTraceEnabled()) {
-                    if (sanItem.size() == 2) {
-                        val name = sanItem.get(1);
-                        LOGGER.trace("Found subject alt name of type [{}] with value [{}]",
-                            sanItem.get(0), name instanceof String ? name : name instanceof byte[] ? getAltnameSequence((byte[]) name) : name);
-                    } else {
-                        LOGGER.trace("SAN item of unexpected size found: [{}]", sanItem);
-                    }
-                }
-                val seq = getOtherNameTypeSAN(sanItem);
-                val upnString = getUPNStringFromSequence(seq);
-                if (upnString != null) {
-                    LOGGER.debug("Found user principal name in certificate: [{}]", upnString);
-                    return upnString;
+    public Optional<String> extractUPNString(final Collection<List<?>> subjectAltNames) {
+        for (val sanItem : subjectAltNames) {
+            if (LOGGER.isTraceEnabled()) {
+                if (sanItem.size() == 2) {
+                    val name = sanItem.get(1);
+                    LOGGER.trace("Found subject alt name of type [{}] with value [{}]",
+                        sanItem.get(0), name instanceof String ? name : name instanceof byte[] ? getAltnameSequence((byte[]) name) : name);
+                } else {
+                    LOGGER.trace("SAN item of unexpected size found: [{}]", sanItem);
                 }
             }
+            val seq = getOtherNameTypeSAN(sanItem);
+            val upnString = getUPNStringFromSequence(seq);
+            if (StringUtils.isNotBlank(upnString)) {
+                LOGGER.debug("Found user principal name in certificate: [{}]", upnString);
+                return Optional.of(upnString);
+            }
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -4,6 +4,8 @@ import org.apereo.cas.adaptors.x509.authentication.handler.support.CRLDistributi
 import org.apereo.cas.adaptors.x509.authentication.handler.support.ResourceCRLRevocationCheckerTests;
 import org.apereo.cas.adaptors.x509.authentication.handler.support.ThresholdExpiredCRLRevocationPolicyTests;
 import org.apereo.cas.adaptors.x509.authentication.handler.support.X509CredentialsAuthenticationHandlerTests;
+import org.apereo.cas.adaptors.x509.authentication.principal.DefaultX509AttributeExtractorTests;
+import org.apereo.cas.adaptors.x509.authentication.principal.EDIPIX509AttributeExtractorTests;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509CertificateCredentialTests;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509CommonNameEDIPIPrincipalResolverTests;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509SerialNumberAndIssuerDNPrincipalResolverTests;
@@ -25,6 +27,8 @@ import org.junit.runner.RunWith;
  * @since 5.0.0
  */
 @SelectClasses({
+    DefaultX509AttributeExtractorTests.class,
+    EDIPIX509AttributeExtractorTests.class,
     X509SerialNumberAndIssuerDNPrincipalResolverTests.class,
     X509SerialNumberPrincipalResolverTests.class,
     X509SubjectDNPrincipalResolverTests.class,

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/DefaultX509AttributeExtractorTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/DefaultX509AttributeExtractorTests.java
@@ -1,0 +1,51 @@
+package org.apereo.cas.adaptors.x509.authentication.principal;
+
+import org.apereo.cas.util.CollectionUtils;
+import org.apereo.cas.util.ResourceUtils;
+
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test cases for {@link DefaultX509AttributeExtractor}.
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@Tag("X509")
+public class DefaultX509AttributeExtractorTests {
+
+    @SneakyThrows
+    private X509Certificate getCertificate(final String certLocation) {
+        return (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
+                ResourceUtils.getRawResourceFrom(certLocation).getInputStream());
+    }
+
+    @Test
+    public void verifyExtractedAttributes() {
+        val extractor = new DefaultX509AttributeExtractor();
+        val attributes = extractor.extractPersonAttributes(getCertificate("classpath:/x509-san-upn-resolver.crt"));
+        assertEquals(CollectionUtils.wrapList("1.2.840.113549.1.1.11"), attributes.get("sigAlgOid"));
+        assertEquals(CollectionUtils.wrapList(
+                "EMAILADDRESS=test@somecompany.com, CN=Test User, OU=Some Department, O=Some Company, ST=District of Columbia, C=US"),
+                attributes.get("subjectDn"));
+        assertEquals(CollectionUtils.wrapList(
+                "1.2.840.113549.1.9.1=#16147465737440736f6d65636f6d70616e792e636f6d,CN=Test User,OU=Some Department,O=Some Company,ST=District of Columbia,C=US"),
+                attributes.get("subjectX500Principal"));
+        assertEquals(CollectionUtils.wrapList(
+                "EMAILADDRESS=ca@somecompany.com, CN=Test CA, OU=Some Department, O=Some Company, L=Washington, ST=District of Columbia, C=US"),
+                attributes.get("issuerDn"));
+        assertEquals(CollectionUtils.wrapList(
+                "1.2.840.113549.1.9.1=#1612636140736f6d65636f6d70616e792e636f6d,CN=Test CA,OU=Some Department,O=Some Company,L=Washington,ST=District of Columbia,C=US"),
+                attributes.get("issuerX500Principal"));
+        assertEquals(CollectionUtils.wrapList("test@somecompany.com"), attributes.get("x509Rfc822Email"));
+        assertEquals(CollectionUtils.wrapList("test-user@some-company-domain"), attributes.get("x509subjectUPN"));
+    }
+
+}

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractorTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/EDIPIX509AttributeExtractorTests.java
@@ -1,0 +1,40 @@
+package org.apereo.cas.adaptors.x509.authentication.principal;
+
+import org.apereo.cas.util.CollectionUtils;
+import org.apereo.cas.util.ResourceUtils;
+
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Test cases for {@link EDIPIX509AttributeExtractor}.
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@Tag("X509")
+public class EDIPIX509AttributeExtractorTests {
+
+    @SneakyThrows
+    private X509Certificate getCertificate(final String certLocation) {
+        return (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
+                ResourceUtils.getRawResourceFrom(certLocation).getInputStream());
+    }
+
+    @Test
+    public void verifyExtractedAttributes() {
+        val extractor = new EDIPIX509AttributeExtractor();
+        val attributes = extractor.extractPersonAttributes(getCertificate("classpath:/x509-san-upn-resolver.crt"));
+        assertNull(attributes.get("x509EDIPI"));
+        val edipi = extractor.extractPersonAttributes(getCertificate("classpath:/edipi.cer")).get("x509EDIPI");
+        assertEquals(edipi, CollectionUtils.wrapList("1234567890"));
+    }
+
+}

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberAndIssuerDNPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberAndIssuerDNPrincipalResolverTests.java
@@ -47,6 +47,7 @@ public class X509SerialNumberAndIssuerDNPrincipalResolverTests {
             .activeAttributeRepositoryIdentifiers(CollectionUtils.wrapSet(IPersonAttributeDao.WILDCARD))
             .build();
         resolver = new X509SerialNumberAndIssuerDNPrincipalResolver(context);
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
     }
 
     @Test

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
@@ -50,7 +50,7 @@ public class X509SerialNumberPrincipalResolverTests {
             .activeAttributeRepositoryIdentifiers(CollectionUtils.wrapSet(IPersonAttributeDao.WILDCARD))
             .build();
         resolver = new X509SerialNumberPrincipalResolver(context);
-        resolver.sexX509AttributeExtractor(new DefaultX509AttributeExtractor());
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
     }
 
     @Test

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SerialNumberPrincipalResolverTests.java
@@ -50,6 +50,7 @@ public class X509SerialNumberPrincipalResolverTests {
             .activeAttributeRepositoryIdentifiers(CollectionUtils.wrapSet(IPersonAttributeDao.WILDCARD))
             .build();
         resolver = new X509SerialNumberPrincipalResolver(context);
+        resolver.sexX509AttributeExtractor(new DefaultX509AttributeExtractor());
     }
 
     @Test

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests.java
@@ -100,6 +100,7 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests {
 
         val resolver = new X509SubjectAlternativeNameRFC822EmailPrincipalResolver(context);
         resolver.setAlternatePrincipalAttribute(alternatePrincipalAttribute);
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
         val certificate = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
             new FileInputStream(getClass().getResource(certPath).getPath()));
 
@@ -113,7 +114,7 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests {
             assertNotNull(principal);
             assertFalse(principal.getAttributes().isEmpty());
             if (requiredAttribute != null) {
-                assertTrue(principal.getAttributes().keySet().contains(requiredAttribute));
+                assertTrue(principal.getAttributes().containsKey(requiredAttribute));
             }
         } else {
             assertNull(principal);

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests.java
@@ -135,6 +135,7 @@ public class X509SubjectAlternativeNameRFC822EmailPrincipalResolverTests {
             .build();
 
         val resolver = new X509SubjectAlternativeNameRFC822EmailPrincipalResolver(context);
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
         val certificate = mock(X509Certificate.class);
         when(certificate.getSubjectAlternativeNames()).thenThrow(new CertificateParsingException());
         assertNull(resolver.resolvePrincipalInternal(certificate));

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolverTests.java
@@ -127,6 +127,7 @@ public class X509SubjectAlternativeNameUPNPrincipalResolverTests {
             .activeAttributeRepositoryIdentifiers(CollectionUtils.wrapSet(IPersonAttributeDao.WILDCARD))
             .build();
         val resolver = new X509SubjectAlternativeNameUPNPrincipalResolver(context);
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
         val certificate = mock(X509Certificate.class);
         when(certificate.getSubjectAlternativeNames()).thenThrow(new CertificateParsingException());
         assertNull(resolver.resolvePrincipalInternal(certificate));

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectAlternativeNameUPNPrincipalResolverTests.java
@@ -96,6 +96,7 @@ public class X509SubjectAlternativeNameUPNPrincipalResolverTests {
             .build();
         val resolver = new X509SubjectAlternativeNameUPNPrincipalResolver(context);
         resolver.setAlternatePrincipalAttribute(alternatePrincipalAttribute);
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
         val certificate = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
             new FileInputStream(getClass().getResource(certPath).getPath()));
 

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectDNPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectDNPrincipalResolverTests.java
@@ -52,6 +52,8 @@ public class X509SubjectDNPrincipalResolverTests {
         resolver = new X509SubjectDNPrincipalResolver(context);
         resolverRFC2253 = new X509SubjectDNPrincipalResolver(context);
         resolverRFC2253.setSubjectDnFormat(X500Principal.RFC2253);
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
+        resolverRFC2253.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
     }
 
     @Test

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectPrincipalResolverTests.java
@@ -106,7 +106,7 @@ public class X509SubjectPrincipalResolverTests {
 
         val resolver = new X509SubjectPrincipalResolver(context);
         resolver.setPrincipalDescriptor(descriptor);
-        resolver.setX509AttributeExtrator(new DefaultX509AttributeExtractor());
+        resolver.setX509AttributeExtractor(new DefaultX509AttributeExtractor());
         val certificate = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
             new FileInputStream(certPath));
 

--- a/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectPrincipalResolverTests.java
+++ b/support/cas-server-support-x509-core/src/test/java/org/apereo/cas/adaptors/x509/authentication/principal/X509SubjectPrincipalResolverTests.java
@@ -106,6 +106,7 @@ public class X509SubjectPrincipalResolverTests {
 
         val resolver = new X509SubjectPrincipalResolver(context);
         resolver.setPrincipalDescriptor(descriptor);
+        resolver.setX509AttributeExtrator(new DefaultX509AttributeExtractor());
         val certificate = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
             new FileInputStream(certPath));
 

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -348,6 +348,7 @@ public class X509AuthenticationConfiguration {
     }
 
     @ConditionalOnMissingBean(name = "x509AttributeExtractor")
+    @RefreshScope
     @Bean
     public X509AttributeExtractor x509AttributeExtractor() {
         val x509 = casProperties.getAuthn().getX509();

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -4,6 +4,9 @@ import org.apereo.cas.adaptors.x509.authentication.CRLFetcher;
 import org.apereo.cas.adaptors.x509.authentication.ResourceCRLFetcher;
 import org.apereo.cas.adaptors.x509.authentication.handler.support.X509CredentialsAuthenticationHandler;
 import org.apereo.cas.adaptors.x509.authentication.ldap.LdaptiveResourceCRLFetcher;
+import org.apereo.cas.adaptors.x509.authentication.principal.DefaultX509AttributeExtractor;
+import org.apereo.cas.adaptors.x509.authentication.principal.EDIPIX509AttributeExtractor;
+import org.apereo.cas.adaptors.x509.authentication.principal.X509AttributeExtractor;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509CommonNameEDIPIPrincipalResolver;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509SerialNumberAndIssuerDNPrincipalResolver;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509SerialNumberPrincipalResolver;
@@ -45,7 +48,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -234,6 +236,7 @@ public class X509AuthenticationConfiguration {
             X509SubjectPrincipalResolver.class,
             principal, personDirectory);
         resolver.setPrincipalDescriptor(x509.getPrincipalDescriptor());
+        resolver.setX509AttributeExtractor(x509AttributeExtractor());
         return resolver;
     }
 
@@ -252,6 +255,7 @@ public class X509AuthenticationConfiguration {
             X509SubjectDNPrincipalResolver.class,
             principal, personDirectory);
         resolver.setSubjectDnFormat(getSubjectDnFormat(subjectDn.getFormat()));
+        resolver.setX509AttributeExtractor(x509AttributeExtractor());
         return resolver;
     }
 
@@ -270,6 +274,7 @@ public class X509AuthenticationConfiguration {
             X509SubjectAlternativeNameUPNPrincipalResolver.class,
             principal, personDirectory);
         resolver.setAlternatePrincipalAttribute(subjectAltNameProperties.getAlternatePrincipalAttribute());
+        resolver.setX509AttributeExtractor(x509AttributeExtractor());
         return resolver;
     }
 
@@ -287,6 +292,7 @@ public class X509AuthenticationConfiguration {
             X509SubjectAlternativeNameRFC822EmailPrincipalResolver.class,
             principal, personDirectory);
         resolver.setAlternatePrincipalAttribute(rfc822EmailProperties.getAlternatePrincipalAttribute());
+        resolver.setX509AttributeExtractor(x509AttributeExtractor());
         return resolver;
     }
 
@@ -320,6 +326,7 @@ public class X509AuthenticationConfiguration {
             principal, personDirectory);
         resolver.setSerialNumberPrefix(serialNoDnProperties.getSerialNumberPrefix());
         resolver.setValueDelimiter(serialNoDnProperties.getValueDelimiter());
+        resolver.setX509AttributeExtractor(x509AttributeExtractor());
         return resolver;
     }
 
@@ -338,6 +345,7 @@ public class X509AuthenticationConfiguration {
             X509CommonNameEDIPIPrincipalResolver.class,
             principal, personDirectory);
         resolver.setAlternatePrincipalAttribute(cnEdipiProperties.getAlternatePrincipalAttribute());
+        resolver.setX509AttributeExtractor(x509AttributeExtractor());
         return resolver;
     }
 
@@ -383,7 +391,6 @@ public class X509AuthenticationConfiguration {
         }
         return x509SubjectDNPrincipalResolver();
     }
-
     private X509SerialNumberPrincipalResolver getX509SerialNumberPrincipalResolver(final X509Properties x509) {
         val serialNoProperties = x509.getSerialNo();
         val personDirectory = casProperties.getPersonDirectory();
@@ -395,7 +402,7 @@ public class X509AuthenticationConfiguration {
             CoreAuthenticationUtils.getAttributeMerger(casProperties.getAuthn().getAttributeRepository().getCore().getMerger()),
             X509SerialNumberPrincipalResolver.class,
             principal, personDirectory);
-
+        resolver.setX509AttributeExtractor(x509AttributeExtractor());
         if (Character.MIN_RADIX <= radix && radix <= Character.MAX_RADIX) {
             if (radix == HEX) {
                 resolver.setRadix(radix);

--- a/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
+++ b/support/cas-server-support-x509/src/main/java/org/apereo/cas/adaptors/x509/config/X509AuthenticationConfiguration.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
@@ -344,6 +345,16 @@ public class X509AuthenticationConfiguration {
     @Bean
     public AuthenticationEventExecutionPlanConfigurer x509AuthenticationEventExecutionPlanConfigurer() {
         return plan -> plan.registerAuthenticationHandlerWithPrincipalResolver(x509CredentialsAuthenticationHandler(), getPrincipalResolver());
+    }
+
+    @ConditionalOnMissingBean(name = "x509AttributeExtractor")
+    @Bean
+    public X509AttributeExtractor x509AttributeExtractor() {
+        val x509 = casProperties.getAuthn().getX509();
+        if (x509.getCnEdipi().isExtractEdipiAsAttribute()) {
+            return new EDIPIX509AttributeExtractor();
+        }
+        return new DefaultX509AttributeExtractor();
     }
 
     private PrincipalResolver getPrincipalResolver() {

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -4,6 +4,7 @@ import org.apereo.cas.adaptors.x509.RequestHeaderX509CertificateExtractorTests;
 import org.apereo.cas.adaptors.x509.X509SubjectDNPrincipalResolverAggregateTests;
 import org.apereo.cas.adaptors.x509.authentication.ldap.LdaptiveResourceCRLFetcherTests;
 import org.apereo.cas.adaptors.x509.config.DefaultX509ConfigTests;
+import org.apereo.cas.adaptors.x509.config.EDIPIX509AttributeExtractorConfigTests;
 
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.platform.suite.api.SelectClasses;
@@ -17,6 +18,7 @@ import org.junit.runner.RunWith;
 @SelectClasses({
     LdaptiveResourceCRLFetcherTests.class,
     DefaultX509ConfigTests.class,
+    EDIPIX509AttributeExtractorConfigTests.class,
     RequestHeaderX509CertificateExtractorTests.class,
     X509SubjectDNPrincipalResolverAggregateTests.class
 })

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
@@ -1,0 +1,41 @@
+package org.apereo.cas.adaptors.x509.config;
+
+import org.apereo.cas.adaptors.x509.BaseX509Tests;
+import org.apereo.cas.adaptors.x509.authentication.principal.EDIPIX509AttributeExtractor;
+import org.apereo.cas.adaptors.x509.authentication.principal.X509AttributeExtractor;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Testing configuration for {@link X509AttributeExtractor} and {@link EDIPIX509AttributeExtractor}.
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@SpringBootTest(classes = BaseX509Tests.SharedTestConfiguration.class,
+    properties = {
+        "cas.authn.x509.principal-type=SUBJECT_DN",
+        "cas.authn.x509.cn-edipi.extract-edipi-as-attribute=true"
+    })
+@Tag("X509")
+public class EDIPIX509AttributeExtractorConfigTests {
+
+    @Autowired
+    @Qualifier("x509AttributeExtractor")
+    private X509AttributeExtractor x509AttributeExtractor;
+
+    /**
+     * If there was a problem, this test would have failed to start up.
+     * Confirm that non-default bean loaded per properties.
+     */
+    @Test
+    public void verifyCorrectX509AttributeExtractorLoaded() {
+        assertNotNull(x509AttributeExtractor);
+        assertEquals(EDIPIX509AttributeExtractor.class, x509AttributeExtractor.getClass());
+    }
+}

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
@@ -1,9 +1,10 @@
 package org.apereo.cas.adaptors.x509.config;
 
-import lombok.val;
 import org.apereo.cas.adaptors.x509.BaseX509Tests;
 import org.apereo.cas.adaptors.x509.authentication.principal.EDIPIX509AttributeExtractor;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509AttributeExtractor;
+
+import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.adaptors.x509.config;
 
+import lombok.val;
 import org.apereo.cas.adaptors.x509.BaseX509Tests;
 import org.apereo.cas.adaptors.x509.authentication.principal.EDIPIX509AttributeExtractor;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509AttributeExtractor;
@@ -8,9 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ResourceLoader;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Testing configuration for {@link X509AttributeExtractor} and {@link EDIPIX509AttributeExtractor}.
@@ -26,6 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class EDIPIX509AttributeExtractorConfigTests {
 
     @Autowired
+    private ResourceLoader resourceLoader;
+
+    @Autowired
     @Qualifier("x509AttributeExtractor")
     private X509AttributeExtractor x509AttributeExtractor;
 
@@ -34,8 +43,10 @@ public class EDIPIX509AttributeExtractorConfigTests {
      * Confirm that non-default bean loaded per properties.
      */
     @Test
-    public void verifyCorrectX509AttributeExtractorLoaded() {
+    public void verifyCorrectX509AttributeExtractorLoaded() throws IOException, CertificateException {
         assertNotNull(x509AttributeExtractor);
-        assertEquals(EDIPIX509AttributeExtractor.class, x509AttributeExtractor.getClass());
+        val certificate = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
+                resourceLoader.getResource("classpath:/edipi.cer").getInputStream());
+        assertTrue(x509AttributeExtractor.extractPersonAttributes(certificate).containsKey("x509EDIPI"));
     }
 }

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/config/EDIPIX509AttributeExtractorConfigTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.adaptors.x509.config;
 import org.apereo.cas.adaptors.x509.BaseX509Tests;
 import org.apereo.cas.adaptors.x509.authentication.principal.EDIPIX509AttributeExtractor;
 import org.apereo.cas.adaptors.x509.authentication.principal.X509AttributeExtractor;
+import org.apereo.cas.util.ResourceUtils;
 
 import lombok.val;
 import org.junit.jupiter.api.Tag;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.ResourceLoader;
 
 import java.io.IOException;
 import java.security.cert.CertificateException;
@@ -33,9 +33,6 @@ import static org.junit.jupiter.api.Assertions.*;
 public class EDIPIX509AttributeExtractorConfigTests {
 
     @Autowired
-    private ResourceLoader resourceLoader;
-
-    @Autowired
     @Qualifier("x509AttributeExtractor")
     private X509AttributeExtractor x509AttributeExtractor;
 
@@ -47,7 +44,7 @@ public class EDIPIX509AttributeExtractorConfigTests {
     public void verifyCorrectX509AttributeExtractorLoaded() throws IOException, CertificateException {
         assertNotNull(x509AttributeExtractor);
         val certificate = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
-                resourceLoader.getResource("classpath:/edipi.cer").getInputStream());
+                ResourceUtils.getResourceFrom("classpath:/edipi.cer").getInputStream());
         assertTrue(x509AttributeExtractor.extractPersonAttributes(certificate).containsKey("x509EDIPI"));
     }
 }


### PR DESCRIPTION
I wanted to extract EDIPI number as an attribute but I didn't want to inflict that attempt on everyone without an option since it is only applicable to a specific certificate issuer. I decided to move the attribute extraction logic out of `AbstractX509PrincipalResolver` and into its own bean and then that is passed to all the x509 person resolvers. I put a property to enable the EDIPI version of the attribute extractor bean in the `CnEdipiPrincipalResolverProperties` which might not be appropriate because users of other principal resolvers would likely enable EDIPI attribute extraction, but the flag to enable the extraction is EDIPI related and principalresolver related... 

A possible enhancement would be to make the attribute extraction bean configurable so that a deployer could control which attributes are extracted and override the names used for the attributes so maybe it deserves its own property class. I could look at doing that or the work could be saved for someone who needed that, and they could override the x509AttributeExractor bean if they wanted to do that.

I moved some static methods into `X509ExtractorUtils` (with edipi and email methods shared for attribute extraction and principal id resolution) and I could consolidate that with `X509UPNExtractorUtils` or break it up into two util classes, one for email and one edipi. 


<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
