### PR TITLE
Properly handle POST binding for SAML logout response

### DIFF
--- a/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
+++ b/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
@@ -162,7 +162,7 @@ public interface CasWebflowConstants {
     String TRANSITION_ID_REDIRECT = "redirect";
 
     /**
-     * Transition id 'redirect' .
+     * Transition id 'post' .
      */
     String TRANSITION_ID_POST = "post";
 

--- a/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
+++ b/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
@@ -162,6 +162,11 @@ public interface CasWebflowConstants {
     String TRANSITION_ID_REDIRECT = "redirect";
 
     /**
+     * Transition id 'redirect' .
+     */
+    String TRANSITION_ID_POST = "post";
+
+    /**
      * Transition id 'skip' .
      */
     String TRANSITION_ID_SKIP = "skip";

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/init.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -e "Removing previous SAML metadata directory"
+rm -Rf "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/saml-md"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/script.js
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/script.js
@@ -1,0 +1,66 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const https = require('https');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+
+    const page = await browser.newPage();
+
+    const service = "https://example.com";
+    await page.goto("https://localhost:8443/cas/login?service=" + service);
+    await page.waitForTimeout(1000);
+    await cas.loginWith(page, "casuser", "Mellon");
+
+    let result = new URL(page.url());
+    let ticket = result.searchParams.get("ticket");
+
+    let options = {
+        protocol: 'https:',
+        hostname: 'localhost',
+        port: 8443,
+        path: '/cas/validate?service=' + service + "&ticket=" + ticket,
+        method: 'GET',
+        rejectUnauthorized: false,
+    };
+
+    const httpGet = options => {
+        return new Promise((resolve, reject) => {
+            https.get(options, res => {
+                res.setEncoding('utf8');
+                const body = [];
+                res.on('data', chunk => body.push(chunk));
+                res.on('end', () => resolve(body.join('')));
+            }).on('error', reject);
+        });
+    };
+    const body = await httpGet(options);
+
+    await page.waitForTimeout(2000);
+
+    await page.setRequestInterception(true);
+    page.once('request', request => {
+        var data = {
+            'method': 'POST',
+            'postData': 'SAMLRequest=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbDJwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIERlc3RpbmF0aW9uPSJodHRwczovL2xvY2FsaG9zdDo4NDQzL2Nhcy9pZHAvcHJvZmlsZS9TQU1MMi9QT1NUL1NMTyIgSUQ9IjEyMzQiIElzc3VlSW5zdGFudD0iMjAyMS0wNi0wMVQxMDowNDoyMi43NzJaIiBWZXJzaW9uPSIyLjAiPjxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iPmh0dHBzOi8vc2FtbHRlc3QuaWQvc2FtbC9zcDwvc2FtbDI6SXNzdWVyPjxzYW1sMjpOYW1lSUQgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6dHJhbnNpZW50Ij5mYWtlbmFtZWlkPC9zYW1sMjpOYW1lSUQ%2BPHNhbWwycDpTZXNzaW9uSW5kZXg%2BZmFrZXNlc3Npb25pbmRleDwvc2FtbDJwOlNlc3Npb25JbmRleD48L3NhbWwycDpMb2dvdXRSZXF1ZXN0Pg%3D%3D',
+            'headers': {
+                ...request.headers(),
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+        };
+
+        request.continue(data);
+
+        page.setRequestInterception(false);
+    });
+
+    const response = await page.goto('https://localhost:8443/cas/idp/profile/SAML2/POST/SLO');
+    await page.waitForTimeout(2000);
+
+    const content = await page.content();
+    assert(content.includes('action="https://samltest.id/Shibboleth.sso/SLO/POST"'));
+    assert(content.includes('<input type="hidden" name="SAMLResponse" value="'));
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/script.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": "saml-idp",
+  "properties": [
+    "--cas.authn.saml-idp.core.entity-id=https://cas.apereo.org/saml/idp/%{random}",
+    "--cas.authn.saml-idp.metadata.file-system.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/saml-md",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--cas.authn.accept.name=STATIC",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/services",
+
+    "--cas.authn.saml-idp.logout.force-signed-logout-requests=false",
+    "--cas.authn.saml-idp.logout.logout-response-binding=urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/init.sh"
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/services/cas-2.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/services/cas-2.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.services.RegexRegisteredService",
+  "serviceId" : "https://example.com",
+  "name" : "CAS",
+  "id" : 2,
+  "evaluationOrder" : 2,
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  },
+  "logoutType": "FRONT_CHANNEL"
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/services/saml-1.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-post/services/saml-1.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "https://samltest.id/.+",
+  "name" : "SAML",
+  "id" : 1,
+  "evaluationOrder" : 1,
+  "metadataLocation" : "https://samltest.id/saml/sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/init.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -e "Removing previous SAML metadata directory"
+rm -Rf "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/saml-md"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/script.js
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/script.js
@@ -1,0 +1,65 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const https = require('https');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+
+    const page = await browser.newPage();
+
+    const service = "https://example.com";
+    await page.goto("https://localhost:8443/cas/login?service=" + service);
+    await page.waitForTimeout(1000);
+    await cas.loginWith(page, "casuser", "Mellon");
+
+    let result = new URL(page.url());
+    let ticket = result.searchParams.get("ticket");
+
+    let options = {
+        protocol: 'https:',
+        hostname: 'localhost',
+        port: 8443,
+        path: '/cas/validate?service=' + service + "&ticket=" + ticket,
+        method: 'GET',
+        rejectUnauthorized: false,
+    };
+
+    const httpGet = options => {
+        return new Promise((resolve, reject) => {
+            https.get(options, res => {
+                res.setEncoding('utf8');
+                const body = [];
+                res.on('data', chunk => body.push(chunk));
+                res.on('end', () => resolve(body.join('')));
+            }).on('error', reject);
+        });
+    };
+    const body = await httpGet(options);
+
+    await page.waitForTimeout(2000);
+
+    await page.setRequestInterception(true);
+    page.once('request', request => {
+        var data = {
+            'method': 'POST',
+            'postData': 'SAMLRequest=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbDJwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIERlc3RpbmF0aW9uPSJodHRwczovL2xvY2FsaG9zdDo4NDQzL2Nhcy9pZHAvcHJvZmlsZS9TQU1MMi9QT1NUL1NMTyIgSUQ9IjEyMzQiIElzc3VlSW5zdGFudD0iMjAyMS0wNi0wMVQxMDowNDoyMi43NzJaIiBWZXJzaW9uPSIyLjAiPjxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iPmh0dHBzOi8vc2FtbHRlc3QuaWQvc2FtbC9zcDwvc2FtbDI6SXNzdWVyPjxzYW1sMjpOYW1lSUQgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6dHJhbnNpZW50Ij5mYWtlbmFtZWlkPC9zYW1sMjpOYW1lSUQ%2BPHNhbWwycDpTZXNzaW9uSW5kZXg%2BZmFrZXNlc3Npb25pbmRleDwvc2FtbDJwOlNlc3Npb25JbmRleD48L3NhbWwycDpMb2dvdXRSZXF1ZXN0Pg%3D%3D',
+            'headers': {
+                ...request.headers(),
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+        };
+
+        request.continue(data);
+
+        page.setRequestInterception(false);
+    });
+
+    const response = await page.goto('https://localhost:8443/cas/idp/profile/SAML2/POST/SLO');
+    await page.waitForTimeout(2000);
+
+    const content = await page.content();
+    assert(content.includes('value="Go to https://samltest.id/Shibboleth.sso/SLO/Redirect?SAMLResponse='));
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/script.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": "saml-idp",
+  "properties": [
+    "--cas.authn.saml-idp.core.entity-id=https://cas.apereo.org/saml/idp/%{random}",
+    "--cas.authn.saml-idp.metadata.file-system.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/saml-md",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--cas.authn.accept.name=STATIC",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/services",
+
+    "--cas.authn.saml-idp.logout.force-signed-logout-requests=false"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/init.sh"
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/services/cas-2.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/services/cas-2.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.services.RegexRegisteredService",
+  "serviceId" : "https://example.com",
+  "name" : "CAS",
+  "id" : 2,
+  "evaluationOrder" : 2,
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  },
+  "logoutType": "FRONT_CHANNEL"
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/services/saml-1.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-sp-logout-redirect/services/saml-1.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "https://samltest.id/.+",
+  "name" : "SAML",
+  "id" : 1,
+  "evaluationOrder" : 1,
+  "metadataLocation" : "https://samltest.id/saml/sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/init.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -e "Removing previous SAML metadata directory"
+rm -Rf "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/saml-md"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/script.js
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/script.js
@@ -1,0 +1,37 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+
+    const page = await browser.newPage();
+    await page.goto("https://localhost:8443/cas/login");
+    await page.waitForTimeout(1000);
+    await cas.loginWith(page, "casuser", "Mellon");
+
+    await page.waitForTimeout(2000);
+
+    await page.setRequestInterception(true);
+    page.once('request', request => {
+        var data = {
+            'method': 'POST',
+            'postData': 'SAMLRequest=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbDJwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIERlc3RpbmF0aW9uPSJodHRwczovL2xvY2FsaG9zdDo4NDQzL2Nhcy9pZHAvcHJvZmlsZS9TQU1MMi9QT1NUL1NMTyIgSUQ9IjEyMzQiIElzc3VlSW5zdGFudD0iMjAyMS0wNi0wMVQxMDowNDoyMi43NzJaIiBWZXJzaW9uPSIyLjAiPjxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iPmh0dHBzOi8vc2FtbHRlc3QuaWQvc2FtbC9zcDwvc2FtbDI6SXNzdWVyPjxzYW1sMjpOYW1lSUQgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6dHJhbnNpZW50Ij5mYWtlbmFtZWlkPC9zYW1sMjpOYW1lSUQ%2BPHNhbWwycDpTZXNzaW9uSW5kZXg%2BZmFrZXNlc3Npb25pbmRleDwvc2FtbDJwOlNlc3Npb25JbmRleD48L3NhbWwycDpMb2dvdXRSZXF1ZXN0Pg%3D%3D',
+            'headers': {
+                ...request.headers(),
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+        };
+
+        request.continue(data);
+
+        page.setRequestInterception(false);
+    });
+
+    const response = await page.goto('https://localhost:8443/cas/idp/profile/SAML2/POST/SLO');
+    await page.waitForTimeout(2000);
+
+    assert(page.url() === 'https://samltest.id/Shibboleth.sso/SLO/POST');
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/script.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": "saml-idp",
+  "properties": [
+    "--cas.authn.saml-idp.core.entity-id=https://cas.apereo.org/saml/idp/%{random}",
+    "--cas.authn.saml-idp.metadata.file-system.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/saml-md",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--cas.authn.accept.name=STATIC",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/services",
+
+    "--cas.authn.saml-idp.logout.force-signed-logout-requests=false",
+    "--cas.authn.saml-idp.logout.logout-response-binding=urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/init.sh"
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/services/saml-1.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-post/services/saml-1.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "https://samltest.id/.+",
+  "name" : "SAML",
+  "id" : 1,
+  "evaluationOrder" : 1,
+  "metadataLocation" : "https://samltest.id/saml/sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/init.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -e "Removing previous SAML metadata directory"
+rm -Rf "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/saml-md"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/script.js
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/script.js
@@ -1,0 +1,37 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+
+    const page = await browser.newPage();
+    await page.goto("https://localhost:8443/cas/login");
+    await page.waitForTimeout(1000);
+    await cas.loginWith(page, "casuser", "Mellon");
+
+    await page.waitForTimeout(2000);
+
+    await page.setRequestInterception(true);
+    page.once('request', request => {
+        var data = {
+            'method': 'POST',
+            'postData': 'SAMLRequest=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbDJwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIERlc3RpbmF0aW9uPSJodHRwczovL2xvY2FsaG9zdDo4NDQzL2Nhcy9pZHAvcHJvZmlsZS9TQU1MMi9QT1NUL1NMTyIgSUQ9IjEyMzQiIElzc3VlSW5zdGFudD0iMjAyMS0wNi0wMVQxMDowNDoyMi43NzJaIiBWZXJzaW9uPSIyLjAiPjxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iPmh0dHBzOi8vc2FtbHRlc3QuaWQvc2FtbC9zcDwvc2FtbDI6SXNzdWVyPjxzYW1sMjpOYW1lSUQgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iIEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOm5hbWVpZC1mb3JtYXQ6dHJhbnNpZW50Ij5mYWtlbmFtZWlkPC9zYW1sMjpOYW1lSUQ%2BPHNhbWwycDpTZXNzaW9uSW5kZXg%2BZmFrZXNlc3Npb25pbmRleDwvc2FtbDJwOlNlc3Npb25JbmRleD48L3NhbWwycDpMb2dvdXRSZXF1ZXN0Pg%3D%3D',
+            'headers': {
+                ...request.headers(),
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+        };
+
+        request.continue(data);
+
+        page.setRequestInterception(false);
+    });
+
+    const response = await page.goto('https://localhost:8443/cas/idp/profile/SAML2/POST/SLO');
+    await page.waitForTimeout(2000);
+
+    assert(page.url().startsWith('https://samltest.id/Shibboleth.sso/SLO/Redirect?SAMLResponse='));
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/script.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": "saml-idp",
+  "properties": [
+    "--cas.authn.saml-idp.core.entity-id=https://cas.apereo.org/saml/idp/%{random}",
+    "--cas.authn.saml-idp.metadata.file-system.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/saml-md",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--cas.authn.accept.name=STATIC",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/services",
+
+    "--cas.authn.saml-idp.logout.force-signed-logout-requests=false"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/init.sh"
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/services/saml-1.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-sp-logout-redirect/services/saml-1.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "https://samltest.id/.+",
+  "name" : "SAML",
+  "id" : 1,
+  "evaluationOrder" : 1,
+  "metadataLocation" : "https://samltest.id/saml/sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
@@ -1780,4 +1780,44 @@ public class WebUtils {
             .build();
         requestContext.getMessageContext().addMessage(msg);
     }
+
+    /**
+     * Put the logout POST url in the flow scope.
+     *
+     * @param requestContext the flow context
+     * @param postUrl the POST url
+     */
+    public static void putLogoutPostUrl(final RequestContext requestContext, final String postUrl) {
+        requestContext.getFlowScope().put("logoutPostUrl", postUrl);
+    }
+
+    /**
+     * Put the logout POST data in the flow scope.
+     *
+     * @param requestContext the flow context
+     * @param postData the POST data
+     */
+    public static void putLogoutPostData(final RequestContext requestContext, final Map<String, Object> postData) {
+        requestContext.getFlowScope().put("logoutPostData", postData);
+    }
+
+    /**
+     * Get the logout POST url from the flow scope.
+     *
+     * @param requestContext the flow context
+     * @return the POST url
+     */
+    public static String getLogoutPostUrl(final RequestContext requestContext) {
+        return (String) requestContext.getFlowScope().get("logoutPostUrl");
+    }
+
+    /**
+     * Get the logout POST data from the flow scope.
+     *
+     * @param requestContext the flow context
+     * @return the POST data
+     */
+    public static Map<String, Object> getLogoutPostData(final RequestContext requestContext) {
+        return (Map<String, Object>) requestContext.getFlowScope().get("logoutPostData");
+    }
 }

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
@@ -22,6 +22,7 @@ import org.springframework.webflow.test.MockFlowExecutionContext;
 import org.springframework.webflow.test.MockFlowSession;
 import org.springframework.webflow.test.MockRequestContext;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -37,6 +38,8 @@ import static org.mockito.Mockito.*;
 @Tag("Utility")
 public class WebUtilsTests {
 
+    private static final String URL = "https://logout.com";
+
     @Test
     public void verifyOperation() {
         val context = new MockRequestContext();
@@ -49,7 +52,7 @@ public class WebUtilsTests {
         val mockExecutionContext = new MockFlowExecutionContext(flowSession);
         context.setFlowExecutionContext(mockExecutionContext);
 
-        WebUtils.putLogoutRedirectUrl(context, "https://logout.com");
+        WebUtils.putLogoutRedirectUrl(context, URL);
         assertNotNull(WebUtils.getLogoutRedirectUrl(context, String.class));
         WebUtils.removeLogoutRedirectUrl(context);
         assertNull(WebUtils.getLogoutRedirectUrl(context, String.class));
@@ -112,5 +115,12 @@ public class WebUtilsTests {
         val ticketRegistrySupport = mock(TicketRegistrySupport.class);
         WebUtils.putTicketGrantingTicketInScopes(context, "TGT-XYZ123");
         assertNull(WebUtils.getPrincipalFromRequestContext(context, ticketRegistrySupport));
+
+        WebUtils.putLogoutPostUrl(context, URL);
+        assertEquals(URL, WebUtils.getLogoutPostUrl(context));
+        val data = new HashMap<String, Object>();
+        data.put("SAMLResponse", "xxx");
+        WebUtils.putLogoutPostData(context, data);
+        assertEquals(data, WebUtils.getLogoutPostData(context));
     }
 }

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/DefaultLogoutWebflowConfigurer.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/DefaultLogoutWebflowConfigurer.java
@@ -79,6 +79,7 @@ public class DefaultLogoutWebflowConfigurer extends AbstractCasWebflowConfigurer
     protected void createFinishLogoutState(final Flow flow) {
         val actionState = createActionState(flow, CasWebflowConstants.STATE_ID_FINISH_LOGOUT, CasWebflowConstants.ACTION_ID_FINISH_LOGOUT);
         createTransitionForState(actionState, CasWebflowConstants.TRANSITION_ID_REDIRECT, CasWebflowConstants.STATE_ID_REDIRECT_VIEW);
+        createTransitionForState(actionState, CasWebflowConstants.TRANSITION_ID_POST, CasWebflowConstants.STATE_ID_POST_VIEW);
         createTransitionForState(actionState, CasWebflowConstants.TRANSITION_ID_FINISH, CasWebflowConstants.STATE_ID_LOGOUT_VIEW);
     }
 
@@ -90,6 +91,7 @@ public class DefaultLogoutWebflowConfigurer extends AbstractCasWebflowConfigurer
     protected void createLogoutViewState(final Flow flow) {
         createEndState(flow, CasWebflowConstants.STATE_ID_REDIRECT_VIEW,
             createExternalRedirectViewFactory("flowScope.logoutRedirectUrl"));
+        createEndState(flow, CasWebflowConstants.STATE_ID_POST_VIEW, CasWebflowConstants.VIEW_ID_POST_RESPONSE);
         val logoutView = createEndState(flow, CasWebflowConstants.STATE_ID_LOGOUT_VIEW, "logout/casLogoutView");
         logoutView.getEntryActionList().add(createEvaluateAction(CasWebflowConstants.ACTION_ID_LOGOUT_VIEW_SETUP));
     }

--- a/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/DefaultLogoutWebflowConfigurerTests.java
+++ b/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/DefaultLogoutWebflowConfigurerTests.java
@@ -27,5 +27,6 @@ public class DefaultLogoutWebflowConfigurerTests extends BaseWebflowConfigurerTe
         assertTrue(flow.containsState(CasWebflowConstants.STATE_ID_FRONT_LOGOUT));
         assertTrue(flow.containsState(CasWebflowConstants.STATE_ID_DO_LOGOUT));
         assertTrue(flow.containsState(CasWebflowConstants.STATE_ID_CONFIRM_LOGOUT_VIEW));
+        assertTrue(flow.containsState(CasWebflowConstants.STATE_ID_POST_VIEW));
     }
 }

--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/logout/FinishLogoutAction.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/web/flow/logout/FinishLogoutAction.java
@@ -27,6 +27,14 @@ public class FinishLogoutAction extends AbstractLogoutAction {
         if (StringUtils.isNotBlank(logoutRedirect)) {
             return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_REDIRECT);
         }
+        val logoutPostUrl = WebUtils.getLogoutPostUrl(context);
+        val logoutPostData = WebUtils.getLogoutPostData(context);
+        if (StringUtils.isNotBlank(logoutPostUrl) && logoutPostData != null) {
+            val flowScope = context.getFlowScope();
+            flowScope.put("originalUrl", logoutPostUrl);
+            flowScope.put("parameters", logoutPostData);
+            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_POST);
+        }
         return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_FINISH);
     }
 }

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/FinishLogoutActionTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/FinishLogoutActionTests.java
@@ -14,6 +14,8 @@ import org.springframework.webflow.context.servlet.ServletExternalContext;
 import org.springframework.webflow.execution.Action;
 import org.springframework.webflow.test.MockRequestContext;
 
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -24,6 +26,9 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @Tag("WebflowActions")
 public class FinishLogoutActionTests extends AbstractWebflowActionsTests {
+
+    private static final String URL = "https://ww.google.com";
+
     @Autowired
     @Qualifier(CasWebflowConstants.ACTION_ID_FINISH_LOGOUT)
     private Action action;
@@ -42,8 +47,23 @@ public class FinishLogoutActionTests extends AbstractWebflowActionsTests {
         val context = new MockRequestContext();
         context.setExternalContext(new ServletExternalContext(new MockServletContext(),
             new MockHttpServletRequest(), new MockHttpServletResponse()));
-        WebUtils.putLogoutRedirectUrl(context, "https://ww.google.com");
+        WebUtils.putLogoutRedirectUrl(context, URL);
         val result = action.execute(context);
         assertEquals(CasWebflowConstants.TRANSITION_ID_REDIRECT, result.getId());
+    }
+
+    @Test
+    public void verifyLogoutPost() throws Exception {
+        val context = new MockRequestContext();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(),
+                new MockHttpServletRequest(), new MockHttpServletResponse()));
+        WebUtils.putLogoutPostUrl(context, URL);
+        val data = new HashMap<String, Object>();
+        data.put("SAMLResponse", "xyz");
+        WebUtils.putLogoutPostData(context, data);
+        val result = action.execute(context);
+        assertEquals(CasWebflowConstants.TRANSITION_ID_POST, result.getId());
+        assertEquals(URL, context.getFlowScope().get("originalUrl"));
+        assertEquals(data, context.getFlowScope().get("parameters"));
     }
 }

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategy.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategy.java
@@ -95,12 +95,12 @@ public class SamlIdPSingleLogoutRedirectionStrategy implements LogoutRedirection
             LOGGER.debug("Logout response binding type is determined as [{}]", binding);
 
             switch (StringUtils.defaultString(binding)) {
-                case SAMLConstants.SAML2_REDIRECT_BINDING_URI:
-                    handleSingleLogoutForRedirectBinding(context, samlLogoutRequest, samlRegisteredService, adaptor);
-                    break;
                 case SAMLConstants.SAML2_POST_BINDING_URI:
-                default:
                     handleSingleLogoutForPostBinding(context, samlLogoutRequest, samlRegisteredService, adaptor);
+                    break;
+                case SAMLConstants.SAML2_REDIRECT_BINDING_URI:
+                default:
+                    handleSingleLogoutForRedirectBinding(context, samlLogoutRequest, samlRegisteredService, adaptor);
                     break;
             }
         }

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategy.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategy.java
@@ -9,7 +9,6 @@ import org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceSe
 import org.apereo.cas.support.saml.web.idp.profile.SamlProfileHandlerConfigurationContext;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.EncodingUtils;
-import org.apereo.cas.util.HttpUtils;
 import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.web.support.WebUtils;
@@ -28,8 +27,6 @@ import org.opensaml.saml.saml2.core.LogoutResponse;
 import org.opensaml.saml.saml2.core.RequestAbstractType;
 import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.webflow.execution.RequestContext;
 
 import javax.servlet.http.HttpServletRequest;
@@ -98,15 +95,12 @@ public class SamlIdPSingleLogoutRedirectionStrategy implements LogoutRedirection
             LOGGER.debug("Logout response binding type is determined as [{}]", binding);
 
             switch (StringUtils.defaultString(binding)) {
-                case SAMLConstants.SAML2_POST_BINDING_URI:
-                    handleSingleLogoutForPostBinding(context, samlLogoutRequest, samlRegisteredService, adaptor);
-                    break;
                 case SAMLConstants.SAML2_REDIRECT_BINDING_URI:
                     handleSingleLogoutForRedirectBinding(context, samlLogoutRequest, samlRegisteredService, adaptor);
                     break;
+                case SAMLConstants.SAML2_POST_BINDING_URI:
                 default:
                     handleSingleLogoutForPostBinding(context, samlLogoutRequest, samlRegisteredService, adaptor);
-                    handleSingleLogoutForRedirectBinding(context, samlLogoutRequest, samlRegisteredService, adaptor);
                     break;
             }
         }
@@ -153,8 +147,7 @@ public class SamlIdPSingleLogoutRedirectionStrategy implements LogoutRedirection
                                                     final SamlRegisteredServiceServiceProviderMetadataFacade adaptor) {
         var sloService = adaptor.getSingleLogoutService(SAMLConstants.SAML2_POST_BINDING_URI);
         if (sloService != null) {
-            val logoutResponse = buildSamlLogoutResponse(adaptor, sloService, context, samlRegisteredService, samlLogoutRequest);
-            postSamlLogoutResponse(sloService, logoutResponse, context);
+            produceSamlLogoutResponsePost(adaptor, sloService, context, samlRegisteredService, samlLogoutRequest);
         }
     }
 
@@ -190,16 +183,25 @@ public class SamlIdPSingleLogoutRedirectionStrategy implements LogoutRedirection
     }
 
     /**
-     * Post saml logout response.
+     * Produce saml logout response post.
      *
-     * @param sloService     the slo service
-     * @param logoutResponse the logout response
-     * @param requestContext the context
+     * @param adaptor           the adaptor
+     * @param sloService        the slo service
+     * @param context           the context
+     * @param registeredService the registered service
+     * @param logoutRequest     the logout request
      */
     @SneakyThrows
-    protected void postSamlLogoutResponse(final SingleLogoutService sloService, final LogoutResponse logoutResponse,
-                                          final RequestContext requestContext) {
-        val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
+    protected void produceSamlLogoutResponsePost(final SamlRegisteredServiceServiceProviderMetadataFacade adaptor,
+                                                 final SingleLogoutService sloService,
+                                                 final RequestContext context,
+                                                 final SamlRegisteredService registeredService,
+                                                 final LogoutRequest logoutRequest) {
+        val logoutResponse = buildSamlLogoutResponse(adaptor, sloService, context, registeredService, logoutRequest);
+        val location = StringUtils.isBlank(sloService.getResponseLocation())
+                ? sloService.getLocation()
+                : sloService.getResponseLocation();
+        LOGGER.trace("Encoding logout response given endpoint [{}] for binding [{}]", location, sloService.getBinding());
 
         val payload = SerializeSupport.nodeToString(XMLObjectSupport.marshall(logoutResponse));
         LOGGER.trace("Logout request payload is [{}]", payload);
@@ -207,22 +209,13 @@ public class SamlIdPSingleLogoutRedirectionStrategy implements LogoutRedirection
         val message = EncodingUtils.encodeBase64(payload);
         LOGGER.trace("Logout message encoded in base64 is [{}]", message);
 
-        val location = StringUtils.isBlank(sloService.getResponseLocation())
-            ? sloService.getLocation()
-            : sloService.getResponseLocation();
-        LOGGER.debug("Sending logout response using [{}] binding to [{}]", sloService.getBinding(), location);
-
-        val parameters = CollectionUtils.<String, Object>wrap(SamlProtocolConstants.PARAMETER_SAML_RESPONSE, message);
+        val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(context);
+        val data = CollectionUtils.<String, Object>wrap(SamlProtocolConstants.PARAMETER_SAML_RESPONSE, message);
         val relayState = request.getParameter(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE);
-        FunctionUtils.doIfNotNull(relayState, value -> parameters.put(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE, value));
+        FunctionUtils.doIfNotNull(relayState, value -> data.put(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE, value));
 
-        val exec = HttpUtils.HttpExecutionRequest.builder()
-            .method(HttpMethod.POST)
-            .url(location)
-            .parameters(parameters)
-            .headers(CollectionUtils.wrap("Content-Type", MediaType.APPLICATION_XML_VALUE))
-            .build();
-        HttpUtils.execute(exec);
+        WebUtils.putLogoutPostUrl(context, location);
+        WebUtils.putLogoutPostData(context, data);
     }
 
     /**

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategyPostBindingTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategyPostBindingTests.java
@@ -82,5 +82,7 @@ public class SamlIdPSingleLogoutRedirectionStrategyPostBindingTests extends Base
 
         samlIdPSingleLogoutRedirectionStrategy.handle(context);
         assertNull(WebUtils.getLogoutRedirectUrl(request, String.class));
+        assertNotNull(WebUtils.getLogoutPostUrl(context));
+        assertNotNull(WebUtils.getLogoutPostData(context));
     }
 }

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategyRedirectBindingTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategyRedirectBindingTests.java
@@ -77,6 +77,7 @@ public class SamlIdPSingleLogoutRedirectionStrategyRedirectBindingTests extends 
 
         samlIdPSingleLogoutRedirectionStrategy.handle(context);
         assertNotNull(WebUtils.getLogoutRedirectUrl(request, String.class));
+        assertNull(WebUtils.getLogoutPostUrl(context));
+        assertNull(WebUtils.getLogoutPostData(context));
     }
-
 }

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/logout/casPropagateLogoutView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/logout/casPropagateLogoutView.html
@@ -76,6 +76,14 @@
                    th:value="${'Go to ' + logoutRedirectUrl}" value="Go to...">
                    <span class="mdc-button__label" th:text="${'Go to ' + logoutRedirectUrl}"></span>
             </button>
+            <form th:if="${logoutPostUrl != null && logoutPostData != null}" th:action="${logoutPostUrl}" method="post">
+                <span th:each="entry : ${logoutPostData}" th:remove="tag">
+                    <input type="hidden" th:name="${entry.key}" th:value="${entry.value}"/>
+                </span>
+                <button type="submit" class="mdc-button mdc-button--raised">
+                    <span class="mdc-button__label" th:text="${'Go to ' + logoutPostUrl}"></span>
+                </button>
+            </form>
         </div>
     </div>
 </main>


### PR DESCRIPTION
I have a SAML SP (pac4j app) integrated via the SAML protocol with a CAS server.

I define the POST binding for the SAML logout responses:

```yaml
cas.authn.saml-idp.logout.logout-response-binding: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
```

For the redirect binding, it is considered front channel and at the end of the logout process, the user is redirected to the SP with the SAML logout response.
For the post binding, it is considered back channel and the CAS server directly calls the SP with the SAML logout response and display its logout page at the end of the logout process.

This PR changes this behavior to consider the POST binding as a front channel communication. Thus, no direct call is made by the CAS server to the SP. At the end of the logout process, an HTTP POST is made to the SP with the `RelayState` and `SAMLResponse` parameters.
