### PR TITLE
fix: always show the label for the "resolved attributes" tables

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casGenericSuccessView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casGenericSuccessView.html
@@ -23,7 +23,7 @@
                 When you are finished, for security reasons, please <a href="logout">log out</a> and exit your web browser.
             </p>
 
-            <p th:unless="${#maps.isEmpty(authentication.principal.attributes)}">
+            <p>
                 The following attributes and services are resolved and available for <strong th:utext="${authentication.principal.id}" />:
             
                 <div id="attribute-tabs" class="mdc-tab-bar" role="tablist">


### PR DESCRIPTION
This fix makes the label over the "resolved attributes" tables (shown after a successful login when "service" is not specified in the request) always displayed - because the tables themselves are also always shown.

Insight: With the current implementation (possibly due to nesting `<div>` inside `<p>`?), the attributes table is displayed anyway, even when there are only `authentication.attributes` present. So using the `th:unless` condition doesn't make much sense here.

Note: I have tested this against 6.2.x (see #5103), but I believe the very same problem exists in the newer CAS versions, although I didn't have time to fully test them yet.

-----

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [ ] Test cases for all modified changes, where applicable -- N/A
- [ ] The same pull request targeted at the master branch, if applicable -- TODO
- [ ] Any documentation on how to configure, test -- N/A
- [ ] Any possible limitations, side effects, etc -- N/A
- [ ] Reference any other pull requests that might be related -- N/A
