### PR TITLE
Change OAuth Service Locators to match on client_id

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
@@ -2,7 +2,7 @@ package org.apereo.cas.support.oauth.services;
 
 import org.apereo.cas.services.DefaultServicesManagerRegisteredServiceLocator;
 import org.apereo.cas.support.oauth.OAuth20Constants;
-
+import org.apereo.cas.util.CollectionUtils;
 import org.springframework.core.Ordered;
 
 /**
@@ -15,8 +15,11 @@ public class OAuth20ServicesManagerRegisteredServiceLocator extends DefaultServi
     public OAuth20ServicesManagerRegisteredServiceLocator() {
         setOrder(Ordered.HIGHEST_PRECEDENCE);
         setRegisteredServiceFilter((registeredService, service) -> service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
-            && registeredService.getClass().equals(OAuthRegisteredService.class)
-            && registeredService.matches(service.getId()));
+            && OAuthRegisteredService.class.isAssignableFrom(registeredService.getClass())
+            && CollectionUtils.firstElement(service.getAttributes().get(OAuth20Constants.CLIENT_ID))
+                .map(id -> ((OAuthRegisteredService) registeredService).getClientId().equals(id))
+                .orElse(false)
+        );
     }
 }
 

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocatorTests.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.support.oauth.services;
 
 import org.apereo.cas.AbstractOAuth20Tests;
-import org.apereo.cas.services.PartialRegexRegisteredServiceMatchingStrategy;
+import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManagerRegisteredServiceLocator;
 import org.apereo.cas.support.oauth.OAuth20Constants;
 
@@ -34,11 +34,45 @@ public class OAuth20ServicesManagerRegisteredServiceLocatorTests extends Abstrac
         assertNotNull(oauthServicesManagerRegisteredServiceLocator);
         assertEquals(Ordered.HIGHEST_PRECEDENCE, oauthServicesManagerRegisteredServiceLocator.getOrder());
         val service = getRegisteredService("clientid123456", UUID.randomUUID().toString());
-        service.setMatchingStrategy(new PartialRegexRegisteredServiceMatchingStrategy());
         val svc = serviceFactory.createService(
-            String.format("https://oauth.example.org/whatever?%s=clientid", OAuth20Constants.CLIENT_ID));
+            String.format("https://oauth.example.org/whatever?%s=clientid123456", OAuth20Constants.CLIENT_ID));
         val result = oauthServicesManagerRegisteredServiceLocator.locate(List.of(service), svc);
         assertNotNull(result);
+    }
+
+    @Test
+    public void verifyNoMatch() {
+        assertNotNull(oauthServicesManagerRegisteredServiceLocator);
+        assertEquals(Ordered.HIGHEST_PRECEDENCE, oauthServicesManagerRegisteredServiceLocator.getOrder());
+        val oidcClientId = UUID.randomUUID().toString();
+        val service = getRegisteredService(oidcClientId, UUID.randomUUID().toString());
+        val svc = serviceFactory.createService(
+                String.format("https://oauth.example.org/whatever?%s=%s", OAuth20Constants.CLIENT_ID, "nomatch"));
+        val result = oauthServicesManagerRegisteredServiceLocator.locate(List.of(service), svc);
+        assertNull(result);
+    }
+
+    @Test
+    public void verifyNoClientId() {
+        assertNotNull(oauthServicesManagerRegisteredServiceLocator);
+        assertEquals(Ordered.HIGHEST_PRECEDENCE, oauthServicesManagerRegisteredServiceLocator.getOrder());
+        val oidcClientId = UUID.randomUUID().toString();
+        val service = getRegisteredService(oidcClientId, UUID.randomUUID().toString());
+        val svc = serviceFactory.createService("https://oauth.example.org/whatever");
+        val result = oauthServicesManagerRegisteredServiceLocator.locate(List.of(service), svc);
+        assertNull(result);
+    }
+
+    @Test
+    public void verifyNoOAuthCandidate() {
+        assertNotNull(oauthServicesManagerRegisteredServiceLocator);
+        assertEquals(Ordered.HIGHEST_PRECEDENCE, oauthServicesManagerRegisteredServiceLocator.getOrder());
+        val oidcClientId = UUID.randomUUID().toString();
+        val service = RegisteredServiceTestUtils.getRegisteredService("https://notooidc.example.org/whatever");
+        val svc = serviceFactory.createService(
+                String.format("https://oauth.example.org/whatever?%s=%s", OAuth20Constants.CLIENT_ID, oidcClientId));
+        val result = oauthServicesManagerRegisteredServiceLocator.locate(List.of(service), svc);
+        assertNull(result);
     }
 
 }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
@@ -1,6 +1,10 @@
 package org.apereo.cas.oidc.services;
 
-import org.apereo.cas.support.oauth.services.OAuth20ServicesManagerRegisteredServiceLocator;
+import org.apereo.cas.services.DefaultServicesManagerRegisteredServiceLocator;
+import org.apereo.cas.services.OidcRegisteredService;
+import org.apereo.cas.support.oauth.OAuth20Constants;
+import org.apereo.cas.util.CollectionUtils;
+import org.springframework.core.Ordered;
 
 /**
  * This is {@link OidcServicesManagerRegisteredServiceLocator}.
@@ -8,6 +12,15 @@ import org.apereo.cas.support.oauth.services.OAuth20ServicesManagerRegisteredSer
  * @author Misagh Moayyed
  * @since 6.3.0
  */
-public class OidcServicesManagerRegisteredServiceLocator extends OAuth20ServicesManagerRegisteredServiceLocator {
+public class OidcServicesManagerRegisteredServiceLocator extends DefaultServicesManagerRegisteredServiceLocator {
+    public OidcServicesManagerRegisteredServiceLocator() {
+        setOrder(Ordered.HIGHEST_PRECEDENCE);
+        setRegisteredServiceFilter((registeredService, service) -> service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
+                && registeredService.getClass().equals(OidcRegisteredService.class)
+                && CollectionUtils.firstElement(service.getAttributes().get(OAuth20Constants.CLIENT_ID))
+                .map(id -> ((OidcRegisteredService) registeredService).getClientId().equals(id))
+                .orElse(false)
+        );
+    }
 }
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServicesManagerRegisteredServiceLocator.java
@@ -1,10 +1,6 @@
 package org.apereo.cas.oidc.services;
 
-import org.apereo.cas.services.DefaultServicesManagerRegisteredServiceLocator;
-import org.apereo.cas.services.OidcRegisteredService;
-import org.apereo.cas.support.oauth.OAuth20Constants;
-
-import org.springframework.core.Ordered;
+import org.apereo.cas.support.oauth.services.OAuth20ServicesManagerRegisteredServiceLocator;
 
 /**
  * This is {@link OidcServicesManagerRegisteredServiceLocator}.
@@ -12,12 +8,6 @@ import org.springframework.core.Ordered;
  * @author Misagh Moayyed
  * @since 6.3.0
  */
-public class OidcServicesManagerRegisteredServiceLocator extends DefaultServicesManagerRegisteredServiceLocator {
-    public OidcServicesManagerRegisteredServiceLocator() {
-        setOrder(Ordered.HIGHEST_PRECEDENCE);
-        setRegisteredServiceFilter((registeredService, service) -> service.getAttributes().containsKey(OAuth20Constants.CLIENT_ID)
-            && registeredService.getClass().equals(OidcRegisteredService.class)
-            && registeredService.matches(service.getId()));
-    }
+public class OidcServicesManagerRegisteredServiceLocator extends OAuth20ServicesManagerRegisteredServiceLocator {
 }
 


### PR DESCRIPTION
Changes the OAuth Service Manager Locators to match only by client_id.  This allows for more exact matches, especially in the cases where a redirect_uri regex can be too encompassing or two OAuth clients can redirect to the same domain such as localhost.