### PR TITLE
build(gradle): build jars after every compilation again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,6 +408,11 @@ subprojects {
         it.options.compilerArgs += casCompilerArgs
     }
 
+    def currentTime = java.time.ZonedDateTime.now(ZoneId.systemDefault())
+    compileJava.doLast {
+        buildDate = currentTime
+    }
+
     tasks.jar.onlyIf {
         project.buildDate != null || !project.buildJarFile.exists()
     }


### PR DESCRIPTION
Explanation: `buildDate` is tested in `tasks.jar.onlyIf` and the committed code was removed in 6c1ac15204a8745a2 probably just by an accident.

So with this fix, we should get a normal "incremental" build behavior again, for example:

1. Have CAS completely built, e. g. in "cas\webapp\cas-server-webapp\build\libs\cas-server-webapp-6.4.0-SNAPSHOT.war".
1. Change a class in one of CAS library projects.
2. Run CAS build again, without running clean and without manually removing the library jar from "build/libs" of the project.
3. The library project gets correctly recompiled.
4. _With the fix_, we also get a new library jar, which also appears within the CAS war. _Without the fix_, we don't get any of this.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
