### PR TITLE
Fix SAML metadata resolution

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManagerRegisteredServiceLocator.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManagerRegisteredServiceLocator.java
@@ -23,8 +23,7 @@ public interface ServicesManagerRegisteredServiceLocator extends Ordered {
      * @param predicateFilter the predicate filter
      * @return the registered service
      */
-    RegisteredService locate(Collection<RegisteredService> candidates, Service service,
-        Predicate<RegisteredService> predicateFilter);
+    RegisteredService locate(Collection<RegisteredService> candidates, Service service);
 
     @Override
     default int getOrder() {

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -94,8 +94,7 @@ public abstract class AbstractServicesManager implements ServicesManager {
 
         var foundService = configurationContext.getRegisteredServiceLocators()
             .stream()
-            .map(locator -> locator.locate(getCandidateServicesToMatch(service.getId()), service,
-                entry -> entry.matches(service.getId())))
+            .map(locator -> locator.locate(getCandidateServicesToMatch(service.getId()), service))
             .filter(Objects::nonNull)
             .findFirst()
             .orElse(null);

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultServicesManagerRegisteredServiceLocator.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultServicesManagerRegisteredServiceLocator.java
@@ -26,16 +26,15 @@ public class DefaultServicesManagerRegisteredServiceLocator implements ServicesM
     private int order = Ordered.LOWEST_PRECEDENCE;
 
     private BiPredicate<RegisteredService, Service> registeredServiceFilter =
-        (registeredService, service) -> registeredService.getClass().equals(RegexRegisteredService.class);
+        (registeredService, service) -> registeredService.getClass().equals(RegexRegisteredService.class) && registeredService.matches(service.getId());
 
     @Override
-    public RegisteredService locate(final Collection<RegisteredService> candidates, final Service service,
-        final Predicate<RegisteredService> requestedFilter) {
-        return candidates
+    public RegisteredService locate(final Collection<RegisteredService> candidates, final Service service) {
+       return candidates
             .stream()
             .filter(entry -> registeredServiceFilter.test(entry, service))
-            .filter(requestedFilter::test)
             .findFirst()
             .orElse(null);
     }
 }
+

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/SamlIdPServicesManagerRegisteredServiceLocator.java
@@ -31,9 +31,10 @@ public class SamlIdPServicesManagerRegisteredServiceLocator extends DefaultServi
         setOrder(Ordered.HIGHEST_PRECEDENCE);
         setRegisteredServiceFilter((registeredService, service) -> {
             val isSamlServiceProvider = isSamlRegisteredService(registeredService, service);
-            if (isSamlServiceProvider && registeredService.matches(service.getId())) {
+            val entityId = getServiceEntityId(service);
+            if (isSamlServiceProvider && registeredService.matches(entityId)) {
                 val samlService = SamlRegisteredService.class.cast(registeredService);
-                val adaptor = SamlRegisteredServiceServiceProviderMetadataFacade.get(resolver, samlService, service.getId());
+                val adaptor = SamlRegisteredServiceServiceProviderMetadataFacade.get(resolver, samlService, entityId);
                 return adaptor.isPresent();
             }
             return false;
@@ -58,4 +59,13 @@ public class SamlIdPServicesManagerRegisteredServiceLocator extends DefaultServi
         }
         return false;
     }
+
+    private String getServiceEntityId(final Service service) {
+        val entityIdAttribute = service.getAttributes().get(SamlProtocolConstants.PARAMETER_ENTITY_ID);
+        if (entityIdAttribute == null) {
+            return service.getId();
+        }
+        return entityIdAttribute.get(0).toString();
+    }
 }
+

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
@@ -100,7 +100,7 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
 
         val entityDescriptor = chainingMetadataResolver.resolveSingle(criterions);
         if (entityDescriptor == null) {
-            LOGGER.warn("Cannot find entity [{}] in metadata provider. Ensure the metadata is valid and has not expired.", entityID);
+            LOGGER.debug("Cannot find entity [{}] in metadata provider. Ensure the metadata is valid and has not expired.", entityID);
             return Optional.empty();
         }
         LOGGER.trace("Located entity descriptor in metadata for [{}]", entityID);


### PR DESCRIPTION
After handling idp/profile/SAML2/Redirect/SSO request CAS redirects to /login page with service parameter pointing itself.

```
GET https://login.umcs.pl/cas/idp/profile/SAML2/Redirect/SSO?SAMLRequest=nVLLjtswDPwVQ3dbtuMEqZAESDcoGmDbDeJ0D70UXJveCJAlVaT6%2BPvKSYtu95BDT4LImeFwwBXBaLzaRj7bI36NSJz9GI0ldWmsRQxWOSBNysKIpLhT7fbDvaqLUvng2HXOiBeU2wwgwsDaWZHtd2vxpaxnzaJqAN90i9lQAgxPdb%2BYp8%2BywcU8NeYlDDNsQGSPGCgx1yIJJTpRxL0lBsupVNZVXs7yankqS1UtVVN9FtkubaMt8IV1ZvakpDTuWdsijh0V3sgOSOrey7TKoA3KyWktj9jrgB3Ltn0Q2faP6TtnKY4YWgzfdIefjvd%2FZQF04RNGYygs8qTNabwcXR8NFv7s5RSPpOtb5zAZSNUeB4iGc%2FIiO%2FwO9K22vbbPt7N8uoJIvT%2BdDvnhoT2JzWrSVpdswuY%2FrI3I0APDK2cr%2BVJ3db2Zj8nRfndwRnc%2Fs3cujMC3DU8V3efDBao4gCWNllPAxrjvdwGBcS04RBRycx3572VufgE%3D&RelayState=https%3A%2F%2Faai.pionier.net.pl%2Ftest%2Fmodule.php%2Fcore%2Fauthenticate.php%3Fas%3Ddefault-sp&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=ai4g0bQUgwPE09wHai2PdHTzNGWBKBax1R70kNvxnO8kTQzRQIb2mAxQC%2BjhFFRyozotHGQJsV421bky%2FX0ByYyrgo0hUEm6W2d5Cee%2FWv66Zf6foS8sqPfcp4K%2FJffO0CzOzIL4%2BOEYBL1q7lHJLLW5Ln3BHG9oc854qGndpLx8eUhoX7yzAnybQImuYE9q9S21%2FwxQzgZK4rxk2bW9R89cwRCHfyxGm2V5vfMKVs%2Fp%2FNHZ%2B%2FL096NQxZvdK%2Fq5UAQ2%2FpcimUwUIdp%2FLVonV6Z%2F1X8GqqRMaEhFV9mDGJMkMmFrNhwQCM2bCvQcYmOrXFKLlnkbZpHfNjTfu7Xo8Q%3D%3D HTTP/1.1
Referer: https://aai.pionier.net.pl/test/module.php/saml/disco.php?entityID=https%3A%2F%2Faai.pionier.net.pl%2Ftest%2Fmodule.php%2Fsaml%2Fsp%2Fmetadata.php%2Fdefault-sp&return=https%3A%2F%2Faai.pionier.net.pl%2Ftest%2Fmodule.php%2Fsaml%2Fsp%2Fdiscoresp.php%3FAuthID%3D_0234614ae9c63f0aafb2d65c6384e654ae50af3e4a%253Ahttps%253A%252F%252Faai.pionier.net.pl%252Ftest%252Fmodule.php%252Fcore%252Fas_login.php%253FAuthId%253Ddefault-sp%2526ReturnTo%253Dhttps%25253A%25252F%25252Faai.pionier.net.pl%25252Ftest%25252Fmodule.php%25252Fcore%25252Fauthenticate.php%25253Fas%25253Ddefault-sp&returnIDParam=idpentityid

HTTP/2.0 302 Found
set-cookie: JSESSIONID=E0A70AFC67C305B9F7BF01E52E503235; Path=/cas; Secure; HttpOnly
location: https://login.umcs.pl/cas/login?service=https://login.umcs.pl/cas/idp/profile/SAML2/Callback?entityId=https://aai.pionier.net.pl/test/module.php/saml/sp/metadata.php/default-sp
```

Unfortunately this triggers a lot of warnings:
```
2021-03-16 10:21:27,231 WARN [org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade] - <Cannot find entity [https://login.umcs.pl/cas/idp/profile/SAML2/Callback?entityId=https%3A%2F%2Faai.pionier.net.pl%2Ftest%2Fmodule.php%2Fsaml%2Fsp%2Fmetadata.php%2Fdefault-sp] in metadata provider. Ensure the metadata is valid and has not expired.>
```

This patch changes SamlIdPServicesManagerRegisteredServiceLocator to match registered service and metadata entities using entityId parameter if it is present in request.

There is also problem in AbstractServicesManager because it tries to match registered service serviceId with service id, which in above case is different to entityId ( https://login.umcs.pl/cas/idp/profile/SAML2/Callback?entityId=https%3A%2F%2Faai.pionier.net.pl%2Ftest%2Fmodule.php%2Fsaml%2Fsp%2Fmetadata.php%2Fdefault-sp  !=  https://aai.pionier.net.pl/test/module.php/saml/sp/metadata.php/default-sp).

I also decreased logging level of "Cannot find entity..." in SamlRegisteredServiceServiceProviderMetadataFacade since it seems that it would be possible to have a few metadata aggregates with serviceId matching anything.