### PR TITLE
DOC: Link to specific GitLab documentation page

### DIFF
--- a/docs/cas-server-documentation/integration/Configuring-SAML-SP-Integrations.md
+++ b/docs/cas-server-documentation/integration/Configuring-SAML-SP-Integrations.md
@@ -128,7 +128,7 @@ The following SAML SP integrations, as samples, are provided by CAS:
 <a href="http://www.accruent.com/">
 <img src="https://user-images.githubusercontent.com/1205228/30735450-f9a12792-9f8b-11e7-941d-7ab4ac7628b9.png" height="48" width="120"></a>
 
-<a href="https://www.gitlab.com/">
+<a href="https://docs.gitlab.com/ee/administration/auth/">
 <img src="https://user-images.githubusercontent.com/1205228/33747990-4d8da06e-db83-11e7-9551-f52630f7d4f0.png" height="38" width="120"></a>
 
 <a href="https://www.hipchat.com/">


### PR DESCRIPTION
Previously, it pointed to the general GitLab home page. The new link is probably more helpful for most admins.

Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable -> *not applicable*
- [x] The same pull request targeted at the master branch, if applicable -> *not applicable*
- [x] Any documentation on how to configure, test -> *not applicable*
- [x] Any possible limitations, side effects, etc -> *none are known*
- [x] Reference any other pull requests that might be related -> *none are known*