### PR TITLE
add redis client connection options

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
@@ -56,10 +56,10 @@ public class BaseRedisProperties implements Serializable {
     private int port = 6379;
 
     /**
-     * Command timeout, default from Lettuce is 60s.
+     * Command timeout.
      */
     @DurationCapable
-    private String timeout;
+    private String timeout = "PT60S";
 
     /**
      * Redis connection pool settings.
@@ -89,7 +89,7 @@ public class BaseRedisProperties implements Serializable {
      * Connection timeout.
      */
     @DurationCapable
-    private String connectTimeout;
+    private String connectTimeout = "PT10S";
 
     /**
      * Setting that describes how Lettuce routes read operations to replica nodes.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
@@ -87,14 +87,13 @@ public class BaseRedisProperties implements Serializable {
     private boolean dynamicRefreshSources = true;
 
     /**
-     * Cluster topology refresh period.
+     * Enables periodic refresh of cluster topology and sets the refresh period.
      */
     @DurationCapable
     private String topologyRefreshPeriod;
 
     /**
-     * Whether adaptive topology refreshing using all available refresh
-     * triggers should be used.
+     * Whether adaptive topology refreshing using all available refresh triggers should be used.
      */
     private boolean adaptiveTopologyRefresh;
 

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.configuration.model.support.redis;
 
+import org.apereo.cas.configuration.support.DurationCapable;
 import org.apereo.cas.configuration.support.RequiredProperty;
 import org.apereo.cas.configuration.support.RequiresModule;
 
@@ -55,9 +56,10 @@ public class BaseRedisProperties implements Serializable {
     private int port = 6379;
 
     /**
-     * Connection timeout in milliseconds.
+     * Command timeout, default from Lettuce is 60s.
      */
-    private int timeout = 2000;
+    @DurationCapable
+    private String timeout;
 
     /**
      * Redis connection pool settings.
@@ -78,9 +80,34 @@ public class BaseRedisProperties implements Serializable {
     private RedisClusterProperties cluster = new RedisClusterProperties();
 
     /**
+     * Whether to discover and query all cluster nodes for obtaining the
+     * cluster topology. When set to false, only the initial seed nodes are
+     * used as sources for topology discovery.
+     */
+    private boolean dynamicRefreshSources = true;
+
+    /**
+     * Cluster topology refresh period.
+     */
+    @DurationCapable
+    private String topologyRefreshPeriod;
+
+    /**
+     * Whether adaptive topology refreshing using all available refresh
+     * triggers should be used.
+     */
+    private boolean adaptiveTopologyRefresh;
+
+    /**
      * Whether or not to use SSL for connection factory.
      */
     private boolean useSsl;
+
+    /**
+     * Connection timeout.
+     */
+    @DurationCapable
+    private String connectTimeout;
 
     /**
      * Setting that describes how Lettuce routes read operations to replica nodes.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
@@ -79,23 +79,6 @@ public class BaseRedisProperties implements Serializable {
     @NestedConfigurationProperty
     private RedisClusterProperties cluster = new RedisClusterProperties();
 
-    /**
-     * Whether to discover and query all cluster nodes for obtaining the
-     * cluster topology. When set to false, only the initial seed nodes are
-     * used as sources for topology discovery.
-     */
-    private boolean dynamicRefreshSources = true;
-
-    /**
-     * Enables periodic refresh of cluster topology and sets the refresh period.
-     */
-    @DurationCapable
-    private String topologyRefreshPeriod;
-
-    /**
-     * Whether adaptive topology refreshing using all available refresh triggers should be used.
-     */
-    private boolean adaptiveTopologyRefresh;
 
     /**
      * Whether or not to use SSL for connection factory.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisClusterProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisClusterProperties.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.configuration.model.support.redis;
 
+import org.apereo.cas.configuration.support.DurationCapable;
 import org.apereo.cas.configuration.support.RequiredProperty;
 import org.apereo.cas.configuration.support.RequiresModule;
 
@@ -41,4 +42,22 @@ public class RedisClusterProperties implements Serializable {
      * The max number of redirects to follow.
      */
     private int maxRedirects;
+
+    /**
+     * Whether to discover and query all cluster nodes for obtaining the
+     * cluster topology. When set to false, only the initial seed nodes are
+     * used as sources for topology discovery.
+     */
+    private boolean dynamicRefreshSources = true;
+
+    /**
+     * Enables periodic refresh of cluster topology and sets the refresh period.
+     */
+    @DurationCapable
+    private String topologyRefreshPeriod;
+
+    /**
+     * Whether adaptive topology refreshing using all available refresh triggers should be used.
+     */
+    private boolean adaptiveTopologyRefresh;
 }

--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -1,8 +1,14 @@
 package org.apereo.cas.redis.core;
 
 import org.apereo.cas.configuration.model.support.redis.BaseRedisProperties;
+import org.apereo.cas.configuration.support.Beans;
 
+import io.lettuce.core.ClientOptions;
 import io.lettuce.core.ReadFrom;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.TimeoutOptions;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -76,11 +82,11 @@ public class RedisObjectFactory {
                                                                    final boolean initialize) {
         var factory = (LettuceConnectionFactory) null;
         if (redis.getSentinel() != null && StringUtils.hasText(redis.getSentinel().getMaster())) {
-            factory = new LettuceConnectionFactory(getSentinelConfig(redis), getRedisPoolConfig(redis));
+            factory = new LettuceConnectionFactory(getSentinelConfig(redis), getRedisPoolClientConfig(redis, true));
         } else if (redis.getCluster() != null && !redis.getCluster().getNodes().isEmpty()) {
-            factory = new LettuceConnectionFactory(getClusterConfig(redis), getRedisPoolConfig(redis));
+            factory = new LettuceConnectionFactory(getClusterConfig(redis), getRedisPoolClientConfig(redis, true));
         } else {
-            factory = new LettuceConnectionFactory(getStandaloneConfig(redis), getRedisPoolConfig(redis));
+            factory = new LettuceConnectionFactory(getStandaloneConfig(redis), getRedisPoolClientConfig(redis, false));
         }
 
         if (initialize) {
@@ -125,20 +131,27 @@ public class RedisObjectFactory {
         return redisConfiguration;
     }
 
-    private static LettucePoolingClientConfiguration getRedisPoolConfig(final BaseRedisProperties redis) {
-        val poolConfig = LettucePoolingClientConfiguration.builder();
+    private static LettucePoolingClientConfiguration getRedisPoolClientConfig(final BaseRedisProperties redis, final boolean cluster) {
+        val poolingClientConfig = LettucePoolingClientConfiguration.builder();
         if (redis.isUseSsl()) {
-            poolConfig.useSsl();
+            poolingClientConfig.useSsl();
             LOGGER.trace("Redis configuration: SSL connections are enabled");
         }
         if (redis.getReadFrom() != null) {
-            poolConfig.readFrom(ReadFrom.valueOf(redis.getReadFrom().name()));
+            poolingClientConfig.readFrom(ReadFrom.valueOf(redis.getReadFrom().name()));
             LOGGER.debug("Redis configuration: readFrom property is set to [{}]", redis.getReadFrom());
         }
-        if (redis.getTimeout() > 0) {
-            poolConfig.commandTimeout(Duration.ofMillis(redis.getTimeout()));
-            LOGGER.trace("Redis configuration: commandTimeout is set to [{}]ms", redis.getTimeout());
+
+        if (StringUtils.hasText(redis.getTimeout())) {
+            val commandTimeout = Beans.newDuration(redis.getTimeout());
+            val commandTimeoutMillis = commandTimeout.toMillis();
+            if (commandTimeoutMillis > 0) {
+                poolingClientConfig.commandTimeout(Duration.ofMillis(commandTimeoutMillis));
+                LOGGER.trace("Redis configuration: commandTimeout is set to [{}]ms", commandTimeoutMillis);
+            }
         }
+
+        poolingClientConfig.clientOptions(createClientOptions(redis, cluster));
 
         val pool = redis.getPool();
         if (pool != null && pool.isEnabled()) {
@@ -162,10 +175,35 @@ public class RedisObjectFactory {
             if (pool.getSoftMinEvictableIdleTimeMillis() > 0) {
                 config.setSoftMinEvictableIdleTimeMillis(pool.getSoftMinEvictableIdleTimeMillis());
             }
-            poolConfig.poolConfig(config);
+            poolingClientConfig.poolConfig(config);
             LOGGER.trace("Redis configuration: the pool is configured to [{}]", config);
         }
-        return poolConfig.build();
+        return poolingClientConfig.build();
+    }
+
+    private static ClientOptions createClientOptions(final BaseRedisProperties redis, final boolean cluster) {
+        val clientOptionsBuilder = initializeClientOptionsBuilder(redis, cluster);
+        if (StringUtils.hasText(redis.getConnectTimeout())) {
+            val connectTimeout = Beans.newDuration(redis.getConnectTimeout());
+            clientOptionsBuilder.socketOptions(SocketOptions.builder().connectTimeout(connectTimeout).build());
+        }
+        return clientOptionsBuilder.timeoutOptions(TimeoutOptions.enabled()).build();
+    }
+
+    private static ClientOptions.Builder initializeClientOptionsBuilder(final BaseRedisProperties redis, final boolean cluster) {
+        if (cluster) {
+            ClusterClientOptions.Builder clusterClientOptionsBuilder = ClusterClientOptions.builder();
+            ClusterTopologyRefreshOptions.Builder refreshBuilder = ClusterTopologyRefreshOptions.builder()
+                .dynamicRefreshSources(redis.isDynamicRefreshSources());
+            if (StringUtils.hasText(redis.getTopologyRefreshPeriod())) {
+                refreshBuilder.enablePeriodicRefresh(Beans.newDuration(redis.getTopologyRefreshPeriod()));
+            }
+            if (redis.isAdaptiveTopologyRefresh()) {
+                refreshBuilder.enableAllAdaptiveRefreshTriggers();
+            }
+            return clusterClientOptionsBuilder.topologyRefreshOptions(refreshBuilder.build());
+        }
+        return ClientOptions.builder();
     }
 
     private static RedisConfiguration getStandaloneConfig(final BaseRedisProperties redis) {

--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -193,11 +193,11 @@ public class RedisObjectFactory {
     private static ClientOptions.Builder initializeClientOptionsBuilder(final BaseRedisProperties redis, final boolean cluster) {
         if (cluster) {
             ClusterTopologyRefreshOptions.Builder refreshBuilder = ClusterTopologyRefreshOptions.builder()
-                .dynamicRefreshSources(redis.isDynamicRefreshSources());
-            if (StringUtils.hasText(redis.getTopologyRefreshPeriod())) {
-                refreshBuilder.enablePeriodicRefresh(Beans.newDuration(redis.getTopologyRefreshPeriod()));
+                .dynamicRefreshSources(redis.getCluster().isDynamicRefreshSources());
+            if (StringUtils.hasText(redis.getCluster().getTopologyRefreshPeriod())) {
+                refreshBuilder.enablePeriodicRefresh(Beans.newDuration(redis.getCluster().getTopologyRefreshPeriod()));
             }
-            if (redis.isAdaptiveTopologyRefresh()) {
+            if (redis.getCluster().isAdaptiveTopologyRefresh()) {
                 refreshBuilder.enableAllAdaptiveRefreshTriggers();
             }
             ClusterClientOptions.Builder clusterClientOptionsBuilder = ClusterClientOptions.builder();

--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -192,7 +192,6 @@ public class RedisObjectFactory {
 
     private static ClientOptions.Builder initializeClientOptionsBuilder(final BaseRedisProperties redis, final boolean cluster) {
         if (cluster) {
-            ClusterClientOptions.Builder clusterClientOptionsBuilder = ClusterClientOptions.builder();
             ClusterTopologyRefreshOptions.Builder refreshBuilder = ClusterTopologyRefreshOptions.builder()
                 .dynamicRefreshSources(redis.isDynamicRefreshSources());
             if (StringUtils.hasText(redis.getTopologyRefreshPeriod())) {
@@ -201,6 +200,7 @@ public class RedisObjectFactory {
             if (redis.isAdaptiveTopologyRefresh()) {
                 refreshBuilder.enableAllAdaptiveRefreshTriggers();
             }
+            ClusterClientOptions.Builder clusterClientOptionsBuilder = ClusterClientOptions.builder();
             return clusterClientOptionsBuilder.topologyRefreshOptions(refreshBuilder.build());
         }
         return ClientOptions.builder();

--- a/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
+++ b/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
@@ -66,6 +66,42 @@ public class RedisObjectFactoryTests {
     }
 
     @Test
+    public void verifyNonDefaultClientConnectionOptions() {
+        val props = new BaseRedisProperties();
+        props.getCluster().getNodes().add(new RedisClusterNodeProperties()
+            .setType("master")
+            .setPort(6379)
+            .setId(UUID.randomUUID().toString())
+            .setName("redis-master")
+            .setHost("localhost"));
+
+        props.getCluster().getNodes().add(new RedisClusterNodeProperties()
+            .setType("slave")
+            .setPort(6380)
+            .setHost("localhost")
+            .setId(UUID.randomUUID().toString())
+            .setName("redis-slave1")
+            .setReplicaOf("redis_server_master"));
+
+        props.getCluster().getNodes().add(new RedisClusterNodeProperties()
+            .setType("slave")
+            .setPort(6381)
+            .setHost("localhost")
+            .setId(UUID.randomUUID().toString())
+            .setName("redis-slave2")
+            .setReplicaOf("redis_server_master"));
+
+        props.setTimeout("PT10S");
+        props.setConnectTimeout("PT5S");
+        props.setAdaptiveTopologyRefresh(true);
+        props.setDynamicRefreshSources(true);
+        props.getCluster().setMaxRedirects(3);
+        val connection = RedisObjectFactory.newRedisConnectionFactory(props, true);
+        assertNotNull(connection);
+    }
+
+
+    @Test
     public void validateRedisReadFromValues() {
         Stream.of(BaseRedisProperties.RedisReadFromTypes.values()).map(Enum::name).forEach(ReadFrom::valueOf);
     }

--- a/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
+++ b/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
@@ -91,8 +91,8 @@ public class RedisObjectFactoryTests {
             .setName("redis-slave2")
             .setReplicaOf("redis_server_master"));
 
-        props.setTimeout("PT10S");
-        props.setConnectTimeout("PT5S");
+        props.setTimeout("");
+        props.setConnectTimeout("");
         props.getCluster().setAdaptiveTopologyRefresh(true);
         props.getCluster().setDynamicRefreshSources(true);
         props.getCluster().setMaxRedirects(3);

--- a/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
+++ b/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
@@ -93,8 +93,8 @@ public class RedisObjectFactoryTests {
 
         props.setTimeout("PT10S");
         props.setConnectTimeout("PT5S");
-        props.setAdaptiveTopologyRefresh(true);
-        props.setDynamicRefreshSources(true);
+        props.getCluster().setAdaptiveTopologyRefresh(true);
+        props.getCluster().setDynamicRefreshSources(true);
         props.getCluster().setMaxRedirects(3);
         val connection = RedisObjectFactory.newRedisConnectionFactory(props, true);
         assertNotNull(connection);


### PR DESCRIPTION
I initially wanted to add a way to set `dynamicRefreshSources` to true but in the process of doing this PR I realized the default is already true and that it must not be cause of my reconnect issue. My re-connect issues are probably due to me not setting enabled to true on the pool config so the testOnBorrow that I was setting to true was not being used. 

In the process of making this PR though I noticed a couple things that don't seem right. The "timeout" that was documented as a connection timeout was actually being used as command timeout. The default command timeout is 60 seconds but CAS was setting the default to 2 seconds which seems low. This PR adds a way to set the actual connect timeout and it leaves "timeout" as the command timeout, which is consistent with what spring boot calls the property. This also changes timeout to be DurationCapable and it defers the defaults to the underlying libraries (spring data/lettuce). 

This PR lets CAS set the equivalent of these spring boot properties:
```
spring.redis.lettuce.cluster.refresh.adaptive
spring.redis.lettuce.cluster.refresh.dynamic-refresh-sources 
spring.redis.lettuce.cluster.refresh.period
spring.redis.connect-timeout
spring.redis.timeout (previously supported command timeout, but now supports duration and default is different)
```

Spring boot has cluster properties split between properties like the following:
```
spring.redis.cluster.max-redirects
spring.redis.cluster.nodes
```
that have CAS equivalents and lettuce specific cluster connection options under `spring.redis.lettuce.cluster...`. I added the new properties to the CAS `RedisClusterProperties` object because I suppose they are all about how to connect to a cluster. 

