### PR TITLE
SamlPostProfileResponse Endpoint enhancements

### DIFF
--- a/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
+++ b/docs/cas-server-documentation/installation/Configuring-SAML2-Authentication.md
@@ -127,7 +127,7 @@ The following endpoints are provided by CAS:
  
 | Endpoint          | Description
 |-------------------|-------------------------------------------------------------------------------------------------------
-| `samlPostProfileResponse` | Obtain a SAML2 response payload by supplying a `username`, `password` and `entityId` as parameters.
+| `samlPostProfileResponse` | Obtain a SAML2 response payload by supplying a `username`, `password`, `entityId` and `encrypt` as parameters.
 
 ### SAML Services
 

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPPostProfileHandlerEndpoint.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPPostProfileHandlerEndpoint.java
@@ -9,6 +9,7 @@ import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.RegisteredServiceAccessStrategyUtils;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.util.RegisteredServiceJsonSerializer;
 import org.apereo.cas.support.saml.SamlProtocolConstants;
 import org.apereo.cas.support.saml.SamlUtils;
 import org.apereo.cas.support.saml.services.SamlRegisteredService;
@@ -35,6 +36,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletRequest;
@@ -53,6 +56,9 @@ import java.util.Objects;
 @Slf4j
 @RestControllerEndpoint(id = "samlPostProfileResponse", enableByDefault = false)
 public class SSOSamlIdPPostProfileHandlerEndpoint extends BaseCasActuatorEndpoint {
+
+    private static final RegisteredServiceJsonSerializer JSON_SERIALIZER = new RegisteredServiceJsonSerializer();
+
     private final ServicesManager servicesManager;
 
     private final AuthenticationSystemSupport authenticationSystemSupport;
@@ -95,22 +101,57 @@ public class SSOSamlIdPPostProfileHandlerEndpoint extends BaseCasActuatorEndpoin
      */
     @GetMapping(produces = MediaType.APPLICATION_XML_VALUE)
     @ResponseBody
-    public ResponseEntity<Object> produce(final HttpServletRequest request, final HttpServletResponse response) {
+    public ResponseEntity<Object> produceGet(final HttpServletRequest request, final HttpServletResponse response) {
+
+        val username = request.getParameter("username");
+        val password = request.getParameter("password");
+        val entityId = request.getParameter(SamlProtocolConstants.PARAMETER_ENTITY_ID);
+        val encrypt = Boolean.parseBoolean(request.getParameter("encrypt"));
+        return produce(request, response, username, password, entityId, encrypt);
+    }
+
+    /**
+     * Produce response entity.
+     *
+     * @param request  the request
+     * @param response the response
+     * @param map the RequestBody
+     * @return the response entity
+     */
+    @PostMapping(produces = MediaType.APPLICATION_XML_VALUE)
+    @ResponseBody
+    public ResponseEntity<Object> producePost(final HttpServletRequest request,
+                                              final HttpServletResponse response,
+                                              final @RequestBody Map<String, String> map) {
+
+        val username = map.get("username");
+        val password = map.get("password");
+        val entityId = map.get(SamlProtocolConstants.PARAMETER_ENTITY_ID);
+        val encrypt = Boolean.parseBoolean(map.get("encrypt"));
+        return produce(request, response, username, password, entityId, encrypt);
+    }
+
+    private ResponseEntity<Object> produce(final HttpServletRequest request,
+                                           final HttpServletResponse response,
+                                           final String username,
+                                           final String password,
+                                           final String entityId,
+                                           final boolean encrypt) {
 
         try {
-            val username = request.getParameter("username");
-            val password = request.getParameter("password");
-            val entityId = request.getParameter(SamlProtocolConstants.PARAMETER_ENTITY_ID);
-            
             val selectedService = this.serviceFactory.createService(entityId);
             val registeredService = this.servicesManager.findServiceBy(selectedService, SamlRegisteredService.class);
             RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(registeredService);
+
+            val loadedService = (SamlRegisteredService) JSON_SERIALIZER.from(JSON_SERIALIZER.toString(registeredService));
+            loadedService.setEncryptAssertions(encrypt);
+            loadedService.setEncryptAttributes(encrypt);
 
             val authnRequest = new AuthnRequestBuilder().buildObject();
             authnRequest.setIssuer(saml20ObjectBuilder.newIssuer(entityId));
 
             val adaptorResult = SamlRegisteredServiceServiceProviderMetadataFacade.get(
-                defaultSamlRegisteredServiceCachingMetadataResolver, registeredService, entityId);
+                defaultSamlRegisteredServiceCachingMetadataResolver, loadedService, entityId);
             if (adaptorResult.isPresent()) {
                 val adaptor = adaptorResult.get();
                 val messageContext = new MessageContext();
@@ -119,8 +160,8 @@ public class SSOSamlIdPPostProfileHandlerEndpoint extends BaseCasActuatorEndpoin
                 map.put(SamlProtocolConstants.PARAMETER_ENCODE_RESPONSE, Boolean.FALSE);
                 val assertion = getAssertion(username, password, entityId);
                 val object = this.responseBuilder.build(authnRequest, request, response, assertion,
-                    registeredService, adaptor, SAMLConstants.SAML2_POST_BINDING_URI, messageContext);
-                val encoded = SamlUtils.transformSamlObject(saml20ObjectBuilder.getOpenSamlConfigBean(), object).toString();
+                    loadedService, adaptor, SAMLConstants.SAML2_POST_BINDING_URI, messageContext);
+                val encoded = SamlUtils.transformSamlObject(saml20ObjectBuilder.getOpenSamlConfigBean(), object, true).toString();
                 return new ResponseEntity<>(encoded, HttpStatus.OK);
             }
         } catch (final Exception e) {

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPPostProfileHandlerEndpoint.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPPostProfileHandlerEndpoint.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.saml.web.idp.profile.sso;
 
+import org.apache.commons.beanutils.BeanUtils;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.DefaultAuthenticationBuilder;
 import org.apereo.cas.authentication.credential.UsernamePasswordCredential;
@@ -9,7 +10,6 @@ import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.RegisteredServiceAccessStrategyUtils;
 import org.apereo.cas.services.ServicesManager;
-import org.apereo.cas.services.util.RegisteredServiceJsonSerializer;
 import org.apereo.cas.support.saml.SamlProtocolConstants;
 import org.apereo.cas.support.saml.SamlUtils;
 import org.apereo.cas.support.saml.services.SamlRegisteredService;
@@ -56,8 +56,6 @@ import java.util.Objects;
 @Slf4j
 @RestControllerEndpoint(id = "samlPostProfileResponse", enableByDefault = false)
 public class SSOSamlIdPPostProfileHandlerEndpoint extends BaseCasActuatorEndpoint {
-
-    private static final RegisteredServiceJsonSerializer JSON_SERIALIZER = new RegisteredServiceJsonSerializer();
 
     private final ServicesManager servicesManager;
 
@@ -143,7 +141,7 @@ public class SSOSamlIdPPostProfileHandlerEndpoint extends BaseCasActuatorEndpoin
             val registeredService = this.servicesManager.findServiceBy(selectedService, SamlRegisteredService.class);
             RegisteredServiceAccessStrategyUtils.ensureServiceAccessIsAllowed(registeredService);
 
-            val loadedService = (SamlRegisteredService) JSON_SERIALIZER.from(JSON_SERIALIZER.toString(registeredService));
+            val loadedService = (SamlRegisteredService) BeanUtils.cloneBean(registeredService);
             loadedService.setEncryptAssertions(encrypt);
             loadedService.setEncryptAttributes(encrypt);
 

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPPostProfileHandlerEndpointTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPPostProfileHandlerEndpointTests.java
@@ -16,6 +16,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.TestPropertySource;
 
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -43,13 +45,27 @@ public class SSOSamlIdPPostProfileHandlerEndpointTests extends BaseSamlIdPConfig
     }
 
     @Test
-    public void verifyOperation() {
+    public void verifyGetOperation() {
         val request = new MockHttpServletRequest();
         request.addParameter("username", "casuser");
         request.addParameter("password", "casuser");
         request.addParameter(SamlProtocolConstants.PARAMETER_ENTITY_ID, samlRegisteredService.getServiceId());
+        request.addParameter("encrypt", "false");
         val response = new MockHttpServletResponse();
-        val entity = endpoint.produce(request, response);
+        val entity = endpoint.produceGet(request, response);
+        assertEquals(HttpStatus.OK, entity.getStatusCode());
+    }
+
+    @Test
+    public void verifyPostOperation() {
+        val request = new MockHttpServletRequest();
+        val map = new HashMap<String, String>();
+        map.put("username", "casuser");
+        map.put("password", "casuser");
+        map.put(SamlProtocolConstants.PARAMETER_ENTITY_ID, samlRegisteredService.getServiceId());
+        map.put("encrypt", "false");
+        val response = new MockHttpServletResponse();
+        val entity = endpoint.producePost(request, response, map);
         assertEquals(HttpStatus.OK, entity.getStatusCode());
     }
 
@@ -59,8 +75,9 @@ public class SSOSamlIdPPostProfileHandlerEndpointTests extends BaseSamlIdPConfig
         request.addParameter("username", "xyz");
         request.addParameter("password", "123");
         request.addParameter(SamlProtocolConstants.PARAMETER_ENTITY_ID, samlRegisteredService.getServiceId());
+        request.addParameter("encrypt", "false");
         val response = new MockHttpServletResponse();
-        val entity = endpoint.produce(request, response);
+        val entity = endpoint.produceGet(request, response);
         assertEquals(HttpStatus.BAD_REQUEST, entity.getStatusCode());
     }
 
@@ -69,8 +86,9 @@ public class SSOSamlIdPPostProfileHandlerEndpointTests extends BaseSamlIdPConfig
         val request = new MockHttpServletRequest();
         request.addParameter("username", "xyz");
         request.addParameter("password", "123");
+        request.addParameter("encrypt", "false");
         val response = new MockHttpServletResponse();
-        val entity = endpoint.produce(request, response);
+        val entity = endpoint.produceGet(request, response);
         assertEquals(HttpStatus.NO_CONTENT, entity.getStatusCode());
     }
 }


### PR DESCRIPTION
PR adds the option to send parameters to the endpoint as a map using the http Post.

Adds 'encrypt' as parameter.  The default is to now return an unencrypted response and attribute statement.  If set to true the response and the attribute statement will be encrypted.

Sets the formatting of the response to be indented.