### PR TITLE
Fix AT Generator to lookup by service by client id

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractor.java
@@ -181,15 +181,16 @@ public class AccessTokenAuthorizationCodeGrantRequestExtractor extends BaseAcces
      * @return the registered service
      */
     protected OAuthRegisteredService getOAuthRegisteredServiceBy(final JEEContext context) {
+        val clientId = OAuth20Utils.getClientIdAndClientSecret(context).getLeft();
         val redirectUri = getRegisteredServiceIdentifierFromRequest(context);
-        var registeredService = OAuth20Utils.getRegisteredOAuthServiceByRedirectUri(
-            getOAuthConfigurationContext().getServicesManager(), redirectUri);
+        val registeredService = StringUtils.isNotBlank(clientId)
+                ? OAuth20Utils.getRegisteredOAuthServiceByClientId(getOAuthConfigurationContext().getServicesManager(), clientId)
+                : OAuth20Utils.getRegisteredOAuthServiceByRedirectUri(getOAuthConfigurationContext().getServicesManager(), redirectUri);
         if (registeredService == null) {
-            val clientId = OAuth20Utils.getClientIdAndClientSecret(context).getLeft();
-            registeredService = OAuth20Utils.getRegisteredOAuthServiceByClientId(
-                getOAuthConfigurationContext().getServicesManager(), clientId);
+            LOGGER.warn("Unable to locate registered service for clientId [{}] or redirectUri [{}]", clientId, redirectUri);
+        } else {
+            LOGGER.debug("Located registered service [{}]", registeredService);
         }
-        LOGGER.debug("Located registered service [{}]", registeredService);
         return registeredService;
     }
 }

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/accesstoken/ext/AccessTokenAuthorizationCodeGrantRequestExtractorTests.java
@@ -83,4 +83,19 @@ public class AccessTokenAuthorizationCodeGrantRequestExtractorTests extends Abst
         assertThrows(UnauthorizedServiceException.class, () -> extractor.extract(request, response));
     }
 
+    @Test
+    public void verifyNoClientIdOrRedirectUri() {
+        val request = new MockHttpServletRequest();
+        request.addParameter(OAuth20Constants.GRANT_TYPE, OAuth20GrantTypes.AUTHORIZATION_CODE.getType());
+
+        val service = getRegisteredService(REDIRECT_URI, CLIENT_ID, CLIENT_SECRET);
+        val principal = RegisteredServiceTestUtils.getPrincipal();
+        val code = addCode(principal, service);
+        request.addParameter(OAuth20Constants.CODE, code.getId());
+
+        val response = new MockHttpServletResponse();
+        val extractor = new AccessTokenAuthorizationCodeGrantRequestExtractor(oauth20ConfigurationContext);
+        assertThrows(UnauthorizedServiceException.class, () -> extractor.extract(request, response));
+    }
+
 }


### PR DESCRIPTION
PR corrects the Access Token generator to first look up RegisteredService by clientId and then fall back to redirectUri if clientId is not found.