### PR TITLE
Allow to invoke actuator's GET /ssoSessions with no type query parameter

### DIFF
--- a/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
+++ b/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -112,7 +113,7 @@ public class SingleSignOnSessionsEndpoint extends BaseCasActuatorEndpoint {
     @ReadOperation
     public Map<String, Object> getSsoSessions(final String type) {
         val sessionsMap = new HashMap<String, Object>();
-        val option = SsoSessionReportOptions.valueOf(type);
+        val option = Optional.ofNullable(type).map(SsoSessionReportOptions::valueOf).orElse(SsoSessionReportOptions.ALL);
         val activeSsoSessions = getActiveSsoSessions(option);
         sessionsMap.put("activeSsoSessions", activeSsoSessions);
         val totalTicketGrantingTickets = new AtomicLong();

--- a/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpointTests.java
+++ b/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpointTests.java
@@ -100,6 +100,8 @@ public class SingleSignOnSessionsEndpointTests extends AbstractCasEndpointTests 
         centralAuthenticationService.addTicket(tgt);
         val results = singleSignOnSessionsEndpoint.getSsoSessions(SingleSignOnSessionsEndpoint.SsoSessionReportOptions.ALL.getType());
         assertFalse(results.isEmpty());
+        results = singleSignOnSessionsEndpoint.getSsoSessions(null);
+        assertFalse(results.isEmpty());
     }
 
     @Test
@@ -108,6 +110,8 @@ public class SingleSignOnSessionsEndpointTests extends AbstractCasEndpointTests 
         tgt.setProxiedBy(CoreAuthenticationTestUtils.getWebApplicationService());
         centralAuthenticationService.addTicket(tgt);
         val results = singleSignOnSessionsEndpoint.getSsoSessions(SingleSignOnSessionsEndpoint.SsoSessionReportOptions.DIRECT.getType());
+        assertFalse(results.isEmpty());
+        results = singleSignOnSessionsEndpoint.getSsoSessions(null);
         assertFalse(results.isEmpty());
     }
 


### PR DESCRIPTION
Currently, invoking `GET /ssoSessions` without passing any `?type=` gives an error. This makes this endpoint not callable by SpringBoot Admin Server UI.