### PR TITLE
WIP, Modifications to support new SearchDnResolver's resolveFromAttribute parameter

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/ldap/AbstractLdapAuthenticationProperties.java
@@ -69,6 +69,10 @@ public abstract class AbstractLdapAuthenticationProperties extends AbstractLdapS
      * </ul>
      */
     private String derefAliases;
+    /**
+     * If this attribute is set, the value found in the first attribute value will be used in place of the DN.
+     */
+    private String resolveFromAttribute;
 
     /**
      * The enum Authentication types.

--- a/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Properties-Common.md
@@ -1305,6 +1305,7 @@ The following  options apply  given the provider's *configuration key*:
 # ${configurationKey}.deref-aliases=NEVER|SEARCHING|FINDING|ALWAYS
 # ${configurationKey}.dn-format=uid=%s,ou=people,dc=example,dc=org
 # ${configurationKey}.principal-attribute-password=password
+# ${configurationKey}.resolve-from-attribute=
 
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -235,7 +235,7 @@ userInfoVersion=1.1.0
 retrofit1Version=1.9.0
 gsonVersion=2.8.6
 
-ldaptiveVersion=2.0.0-RC5
+ldaptiveVersion=2.0.2-SNAPSHOT
 unboundidVersion=5.0.1
 
 jcifsVersion=1.3.17

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -638,6 +638,7 @@ public class LdapUtils {
         resolver.setAllowMultipleDns(l.isAllowMultipleDns());
         resolver.setConnectionFactory(connectionFactoryForSearch);
         resolver.setUserFilter(l.getSearchFilter());
+        resolver.setResolveFromAttribute(l.getResolveFromAttribute());
 
         if (l.isFollowReferrals()) {
             resolver.setSearchResultHandlers(new FollowSearchReferralHandler());

--- a/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/DnFromAttributeAuthenticationHandlerTests.java
+++ b/support/cas-server-support-ldap/src/test/java/org/apereo/cas/authentication/DnFromAttributeAuthenticationHandlerTests.java
@@ -1,0 +1,51 @@
+package org.apereo.cas.authentication;
+
+import lombok.val;
+import org.apereo.cas.authentication.credential.UsernamePasswordCredential;
+import org.apereo.cas.util.junit.EnabledIfPortOpen;
+import org.jooq.lambda.Unchecked;
+import org.jooq.lambda.UncheckedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import javax.security.auth.login.AccountNotFoundException;
+
+import java.util.Arrays;
+
+import static org.apereo.cas.util.junit.Assertions.assertThrowsWithRootCause;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit test for {@link LdapAuthenticationHandler}.
+ *
+ * @author Marvin S. Addison
+ * @author Misagh Moayyed
+ * @since 4.0.0
+ */
+@TestPropertySource(properties = {
+    "cas.authn.ldap[0].type=AUTHENTICATED",
+    "cas.authn.ldap[0].ldap-url=ldap://localhost:10389",
+    "cas.authn.ldap[0].base-dn=dc=example,dc=org",
+    "cas.authn.ldap[0].search-filter=cn={user}",
+    "cas.authn.ldap[0].bind-dn=cn=Directory Manager",
+    "cas.authn.ldap[0].bind-credential=password",
+    "cas.authn.ldap[0].resolve-from-attribute=owner",
+    "cas.authn.ldap[0].principal-attribute-list=description,cn"
+    })
+@EnabledIfPortOpen(port = 10389)
+@Tag("Ldap")
+public class DnFromAttributeAuthenticationHandlerTests extends BaseLdapAuthenticationHandlerTests {
+
+    @Override
+    String getUsername() {
+        return "PD Managers";
+    }
+
+    @Override
+    String getSuccessPassword() {
+        return "password";
+    }
+}


### PR DESCRIPTION
Dear all,

By default, CAS LDAP module in the AUTHENTICATED or ANONYMOUS configuration will search for an entry using the search settings, obtain the entry's DN, authenticate against that DN, and then proceed with attribute resolution.

I have included the code for allowing to use an arbitrary LDAP entry's attribute to use to autenticate against. The solution is to add a resolveFromAttribute in the SearchDnResolver that, when present, will make the resolver to try to autenticate using the DN on the attribute specificated. 

I added an example in LDAPTIVE:
https://github.com/vt-middleware/ldaptive/pull/192#issue-572715575

For the test, I have used a modified version of the mmoayyed/ldap Docker image. The modification is the following:

#ldapmodify ...
dn: cn=PD Managers,ou=Groups,dc=example,dc=org
changetype: modify
add: owner
owner: cn=admin,dc=example,dc=org

In this example, the test defines the new configuration parameter set to:
cas.authn.ldap[0].resolve-from-attribute=owner

The test checks that the user can authenticate using PD Managers as username and admin's credential.

The ldaptive dependency is set to 2.0.2-SNAPSHOT (compiled from PR https://github.com/vt-middleware/ldaptive/pull/192).

WIP, things to do:
- Update the depedency when LDAPTIVE is ready (I will follow ldaptive and update the PR)
- Add sample to mmoayyed/ldap Docker image or other place to not break the build (I contact to Misagh if needed).

Do you see any problem with this implementation?

Best regards,
Miguel
