### PR TITLE
allow log4j2.xml baseDir to be overridden by system property

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
+++ b/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
@@ -30,8 +30,8 @@ Set -Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContext
             <PatternLayout pattern="%highlight{%d %p [%c] - &lt;%m&gt;}%n" alwaysWriteExceptions="${sys:log.console.stacktraces}"/>
         </Console>
 
-        <RollingFile name="file" fileName="${baseDir}/cas.log" append="true"
-                     filePattern="${baseDir}/cas-%d{yyyy-MM-dd-HH}-%i.log"
+        <RollingFile name="file" fileName="${sys:baseDir}/cas.log" append="true"
+                     filePattern="${sys:baseDir}/cas-%d{yyyy-MM-dd-HH}-%i.log"
                      immediateFlush="false">
             <PatternLayout pattern="%highlight{%d %p [%c] - &lt;%m&gt;%n}"
                            alwaysWriteExceptions="${sys:log.file.stacktraces}" />
@@ -41,15 +41,15 @@ Set -Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContext
                 <TimeBasedTriggeringPolicy />
             </Policies>
             <DefaultRolloverStrategy max="5" compressionLevel="9">
-                <Delete basePath="${baseDir}" maxDepth="2">
+                <Delete basePath="${sys:baseDir}" maxDepth="2">
                     <IfFileName glob="*/*.log.gz" />
                     <IfLastModified age="7d" />
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>
 
-        <RollingFile name="stacktracefile" fileName="${baseDir}/cas_stacktrace.log" append="true"
-                     filePattern="${baseDir}/cas_stacktrace-%d{yyyy-MM-dd-HH}-%i.log"
+        <RollingFile name="stacktracefile" fileName="${sys:baseDir}/cas_stacktrace.log" append="true"
+                     filePattern="${sys:baseDir}/cas_stacktrace-%d{yyyy-MM-dd-HH}-%i.log"
                      immediateFlush="false">
             <PatternLayout pattern="%highlight{%d %p [%c] - &lt;%m&gt;%n}" />
             <Policies>
@@ -58,15 +58,15 @@ Set -Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContext
                 <TimeBasedTriggeringPolicy />
             </Policies>
             <DefaultRolloverStrategy max="5" compressionLevel="9">
-                <Delete basePath="${baseDir}" maxDepth="2">
+                <Delete basePath="${sys:baseDir}" maxDepth="2">
                     <IfFileName glob="*/*.log.gz" />
                     <IfLastModified age="7d" />
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>
 
-        <RollingFile name="auditlogfile" fileName="${baseDir}/cas_audit.log" append="true"
-                     filePattern="${baseDir}/cas_audit-%d{yyyy-MM-dd-HH}-%i.log"
+        <RollingFile name="auditlogfile" fileName="${sys:baseDir}/cas_audit.log" append="true"
+                     filePattern="${sys:baseDir}/cas_audit-%d{yyyy-MM-dd-HH}-%i.log"
                      immediateFlush="false">
             <PatternLayout pattern="%highlight{%d %p [%c] - %m%n}" />
             <Policies>
@@ -75,7 +75,7 @@ Set -Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContext
                 <TimeBasedTriggeringPolicy />
             </Policies>
             <DefaultRolloverStrategy max="5" compressionLevel="9">
-                <Delete basePath="${baseDir}" maxDepth="2">
+                <Delete basePath="${sys:baseDir}" maxDepth="2">
                     <IfFileName glob="*/*.log.gz" />
                     <IfLastModified age="7d" />
                 </Delete>


### PR DESCRIPTION
This specifies baseDir in log4j2.xml to use a system property (-DbaseDir=/tmp) but if it isn't set then it will fall back to the log42.xml baseDir property that it is using now. This allows for overriding the default config without changing it or using the overlay/initializr config (which may also need this change, if this is accepted). 