### PR TITLE
build(gradle): fixing when logs deletion happens for cleanLogs task

### DIFF
--- a/gradle/tasks.gradle
+++ b/gradle/tasks.gradle
@@ -58,7 +58,9 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 task cleanLogs(description: "Clean build log files") {
-    delete fileTree(dir: project.projectDir, includes: ["**/*.log", "**/*.gz", "**/*.log.gz", "**/*.orig"])
+    doLast {
+        delete fileTree(dir: project.projectDir, includes: ["**/*.log", "**/*.gz", "**/*.log.gz", "**/*.orig"])
+    }
 }
 
 task showConfiguration {


### PR DESCRIPTION
Probably unintentionally, cleanLogs task body was executed in the configuration phase already, i. e. every time. Moving it to the execution phase - this improves builds' performance greatly.

For example, the fix seems to spare about 20 seconds for every Gradle build run on my Windows. It wouldn't be probably that much on a Linux machine (or a faster PC 😉 ).

Another positive side effect is avoiding this error when you've got CAS Tomcat currently running:

```
$ ./gradlew <anything>
Starting a Gradle Daemon (subsequent builds will be faster)
Configuration on demand is an incubating feature.

FAILURE: Build failed with an exception.

* Where:
Script 'D:\projects\my-forks\cas\gradle\tasks.gradle' line: 61

* What went wrong:
A problem occurred evaluating script.
> java.io.IOException: Unable to delete file 'D:\projects\my-forks\cas\build\tomcat\logs\access_log.2021-03-28.log'
```

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
