### PR TITLE
Remove duplicate logout requests

### DIFF
--- a/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultLogoutManager.java
+++ b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultLogoutManager.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,6 +79,12 @@ public class DefaultLogoutManager implements LogoutManager {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList()))
             .flatMap(Collection::stream)
+            .filter(distinctByKey(request -> request.getService()))
             .collect(Collectors.toList());
+    }
+
+    private static <T> Predicate<T> distinctByKey(final Function<? super T, Object> keyExtractor) {
+        val seen = new ConcurrentHashMap<>();
+        return t -> seen.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
     }
 }


### PR DESCRIPTION
I have a SP (pac4j app) integrated via the SAML protocol with a CAS server.

In CAS, I configure my SP to logout via the front channel:

```xml
{
  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
  "serviceId" : "http://localhost:8081.*",
  "name" : "SAMLService",
  "id" : 1,
  "evaluationOrder" : 1,
  "metadataLocation" : "/Users/jleleu/sources/spring-webmvc-pac4j-boot-demo/sp-metadata.xml",
  "logoutType": "FRONT_CHANNEL"
}
```

I also want the SAML logout responses to be sent via the HTTP-Redirect binding:

```yml
cas.authn.saml-idp.logout.logout-response-binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect
```

After a successful SAML login, I perform a SAML logout: the SP sends a SAML logout request to CAS which displays its logout page. Two AJAX logout requests are sent from the logout page and a button is available whose link is the SAML logout response to the callback app URL.

We should not have two AJAX logout requests for the same service (I only logged in for one SAML service).

When using the back channel logout, the problem does not arise as a check is made to see if the logout request has already been sent for this service and it discards the second logout request.

I think there is an issue with the `SingleLogoutServiceMessageHandler` and the `SingleLogoutServiceLogoutUrlBuilder` definitions.

I don't understand why we have a `ChainingSingleLogoutServiceLogoutUrlBuilder` containing the URL builders for OIDC, SAML (`SamlIdPSingleLogoutServiceLogoutUrlBuilder`) and CAS (`DefaultSingleLogoutServiceLogoutUrlBuilder`) which is used both for the SAML (`SamlIdPSingleLogoutServiceMessageHandler`) and default (`DefaultSingleLogoutServiceMessageHandler`) message handlers.
I would have expected the SAML message handler to have the SAML URL builder and the default message handler to have the OIDC and default URL builders.


Instead of changing that where I fear side effects (and I think there is certainly a good reason for that), I propose to ensure that there can't be multiple logout requests for the same service. Which is a more general protection.

This is what this PR is about.

