### PR TITLE
Avoid duplicate service in DomainManager when a service is edited

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/domain/DefaultDomainAwareServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/domain/DefaultDomainAwareServicesManager.java
@@ -52,7 +52,7 @@ public class DefaultDomainAwareServicesManager extends AbstractServicesManager i
             ? map.get(domain)
             : new TreeSet<RegisteredService>();
         LOGGER.debug("Added service [{}] mapped to domain definition [{}]", r, domain);
-        services.remove(findServiceBy(r.getId()));
+        services.removeIf(s -> s.getId() == r.getId());
         services.add(r);
         map.put(domain, services);
     }

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/domain/DefaultDomainAwareServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/domain/DefaultDomainAwareServicesManager.java
@@ -52,6 +52,7 @@ public class DefaultDomainAwareServicesManager extends AbstractServicesManager i
             ? map.get(domain)
             : new TreeSet<RegisteredService>();
         LOGGER.debug("Added service [{}] mapped to domain definition [{}]", r, domain);
+        services.remove(findServiceBy(r.getId()));
         services.add(r);
         map.put(domain, services);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Platform metadata for releases, POM generation, etc.
 #################################################
 group=org.apereo.cas
-version=6.3.3-SNAPSHOT
+version=6.3.3-SNAPSHOT-DOMAIN
 
 projectUrl=https://www.apereo.org/cas
 projectInceptionYear=2004

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Platform metadata for releases, POM generation, etc.
 #################################################
 group=org.apereo.cas
-version=6.3.3-SNAPSHOT-DOMAIN
+version=6.3.3-SNAPSHOT
 
 projectUrl=https://www.apereo.org/cas
 projectInceptionYear=2004


### PR DESCRIPTION
PR provides a solution to an issue that mostly affects CAS Manager.  If a change is made to one of the fields in a service that is part of the compareTo() method, the changed service is added as a new service in the domain instead of replacing the existing service in the map.  This fix removes a service by Id if found in the domain before adding the edited service to the domain map to avoid the duplicate.  