### PR TITLE
Fix the default size of the encryption key for OAuth

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/util/EncryptionJwtCryptoProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/util/EncryptionJwtCryptoProperties.java
@@ -25,7 +25,7 @@ public class EncryptionJwtCryptoProperties implements Serializable {
     private static final long serialVersionUID = 616825635591169628L;
 
     /**
-     * The encryption key is a JWT whose length is defined by the signing key size setting.
+     * The encryption key is a JWT whose length is defined by the encryption key size setting.
      */
     @RequiredProperty
     private String key = StringUtils.EMPTY;
@@ -33,5 +33,5 @@ public class EncryptionJwtCryptoProperties implements Serializable {
     /**
      * The encryption key size.
      */
-    private int keySize = 512;
+    private int keySize = 256;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/util/EncryptionJwtCryptoProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/util/EncryptionJwtCryptoProperties.java
@@ -33,5 +33,5 @@ public class EncryptionJwtCryptoProperties implements Serializable {
     /**
      * The encryption key size.
      */
-    private int keySize = 256;
+    private int keySize = 512;
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -7,6 +7,7 @@ import org.apereo.cas.configuration.support.RequiresModule;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.apereo.cas.util.crypto.CipherExecutor;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.io.Serializable;
@@ -107,5 +108,10 @@ public class OAuthProperties implements Serializable {
          * where all attributes are flattened down to one level only.
          */
         FLAT
+    }
+
+    public OAuthProperties() {
+        crypto.getEncryption().setKeySize(CipherExecutor.DEFAULT_STRINGABLE_ENCRYPTION_KEY_SIZE);
+        crypto.getSigning().setKeySize(CipherExecutor.DEFAULT_STRINGABLE_SIGNING_KEY_SIZE);
     }
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oauth/OAuthProperties.java
@@ -3,11 +3,11 @@ package org.apereo.cas.configuration.model.support.oauth;
 import org.apereo.cas.configuration.model.core.util.EncryptionOptionalSigningOptionalJwtCryptographyProperties;
 import org.apereo.cas.configuration.model.support.uma.UmaProperties;
 import org.apereo.cas.configuration.support.RequiresModule;
+import org.apereo.cas.util.crypto.CipherExecutor;
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.apereo.cas.util.crypto.CipherExecutor;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.io.Serializable;


### PR DESCRIPTION
I encountered this  issue when I wanted to encrypt an OAuth secret.

The `EncryptionJwtCryptoProperties` class with an encryption key of 512 is only used in the `EncryptionJwtSigningJwtCryptographyProperties` class where the algorithm is `"A128CBC-HS256"`.

There is a mismatch here: the encryption key size should be 256 to match the algorithm: `A128CBC-HS256`.

Though, I fixed it like it is done in other CAS places: the encryption key size is forced to 256 in the properties class constructor.