### PR TITLE
Fix resolution of MetadataResolver for metadata aggregates

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
@@ -97,6 +97,9 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
             criterions.add(new EntityIdCriterion(entityID), true);
             LOGGER.debug("Locating metadata for entityID [{}] by attempting to run through the metadata chain...", entityID);
             val chainingMetadataResolver = resolver.resolve(registeredService, criterions);
+            if (chainingMetadataResolver == null) {
+                return Optional.empty();
+            }
             LOGGER.info("Resolved metadata chain from [{}]. Filtering the chain by entity ID [{}]",
                 registeredService.getMetadataLocation(), entityID);
 
@@ -120,7 +123,6 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
             LoggingUtils.error(LOGGER, e);
         }
         return Optional.empty();
-
     }
     
     public ZonedDateTime getValidUntil() {


### PR DESCRIPTION
Currently saml metadata resolver is invalidated metadata doesn't contain queried entityId.
This behaviour may cause performance problems when service metadata aggregate is large enough.
It could be possible to ddos cas by signing in to saml service with entityId not present in metadata aggregate.

To reproduce this problem define one (or two) saml services with metadata aggregates and serviceId: '^https://.*'
Then sign in to any service not present in the first evaluated metadata.

