### PR TITLE
Fix classes ordering for Kryo serialization

### DIFF
--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/kryo/CloseableKryoFactory.java
@@ -110,7 +110,9 @@ public class CloseableKryoFactory implements FactoryBean<CloseableKryo> {
         registerNativeJdkComponentsWithKryo(kryo);
         registerImmutableOrEmptyCollectionsWithKryo(kryo);
 
-        classesToRegister.forEach(c -> {
+        val classes = new ArrayList<>(classesToRegister);
+        classes.sort((c1, c2) -> c1.getName().compareTo(c2.getName()));
+        classes.forEach(c -> {
             LOGGER.trace("Registering serializable class [{}] with Kryo", c.getName());
             kryo.register(c);
         });


### PR DESCRIPTION
It's been a few versions since I have used Memcached with CAS.

Maybe I'm missing something obvious, but it does not seem to work. The order in which classes are registered for the Kryo serialization is not the same for every start of the CAS server. You can confirm that by enabling trace logs on `org.apereo.cas.memcached.kryo.CloseableKryoFactory`.
Thus, the serialization/deserialization process does not work between multiple nodes of the same cluster or if you restart the CAS server.

I tested the issue in v6.3 and v6.4.

My naive proposal is to order classes by names.
