### PR TITLE
test git clone over https with private repo

### DIFF
--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -195,7 +195,7 @@ public class GitRepositoryBuilder {
                 .map(GitRepositoryBuilder::getBranchPath)
                 .collect(Collectors.toList()));
         }
-        LOGGER.debug("Cloning repository at [{}] with branch [{}]", this.repositoryDirectory, this.activeBranch);
+        LOGGER.debug("Cloning repository to [{}] with branch [{}]", this.repositoryDirectory, this.activeBranch);
         return new GitRepository(cloneCommand.call(), credentialsProviders,
             transportCallback, this.timeoutInSeconds, this.signCommits);
     }

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -1,11 +1,14 @@
 package org.apereo.cas.git;
 
+
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.git.services.BaseGitProperties;
 import org.apereo.cas.util.ResourceUtils;
 
 import lombok.val;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.file.PathUtils;
+import org.apache.commons.io.file.StandardDeleteOption;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -15,7 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.core.io.ClassPathResource;
 
-import java.io.File;
+import java.io.*;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,7 +44,7 @@ public class GitRepositoryBuilderTests {
         props.setBranchesToClone("master");
         props.setClearExistingIdentities(true);
         props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
-            FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
+            FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID()));
         props.setPrivateKeyPassphrase("mis@gh");
         props.getPrivateKey().setLocation(new ClassPathResource("apereocasgithub"));
         props.setStrictHostKeyChecking(false);
@@ -57,7 +60,7 @@ public class GitRepositoryBuilderTests {
         props.setPassword("password");
         props.setBranchesToClone("master");
         props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
-            FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
+            FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID()));
         props.setPrivateKeyPassphrase("something");
         props.setSshSessionPassword("more-password");
         props.getPrivateKey().setLocation(new ClassPathResource("priv.key"));
@@ -81,24 +84,33 @@ public class GitRepositoryBuilderTests {
         props.setPassword("password");
         props.setBranchesToClone("master");
         props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
-            "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
+            "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID()));
         val builder = GitRepositoryBuilder.newInstance(props);
         assertDoesNotThrow(builder::build);
     }
 
+    /**
+     * This test uses a dummy private repo on gitlab and the username password is a read-only deploy token.
+     * Tests client auth of https and cloning repositories with multiple jgit http client implementations.
+     * @throws IOException IO error
+     */
     @Test
-    public void verifyBuildWithHttpClientOptions() throws Exception {
+    public void verifyBuildWithHttpClientOptions() throws IOException {
+        val readonlyDeployToken = "ST8hSZUWDs7ujS83EVnk";
         for (BaseGitProperties.HttpClientTypes type : BaseGitProperties.HttpClientTypes.values()) {
             val props = casProperties.getServiceRegistry().getGit();
             props.setHttpClientType(type);
-            props.setRepositoryUrl("https://github.com/mmoayyed/sample-data.git");
-            props.setUsername("casuser");
-            props.setPassword("password");
+            props.setRepositoryUrl("https://gitlab.com/hdeadman-bah/cas-git-auth-test.git");
+            props.setUsername("cas-app");
+            props.setPassword(readonlyDeployToken);
             props.setBranchesToClone("master");
-            props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
-                "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID().toString()));
+            val cloneDir = "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID();
+            props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(cloneDir));
             val builder = GitRepositoryBuilder.newInstance(props);
-            assertDoesNotThrow(builder::build);
+            val gitRepository = builder.build();
+            assertTrue(new File(gitRepository.getRepositoryDirectory(), "README.md").exists());
+            gitRepository.destroy();
+            PathUtils.deleteDirectory(gitRepository.getRepositoryDirectory().toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY);
         }
     }
 


### PR DESCRIPTION
Gitlab.com doesn't require this but at least some versions of gitlab hosted (e.g. v12) seem to require that access tokens are specified on the URL so this will substitute ${username} and ${password} tokens if they are present on the URL with the username/password properties for that particular git repository. This also adds a test that only works if https auth is working b/c it is using a mostly empty private repo with a read-only access token that never expires. 