### PR TITLE
Add kid header to OpenID id-token

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/EncodingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/EncodingUtils.java
@@ -467,6 +467,13 @@ public class EncodingUtils {
         jws.setAlgorithmHeaderValue(algHeaderValue);
         jws.setKey(key);
         jws.setHeader("typ", "JWT");
+        if(key instanceof JsonWebKey) {
+            JsonWebKey jsonWebKey = (JsonWebKey) key;
+            if (StringUtils.isNotBlank(jsonWebKey.getKeyId())) {
+                jws.setKeyIdHeaderValue(jsonWebKey.getKeyId());
+            }
+        }
+
         headers.forEach((k, v) -> jws.setHeader(k, v.toString()));
         return jws.getCompactSerialization().getBytes(StandardCharsets.UTF_8);
     }


### PR DESCRIPTION
- Currently OpenID id-token doesn't include the key used to sign the token. Client applications cannot understand which key from those retrieved from /oidc/jwks was used to sign.
- This is an easy piece of code which works in the same ways as `public static String signJws(JwtClaims,PublicJsonWebKey,String,Map<String, Object>)`, usefull to add "kid" header to id-token.

