### PR TITLE
Set timeouts for HttpUtils

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpUtils.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -44,6 +45,12 @@ public class HttpUtils {
     private static final int MAX_CONNECTIONS = 200;
 
     private static final int MAX_CONNECTIONS_PER_ROUTE = 20;
+
+    private static final int CONNECT_TIMEOUT_IN_MILLISECONDS = 500;
+
+    private static final int CONNECTION_REQUEST_TIMEOUT_IN_MILLISECONDS = 5 * 1000;
+
+    private static final int SOCKET_TIMEOUT_IN_MILLISECONDS = 10 * 1000;
 
     @SuperBuilder
     @Getter
@@ -207,10 +214,16 @@ public class HttpUtils {
     }
 
     private HttpClientBuilder getHttpClientBuilder() {
+        val requestConfig = RequestConfig.custom();
+        requestConfig.setConnectTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS);
+        requestConfig.setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT_IN_MILLISECONDS);
+        requestConfig.setSocketTimeout(SOCKET_TIMEOUT_IN_MILLISECONDS);
+
         return HttpClientBuilder
             .create()
             .useSystemProperties()
             .setMaxConnTotal(MAX_CONNECTIONS)
-            .setMaxConnPerRoute(MAX_CONNECTIONS_PER_ROUTE);
+            .setMaxConnPerRoute(MAX_CONNECTIONS_PER_ROUTE)
+            .setDefaultRequestConfig(requestConfig.build());
     }
 }


### PR DESCRIPTION
I encountered the issue for CAS 6.2.

Without timeouts defined on the `HttpClient`, the CAS server can be fully blocked by external not-responding systems.

BTW, I missed the change but I see that since v6.3.x, the `HttpClient` is now built for every HTTP request, I fear a strong performance impact as I changed things the opposite way in 5.x.
