### PR TITLE
fix: keep honoring language requested in "Accept-Language" header

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/CasLocaleChangeInterceptor.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/CasLocaleChangeInterceptor.java
@@ -26,8 +26,7 @@ public class CasLocaleChangeInterceptor extends LocaleChangeInterceptor {
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
                              final Object handler) throws ServletException {
-        val newLocale = request.getParameter(localeProperties.getParamName());
-        if (localeProperties.isForceDefaultLocale() || StringUtils.isBlank(newLocale)) {
+        if (localeProperties.isForceDefaultLocale()) {
             val localeResolver = RequestContextUtils.getLocaleResolver(request);
             if (localeResolver != null) {
                 val locale = new Locale(localeProperties.getDefaultValue());

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/CasLocaleChangeInterceptorTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/CasLocaleChangeInterceptorTests.java
@@ -23,8 +23,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("Web")
 public class CasLocaleChangeInterceptorTests {
 
+    // note: default request locale returned from MockHttpServletRequest is ENGLISH
+    
     @Test
-    public void verifyOp() throws Exception {
+    public void verifyRequestHeaderBeatsCasDefault() throws Exception {
         val request = new MockHttpServletRequest();
         val response = new MockHttpServletResponse();
 
@@ -32,11 +34,11 @@ public class CasLocaleChangeInterceptorTests {
         request.setAttribute(DispatcherServlet.LOCALE_RESOLVER_ATTRIBUTE, resolver);
         val interceptor = new CasLocaleChangeInterceptor(new LocaleProperties().setDefaultValue("fr"));
         interceptor.preHandle(request, response, new Object());
-        assertEquals(Locale.FRENCH, resolver.resolveLocale(request));
+        assertEquals(Locale.ENGLISH, resolver.resolveLocale(request));
     }
 
     @Test
-    public void verifyOpWithParam() throws Exception {
+    public void verifyRequestParamBeatsCasDefault() throws Exception {
         val request = new MockHttpServletRequest();
         request.addParameter("locale", "it");
         val response = new MockHttpServletResponse();
@@ -48,11 +50,10 @@ public class CasLocaleChangeInterceptorTests {
         assertEquals(Locale.ITALIAN, resolver.resolveLocale(request));
     }
 
-
     @Test
-    public void verifyForceOpWithParam() throws Exception {
+    public void verifyForcedCasDefaultBeatsAll() throws Exception {
         val request = new MockHttpServletRequest();
-        request.addParameter("locale", "de");
+        request.addParameter("locale", "it");
         val response = new MockHttpServletResponse();
 
         val resolver = new SessionLocaleResolver();
@@ -62,15 +63,4 @@ public class CasLocaleChangeInterceptorTests {
         assertEquals(Locale.FRENCH, resolver.resolveLocale(request));
     }
 
-    @Test
-    public void verifyDefault() throws Exception {
-        val request = new MockHttpServletRequest();
-        val response = new MockHttpServletResponse();
-
-        val resolver = new SessionLocaleResolver();
-        request.setAttribute(DispatcherServlet.LOCALE_RESOLVER_ATTRIBUTE, resolver);
-        val interceptor = new CasLocaleChangeInterceptor(new LocaleProperties());
-        interceptor.preHandle(request, response, new Object());
-        assertEquals(Locale.ENGLISH, resolver.resolveLocale(request));
-    }
 }


### PR DESCRIPTION
The previous version of `CasLocaleChangeInterceptor` would lead to users being surprised, because their preferred language set in their browser / OS wouldn't be taken into account anymore. I. e. ignore the client's preferences only when `cas.locale.force-default-locale=true` is set.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
