### PR TITLE
Add method to remove definition from AttributeDefinitionStore

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/authentication/attribute/AttributeDefinitionStore.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/authentication/attribute/AttributeDefinitionStore.java
@@ -56,6 +56,14 @@ public interface AttributeDefinitionStore {
     AttributeDefinitionStore registerAttributeDefinition(String key, AttributeDefinition defn);
 
     /**
+     * Removes attribute definition attribute by key.
+     *
+     * @param key the key
+     * @return the attribute definition store
+     */
+    AttributeDefinitionStore removeAttributeDefinition(String key);
+
+    /**
      * Locate attribute definition.
      *
      * @param name the name

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/attribute/DefaultAttributeDefinitionStore.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/attribute/DefaultAttributeDefinitionStore.java
@@ -111,6 +111,19 @@ public class DefaultAttributeDefinitionStore implements AttributeDefinitionStore
     }
 
     @Override
+    public AttributeDefinitionStore removeAttributeDefinition(final String key) {
+        LOGGER.debug("Removing attribute definition by key [{}]", key);
+
+        if (this.attributeDefinitions.containsKey(key)) {
+            val defn = this.attributeDefinitions.remove(key);
+            LOGGER.debug("Attribute definition [{}] has been removed from the definition store", defn);
+        } else {
+            LOGGER.debug("Attribute definition with the registered key [{}] was not found and the store was not altered", key);
+        }
+        return this;
+    }
+
+    @Override
     public Optional<AttributeDefinition> locateAttributeDefinition(final String key) {
         LOGGER.trace("Locating attribute definition for [{}]", key);
         return Optional.ofNullable(attributeDefinitions.get(key));

--- a/support/cas-server-support-person-directory/src/test/java/org/apereo/cas/DefaultAttributeDefinitionStoreTests.java
+++ b/support/cas-server-support-person-directory/src/test/java/org/apereo/cas/DefaultAttributeDefinitionStoreTests.java
@@ -344,4 +344,20 @@ public class DefaultAttributeDefinitionStoreTests {
         assertTrue(store.isEmpty());
     }
 
+    @Test
+    public void verifyRemoveDefinition() {
+        val store = new DefaultAttributeDefinitionStore();
+        store.setScope("example.org");
+        val defn = DefaultAttributeDefinition.builder()
+                .key("eduPersonPrincipalName")
+                .name("urn:oid:1.3.6.1.4.1.5923.1.1.1.6")
+                .build();
+
+        store.registerAttributeDefinition(defn);
+        assertNotNull(store.locateAttributeDefinition(defn.getKey()));
+        assertFalse(store.getAttributeDefinitions().isEmpty());
+        store.removeAttributeDefinition(defn.getKey());
+        assertNull(store.locateAttributeDefinition(defn.getKey()));
+    }
+
 }


### PR DESCRIPTION
PR adds a method to be able to remove an AttributeDefinition from an AttributeDefinitionStore that is loaded in memory.  This method is needed for a new feature in CAS Management to be able to edit and sync an attribute definitions to CAS servers.
