### PR TITLE
Support for the merge entries search handler (in LDAP).

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapSearchEntryHandlersProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/LdapSearchEntryHandlersProperties.java
@@ -24,7 +24,7 @@ public class LdapSearchEntryHandlersProperties implements Serializable {
     private static final long serialVersionUID = -5198990160347131821L;
     /**
      * The type of search entry handler to choose.
-     * Accepted values are {@code OBJECT_GUID,OBJECT_SID,CASE_CHANGE,DN_ATTRIBUTE_ENTRY,MERGE,PRIMARY_GROUP,RANGE_ENTRY,RECURSIVE_ENTRY}
+     * Accepted values are {@code OBJECT_GUID,OBJECT_SID,CASE_CHANGE,DN_ATTRIBUTE_ENTRY,MERGE,PRIMARY_GROUP,RANGE_ENTRY,RECURSIVE_ENTRY, MERGE_ENTRIES}
      */
     private SearchEntryHandlerTypes type;
     /**
@@ -57,6 +57,13 @@ public class LdapSearchEntryHandlersProperties implements Serializable {
      */
     @NestedConfigurationProperty
     private RecursiveSearchEntryHandlersProperties recursive = new RecursiveSearchEntryHandlersProperties();
+
+    /**
+     * Merges the values of one or more attributes in all entries into a single attribute. The merged attribute may or may not already
+     * exist on the entry. If it does exist it's existing values will remain intact.
+     */
+    @NestedConfigurationProperty
+    private MergeAllEntriesAttributesSearchEntryHandlersProperties mergeAllAttribute = new MergeAllEntriesAttributesSearchEntryHandlersProperties();
 
     /**
      * The enum Search entry handler types.
@@ -94,6 +101,10 @@ public class LdapSearchEntryHandlersProperties implements Serializable {
         /**
          * Recursive entry search handler.
          */
-        RECURSIVE_ENTRY
+        RECURSIVE_ENTRY,
+        /**
+         * Merge entries handler.
+         */
+        MERGE_ENTRIES
     }
 }

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -1353,3 +1353,4 @@ The following types are supported:
 | `PRIMARY_GROUP` | Constructs the primary group SID and then searches for that group and puts it's DN in the 'memberOf' attribute of the original search entry. 
 | `RANGE_ENTRY` |  Rewrites attributes returned from Active Directory to include all values by performing additional searches.
 | `RECURSIVE_ENTRY` | This recursively searches based on a supplied attribute and merges those results into the original entry.
+| `MERGE_ENTRIES` | Merges all entries in the search result by merging the attributes with the same name.

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -61,12 +61,7 @@ import org.ldaptive.control.PasswordPolicyControl;
 import org.ldaptive.control.util.PagedResultsClient;
 import org.ldaptive.extended.ExtendedOperation;
 import org.ldaptive.extended.PasswordModifyRequest;
-import org.ldaptive.handler.CaseChangeEntryHandler;
-import org.ldaptive.handler.DnAttributeEntryHandler;
-import org.ldaptive.handler.LdapEntryHandler;
-import org.ldaptive.handler.MergeAttributeEntryHandler;
-import org.ldaptive.handler.RecursiveResultHandler;
-import org.ldaptive.handler.SearchResultHandler;
+import org.ldaptive.handler.*;
 import org.ldaptive.pool.BindConnectionPassivator;
 import org.ldaptive.pool.IdlePruneStrategy;
 import org.ldaptive.referral.FollowSearchReferralHandler;
@@ -1050,6 +1045,9 @@ public class LdapUtils {
                     searchResultHandlers.add(
                         new RecursiveResultHandler(recursive.getSearchAttribute(),
                             recursive.getMergeAttributes().toArray(ArrayUtils.EMPTY_STRING_ARRAY)));
+                    break;
+                case MERGE_ENTRIES:
+                    searchResultHandlers.add(new MergeResultHandler());
                     break;
                 default:
                     break;

--- a/support/cas-server-support-ldap-core/src/main/java/org/ldaptive/handler/MergeResultHandler.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/ldaptive/handler/MergeResultHandler.java
@@ -1,0 +1,41 @@
+package org.ldaptive.handler;
+
+import org.ldaptive.LdapUtils;
+import org.ldaptive.SearchResponse;
+
+/**
+ * Merges the values of the attributes in all entries into a single entry.
+ *
+ * TODO: REMOVE THIS CLASS
+ * THIS CLASS WAS ADDED IN ORDER TO TEST LDAPTATIVE CHANGES. SHOULD BE REMOVED
+ * AS SOON AS THE NEW LDAPTIVE LIBRARY IS RELEASED AND INCORPORATED TO CAS
+ *
+ * @author  Middleware Services
+ */
+public final class MergeResultHandler extends AbstractEntryHandler<SearchResponse> implements SearchResultHandler {
+
+    public MergeResultHandler() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return LdapUtils.computeHashCode(829);
+    }
+
+    public String toString() {
+        return "[" + this.getClass().getName() + "@" + this.hashCode() + "]";
+    }
+
+    @Override
+    public SearchResponse apply(SearchResponse searchResponse) {
+        return SearchResponse.merge(searchResponse);
+    }
+}

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/principal/PersonDirectoryMergeEntriesTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/principal/PersonDirectoryMergeEntriesTests.java
@@ -1,0 +1,70 @@
+package org.apereo.cas.authentication.principal;
+
+import lombok.val;
+import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.authentication.CoreAuthenticationUtils;
+import org.apereo.cas.authentication.credential.UsernamePasswordCredential;
+import org.apereo.cas.authentication.handler.support.SimpleTestUsernamePasswordAuthenticationHandler;
+import org.apereo.cas.authentication.principal.resolvers.ChainingPrincipalResolver;
+import org.apereo.cas.authentication.principal.resolvers.EchoingPrincipalResolver;
+import org.apereo.cas.config.CasPersonDirectoryConfiguration;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.util.junit.EnabledIfPortOpen;
+import org.apereo.services.persondir.IPersonAttributeDao;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This is {@link PersonDirectoryMergeEntriesTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+@SpringBootTest(classes = {
+    CasPersonDirectoryConfiguration.class,
+    RefreshAutoConfiguration.class
+}, properties = {
+    "cas.authn.attribute-repository.ldap[0].base-dn=dc=example,dc=org",
+    "cas.authn.attribute-repository.ldap[0].ldap-url=ldap://localhost:10389",
+    "cas.authn.attribute-repository.ldap[0].search-filter=uniqueMember=cn=Directory Manager",
+    "cas.authn.attribute-repository.ldap[0].attributes.cn=cn",
+    "cas.authn.attribute-repository.ldap[0].attributes.description=description",
+    "cas.authn.attribute-repository.ldap[0].attributes.entryDN=entryDN",
+    "cas.authn.attribute-repository.ldap[0].search-entry-handlers[0].type=MERGE_ENTRIES"
+})
+@DirtiesContext
+@Tag("Ldap")
+@EnabledIfPortOpen(port = 10389)
+public class PersonDirectoryMergeEntriesTests {
+    @Autowired
+    @Qualifier("attributeRepository")
+    private IPersonAttributeDao attributeRepository;
+
+    @Autowired
+    private CasConfigurationProperties casProperties;
+
+    @Test
+    public void verifyResolver() {
+        val resolver = CoreAuthenticationUtils.newPersonDirectoryPrincipalResolver(PrincipalFactoryUtils.newPrincipalFactory(),
+            this.attributeRepository, casProperties.getPersonDirectory());
+        val p = resolver.resolve(new UsernamePasswordCredential("admin", "password"),
+            Optional.of(CoreAuthenticationTestUtils.getPrincipal()),
+            Optional.of(new SimpleTestUsernamePasswordAuthenticationHandler()));
+        assertNotNull(p);
+        assertTrue(p.getAttributes().containsKey("description"));
+        assertTrue(p.getAttributes().containsKey("entryDN"));
+    }
+}


### PR DESCRIPTION
Dear all,

I have added a search handler that uses the SearchResults.merge() function to join (or merge) all the entries by attribute name. I added the functionality to LDAPTIVE in [pull 191](https://github.com/vt-middleware/ldaptive/pull/191).

The use case is to collect emails belonging to the same person with the search handler.

The person (the authenticated entry in CAS) is like this:

dn: person:1234,o=people,dc=...
person: 1234
...

The email entries are like this:

dn: my@mail.com,dc=...
mail:, my@mail.com
owner: person:1234,o=people,dc=...
...


It's still **pending to upgrade ldaptive version** once it is released and then remove the copy in the source project. Meanwhile, do you need further details or add any ioher unit tests?

Bests regards,
Miguel