### PR TITLE
Avoid unhandled exception if x509 cert header invalid

### DIFF
--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/RequestHeaderX509CertificateExtractor.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/RequestHeaderX509CertificateExtractor.java
@@ -79,7 +79,7 @@ public class RequestHeaderX509CertificateExtractor implements X509CertificateExt
             return null;
         }
 
-        if (Objects.requireNonNull(certHeaderValue).length() < X509_HEADER.length()) {
+        if (Objects.requireNonNull(certHeaderValue).length() - X509_FOOTER.length() < X509_HEADER.length()) {
             LOGGER.debug("Header [{}] found but it is too short to parse. Header value: [{}]", sslClientCertHeader, certHeaderValue);
             return null;
         }
@@ -93,6 +93,7 @@ public class RequestHeaderX509CertificateExtractor implements X509CertificateExt
             LOGGER.debug("Certificate extracted from header [{}] with subject: [{}]", sslClientCertHeader, cert.getSubjectDN());
             return new X509Certificate[]{cert};
         } catch (final Exception e) {
+            LOGGER.debug("Could not parse certificate from header: [{}] with sanitized value: [{}]", sslClientCertHeader, body);
             LoggingUtils.warn(LOGGER, e);
         }
         return null;

--- a/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/RequestHeaderX509CertificateExtractorTests.java
+++ b/support/cas-server-support-x509/src/test/java/org/apereo/cas/adaptors/x509/RequestHeaderX509CertificateExtractorTests.java
@@ -47,6 +47,30 @@ public class RequestHeaderX509CertificateExtractorTests {
     }
 
     @Test
+    public void verifyBadHeaderLength2() {
+        val cert = RequestHeaderX509CertificateExtractor.X509_HEADER;
+        val request = new MockHttpServletRequest();
+        request.addHeader(casProperties.getAuthn().getX509().getSslHeaderName(), cert);
+        assertNull(x509CertificateExtractor.extract(request));
+    }
+
+    @Test
+    public void verifyBadHeaderLength3() {
+        val cert = RequestHeaderX509CertificateExtractor.X509_HEADER + RequestHeaderX509CertificateExtractor.X509_FOOTER;
+        val request = new MockHttpServletRequest();
+        request.addHeader(casProperties.getAuthn().getX509().getSslHeaderName(), cert);
+        assertNull(x509CertificateExtractor.extract(request));
+    }
+
+    @Test
+    public void verifyBadHeaderLength4() {
+        val cert = RequestHeaderX509CertificateExtractor.X509_HEADER + " " + RequestHeaderX509CertificateExtractor.X509_FOOTER;
+        val request = new MockHttpServletRequest();
+        request.addHeader(casProperties.getAuthn().getX509().getSslHeaderName(), cert);
+        assertNull(x509CertificateExtractor.extract(request));
+    }
+
+    @Test
     public void verifyBadHeader() {
         val cert = RequestHeaderX509CertificateExtractor.X509_HEADER + "\nwhatever\n" + RequestHeaderX509CertificateExtractor.X509_FOOTER;
         val request = new MockHttpServletRequest();


### PR DESCRIPTION
The RequestHeaderX509CertificateExtractor.extract method generally tries to return null for any failures to reconstitute a certificate from the value in a http header but certain invalid headers (in my case `-----BEGIN CERTIFICATE-----`) were causing the sanitizeCertificateBody to fail with an exception. This avoids calling sanitizeCertificateBody with values that will cause it to  throw an exception. 

```
^[[1;31m2021-05-20 22:01:15,422 ERROR [org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/cas].[dispatcherServlet]] - <Servlet.service() for servlet [dispatcherServlet] in context with path [/cas] threw exception [R
^[[m java.lang.StringIndexOutOfBoundsException: begin 27, end 2, length 27
        at java.lang.String.checkBoundsBeginEnd(String.java:3319) ~[?:?]
        at java.lang.String.substring(String.java:1874) ~[?:?]
        at org.apereo.cas.adaptors.x509.authentication.RequestHeaderX509CertificateExtractor.sanitizeCertificateBody(RequestHeaderX509CertificateExtractor.java:122) ~[cas-server-support-x509-core-6.4.0-SNAPSHOT.jar!/:6.4.0-SNA
        at org.apereo.cas.adaptors.x509.authentication.RequestHeaderX509CertificateExtractor.extract(RequestHeaderX509CertificateExtractor.java:88) ~[cas-server-support-x509-core-6.4.0-SNAPSHOT.jar!/:6.4.0-SNAPSHOT]
        at jdk.internal.reflect.GeneratedMethodAccessor465.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
```