### PR TITLE
Call getCandidateServicesToMatch once for all locators

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -97,12 +97,10 @@ public abstract class AbstractServicesManager implements ServicesManager {
             return null;
         }
 
+        val candidates = getCandidateServicesToMatch(service.getId());
         var foundService = configurationContext.getRegisteredServiceLocators()
             .stream()
-            .map(locator -> {
-                val candidates = getCandidateServicesToMatch(service.getId());
-                return locator.locate(candidates, service);
-            })
+            .map(locator -> locator.locate(candidates, service))
             .filter(Objects::nonNull)
             .findFirst()
             .orElse(null);


### PR DESCRIPTION
Moves getCandidateServicesToMatch out of Lambda and so a list of services to match is only generated once before applying locators.
