### PR TITLE
fix mongo dependencies, otherwise will get older version from springboot

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1667,6 +1667,9 @@ ext.libraries = [
                     exclude(group: "commons-cli", module: "commons-cli")
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 },
+                dependencies.create("org.mongodb:bson:$mongoDriverVersion") {
+                    exclude(group: "org.slf4j", module: "slf4j-api")
+                },
                 dependencies.create("org.springframework.data:spring-data-mongodb:$springDataMongoDbVersion") {
                     exclude(group: "commons-logging", module: "commons-logging")
                     exclude(group: "org.slf4j", module: "jcl-over-slf4j")


### PR DESCRIPTION
Trying to run RC3 build got this error: 
```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.mongodb.MongoClientSettings]: Factory method 'mongoClientSettings' threw exception; nested exception is java.lang.NoClassDefFoundError: org/bson/codecs/JsonObjectCodecProvider
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:185)
        at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:653)
        ... 27 more
Caused by: java.lang.NoClassDefFoundError: org/bson/codecs/JsonObjectCodecProvider
        at com.mongodb.MongoClientSettings.<clinit>(MongoClientSettings.java:61)
        at org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration$MongoClientSettingsConfiguration.mongoClientSettings(MongoAutoConfiguration.java:64)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154)
        ... 28 more
Caused by: java.lang.ClassNotFoundException: org.bson.codecs.JsonObjectCodecProvider
        at java.base/java.net.URLClassLoader.findClass(Unknown Source)
        at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
        at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:151)
        at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
        ... 35 more
```

WAR had these jars:
```
runner@fv-az108-531:~/work/cas-initializr/cas-initializr$ jar -tf ./tmp/cas-overlay/build/libs/app.war | grep mongo
WEB-INF/lib/cas-server-support-mongo-core-6.4.0-RC3.jar
WEB-INF/lib/mongodb-driver-sync-4.2.2.jar
WEB-INF/lib/mongodb-driver-core-4.2.2.jar
WEB-INF/lib/spring-data-mongodb-3.1.7.jar
runner@fv-az108-531:~/work/cas-initializr/cas-initializr$ jar -tf ./tmp/cas-overlay/build/libs/app.war | grep bson
WEB-INF/lib/bson-4.1.2.jar
```

bson version needs to be 4.2.2 
