### PR TITLE
Prevent potential NP with OIDC Scopes

### DIFF
--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
@@ -104,6 +104,6 @@ public abstract class BaseOidcScopeAttributeReleasePolicy extends AbstractRegist
 
     @Override
     public List<String> getRequestedDefinitions() {
-        return allowedAttributes;
+        return allowedAttributes != null ? allowedAttributes : new ArrayList<>();
     }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcOpenIdScopeAttributeReleasePolicyTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/claims/OidcOpenIdScopeAttributeReleasePolicyTests.java
@@ -22,5 +22,6 @@ public class OidcOpenIdScopeAttributeReleasePolicyTests extends AbstractOidcTest
         val policy = new OidcOpenIdScopeAttributeReleasePolicy();
         assertEquals(OidcConstants.StandardScopes.OPENID.getScope(), policy.getScopeType());
         assertTrue(policy.getAllowedAttributes().isEmpty());
+        assertTrue(policy.getRequestedDefinitions().isEmpty());
     }
 }


### PR DESCRIPTION
PR prevents a null pointer in BaseOIDCScopeAttributeReleasePolicy if extending class does not set any claims.