### PR TITLE
 Use UTF-8 for entity in JSON

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/HttpUtils.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -176,7 +177,7 @@ public class HttpUtils {
         if ("post".equalsIgnoreCase(method)) {
             val request = new HttpPost(uri);
             if (StringUtils.isNotBlank(entity)) {
-                val stringEntity = new StringEntity(entity);
+                val stringEntity = new StringEntity(entity, StandardCharsets.UTF_8);
                 request.setEntity(stringEntity);
             }
             return request;


### PR DESCRIPTION
I have a custom authentication handler in my CAS server. It relies on a JSON web service to validate credentials.
I reuse the `HttpUtils` component to post my JSON request.

Though, I use French accents and it does not work properly: I realize that the default encoding for the `StringEntity` is "ISO-8859-1".

So I propose to use the "UTF-8" encoding for `StringEntity` in `HttpUtils` as we use "UTF-8" everywhere.
