### PR TITLE
Add the protocol property for Memcached

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/memcached/BaseMemcachedProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/memcached/BaseMemcachedProperties.java
@@ -92,6 +92,11 @@ public class BaseMemcachedProperties implements Serializable {
     private String hashAlgorithm = "FNV1_64_HASH";
 
     /**
+     * Protocol. Acceptable values are {@code TEXT, BINARY}.
+     */
+    private String protocol = "TEXT";
+
+    /**
      * Sets the cap on the number of objects that can be allocated by
      * the pool (checked out to clients, or idle awaiting checkout) at a given time. Use a negative value for no limit.
      */

--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/MemcachedPooledClientConnectionFactory.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/MemcachedPooledClientConnectionFactory.java
@@ -49,6 +49,9 @@ public class MemcachedPooledClientConnectionFactory extends BasePooledObjectFact
         if (StringUtils.isNotBlank(memcachedProperties.getHashAlgorithm())) {
             factoryBean.setHashAlg(DefaultHashAlgorithm.valueOf(memcachedProperties.getHashAlgorithm()));
         }
+        if (StringUtils.isNotBlank(memcachedProperties.getProtocol())) {
+            factoryBean.setProtocol(ConnectionFactoryBuilder.Protocol.valueOf(memcachedProperties.getProtocol()));
+        }
 
         factoryBean.setDaemon(memcachedProperties.isDaemon());
         factoryBean.setShouldOptimize(memcachedProperties.isShouldOptimize());


### PR DESCRIPTION
I'm migrating a CAS server from version 3.5 to the latest version. It uses Memcached.

I notice that it's no longer possible to set the protocol property, which is really strange as it's an important feature and as it's default value (text) is less efficient (than binary).

I may be missing something, but this PR allows to set again the Memcached protocol.
