### PR TITLE
Oauth not using service matching strategy to verify redirect_uri

### DIFF
--- a/docs/cas-server-documentation/release_notes/RC4.md
+++ b/docs/cas-server-documentation/release_notes/RC4.md
@@ -70,6 +70,8 @@ CAS test coverage across all modules in the codebase has now reached `91%` and c
 - CAS CI builds are updated to ensure all web application types can be deployed successfully via external servlet containers.
 - System properties used during the build now use the proper Gradle API to respect the configuration cache.
 - Additional puppeteer tests to ensure authentication interrupts do function correctly with or without authentication warnings.
+- The `authenticationHandlers` actuator endpoint is corrected to respond with the collection of registered authentication handlers.
+- The `xml-apis` module dependency is now removed from the CAS dependency graph.
 
 ## Library Upgrades
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
@@ -388,13 +388,14 @@ public class OAuth20Utils {
      * @param redirectUri       the callback url
      * @return whether the callback url is valid
      */
-    public static boolean checkCallbackValid(final @NonNull RegisteredService registeredService, final String redirectUri) {
-        val registeredServiceId = registeredService.getServiceId();
-        if (!redirectUri.matches(registeredServiceId)) {
+    public static boolean checkCallbackValid(final @NonNull RegisteredService registeredService,
+                                             final String redirectUri) {
+        val matchingStrategy = registeredService.getMatchingStrategy();
+        if (matchingStrategy == null || !matchingStrategy.matches(registeredService, redirectUri)) {
             LOGGER.error("Unsupported [{}]: [{}] does not match what is defined for registered service: [{}]. "
                     + "Service is considered unauthorized. Verify the service definition in the registry is correct "
                     + "and does in fact match the client [{}]",
-                OAuth20Constants.REDIRECT_URI, redirectUri, registeredServiceId, redirectUri);
+                OAuth20Constants.REDIRECT_URI, redirectUri, registeredService.getServiceId(), redirectUri);
             return false;
         }
         return true;

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
@@ -393,8 +393,8 @@ public class OAuth20Utils {
         val matchingStrategy = registeredService.getMatchingStrategy();
         if (matchingStrategy == null || !matchingStrategy.matches(registeredService, redirectUri)) {
             LOGGER.error("Unsupported [{}]: [{}] does not match what is defined for registered service: [{}]. "
-                    + "Service is considered unauthorized. Verify the service definition in the registry is correct "
-                    + "and does in fact match the client [{}]",
+                    + "Service is considered unauthorized. Verify the service matching strategy used in the service "
+                    + "definition is correct and does in fact match the client [{}]",
                 OAuth20Constants.REDIRECT_URI, redirectUri, registeredService.getServiceId(), redirectUri);
             return false;
         }

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
@@ -1,6 +1,8 @@
 package org.apereo.cas.support.oauth.util;
 
 import org.apereo.cas.CasProtocolConstants;
+import org.apereo.cas.services.FullRegexRegisteredServiceMatchingStrategy;
+import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.oauth.OAuth20Constants;
@@ -79,6 +81,17 @@ public class OAuth20UtilsTests {
         assertTrue(OAuth20Utils.isAuthorizedGrantTypeForService(context, registeredService));
         assertTrue(OAuth20Utils.isAuthorizedGrantTypeForService(
             OAuth20GrantTypes.PASSWORD.getType(), new OAuthRegisteredService()));
+    }
+
+    @Test
+    public void verifyCheckCallbackValid() {
+        val registeredService = mock(RegisteredService.class);
+        when(registeredService.getServiceId()).thenReturn("http://test.org/.*");
+        when(registeredService.getMatchingStrategy()).thenReturn(null);
+        assertFalse(OAuth20Utils.checkCallbackValid(registeredService, "http://test.org/cas"));
+        when(registeredService.getMatchingStrategy()).thenReturn(new FullRegexRegisteredServiceMatchingStrategy());
+        assertTrue(OAuth20Utils.checkCallbackValid(registeredService, "http://test.org/cas"));
+        assertFalse(OAuth20Utils.checkCallbackValid(registeredService, "http://test2.org/cas"));
     }
 
     @Test

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/util/OAuth20UtilsTests.java
@@ -2,7 +2,6 @@ package org.apereo.cas.support.oauth.util;
 
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.services.FullRegexRegisteredServiceMatchingStrategy;
-import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.oauth.OAuth20Constants;
@@ -85,11 +84,11 @@ public class OAuth20UtilsTests {
 
     @Test
     public void verifyCheckCallbackValid() {
-        val registeredService = mock(RegisteredService.class);
-        when(registeredService.getServiceId()).thenReturn("http://test.org/.*");
-        when(registeredService.getMatchingStrategy()).thenReturn(null);
+        val registeredService = new OAuthRegisteredService();
+        registeredService.setServiceId("http://test.org/.*");
+        registeredService.setMatchingStrategy(null);
         assertFalse(OAuth20Utils.checkCallbackValid(registeredService, "http://test.org/cas"));
-        when(registeredService.getMatchingStrategy()).thenReturn(new FullRegexRegisteredServiceMatchingStrategy());
+        registeredService.setMatchingStrategy(new FullRegexRegisteredServiceMatchingStrategy());
         assertTrue(OAuth20Utils.checkCallbackValid(registeredService, "http://test.org/cas"));
         assertFalse(OAuth20Utils.checkCallbackValid(registeredService, "http://test2.org/cas"));
     }


### PR DESCRIPTION
This change is to use the service matching strategy with oauth, actually it always compares with a regex but if someone creates a new custom service matching strategy it is not being used and the application is rejected saying it is not supported. Applications that are not using a custom strategy should not be affected by this change because FullRegexRegisteredServiceMatchingStrategy is used by default.