### PR TITLE
Fix OIDC + attribute definition

### DIFF
--- a/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
+++ b/support/cas-server-support-oidc-core/src/main/java/org/apereo/cas/oidc/claims/BaseOidcScopeAttributeReleasePolicy.java
@@ -43,7 +43,7 @@ public abstract class BaseOidcScopeAttributeReleasePolicy extends AbstractRegist
 
     private static final long serialVersionUID = -7302163334687300920L;
 
-    private List<String> allowedAttributes;
+    private List<String> allowedAttributes = new ArrayList<>();
 
     @JsonIgnore
     private String scopeType;


### PR DESCRIPTION
I have an OIDC client (pac4j app) integrated via the OIDC protocol with a CAS server.

I have this OIDC definition:

```
{
  "@class" : "org.apereo.cas.services.OidcRegisteredService",
  "clientId": "myclient",
  "clientSecret": "mysecret",
  "serviceId" : "^http://localhost:.*",
  "name": "OIDC",
  "id": 1,
  "scopes" : [ "java.util.HashSet",
    [ "openid", "email", "profile" ]
  ]
}
```

I also want to use an attribute definition for the `nickname`:

```
{
  "@class" : "java.util.TreeMap",
  "employeeId" : {
    "@class" : "org.apereo.cas.authentication.attribute.DefaultAttributeDefinition",
    "key" : "nickname",
    "scoped" : true,
    "attribute" : "email",
    "script": "classpath:/attribute-definitions.groovy"
  }
}
```

And this Groovy attribute definition script:

```
def run(Object[] args) {
    def attributeName = args[0]
    def attributeValues = args[1]
    def logger = args[2]
    logger.info("name: ${attributeName}, values: ${attributeValues}")
    return ["jéjé"]
}
```

When logging in with the OIDC protocol and for this app and for the "oidc" and "profile" scopes, I have the following error (NPE):

```
ERROR [org.apereo.cas.support.oauth.web.endpoints.OAuth20AccessTokenEndpointController] - <Could not identify and extract access token request>
java.lang.NullPointerException: null
  at org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy.resolveAttributesFromAttributeDefinitionStore(AbstractRegisteredServiceAttributeReleasePolicy.java:182) ~[cas-server-core-authentication-attributes-6.3.4.jar:6.3.4]
  at org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy.getAttributes(AbstractRegisteredServiceAttributeReleasePolicy.java:102) ~[cas-server-core-authentication-attributes-6.3.4.jar:6.3.4]
  at org.apereo.cas.oidc.profile.OidcProfileScopeToAttributesFilter.lambda$filterAttributesByScope$1(OidcProfileScopeToAttributesFilter.java:165) ~[cas-server-support-oidc-core-api-6.3.4.jar:6.3.4]
  at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[?:?]
  at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177) ~[?:?]
  at java.util.Iterator.forEachRemaining(Iterator.java:133) ~[?:?]
  at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[?:?]
  at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
  at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
  at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
  at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
  at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
  at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) ~[?:?]
  at org.apereo.cas.oidc.profile.OidcProfileScopeToAttributesFilter.filterAttributesByScope(OidcProfileScopeToAttributesFilter.java:169) ~[cas-server-support-oidc-core-api-6.3.4.jar:6.3.4]
  at org.apereo.cas.oidc.profile.OidcProfileScopeToAttributesFilter.getAttributesAllowedForService(OidcProfileScopeToAttributesFilter.java:104) ~[cas-server-support-oidc-core-api-6.3.4.jar:6.3.4]
  at org.apereo.cas.oidc.profile.OidcProfileScopeToAttributesFilter.filter(OidcProfileScopeToAttributesFilter.java:75) ~[cas-server-support-oidc-core-api-6.3.4.jar:6.3.4]
```

This PR fixes this issue.

I will port forward if necessary.
