### PR TITLE
Add getAllServicesOfType method to ServicesManager

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/ServicesManager.java
@@ -151,6 +151,18 @@ public interface ServicesManager extends Ordered {
     Collection<RegisteredService> getAllServices();
 
     /**
+     * Retrieve the collection of all registered services that are of the class type passed.
+     * Services that are returned are valid, non-expired, etc.
+     * Operation should perform no reloads, and must return a cached
+     * copy of services that are already loaded.
+     *
+     * @param <T>   the type parameter
+     * @param clazz type of registered service to return.
+     * @return the collection of all services that match the class type.
+     */
+    <T extends RegisteredService> Collection<T> getAllServicesOfType(Class<T> clazz);
+
+    /**
      * Gets services stream.
      * <p>
      * The returning stream may be bound to an IO channel (such as database connection),

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ChainingServicesManager.java
@@ -138,6 +138,14 @@ public class ChainingServicesManager implements ServicesManager {
     }
 
     @Override
+    public <T extends RegisteredService> Collection<T> getAllServicesOfType(final Class<T> clazz) {
+        return serviceManagers.stream()
+                .filter(s -> s.supports(clazz))
+                .flatMap(s -> s.getAllServicesOfType(clazz).stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public Collection<RegisteredService> load() {
         return serviceManagers.stream()
             .flatMap(s -> s.load().stream())

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -64,6 +64,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         assertNotNull(servicesManager.findServiceByName(TEST));
         assertNotNull(servicesManager.findServiceByName(TEST, RegexRegisteredService.class));
         assertTrue(servicesManager.count() > 0);
+        assertTrue(servicesManager.getAllServicesOfType(RegexRegisteredService.class).size() > 0);
     }
 
     @Test

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
@@ -109,10 +109,8 @@ public class OAuth20Utils {
 
     private static OAuthRegisteredService getRegisteredOAuthServiceByPredicate(final ServicesManager servicesManager,
                                                                                final Predicate<OAuthRegisteredService> predicate) {
-        val services = servicesManager.getAllServices();
+        val services = servicesManager.getAllServicesOfType(OAuthRegisteredService.class);
         return services.stream()
-            .filter(OAuthRegisteredService.class::isInstance)
-            .map(OAuthRegisteredService.class::cast)
             .filter(predicate)
             .findFirst()
             .orElse(null);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/jwks/OidcJwksEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/jwks/OidcJwksEndpointController.java
@@ -59,10 +59,8 @@ public class OidcJwksEndpointController extends BaseOAuth20Controller {
             val jsonWebKeySet = new JsonWebKeySet(jsonJwks);
 
             val servicesManager = getOAuthConfigurationContext().getServicesManager();
-            servicesManager.getAllServices()
+            servicesManager.getAllServicesOfType(OidcRegisteredService.class)
                 .stream()
-                .filter(s -> s instanceof OidcRegisteredService)
-                .map(s -> (OidcRegisteredService) s)
                 .filter(s -> StringUtils.isNotBlank(s.getJwks()))
                 .forEach(service -> {
                     val set = OidcJsonWebKeyStoreUtils.getJsonWebKeySet(service, getOAuthConfigurationContext().getApplicationContext());


### PR DESCRIPTION
PR adds method to ServicesManager to a return all services of a given Class with performance improvements over using a filter with a predicate.  Specifically in cases where ChainingServicesManager is uses separate managers for services of different type.

An approach we have found useful is have separate ServicesManagers for CAS, SAML and OAuth registered services.  This allows SAML and OAuth look ups to ignore the thousands of registered CAS services and apply matching to smaller, targeted sets to increase performance and avoid unintentional matches of services of different protocols.  

This would help performance of CAS Management as well, when listing and editing SAML and OAuth services.
