### PR TITLE
update documentation about CASCADE aggregation

### DIFF
--- a/docs/cas-server-documentation/_includes/attribute-resolution-configuration.md
+++ b/docs/cas-server-documentation/_includes/attribute-resolution-configuration.md
@@ -43,4 +43,6 @@ when multiple attribute repository sources are defined to fetch data:
 | Type            | Description
 |-----------------|-------------------------------------------------------------
 | `MERGE`         | Default. Query multiple repositories in order and merge the results into a single result set.
-| `CASCADE`       | Same as above; results from each query are passed down to the next attribute repository source.
+| `CASCADE`       | Same as above; results from each query are passed down to the next attribute repository source. If the first repository queried has no results, no further attribute repositories will be queried.  
+                    
+                   


### PR DESCRIPTION
I was working on a test project and I wanted to leave the default in-memory user and stub repository I was using, but when I added LDAP attribute repository and had the aggregation set to CASCADE, the stub repo stopped working b/c the dummy user wasn't in LDAP attribute repository. This documentation update might have made it easier to figure out what was going on. 

This is a result of the code `dao.setStopIfFirstDaoReturnsNull(true);` in 
```
            case CASCADE:
                val dao = new CascadingPersonAttributeDao();
                dao.setAddOriginalAttributesToQuery(true);
                dao.setStopIfFirstDaoReturnsNull(true);
```
