### PR TITLE
Backport internal validation for SAML support

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/util/InternalTicketValidator.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/util/InternalTicketValidator.java
@@ -1,4 +1,4 @@
-package org.apereo.cas.support.oauth.profile;
+package org.apereo.cas.util;
 
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.principal.ServiceFactory;
@@ -14,13 +14,13 @@ import org.jasig.cas.client.validation.TicketValidator;
 import java.util.Map;
 
 /**
- * This is a ticket validator for pac4j client that uses CAS back channels to validate ST.
+ * This is a ticket validator that uses CAS back channels to validate ST.
  *
  * @author Kirill Gagarski
  * @since 6.1.0
  */
 @RequiredArgsConstructor
-public class CasServerApiBasedTicketValidator implements TicketValidator {
+public class InternalTicketValidator implements TicketValidator {
     private final CentralAuthenticationService centralAuthenticationService;
 
     private final ServiceFactory<WebApplicationService> webApplicationServiceFactory;

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -36,6 +36,7 @@ import org.apereo.cas.ticket.registry.DistributedTicketRegistryTests;
 import org.apereo.cas.ticket.serialization.DefaultTicketStringSerializationManagerTests;
 import org.apereo.cas.util.DefaultUniqueTicketIdGeneratorTests;
 import org.apereo.cas.util.GroovyUniqueTicketIdGeneratorTests;
+import org.apereo.cas.util.InternalTicketValidatorTests;
 import org.apereo.cas.util.TicketEncryptionDecryptionTests;
 
 import org.junit.platform.runner.JUnitPlatform;
@@ -83,6 +84,7 @@ import org.junit.runner.RunWith;
     NeverExpiresExpirationPolicyTests.class,
     DefaultTicketRegistryCleanerTests.class,
     TicketSerializersTests.class,
+    InternalTicketValidatorTests.class,
     Cas20ProxyHandlerTests.class,
     GroovyUniqueTicketIdGeneratorTests.class,
     DefaultTicketCatalogTests.class

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/InternalTicketValidatorTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/util/InternalTicketValidatorTests.java
@@ -1,6 +1,5 @@
-package org.apereo.cas.support.oauth.profile;
+package org.apereo.cas.util;
 
-import org.apereo.cas.AbstractOAuth20Tests;
 import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.authentication.principal.WebApplicationServiceFactory;
@@ -15,13 +14,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * This is {@link CasServerApiBasedTicketValidatorTests}.
+ * This is {@link InternalTicketValidatorTests}.
  *
  * @author Misagh Moayyed
  * @since 6.3.0
  */
-@Tag("OAuth")
-public class CasServerApiBasedTicketValidatorTests extends AbstractOAuth20Tests {
+@Tag("Tickets")
+public class InternalTicketValidatorTests {
 
     @Test
     public void verifyOperation() {
@@ -29,7 +28,7 @@ public class CasServerApiBasedTicketValidatorTests extends AbstractOAuth20Tests 
         val assertion = mock(Assertion.class);
         when(assertion.getPrimaryAuthentication()).thenReturn(RegisteredServiceTestUtils.getAuthentication());
         when(cas.validateServiceTicket(anyString(), any(Service.class))).thenReturn(assertion);
-        val validator = new CasServerApiBasedTicketValidator(cas, new WebApplicationServiceFactory());
+        val validator = new InternalTicketValidator(cas, new WebApplicationServiceFactory());
         assertNotNull(validator.validate("ST-12345", RegisteredServiceTestUtils.CONST_TEST_URL2));
 
     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -23,7 +23,7 @@ import org.apereo.cas.support.oauth.authenticator.OAuth20ProofKeyCodeExchangeAut
 import org.apereo.cas.support.oauth.authenticator.OAuth20RefreshTokenAuthenticator;
 import org.apereo.cas.support.oauth.authenticator.OAuth20UsernamePasswordAuthenticator;
 import org.apereo.cas.support.oauth.authenticator.OAuthAuthenticationClientProvider;
-import org.apereo.cas.support.oauth.profile.CasServerApiBasedTicketValidator;
+import org.apereo.cas.util.InternalTicketValidator;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20ProfileScopeToAttributesFilter;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20UserProfileDataCreator;
 import org.apereo.cas.support.oauth.profile.OAuth20ProfileScopeToAttributesFilter;
@@ -257,7 +257,7 @@ public class CasOAuth20Configuration {
         val server = casProperties.getServer();
 
         val cfg = new CasConfiguration(server.getLoginUrl());
-        val validator = new CasServerApiBasedTicketValidator(centralAuthenticationService.getObject(), webApplicationServiceFactory.getObject());
+        val validator = new InternalTicketValidator(centralAuthenticationService.getObject(), webApplicationServiceFactory.getObject());
         cfg.setDefaultTicketValidator(validator);
 
         val oauthCasClient = new CasClient(cfg);

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
@@ -6,7 +6,6 @@ import org.apereo.cas.support.oauth.authenticator.OAuth20ClientIdClientSecretAut
 import org.apereo.cas.support.oauth.authenticator.OAuth20ProofKeyCodeExchangeAuthenticatorTests;
 import org.apereo.cas.support.oauth.authenticator.OAuth20RefreshTokenAuthenticatorTests;
 import org.apereo.cas.support.oauth.authenticator.OAuth20UsernamePasswordAuthenticatorTests;
-import org.apereo.cas.support.oauth.profile.CasServerApiBasedTicketValidatorTests;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20ProfileScopeToAttributesFilterTests;
 import org.apereo.cas.support.oauth.profile.DefaultOAuth20UserProfileDataCreatorTests;
 import org.apereo.cas.support.oauth.profile.OAuth20ClientIdAwareProfileManagerTests;
@@ -130,7 +129,6 @@ import org.junit.runner.RunWith;
     InvalidOAuth20DeviceTokenExceptionTests.class,
     DefaultOAuth20UserProfileDataCreatorTests.class,
     OAuth20ClientIdAwareProfileManagerTests.class,
-    CasServerApiBasedTicketValidatorTests.class,
     DefaultOAuth20ProfileScopeToAttributesFilterTests.class,
     OAuth20AuthenticationServiceSelectionStrategyTests.class,
     OAuth20ServicesManagerRegisteredServiceLocatorTests.class,

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/SamlProfileHandlerConfigurationContext.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/SamlProfileHandlerConfigurationContext.java
@@ -23,7 +23,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.jasig.cas.client.validation.AbstractUrlBasedTicketValidator;
+import org.jasig.cas.client.validation.TicketValidator;
 import org.opensaml.saml.common.SAMLObject;
 import org.pac4j.core.context.JEEContext;
 import org.pac4j.core.context.session.SessionStore;
@@ -68,7 +68,7 @@ public class SamlProfileHandlerConfigurationContext {
 
     private final SamlProfileObjectBuilder<? extends SAMLObject> samlFaultResponseBuilder;
 
-    private final AbstractUrlBasedTicketValidator ticketValidator;
+    private final TicketValidator ticketValidator;
 
     private final TicketRegistry ticketRegistry;
 

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPProfileCallbackHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPProfileCallbackHandlerController.java
@@ -49,12 +49,11 @@ public class SSOSamlIdPProfileCallbackHandlerController extends AbstractSamlIdPP
     private Assertion validateRequestAndBuildCasAssertion(final HttpServletResponse response,
                                                           final HttpServletRequest request,
                                                           final Pair<AuthnRequest, MessageContext> pair) throws Exception {
-        val authnRequest = pair.getKey();
         val ticket = request.getParameter(CasProtocolConstants.PARAMETER_TICKET);
-        getSamlProfileHandlerConfigurationContext().getTicketValidator().setRenew(authnRequest.isForceAuthn());
+        val validator = getSamlProfileHandlerConfigurationContext().getTicketValidator();
         val serviceUrl = constructServiceUrl(request, response, pair);
         LOGGER.trace("Created service url for validation: [{}]", serviceUrl);
-        val assertion = getSamlProfileHandlerConfigurationContext().getTicketValidator().validate(ticket, serviceUrl);
+        val assertion = validator.validate(ticket, serviceUrl);
         logCasValidationAssertion(assertion);
         return assertion;
     }

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPProfileCallbackHandlerControllerTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPProfileCallbackHandlerControllerTests.java
@@ -12,8 +12,7 @@ import org.apereo.cas.util.EncodingUtils;
 import lombok.val;
 import org.apache.http.HttpStatus;
 import org.jasig.cas.client.authentication.AttributePrincipalImpl;
-import org.jasig.cas.client.validation.AbstractUrlBasedTicketValidator;
-import org.jasig.cas.client.validation.Assertion;
+import org.jasig.cas.client.validation.TicketValidator;
 import org.jasig.cas.client.validation.AssertionImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
@@ -37,10 +36,10 @@ import org.springframework.test.context.TestPropertySource;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.net.URL;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * This is {@link SSOSamlIdPProfileCallbackHandlerControllerTests}.
@@ -147,23 +146,11 @@ public class SSOSamlIdPProfileCallbackHandlerControllerTests extends BaseSamlIdP
     public static class SamlIdPTestConfiguration {
 
         @Bean
-        public AbstractUrlBasedTicketValidator casClientTicketValidator() {
-            return new AbstractUrlBasedTicketValidator("https://cas.example.org") {
-                @Override
-                protected String getUrlSuffix() {
-                    return "/cas";
-                }
-
-                @Override
-                protected Assertion parseResponseFromServer(final String s) {
-                    return new AssertionImpl(new AttributePrincipalImpl("casuser", CollectionUtils.wrap("cn", "cas")));
-                }
-
-                @Override
-                protected String retrieveResponseFromServer(final URL url, final String s) {
-                    return "the-response";
-                }
-            };
+        public TicketValidator samlIdPTicketValidator() throws Exception {
+            val validator = mock(TicketValidator.class);
+            val principal = new AttributePrincipalImpl("casuser", CollectionUtils.wrap("cn", "cas"));
+            when(validator.validate(anyString(), anyString())).thenReturn(new AssertionImpl(principal));
+            return validator;
         }
     }
 }


### PR DESCRIPTION
Partial backport of: https://github.com/apereo/cas/commit/5d968ae4dc8730d0ebfb1efe8c20a9e6acae95cd to use an internal CAS validation for the SAML server support.