### PR TITLE
Fix NPE in String find and match methods

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/RegexUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/RegexUtils.java
@@ -100,7 +100,12 @@ public class RegexUtils {
      * @see Matcher#matches()
      */
     public static boolean matches(final Pattern pattern, final String string) {
-        return pattern.matcher(string).matches();
+        try {
+            return pattern.matcher(string).matches();
+        } catch (NullPointerException npe) {
+            LOGGER.trace("Value to match is null! ", npe);
+            return false;
+        }
     }
 
     /**
@@ -113,11 +118,16 @@ public class RegexUtils {
      */
     public static boolean matches(final Pattern pattern, final String value, final boolean completeMatch) {
         val matcher = pattern.matcher(value);
-        LOGGER.debug("Matching value [{}] against pattern [{}]", value, pattern.pattern());
-        if (completeMatch) {
-            return matcher.matches();
+        try {
+            LOGGER.debug("Matching value [{}] against pattern [{}]", value, pattern.pattern());
+            if (completeMatch) {
+                return matcher.matches();
+            }
+            return matcher.find();
+        } catch (NullPointerException npe) {
+            LOGGER.trace("Value to match is null! ", npe);
+            return false;
         }
-        return matcher.find();
     }
 
     /**
@@ -129,7 +139,12 @@ public class RegexUtils {
      * @see Matcher#find()
      */
     public static boolean find(final Pattern pattern, final String string) {
-        return pattern.matcher(string).find();
+        try {
+            return pattern.matcher(string).find();
+        } catch (NullPointerException npe) {
+            LOGGER.trace("Value to find is null! ", npe);
+            return false;
+        }
     }
 
     /**
@@ -140,7 +155,12 @@ public class RegexUtils {
      * @return true/false
      */
     public static boolean find(final String pattern, final String string) {
-        return createPattern(pattern, Pattern.CASE_INSENSITIVE).matcher(string).find();
+        try {
+            return createPattern(pattern, Pattern.CASE_INSENSITIVE).matcher(string).find();
+        } catch (NullPointerException npe) {
+            LOGGER.trace("Value to find is null! ", npe);
+            return false;
+        }
     }
 
 }

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/RegexUtilsTests.java
@@ -36,4 +36,14 @@ public class RegexUtilsTests {
     public void verifyNullRegex() {
         assertFalse(RegexUtils.isValidRegex(null));
     }
+
+    @Test
+    public void verifyNullFindValue() {
+        assertFalse(RegexUtils.find(RegexUtils.MATCH_NOTHING_PATTERN.toString(), null));
+    }
+
+    @Test
+    public void verifyNullMatchValue() {
+        assertFalse(RegexUtils.matches(RegexUtils.MATCH_NOTHING_PATTERN, null));
+    }
 }


### PR DESCRIPTION
Currently null values break the find and match methods leading to unintended results (such as an error instead of MFA prompt in certain situations). Fixes these methods to be resilient.