### PR TITLE
Make easier to run scheduled jobs on single host

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/quartz/SchedulingProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/quartz/SchedulingProperties.java
@@ -33,9 +33,10 @@ public class SchedulingProperties implements Serializable {
     /**
      * Overrides enabled property value of true if this property does not match hostname of CAS server.
      * This can be useful if deploying CAS with an image in a statefulset where all names are predicatable but
-     * where having different configurations for different servers is hard.
+     * where having different configurations for different servers is hard. The value can be an exact hostname
+     * or a regular expression that will be used to match the hostname.
      */
-    private String enabledOnHost;
+    private String enabledOnHost = ".*";
 
     /**
      * String representation of a start delay of loading data for a data store implementation.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/quartz/SchedulingProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/quartz/SchedulingProperties.java
@@ -31,6 +31,13 @@ public class SchedulingProperties implements Serializable {
     private boolean enabled = true;
 
     /**
+     * Overrides enabled property value of true if this property does not match hostname of CAS server.
+     * This can be useful if deploying CAS with an image in a statefulset where all names are predicatable but
+     * where having different configurations for different servers is hard.
+     */
+    private String enabledOnHost;
+
+    /**
      * String representation of a start delay of loading data for a data store implementation.
      * This is the delay between scheduler startup and first job’s execution
      */

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/quartz/SchedulingProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/quartz/SchedulingProperties.java
@@ -31,7 +31,7 @@ public class SchedulingProperties implements Serializable {
     private boolean enabled = true;
 
     /**
-     * Overrides enabled property value of true if this property does not match hostname of CAS server.
+     * Overrides {@link SchedulingProperties#enabled} property value of true if this property does not match hostname of CAS server.
      * This can be useful if deploying CAS with an image in a statefulset where all names are predicatable but
      * where having different configurations for different servers is hard. The value can be an exact hostname
      * or a regular expression that will be used to match the hostname.

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
@@ -8,11 +8,11 @@ import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.registry.TicketRegistryCleaner;
 import org.apereo.cas.ticket.registry.support.LockingStrategy;
 import org.apereo.cas.util.LoggingUtils;
+import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostname;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostname;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostname.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostname.java
@@ -1,0 +1,28 @@
+package org.apereo.cas.util.spring.boot;
+
+import org.springframework.context.annotation.Conditional;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This is {@link ConditionalOnMatchingHostname} allows beans to be created on one host in a cluster.
+ *
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(MatchingHostCondition.class)
+public @interface ConditionalOnMatchingHostname {
+    /**
+     * Name of the property containing the hostname to match as its value.
+     *
+     * @return the string
+     */
+    String name();
+
+}

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostname.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostname.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Target;
 @Conditional(MatchingHostCondition.class)
 public @interface ConditionalOnMatchingHostname {
     /**
-     * Name of the property containing the hostname to match as its value.
+     * Name of the property containing the hostname to match as its value (may be Java regular expression).
      *
      * @return the string
      */

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
@@ -1,0 +1,34 @@
+package org.apereo.cas.util.spring.boot;
+
+import org.apereo.cas.util.InetAddressUtils;
+
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * This is {@link MatchingHostCondition}.
+ *
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+public class MatchingHostCondition extends SpringBootCondition {
+
+    @Override
+    public ConditionOutcome getMatchOutcome(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+        val name = metadata.getAnnotationAttributes(ConditionalOnMatchingHostname.class.getName()).get("name").toString();
+
+        val hostnameToMatch = context.getEnvironment().getProperty(name);
+        if (StringUtils.isBlank(hostnameToMatch)) {
+            return ConditionOutcome.match("No hostname set with property: " + name);
+        }
+        if (hostnameToMatch.equalsIgnoreCase(InetAddressUtils.getCasServerHostName())) {
+            return ConditionOutcome.match("Hostname matches value for " + name);
+        }
+        return ConditionOutcome.noMatch("Hostname doesn't match value for " + name);
+    }
+
+}

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
@@ -25,9 +25,7 @@ public class MatchingHostCondition extends SpringBootCondition {
         if (StringUtils.isBlank(hostnameToMatch)) {
             return ConditionOutcome.match("No hostname set with property: " + name);
         }
-        val pattern = RegexUtils.createPattern(hostnameToMatch);
-        val matcher = pattern.matcher(InetAddressUtils.getCasServerHostName());
-        if (matcher.find()) {
+        if (RegexUtils.find(hostnameToMatch, InetAddressUtils.getCasServerHostName())) {
             return ConditionOutcome.match("Hostname matches value for " + name);
         }
         return ConditionOutcome.noMatch("Hostname doesn't match value for " + name);

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
@@ -20,11 +20,7 @@ public class MatchingHostCondition extends SpringBootCondition {
 
     @Override
     public ConditionOutcome getMatchOutcome(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
-        val attributes = metadata.getAnnotationAttributes(ConditionalOnMatchingHostname.class.getName());
-        if (attributes == null) {
-            return ConditionOutcome.match("No annotation attributes found");
-        }
-        val name = attributes.get("name").toString();
+        val name = metadata.getAnnotationAttributes(ConditionalOnMatchingHostname.class.getName()).get("name").toString();
         val hostnameToMatch = context.getEnvironment().getProperty(name);
         if (StringUtils.isBlank(hostnameToMatch)) {
             return ConditionOutcome.match("No hostname set with property: " + name);

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/boot/MatchingHostCondition.java
@@ -1,10 +1,10 @@
 package org.apereo.cas.util.spring.boot;
 
 import org.apereo.cas.util.InetAddressUtils;
+import org.apereo.cas.util.RegexUtils;
 
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.apereo.cas.util.RegexUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.context.annotation.ConditionContext;

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/AllUtilTestsSuite.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/AllUtilTestsSuite.java
@@ -27,6 +27,7 @@ import org.apereo.cas.util.spring.ConvertersTests;
 import org.apereo.cas.util.spring.SpringAwareMessageMessageInterpolatorTests;
 import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolverTests;
 import org.apereo.cas.util.spring.boot.BeanDefinitionStoreFailureAnalyzerTests;
+import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostnameTests;
 import org.apereo.cas.util.spring.boot.DefaultCasBannerTests;
 import org.apereo.cas.util.ssl.CompositeX509KeyManagerTests;
 import org.apereo.cas.util.ssl.CompositeX509TrustManagerTests;
@@ -60,6 +61,7 @@ import org.junit.platform.suite.api.Suite;
     ConvertersTests.class,
     SchedulingUtilsTests.class,
     BeanDefinitionStoreFailureAnalyzerTests.class,
+    ConditionalOnMatchingHostnameTests.class,
     SimpleHttpClientFactoryBeanTests.class,
     GroovyScriptResourceCacheManagerTests.class,
     LoggingUtilsTests.class,

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
@@ -4,14 +4,15 @@ import org.apereo.cas.util.InetAddressUtils;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Hal Deadman
  * @since 6.4.0
  */
+@Tag("Simple")
 public class ConditionalOnMatchingHostnameTests {
 
     private static String HOSTNAME;
@@ -85,7 +87,7 @@ public class ConditionalOnMatchingHostnameTests {
         assertThat(this.context.containsBean("bar")).isFalse();
     }
 
-    @Configuration(proxyBeanMethods = false)
+    @TestConfiguration("ConfigurationBeansDependOnHost")
     @ConditionalOnMatchingHostname(name = "hostname")
     static class ConfigurationBeansDependOnHost {
 
@@ -96,7 +98,7 @@ public class ConditionalOnMatchingHostnameTests {
 
     }
 
-    @Configuration(proxyBeanMethods = false)
+    @TestConfiguration("ConfigurationBeansDependOnHostAndProperty")
     @ConditionalOnProperty(name = "someproperty", havingValue="true")
     @ConditionalOnMatchingHostname(name = "hostname")
     static class ConfigurationBeansDependOnHostAndProperty {

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
@@ -1,0 +1,116 @@
+package org.apereo.cas.util.spring.boot;
+
+import org.apereo.cas.util.InetAddressUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is {@link ConditionalOnMatchingHostnameTests}.
+ *
+ * @author Hal Deadman
+ * @since 6.4.0
+ */
+public class ConditionalOnMatchingHostnameTests {
+
+    private static String HOSTNAME;
+
+    private ConfigurableApplicationContext context;
+
+    private ConfigurableEnvironment environment = new StandardEnvironment();
+
+    @BeforeAll
+    static void setup() {
+        HOSTNAME = InetAddressUtils.getCasServerHostName();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    void regexMatch() {
+        load(ConfigurationBeansDependOnHost.class, "hostname=.*");
+        assertThat(this.context.containsBean("foo")).isTrue();
+    }
+
+    @Test
+    void exactMatch() {
+        load(ConfigurationBeansDependOnHost.class, "hostname=" + HOSTNAME);
+        assertThat(this.context.containsBean("foo")).isTrue();
+    }
+
+    @Test
+    void blankMatch() {
+        load(ConfigurationBeansDependOnHost.class, "hostname=");
+        assertThat(this.context.containsBean("foo")).isTrue();
+    }
+
+    @Test
+    void doesNotMatch() {
+        load(ConfigurationBeansDependOnHost.class, "hostname=notright");
+        assertThat(this.context.containsBean("foo")).isFalse();
+    }
+
+    @Test
+    void doesNotMatch2() {
+        load(ConfigurationBeansDependOnHost.class, "hostname="+ HOSTNAME + "2");
+        assertThat(this.context.containsBean("foo")).isFalse();
+    }
+
+    @Test
+    void exactMatchAndPropertyTrue() {
+        load(ConfigurationBeansDependOnHostAndProperty.class, "hostname=" + HOSTNAME, "someproperty=true");
+        assertThat(this.context.containsBean("bar")).isTrue();
+    }
+
+    @Test
+    void exactMatchAndPropertyFalse() {
+        load(ConfigurationBeansDependOnHostAndProperty.class, "hostname=" + HOSTNAME, "someproperty=false");
+        assertThat(this.context.containsBean("bar")).isFalse();
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnMatchingHostname(name = "hostname")
+    static class ConfigurationBeansDependOnHost {
+
+        @Bean
+        String foo() {
+            return "foo";
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnProperty(name = "someproperty", havingValue="true")
+    @ConditionalOnMatchingHostname(name = "hostname")
+    static class ConfigurationBeansDependOnHostAndProperty {
+
+        @Bean
+        String bar() {
+            return "bar";
+        }
+
+    }
+
+    private void load(final Class<?> config, final String... environment) {
+        TestPropertyValues.of(environment).applyTo(this.environment);
+        this.context = new SpringApplicationBuilder(config).environment(this.environment).web(WebApplicationType.NONE)
+            .run();
+    }
+}

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
@@ -99,7 +99,7 @@ public class ConditionalOnMatchingHostnameTests {
     static class ConfigurationBeansDependOnHost {
 
         @Bean
-        String foo() {
+        public String foo() {
             return "foo";
         }
 
@@ -111,7 +111,7 @@ public class ConditionalOnMatchingHostnameTests {
     static class ConfigurationBeansDependOnHostAndProperty {
 
         @Bean
-        String bar() {
+        public String bar() {
             return "bar";
         }
 

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/spring/boot/ConditionalOnMatchingHostnameTests.java
@@ -87,6 +87,13 @@ public class ConditionalOnMatchingHostnameTests {
         assertThat(this.context.containsBean("bar")).isFalse();
     }
 
+    @Test
+    void hostnamePropertyNotSet() {
+        load(ConfigurationBeansDependOnHostAndProperty.class, "someproperty=true");
+        assertThat(this.context.containsBean("bar")).isTrue();
+    }
+
+
     @TestConfiguration("ConfigurationBeansDependOnHost")
     @ConditionalOnMatchingHostname(name = "hostname")
     static class ConfigurationBeansDependOnHost {

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
@@ -1,23 +1,16 @@
 package org.apereo.cas.config;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.mongo.MongoDbConnectionFactory;
 import org.apereo.cas.ticket.TicketCatalog;
-import org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner;
 import org.apereo.cas.ticket.registry.MongoDbTicketRegistry;
-import org.apereo.cas.ticket.registry.NoOpTicketRegistryCleaner;
 import org.apereo.cas.ticket.registry.TicketRegistry;
-import org.apereo.cas.ticket.registry.TicketRegistryCleaner;
-import org.apereo.cas.ticket.registry.support.LockingStrategy;
 import org.apereo.cas.ticket.serialization.TicketSerializationManager;
 import org.apereo.cas.util.CoreTicketUtils;
-import org.apereo.cas.util.InetAddressUtils;
 import org.apereo.cas.util.MongoDbTicketRegistryFacilitator;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -62,28 +55,6 @@ public class MongoDbTicketRegistryConfiguration {
         new MongoDbTicketRegistryFacilitator(ticketCatalog, mongoTemplate, mongo.isDropCollection())
             .createTicketCollections();
         return registry;
-    }
-
-    @Autowired
-    @Bean
-    public TicketRegistryCleaner ticketRegistryCleaner(@Qualifier("lockingStrategy") final LockingStrategy lockingStrategy,
-                                                       @Qualifier(LogoutManager.DEFAULT_BEAN_NAME) final LogoutManager logoutManager,
-                                                       @Qualifier("ticketRegistry") final TicketRegistry ticketRegistry) {
-        val isCleanerEnabled = casProperties.getTicket().getRegistry().getCleaner().getSchedule().isEnabled();
-        if (isCleanerEnabled) {
-            val enableOnHost = casProperties.getTicket().getRegistry().getCleaner().getSchedule().getEnabledOnHost();
-            if (StringUtils.isBlank(enableOnHost) || enableOnHost.equalsIgnoreCase(InetAddressUtils.getCasServerHostName())) {
-                LOGGER.debug("Ticket registry cleaner for MongoDb is enabled.");
-                return new DefaultTicketRegistryCleaner(lockingStrategy, logoutManager, ticketRegistry);
-            } else {
-                LOGGER.debug("Ticket registry cleaner is enabled but only on server: [{}]", enableOnHost);
-                return NoOpTicketRegistryCleaner.getInstance();
-            }
-        }
-        LOGGER.debug("Ticket registry cleaner for MongoDb is not enabled. "
-            + "Expired tickets are not forcefully collected and cleaned by CAS. It is up to the ticket registry itself to "
-            + "clean up tickets based on expiration and eviction policies.");
-        return NoOpTicketRegistryCleaner.getInstance();
     }
 
     @ConditionalOnMissingBean(name = "mongoDbTicketRegistryTemplate")

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
@@ -9,7 +9,6 @@ import org.apereo.cas.ticket.serialization.TicketSerializationManager;
 import org.apereo.cas.util.CoreTicketUtils;
 import org.apereo.cas.util.MongoDbTicketRegistryFacilitator;
 
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +30,6 @@ import javax.net.ssl.SSLContext;
  */
 @Configuration("mongoTicketRegistryConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@Slf4j
 public class MongoDbTicketRegistryConfiguration {
     @Autowired
     private CasConfigurationProperties casProperties;

--- a/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
+++ b/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
@@ -3,7 +3,6 @@ package org.apereo.cas.trusted.authentication.storage;
 import org.apereo.cas.configuration.model.support.mfa.trusteddevice.TrustedDevicesMultifactorProperties;
 import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustStorage;
 import org.apereo.cas.util.LoggingUtils;
-import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostname;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +30,6 @@ public class MultifactorAuthenticationTrustStorageCleaner {
     /**
      * Clean up expired records.
      */
-    @ConditionalOnMatchingHostname(name = "cas.authn.mfa.trusted.cleaner.schedule.enabled-on-host")
     @Scheduled(initialDelayString = "${cas.authn.mfa.trusted.cleaner.schedule.start-delay:PT10S}",
         fixedDelayString = "${cas.authn.mfa.trusted.cleaner.schedule.repeat-interval:PT60S}")
     public void clean() {

--- a/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
+++ b/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
@@ -1,16 +1,13 @@
 package org.apereo.cas.trusted.authentication.storage;
 
-
 import org.apereo.cas.configuration.model.support.mfa.trusteddevice.TrustedDevicesMultifactorProperties;
 import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustStorage;
-import org.apereo.cas.util.InetAddressUtils;
 import org.apereo.cas.util.LoggingUtils;
+import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostname;
 
-import lombok.val;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,23 +31,19 @@ public class MultifactorAuthenticationTrustStorageCleaner {
     /**
      * Clean up expired records.
      */
+    @ConditionalOnMatchingHostname(name = "cas.authn.mfa.trusted.cleaner.schedule.enabled-on-host")
     @Scheduled(initialDelayString = "${cas.authn.mfa.trusted.cleaner.schedule.start-delay:PT10S}",
         fixedDelayString = "${cas.authn.mfa.trusted.cleaner.schedule.repeat-interval:PT60S}")
     public void clean() {
         if (!trustedProperties.getCleaner().getSchedule().isEnabled()) {
             LOGGER.debug("[{}] is disabled; expired trusted authentication records will not be removed automatically", getClass().getName());
         } else {
-            val enableOnHost = trustedProperties.getCleaner().getSchedule().getEnabledOnHost();
-            if (StringUtils.isBlank(enableOnHost) || enableOnHost.equalsIgnoreCase(InetAddressUtils.getCasServerHostName())) {
-                try {
-                    LOGGER.trace("Proceeding to clean up expired trusted authentication records...");
-                    SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
-                    this.storage.remove();
-                } catch (final Exception e) {
-                    LoggingUtils.error(LOGGER, e);
-                }
-            } else {
-                LOGGER.trace("[{}] is disabled because host does not match [{}]", getClass().getName(), enableOnHost);
+            try {
+                LOGGER.trace("Proceeding to clean up expired trusted authentication records...");
+                SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
+                this.storage.remove();
+            } catch (final Exception e) {
+                LoggingUtils.error(LOGGER, e);
             }
         }
     }

--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/config/MultifactorAuthnTrustConfiguration.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/trusted/config/MultifactorAuthnTrustConfiguration.java
@@ -22,6 +22,7 @@ import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.cipher.CipherExecutorUtils;
 import org.apereo.cas.util.crypto.CipherExecutor;
 import org.apereo.cas.util.function.FunctionUtils;
+import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostname;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
@@ -142,6 +143,7 @@ public class MultifactorAuthnTrustConfiguration {
         return CipherExecutor.noOp();
     }
 
+    @ConditionalOnMatchingHostname(name = "cas.authn.mfa.trusted.cleaner.schedule.enabled-on-host")
     @ConditionalOnProperty(prefix = "cas.authn.mfa.trusted.cleaner.schedule", name = "enabled", havingValue = "true", matchIfMissing = true)
     @ConditionalOnMissingBean(name = "mfaTrustStorageCleaner")
     @Bean


### PR DESCRIPTION
When running CAS via a docker image and/or with cloud configuration that is common across all servers, it can be difficult to enable a scheduled job like the ticket registry cleaner so that it only runs on a single server (since CAS isn't using a quartz DB afaik). This add a property that can contain a hostname and if the hostname in the property matches the hostname of the server where the server is starting up then it will enable the scheduled job, otherwise it will not. 

The first commit did this programmatically but then I changed it in the 2nd commit to use a custom `@ConditionalOnMatchingHostname` annotation. 

I removed the ticketRegistryCleaner bean from MongoDbTicketRegistryConfiguration b/c it looked to be the same as the bean defined in CasCoreTicketsSchedulingConfiguration. I am not sure if the annotation will work on the MultifactorAuthenticationTrustStorageCleaner since it is using `@Scheduled` annotation and don't know if that makes a bean or not. 

Still need to test and add test, just looking for some feedback on the approach, annotation or not, or whether there is an alternative way to achieve this. 