### PR TITLE
log warning when no-op running for change password

### DIFF
--- a/ci/tests/puppeteer/run.sh
+++ b/ci/tests/puppeteer/run.sh
@@ -110,11 +110,6 @@ exitScript="${exitScript//\$\{PWD\}/${PWD}}"
   chmod +x "${exitScript}" && \
   eval "${exitScript}"
 
-if [[ "${CI}" == "true" ]]; then  
-  docker container stop $(docker container ls -aq) >/dev/null 2>&1 || true
-  docker container rm $(docker container ls -aq) >/dev/null 2>&1 || true
-fi
-
 if [[ "${CI}" != "true" ]]; then
   echo -e "Hit enter to cleanup scenario ${scenario} that ended with exit code $RC \n"
   read -r
@@ -125,4 +120,10 @@ kill -9 $pid
 rm "$PWD"/cas.war
 rm "$PWD"/ci/tests/puppeteer/overlay/thekeystore
 rm -Rf "$PWD"/ci/tests/puppeteer/overlay
+
+if [[ "${CI}" == "true" ]]; then
+  docker container stop $(docker container ls -aq) >/dev/null 2>&1 || true
+  docker container rm $(docker container ls -aq) >/dev/null 2>&1 || true
+fi
+
 exit $RC

--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
@@ -140,12 +140,13 @@ public class BasePasswordManagementService implements PasswordManagementService 
     /**
      * Change password internally, by the impl.
      *
-     * @param c    the credential
+     * @param credential the credential
      * @param bean the bean
      * @return true/false
      * @throws InvalidPasswordException if new password fails downstream validation
      */
-    public boolean changeInternal(final Credential c, final PasswordChangeRequest bean) throws InvalidPasswordException {
+    public boolean changeInternal(final Credential credential, final PasswordChangeRequest bean) throws InvalidPasswordException {
+        LOGGER.warn("Using no-op password change impl. Appropriate password management service is not configured.");
         return false;
     }
 }

--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/BasePasswordManagementService.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 @Getter
-public class BasePasswordManagementService implements PasswordManagementService {
+public abstract class BasePasswordManagementService implements PasswordManagementService {
 
     /**
      * Password management settings.
@@ -145,8 +145,5 @@ public class BasePasswordManagementService implements PasswordManagementService 
      * @return true/false
      * @throws InvalidPasswordException if new password fails downstream validation
      */
-    public boolean changeInternal(final Credential credential, final PasswordChangeRequest bean) throws InvalidPasswordException {
-        LOGGER.warn("Using no-op password change impl. Appropriate password management service is not configured.");
-        return false;
-    }
+    public abstract boolean changeInternal(Credential credential, PasswordChangeRequest bean) throws InvalidPasswordException;
 }

--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/NoOpPasswordManagementService.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/NoOpPasswordManagementService.java
@@ -1,9 +1,13 @@
 package org.apereo.cas.pm.impl;
 
+import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.configuration.model.support.pm.PasswordManagementProperties;
 import org.apereo.cas.pm.BasePasswordManagementService;
+import org.apereo.cas.pm.InvalidPasswordException;
+import org.apereo.cas.pm.PasswordChangeRequest;
 import org.apereo.cas.util.crypto.CipherExecutor;
 
+import lombok.extern.slf4j.Slf4j;
 import java.io.Serializable;
 
 /**
@@ -12,10 +16,17 @@ import java.io.Serializable;
  * @author Misagh Moayyed
  * @since 5.1.0
  */
+@Slf4j
 public class NoOpPasswordManagementService extends BasePasswordManagementService {
     public NoOpPasswordManagementService(final CipherExecutor<Serializable, String> cipherExecutor,
                                          final String issuer,
                                          final PasswordManagementProperties passwordManagementProperties) {
         super(passwordManagementProperties, cipherExecutor, issuer, null);
+    }
+
+    @Override
+    public boolean changeInternal(final Credential credential, final PasswordChangeRequest bean) throws InvalidPasswordException {
+        LOGGER.warn("Using no-op password change impl. Appropriate password management service is not configured.");
+        return false;
     }
 }


### PR DESCRIPTION
This logs a warning if the base "changeInternal()" for changing password runs. This almost certainly means that someone has not configured the appropriate password change implemenation and is probably not what they want. I think warn is appropriate so they see the message without having to turn on debug, and they can suppress via log4j config if they somehow want that no-op impl. 

Also move puppeteer docker shutdown until after CAS shutdown to avoid seeing errors in CAS logs (caused by backend shutdown, eg. LDAP server shutting down). 
