### PR TITLE
remove theme resources WebMvcConfigurer, as it breaks static files

### DIFF
--- a/support/cas-server-support-themes/src/main/java/org/apereo/cas/services/web/config/CasThemesConfiguration.java
+++ b/support/cas-server-support-themes/src/main/java/org/apereo/cas/services/web/config/CasThemesConfiguration.java
@@ -8,7 +8,6 @@ import org.apereo.cas.services.web.RegisteredServiceThemeResolver;
 import org.apereo.cas.services.web.RequestHeaderThemeResolver;
 import org.apereo.cas.util.ResourceUtils;
 
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -44,7 +43,6 @@ import java.util.stream.Collectors;
  */
 @Configuration(value = "casThemesConfiguration", proxyBeanMethods = false)
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@Slf4j
 public class CasThemesConfiguration {
     @Autowired
     @Qualifier("authenticationServiceSelectionPlan")
@@ -56,9 +54,6 @@ public class CasThemesConfiguration {
 
     @Autowired
     private CasConfigurationProperties casProperties;
-
-    @Autowired
-    private ObjectProvider<ThymeleafProperties> properties;
 
     @Bean
     public Supplier<Map<String, String>> serviceThemeResolverSupportedBrowsers() {
@@ -111,32 +106,5 @@ public class CasThemesConfiguration {
             .addResolver(fixedResolver);
         chainingThemeResolver.setDefaultThemeName(defaultThemeName);
         return chainingThemeResolver;
-    }
-    
-    @Bean
-    @ConditionalOnMissingBean(name = "themesStaticResourcesWebMvcConfigurer")
-    public WebMvcConfigurer themesStaticResourcesWebMvcConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addResourceHandlers(final ResourceHandlerRegistry registry) {
-                val templatePrefixes = casProperties.getView().getTemplatePrefixes();
-                if (!templatePrefixes.isEmpty()) {
-                    val registration = registry.addResourceHandler("/**");
-                    val resources = templatePrefixes
-                        .stream()
-                        .map(prefix -> StringUtils.appendIfMissing(prefix, "/"))
-                        .map(Unchecked.function(ResourceUtils::getRawResourceFrom))
-                        .toArray(Resource[]::new);
-                    LOGGER.debug("Adding resource handler for resources [{}]", (Object[]) resources);
-                    registration.addResourceLocations(templatePrefixes.toArray(ArrayUtils.EMPTY_STRING_ARRAY));
-                    registration.setUseLastModified(true);
-                    val cache = properties.getIfAvailable() != null && properties.getObject().isCache();
-                    val chainRegistration = registration.resourceChain(cache);
-                    val resolver = new PathResourceResolver();
-                    resolver.setAllowedLocations(resources);
-                    chainRegistration.addResolver(resolver);
-                }
-            }
-        };
     }
 }


### PR DESCRIPTION
I'm submitting this not necessarily because I think that this bean should actually be entirely removed, but because I don't really understand why it's there. This bean, due to its use on L124 of the `/**` prefix, completely removes the ability of the servlet to serve static files, thus breaking the entire interface when `cas.view.template-prefixes` is in use. Moreover, I don't understand why the existing logic that sets additional template locations, specifically the `chainingTemplateViewResolver` bean found in `CasThymeleafConfiguration`, is insufficient for the purpose - I've been using `cas.view.template-prefixes` for quite a while now for dev builds, with no issues.

In my (admittedly brief) testing, overriding this bean in my overlay with a no-op returns functionality. I suppose it would also be possible to add a `ClasspathResource` to the registration created, but that seems, to me anyway, misdirected, as serving the base CAS JS and CSS is then dependent on this supposedly theme-specific WebMvcConfigurer, an obvious collision of separate concerns, as well as seeming unnecessary as long as the logic in `CasThymeleafConfiguration` is sufficient. 