### PR TITLE
add support for alternate jgit http client

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -115,4 +115,28 @@ public abstract class BaseGitProperties implements Serializable {
     @NestedConfigurationProperty
     @RequiredProperty
     private SpringResourceProperties cloneDirectory = new SpringResourceProperties();
+
+    /**
+     * Implementation of HTTP client to use when doing git operations via http/https.
+     * The jgit library sets the connection factory statically (globally) so this property should
+     * be set to the same value for all git repositories (services, saml, etc). Not doing
+     * so might result in one connection factory being used for clone and another for subsequent
+     * fetches.
+     */
+    private HttpClientType httpClientType = HttpClientType.JDK;
+
+    /**
+     * The jgit library supports multiple HTTP client implementations.
+     */
+    public enum HttpClientType {
+        /**
+         * Built-in JDK http/https client.
+         */
+        JDK,
+        /**
+         * Apache HTTP Client http/https client.
+         */
+        HTTP_CLIENT
+    }
+
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -84,6 +84,11 @@ ext.libraries = [
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     exclude(group: "org.apache.httpcomponents", module: "httpclient")
                     exclude(group: "org.apache.commons", module: "commons-lang3")
+                },
+                dependencies.create("org.eclipse.jgit:org.eclipse.jgit.http.apache:$jgitVersion") {
+                    exclude(group: "org.slf4j", module: "slf4j-api")
+                    exclude(group: "org.apache.httpcomponents", module: "httpclient")
+                    exclude(group: "org.apache.commons", module: "commons-lang3")
                 }
         ],
         webauthn                    : [

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -18,11 +18,14 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.transport.ChainingCredentialsProvider;
 import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.HttpTransport;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
 import org.eclipse.jgit.transport.NetRCCredentialsProvider;
 import org.eclipse.jgit.transport.OpenSshConfig;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.transport.http.JDKHttpConnectionFactory;
+import org.eclipse.jgit.transport.http.apache.HttpClientConnectionFactory;
 import org.eclipse.jgit.util.FS;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
@@ -65,6 +68,8 @@ public class GitRepositoryBuilder {
 
     private final boolean clearExistingIdentities;
 
+    private final BaseGitProperties.HttpClientType httpClientType;
+
     private static String getBranchPath(final String branchName) {
         return "refs/heads/" + branchName;
     }
@@ -88,7 +93,8 @@ public class GitRepositoryBuilder {
             .timeoutInSeconds(Beans.newDuration(props.getTimeout()).toSeconds())
             .signCommits(props.isSignCommits())
             .clearExistingIdentities(props.isClearExistingIdentities())
-            .strictHostKeyChecking(props.isStrictHostKeyChecking());
+            .strictHostKeyChecking(props.isStrictHostKeyChecking())
+            .httpClientType(props.getHttpClientType());
         if (StringUtils.hasText(props.getUsername())) {
             val providers = CollectionUtils.wrapList(
                 new UsernamePasswordCredentialsProvider(props.getUsername(), props.getPassword()),
@@ -110,34 +116,41 @@ public class GitRepositoryBuilder {
      * @return the transport config callback
      */
     protected TransportConfigCallback buildTransportConfigCallback() {
-        val sshSessionFactory = new JschConfigSessionFactory() {
-            @Override
-            protected void configure(final OpenSshConfig.Host host, final Session session) {
-                if (StringUtils.hasText(sshSessionPassword)) {
-                    session.setPassword(sshSessionPassword);
-                }
-                if (!strictHostKeyChecking) {
-                    session.setConfig("StrictHostKeyChecking", "no");
-                }
-            }
-
-            @Override
-            protected JSch createDefaultJSch(final FS fs) throws JSchException {
-                val defaultJSch = super.createDefaultJSch(fs);
-                if (clearExistingIdentities) {
-                    defaultJSch.removeAllIdentity();
-                }
-
-                if (StringUtils.hasText(privateKeyPath)) {
-                    defaultJSch.addIdentity(privateKeyPath, privateKeyPassphrase);
-                }
-                return defaultJSch;
-            }
-        };
         return transport -> {
             if (transport instanceof SshTransport) {
+                val sshSessionFactory = new JschConfigSessionFactory() {
+                    @Override
+                    protected void configure(final OpenSshConfig.Host host, final Session session) {
+                        if (StringUtils.hasText(sshSessionPassword)) {
+                            session.setPassword(sshSessionPassword);
+                        }
+                        if (!strictHostKeyChecking) {
+                            session.setConfig("StrictHostKeyChecking", "no");
+                        }
+                    }
+
+                    @Override
+                    protected JSch createDefaultJSch(final FS fs) throws JSchException {
+                        val defaultJSch = super.createDefaultJSch(fs);
+                        if (clearExistingIdentities) {
+                            defaultJSch.removeAllIdentity();
+                        }
+
+                        if (StringUtils.hasText(privateKeyPath)) {
+                            defaultJSch.addIdentity(privateKeyPath, privateKeyPassphrase);
+                        }
+                        return defaultJSch;
+                    }
+                };
                 val sshTransport = (SshTransport) transport;
                 sshTransport.setSshSessionFactory(sshSessionFactory);
+            }
+            if (transport instanceof HttpTransport) {
+                if (httpClientType == BaseGitProperties.HttpClientType.JDK) {
+                    HttpTransport.setConnectionFactory(new JDKHttpConnectionFactory());
+                } else if (httpClientType == BaseGitProperties.HttpClientType.HTTP_CLIENT) {
+                    HttpTransport.setConnectionFactory(new HttpClientConnectionFactory());
+                }
             }
         };
     }

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.git;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.support.git.services.BaseGitProperties;
 import org.apereo.cas.util.ResourceUtils;
 
 import lombok.val;
@@ -84,4 +85,21 @@ public class GitRepositoryBuilderTests {
         val builder = GitRepositoryBuilder.newInstance(props);
         assertDoesNotThrow(builder::build);
     }
+
+    @Test
+    public void verifyBuildWithHttpClientOptions() throws Exception {
+        for (BaseGitProperties.HttpClientType type : BaseGitProperties.HttpClientType.values()) {
+            val props = casProperties.getServiceRegistry().getGit();
+            props.setHttpClientType(type);
+            props.setRepositoryUrl("https://github.com/mmoayyed/sample-data.git");
+            props.setUsername("casuser");
+            props.setPassword("password");
+            props.setBranchesToClone("master");
+            props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
+                "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
+            val builder = GitRepositoryBuilder.newInstance(props);
+            assertDoesNotThrow(builder::build);
+        }
+    }
+
 }


### PR DESCRIPTION
I am running into an issue trying to clone via https (ssh is blocked) through an ssl proxy. I don't know if this will fix the issue but I would like to have the option of trying to the non-default http client for troubleshooting purposes. For some reason JGit makes this choice static/global so I put in the docs how the same value should be used for all cloned repositories, but maybe I should only be setting the factory if it is not the default, that way setting it for one would set it for all. 
