### PR TITLE
Bug with provider-selection-enabled MFA

### DIFF
--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationContextValidator.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/DefaultMultifactorAuthenticationContextValidator.java
@@ -61,19 +61,25 @@ public class DefaultMultifactorAuthenticationContextValidator implements Multifa
         LOGGER.trace("Attempting to match requested authentication context [{}] against [{}]", requestedContext, contexts);
         val providerMap = MultifactorAuthenticationUtils.getAvailableMultifactorAuthenticationProviders(this.applicationContext);
         LOGGER.trace("Available MFA providers are [{}]", providerMap.values());
-        val requestedProvider = locateRequestedProvider(providerMap.values(), requestedContext);
+        String requestedContextTmp=requestedContext;
+        if (ChainingMultifactorAuthenticationProvider.DEFAULT_IDENTIFIER.equals(requestedContext)){
+            requestedContextTmp=CollectionUtils.firstElement(contexts).get().toString();
+            LOGGER.trace("MFA-Composite detected: manage requested context as  against [{}]", requestedContextTmp);
+        }
+        final String requestedContextFinal=requestedContextTmp;
+        val requestedProvider = locateRequestedProvider(providerMap.values(), requestedContextFinal);
         if (requestedProvider.isEmpty()) {
             LOGGER.debug("Requested authentication provider cannot be recognized.");
             return MultifactorAuthenticationContextValidationResult.builder().success(false).build();
         }
-        LOGGER.debug("Requested context is [{}] and available contexts are [{}]", requestedContext, contexts);
-        if (contexts.stream().anyMatch(ctx -> ctx.toString().equals(requestedContext))) {
-            LOGGER.debug("Requested authentication context [{}] is satisfied", requestedContext);
+        LOGGER.debug("Requested context is [{}] and available contexts are [{}]", requestedContextFinal, contexts);
+        if (contexts.stream().anyMatch(ctx -> ctx.toString().equals(requestedContextFinal))) {
+            LOGGER.debug("Requested authentication context [{}] is satisfied", requestedContextFinal);
             return MultifactorAuthenticationContextValidationResult.builder()
                 .success(true).provider(requestedProvider).build();
         }
         if (StringUtils.isNotBlank(this.mfaTrustedAuthnAttributeName) && attributes.containsKey(this.mfaTrustedAuthnAttributeName)) {
-            LOGGER.debug("Requested authentication context [{}] is satisfied since device is already trusted", requestedContext);
+            LOGGER.debug("Requested authentication context [{}] is satisfied since device is already trusted", requestedContextFinal);
             return MultifactorAuthenticationContextValidationResult.builder()
                 .success(true).provider(requestedProvider).build();
         }


### PR DESCRIPTION
Description: Correcting Bug when selection menu is enabled and there are multiple MFA available for a service

Test case:
- Configure cas.authn.mfa.provider-selection-enabled=true
- No global MFA provider is set
- Configure a service with multiple MFA:
for example: 
 multifactorPolicy: {
        multifactorAuthenticationProviders: [
            'mfa-gauth',
            'mfa-u2f',
            'mfa-simple'
        ],
        failureMode: 'CLOSED',
        bypassEnabled: false,
        forceExecution: false,
        bypassTrustedDeviceEnabled: false,
        _class: 'org.apereo.cas.services.DefaultRegisteredServiceMultifactorPolicy'
    },
- Authenticate to this service
- Authenticate with user/password
- Select the MFA to use
- Authenticate with the selected MFA

Result:
After successfully authenticate to the MFA, the service could not validate the Service Ticket
CAs throws an INVALID_AUTHENTICATION_CONTEXT error 
the logs show "Attempting to match requested authentication context [mfa-composite] against [[<selected-mfa>]]", where <selected-mfa> is the real selected MFA by user

Expected result: 
Successfull service ticket validation

Correction:
When a service is configured with a ChainingMultifactorAuthenticationProvider (mfa-composite), the DefaultMultifactorAuthenticationContextValidator fails
The patch detects this case and replace the requestedContext (mfa-composite) by the context of the real selected MFA from the authentication attributes
