### PR TITLE
Fix resolution of MetadataResolver for metadata aggregates

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
@@ -102,7 +102,7 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
 
             val entityDescriptor = chainingMetadataResolver.resolveSingle(criterions);
             if (entityDescriptor == null) {
-                LOGGER.warn("Cannot find entity [{}] in metadata provider. Ensure the metadata is valid and has not expired.", entityID);
+                LOGGER.debug("Cannot find entity [{}] in metadata provider. Ensure the metadata is valid and has not expired.", entityID);
                 return Optional.empty();
             }
             LOGGER.trace("Located entity descriptor in metadata for [{}]", entityID);
@@ -120,7 +120,6 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
             LoggingUtils.error(LOGGER, e);
         }
         return Optional.empty();
-
     }
     
     public ZonedDateTime getValidUntil() {

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceCacheKey.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceCacheKey.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 @Getter
 public class SamlRegisteredServiceCacheKey implements Serializable {
     private static final long serialVersionUID = -7238573226470492601L;
+    private static final String KEY_SEPARATOR = " ";
 
     private final String id;
 
@@ -55,9 +56,10 @@ public class SamlRegisteredServiceCacheKey implements Serializable {
 
     private static String getCacheKeyForRegisteredService(final SamlRegisteredService service, final CriteriaSet criteriaSet) {
         if (SamlUtils.isDynamicMetadataQueryConfigured(service.getMetadataLocation())) {
-            return criteriaSet.contains(EntityIdCriterion.class)
-                ? Objects.requireNonNull(criteriaSet.get(EntityIdCriterion.class)).getEntityId()
-                : service.getServiceId();
+            return service.getId()
+                + (criteriaSet.contains(EntityIdCriterion.class)
+                    ? KEY_SEPARATOR + Objects.requireNonNull(criteriaSet.get(EntityIdCriterion.class)).getEntityId()
+                    : "");
         }
         return service.getMetadataLocation();
     }

--- a/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceCacheKeyTests.java
+++ b/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceCacheKeyTests.java
@@ -55,7 +55,7 @@ public class SamlRegisteredServiceCacheKeyTests {
         val result1 = new SamlRegisteredServiceCacheKey(service, criteriaSet);
         assertNotNull(result1.getId());
         assertNotNull(result1.toString());
-        assertEquals(entityIdCriterion.getEntityId(), result1.getCacheKey());
+        assertEquals(service.getId() + " " + entityIdCriterion.getEntityId(), result1.getCacheKey());
 
         val result2 = new SamlRegisteredServiceCacheKey(service, criteriaSet);
         assertEquals(result1, result2);
@@ -74,6 +74,6 @@ public class SamlRegisteredServiceCacheKeyTests {
 
         val results = new SamlRegisteredServiceCacheKey(service, criteriaSet);
         assertNotNull(results.getId());
-        assertEquals(service.getServiceId(), results.getCacheKey());
+        assertEquals(String.valueOf(service.getId()), results.getCacheKey());
     }
 }

--- a/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceDefaultCachingMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceDefaultCachingMetadataResolverTests.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestPropertySource(properties = "cas.authn.saml-idp.metadata.metadata-backup-location=file:${#systemProperties['java.io.tmpdir']}")
 public class SamlRegisteredServiceDefaultCachingMetadataResolverTests extends BaseSamlIdPServicesTests {
     @Test
-    public void verifyRetryableOpWithFailure() {
+    public void verifySearchForEntityInMetadataFailure() {
         val criteriaSet = new CriteriaSet();
         criteriaSet.add(new EntityIdCriterion("urn:app.e2ma.net"));
         criteriaSet.add(new EntityRoleCriterion(SPSSODescriptor.DEFAULT_ELEMENT_NAME));
@@ -49,7 +49,7 @@ public class SamlRegisteredServiceDefaultCachingMetadataResolverTests extends Ba
     }
 
     @Test
-    public void verifyRetryableOp() {
+    public void verifySearchForEntityInMetadata() {
         val criteriaSet = new CriteriaSet();
         criteriaSet.add(new EntityIdCriterion("https://carmenwiki.osu.edu/shibboleth"));
         criteriaSet.add(new EntityRoleCriterion(SPSSODescriptor.DEFAULT_ELEMENT_NAME));

--- a/support/cas-server-support-saml-idp/src/test/resources/metadata/no-testshib-providers.xml
+++ b/support/cas-server-support-saml-idp/src/test/resources/metadata/no-testshib-providers.xml
@@ -1,0 +1,191 @@
+<EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two"
+                    xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                    xmlns:mdalg="urn:oasis:names:tc:SAML:metadata:algsupport" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+
+    <EntityDescriptor entityID="https://sp.no-testshib.org/shibboleth-sp"
+                      xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                      xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                      xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+                      xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+                      xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+                      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                      xmlns:xrd="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+
+        <Extensions>
+            <mdattr:EntityAttributes>
+                <saml:Attribute Name="http://macedir.org/entity-category" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                    <saml:AttributeValue>
+                        http://id.incommon.org/category/research-and-scholarship
+                    </saml:AttributeValue>
+                </saml:Attribute>
+                <saml:Attribute Name="http://macedir.org/entity-category" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                    <saml:AttributeValue>
+                        http://refeds.org/category/research-and-scholarship
+                    </saml:AttributeValue>
+                </saml:Attribute>
+            </mdattr:EntityAttributes>
+
+            <mdalg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
+            <mdalg:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            <mdalg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha384"/>
+            <mdalg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+            <mdalg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha224"/>
+
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2009/xmldsig11#dsa-sha256"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+            <mdalg:SigningMethod Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+        </Extensions>
+
+
+        <!-- An SP supporting SAML 1 and 2 contains this element with protocol support as shown. -->
+        <SPSSODescriptor
+                protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol http://schemas.xmlsoap.org/ws/2003/07/secext">
+
+            <Extensions>
+                <!-- A request initiator at /Testshib that you can use to customize authentication requests issued to your IdP by TestShib. -->
+                <init:RequestInitiator xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://sp.testshib.org/Shibboleth.sso/TestShib"/>
+
+                <mdui:UIInfo>
+                    <mdui:DisplayName xml:lang="en">TestShib Test SP</mdui:DisplayName>
+                    <mdui:Description xml:lang="en">TestShib SP. Log into this to test your machine.
+                        Once logged in check that all attributes that you expected have been
+                        released.
+                    </mdui:Description>
+                    <mdui:Logo height="88" width="253">https://www.testshib.org/testshibtwo.jpg</mdui:Logo>
+                </mdui:UIInfo>
+            </Extensions>
+
+            <KeyDescriptor>
+                <ds:KeyInfo>
+                    <ds:X509Data>
+                        <ds:X509Certificate>
+                            MIIEPjCCAyagAwIBAgIBADANBgkqhkiG9w0BAQUFADB3MQswCQYDVQQGEwJVUzEV
+                            MBMGA1UECBMMUGVubnN5bHZhbmlhMRMwEQYDVQQHEwpQaXR0c2J1cmdoMSIwIAYD
+                            VQQKExlUZXN0U2hpYiBTZXJ2aWNlIFByb3ZpZGVyMRgwFgYDVQQDEw9zcC50ZXN0
+                            c2hpYi5vcmcwHhcNMDYwODMwMjEyNDM5WhcNMTYwODI3MjEyNDM5WjB3MQswCQYD
+                            VQQGEwJVUzEVMBMGA1UECBMMUGVubnN5bHZhbmlhMRMwEQYDVQQHEwpQaXR0c2J1
+                            cmdoMSIwIAYDVQQKExlUZXN0U2hpYiBTZXJ2aWNlIFByb3ZpZGVyMRgwFgYDVQQD
+                            Ew9zcC50ZXN0c2hpYi5vcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+                            AQDJyR6ZP6MXkQ9z6RRziT0AuCabDd3x1m7nLO9ZRPbr0v1LsU+nnC363jO8nGEq
+                            sqkgiZ/bSsO5lvjEt4ehff57ERio2Qk9cYw8XCgmYccVXKH9M+QVO1MQwErNobWb
+                            AjiVkuhWcwLWQwTDBowfKXI87SA7KR7sFUymNx5z1aoRvk3GM++tiPY6u4shy8c7
+                            vpWbVfisfTfvef/y+galxjPUQYHmegu7vCbjYP3On0V7/Ivzr+r2aPhp8egxt00Q
+                            XpilNai12LBYV3Nv/lMsUzBeB7+CdXRVjZOHGuQ8mGqEbsj8MBXvcxIKbcpeK5Zi
+                            JCVXPfarzuriM1G5y5QkKW+LAgMBAAGjgdQwgdEwHQYDVR0OBBYEFKB6wPDxwYrY
+                            StNjU5P4b4AjBVQVMIGhBgNVHSMEgZkwgZaAFKB6wPDxwYrYStNjU5P4b4AjBVQV
+                            oXukeTB3MQswCQYDVQQGEwJVUzEVMBMGA1UECBMMUGVubnN5bHZhbmlhMRMwEQYD
+                            VQQHEwpQaXR0c2J1cmdoMSIwIAYDVQQKExlUZXN0U2hpYiBTZXJ2aWNlIFByb3Zp
+                            ZGVyMRgwFgYDVQQDEw9zcC50ZXN0c2hpYi5vcmeCAQAwDAYDVR0TBAUwAwEB/zAN
+                            BgkqhkiG9w0BAQUFAAOCAQEAc06Kgt7ZP6g2TIZgMbFxg6vKwvDL0+2dzF11Onpl
+                            5sbtkPaNIcj24lQ4vajCrrGKdzHXo9m54BzrdRJ7xDYtw0dbu37l1IZVmiZr12eE
+                            Iay/5YMU+aWP1z70h867ZQ7/7Y4HW345rdiS6EW663oH732wSYNt9kr7/0Uer3KD
+                            9CuPuOidBacospDaFyfsaJruE99Kd6Eu/w5KLAGG+m0iqENCziDGzVA47TngKz2v
+                            PVA+aokoOyoz3b53qeti77ijatSEoKjxheBWpO+eoJeGq/e49Um3M2ogIX/JAlMa
+                            Inh+vYSYngQB2sx9LGkR9KHaMKNIGCDehk93Xla4pWJx1w==
+                        </ds:X509Certificate>
+                    </ds:X509Data>
+                </ds:KeyInfo>
+                <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes192-gcm"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"/>
+                <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            </KeyDescriptor>
+
+            <!-- This tells IdPs that Single Logout is supported and where/how to request it. -->
+
+            <SingleLogoutService Location="https://sp.testshib.org/Shibboleth.sso/SLO/SOAP"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"/>
+            <SingleLogoutService Location="https://sp.testshib.org/Shibboleth.sso/SLO/Redirect"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"/>
+            <SingleLogoutService Location="https://httpbin.org/post"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"/>
+            <SingleLogoutService Location="https://sp.testshib.org/Shibboleth.sso/SLO/Artifact"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"/>
+
+
+            <!-- This tells IdPs that you only need transient identifiers. -->
+            <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+            <NameIDFormat>urn:mace:shibboleth:1.0:nameIdentifier</NameIDFormat>
+
+            <AttributeConsumingService index="1">
+                <ServiceName xml:lang="en">Sample Service</ServiceName>
+                <ServiceDescription xml:lang="en">An example service that requires a human-readable identifier and optional name and e-mail address.</ServiceDescription>
+
+                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:mace:dir:attribute-def:eduPersonPrincipalName" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri"/>
+                <RequestedAttribute FriendlyName="mail" Name="urn:mace:dir:attribute-def:mail" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri"/>
+                <RequestedAttribute FriendlyName="displayName" Name="urn:mace:dir:attribute-def:displayName" NameFormat="urn:mace:shibboleth:1.0:attributeNamespace:uri"/>
+
+                <RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+                <RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+                <RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+
+            </AttributeConsumingService>
+
+            <!--
+        This tells IdPs where and how to send authentication assertions. Mostly
+        the SP will tell the IdP what location to use in its request, but this
+        is how the IdP validates the location and also figures out which
+        SAML version/binding to use.
+        -->
+
+            <AssertionConsumerService index="1" isDefault="true"
+                                      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                      Location="https://sp.testshib.org/Shibboleth.sso/SAML2/POST"/>
+            <AssertionConsumerService index="2"
+                                      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+                                      Location="https://sp.testshib.org/Shibboleth.sso/SAML2/POST-SimpleSign"/>
+            <AssertionConsumerService index="3"
+                                      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+                                      Location="https://sp.testshib.org/Shibboleth.sso/SAML2/Artifact"/>
+            <AssertionConsumerService index="4"
+                                      Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post"
+                                      Location="https://sp.testshib.org/Shibboleth.sso/SAML/POST"/>
+            <AssertionConsumerService index="5"
+                                      Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01"
+                                      Location="https://sp.testshib.org/Shibboleth.sso/SAML/Artifact"/>
+            <AssertionConsumerService index="6"
+                                      Binding="http://schemas.xmlsoap.org/ws/2003/07/secext"
+                                      Location="https://sp.testshib.org/Shibboleth.sso/ADFS"/>
+
+            <!-- A couple additional assertion consumers for the registration webapp. -->
+
+            <AssertionConsumerService index="7"
+                                      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                      Location="https://www.testshib.org/Shibboleth.sso/SAML2/POST"/>
+            <AssertionConsumerService index="8"
+                                      Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post"
+                                      Location="https://www.testshib.org/Shibboleth.sso/SAML/POST"/>
+            <AssertionConsumerService index="9"
+                                      Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                      Location="https://index9.testshib.org/Shibboleth.sso/SAML/POST"/>
+        </SPSSODescriptor>
+
+        <!-- This is just information about the entity in human terms. -->
+        <Organization>
+            <OrganizationName xml:lang="en">TestShib Two Service Provider</OrganizationName>
+            <OrganizationDisplayName xml:lang="en">TestShib Two</OrganizationDisplayName>
+            <OrganizationURL xml:lang="en">http://www.testshib.org/testshib-two/</OrganizationURL>
+        </Organization>
+        <ContactPerson contactType="technical">
+            <GivenName>Nate</GivenName>
+            <SurName>Klingenstein</SurName>
+            <EmailAddress>ndk@internet2.edu</EmailAddress>
+        </ContactPerson>
+
+    </EntityDescriptor>
+
+</EntitiesDescriptor>
+


### PR DESCRIPTION
Currently saml metadata resolver is invalidated metadata doesn't contain queried entityId.
This behaviour may cause performance problems when service metadata aggregate is large enough.
It could be possible to ddos cas by signing in to saml service with entityId not present in metadata aggregate.

To reproduce this problem define one (or two) saml services with metadata aggregates and serviceId: '^https://.*'
Then sign in to any service not present in the first evaluated metadata.

Let me know if this patch meets you expectations. I will prepare analogical patch for master branch.