### PR TITLE
wrong file use for whatwg-fetch.js (export error problem in browser)

### DIFF
--- a/core/cas-server-core-web/src/main/resources/cas_common_messages.properties
+++ b/core/cas-server-core-web/src/main/resources/cas_common_messages.properties
@@ -19,7 +19,7 @@ webjars.cssVarsPonyfill.js=/webjars/css-vars-ponyfill/${cssVarsPonyfillVersion}/
 
 webjars.text-encoding.js=/webjars/text-encoding/${textEncodingVersion}/lib/encoding.js
 webjars.text-encoding-indexes.js=/webjars/text-encoding/${textEncodingVersion}/lib/encoding-indexes.js
-webjars.whatwg-fetch.js=/webjars/whatwg-fetch/${whatWgFetchVersion}/fetch.js
+webjars.whatwg-fetch.js=/webjars/whatwg-fetch/${whatWgFetchVersion}/dist/fetch.umd.js
 webjars.base64.js=/webjars/base64-js/${base64JsVersion}/base64js.min.js
 
 webjars.socket.js=/webjars/sockjs-client/${socketJsClientVersion}/sockjs.min.js


### PR DESCRIPTION
Hello, i found a bug. There was use wrong js file for whatwg-fetch. Pointing to the Issue here https://github.com/github/fetch/issues/656#issuecomment-420219378 i fix this. And problem with unknown word export disapear.