### PR TITLE
fix tests on windows

### DIFF
--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -96,6 +96,7 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
 
             val git = Git.init().setDirectory(gitDir).setBare(false).call();
             FileUtils.write(new File(gitDir, "readme.txt"), "text", StandardCharsets.UTF_8);
+            git.add().addFilepattern("*.txt").call();
             git.commit().setSign(false).setMessage("Initial commit").call();
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -127,11 +127,11 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
 
     @AfterAll
     public static void cleanUp() throws Exception {
-        PathUtils.delete(new File(FileUtils.getTempDirectory() + "cas-sample-data").toPath(),
-                StandardDeleteOption.OVERRIDE_READ_ONLY);
+        val gitRepoDir = new File(FileUtils.getTempDirectory(), "cas-sample-data");
+        PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY);
         val gitDir = new File(FileUtils.getTempDirectory(), GitServiceRegistryProperties.DEFAULT_CAS_SERVICE_REGISTRY_NAME);
         if (gitDir.exists()) {
-            PathUtils.delete(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY);
+            PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY);
         }
     }
 }

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -92,6 +92,7 @@ public class GitServiceRegistryTests extends AbstractServiceRegistryTests {
             }
             val gitSampleRepo = Git.init().setDirectory(gitRepoSampleDir).setBare(false).call();
             FileUtils.write(new File(gitRepoSampleDir, "readme.txt"), "text", StandardCharsets.UTF_8);
+            gitSampleRepo.add().addFilepattern("*.txt").call();
             gitSampleRepo.commit().setSign(false).setMessage("Initial commit").call();
 
             val git = Git.init().setDirectory(gitDir).setBare(false).call();

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataGeneratorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataGeneratorTests.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestPropertySource(properties = {
     "cas.authn.saml-idp.metadata.git.sign-commits=false",
     "cas.authn.saml-idp.metadata.git.idp-metadata-enabled=true",
-    "cas.authn.saml-idp.metadata.git.repository-url=file://${java.io.tmpdir}/cas-saml-metadata.git"
+    "cas.authn.saml-idp.metadata.git.repository-url=file://${java.io.tmpdir}/cas-saml-metadata"
 })
 @Tag("FileSystem")
 @Slf4j

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataGeneratorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataGeneratorTests.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestPropertySource(properties = {
     "cas.authn.saml-idp.metadata.git.sign-commits=false",
     "cas.authn.saml-idp.metadata.git.idp-metadata-enabled=true",
-    "cas.authn.saml-idp.metadata.git.repository-url=file:${java.io.tmpdir}/cas-saml-metadata.git"
+    "cas.authn.saml-idp.metadata.git.repository-url=file://${java.io.tmpdir}/cas-saml-metadata.git"
 })
 @Tag("FileSystem")
 @Slf4j

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataLocatorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataLocatorTests.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,7 +32,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestPropertySource(properties = {
     "cas.authn.saml-idp.metadata.git.sign-commits=false",
     "cas.authn.saml-idp.metadata.git.idp-metadata-enabled=true",
-    "cas.authn.saml-idp.metadata.git.repository-url=file://${java.io.tmpdir}/cas-metadata-idp"
+    "cas.authn.saml-idp.metadata.git.repository-url=file://${java.io.tmpdir}/cas-metadata-idp",
+    "cas.authn.saml-idp.metadata.git.clone-directory.location=file://${java.io.tmpdir}/cas-saml-metadata-gsimlt"
 })
 @Tag("FileSystem")
 @Slf4j
@@ -42,9 +44,7 @@ public class GitSamlIdPMetadataLocatorTests extends BaseGitSamlMetadataTests {
     public static void setup() {
         try {
             val gitDir = new File(FileUtils.getTempDirectory(), "cas-metadata-idp");
-            if (gitDir.exists()) {
-                PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY);
-            }
+            cleanUp();
             if (!gitDir.mkdir()) {
                 throw new IllegalArgumentException("Git repository directory location " + gitDir + " cannot be located/created");
             }
@@ -63,6 +63,16 @@ public class GitSamlIdPMetadataLocatorTests extends BaseGitSamlMetadataTests {
         val gitRepoDir = new File(FileUtils.getTempDirectory(), "cas-metadata-idp");
         if (gitRepoDir.exists()) {
             PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY);
+        }
+        val cloneDirectory = "cas-saml-metadata-gsimlt";
+        val gitCloneRepoDir = new File(FileUtils.getTempDirectory(), cloneDirectory);
+        val cloneRepoPath = gitCloneRepoDir.toPath();
+        if (gitCloneRepoDir.exists()) {
+            try {
+                PathUtils.deleteDirectory(cloneRepoPath, StandardDeleteOption.OVERRIDE_READ_ONLY);
+            } catch (final FileSystemException e) {
+                LOGGER.warn("Can't cleanup [{}] until bean closed: [{}]", cloneRepoPath, e.getMessage());
+            }
         }
     }
 

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataLocatorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataLocatorTests.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestPropertySource(properties = {
     "cas.authn.saml-idp.metadata.git.sign-commits=false",
     "cas.authn.saml-idp.metadata.git.idp-metadata-enabled=true",
-    "cas.authn.saml-idp.metadata.git.repository-url=file:${java.io.tmpdir}/cas-metadata-idp"
+    "cas.authn.saml-idp.metadata.git.repository-url=file://${java.io.tmpdir}/cas-metadata-idp"
 })
 @Tag("FileSystem")
 @Slf4j
@@ -50,6 +50,7 @@ public class GitSamlIdPMetadataLocatorTests extends BaseGitSamlMetadataTests {
             }
             val git = Git.init().setDirectory(gitDir).setBare(false).call();
             FileUtils.write(new File(gitDir, "readme.txt"), "text", StandardCharsets.UTF_8);
+            git.add().addFilepattern("*.txt").call();
             git.commit().setSign(false).setMessage("Initial commit").call();
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolverTests.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
     "cas.authn.saml-idp.metadata.git.sign-commits=false",
     "cas.authn.saml-idp.metadata.git.push-changes=true",
     "cas.authn.saml-idp.metadata.git.idp-metadata-enabled=true",
-    "cas.authn.saml-idp.metadata.git.repository-url=file:${java.io.tmpdir}/cas-metadata-data"
+    "cas.authn.saml-idp.metadata.git.repository-url=file://${java.io.tmpdir}/cas-metadata-data"
 })
 @Slf4j
 @Tag("FileSystem")
@@ -54,6 +54,7 @@ public class GitSamlRegisteredServiceMetadataResolverTests extends BaseGitSamlMe
             }
             val git = Git.init().setDirectory(gitDir).setBare(false).call();
             FileUtils.write(new File(gitDir, "readme.txt"), "text", StandardCharsets.UTF_8);
+            git.add().addFilepattern("*.txt").call();
             git.commit().setSign(false).setMessage("Initial commit").call();
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);


### PR DESCRIPTION
These tests worked locally on windows. The `file:` url instead of `file://` might work on other platforms but jgit seems to treat "file" as a hostname if it sees file:C:\Users\xyz\temp. I also did an add before the commit, not sure that is necessary but it seemed like it was writing a file before commit and I think the commit was ending up empty. 