### PR TITLE
Fix isDefault support for SAML2 ACS

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.support.SAML2MetadataSupport;
 import org.opensaml.saml.saml2.core.RequestAbstractType;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.ContactPerson;
@@ -221,7 +222,9 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
      * @return the assertion consumer service
      */
     public AssertionConsumerService getAssertionConsumerService(final String binding) {
-        return getAssertionConsumerServices().stream().filter(acs -> acs.getBinding().equalsIgnoreCase(binding)).findFirst().orElse(null);
+        val acsList = getAssertionConsumerServices().stream()
+                .filter(acs -> acs.getBinding().equalsIgnoreCase(binding)).collect(Collectors.toList());
+        return SAML2MetadataSupport.getDefaultIndexedEndpoint(acsList);
     }
 
     /**

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacadeTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacadeTests.java
@@ -43,7 +43,9 @@ public class SamlRegisteredServiceServiceProviderMetadataFacadeTests extends Bas
         assertNotNull(adaptor.getExtensions());
         assertNotNull(adaptor.getSupportedProtocols());
         assertNotNull(adaptor.getSingleLogoutService());
-        assertNotNull(adaptor.getAssertionConsumerServiceForPostBinding());
+        val acs = adaptor.getAssertionConsumerServiceForPostBinding();
+        assertNotNull(acs);
+        assertEquals(7, acs.getIndex());
         assertNotNull(adaptor.getAssertionConsumerServiceForArtifactBinding());
         assertTrue(adaptor.assertionConsumerServicesSize() > 0);
         assertFalse(adaptor.isWantAssertionsSigned());

--- a/support/cas-server-support-saml-idp/src/test/resources/metadata/testshib-providers.xml
+++ b/support/cas-server-support-saml-idp/src/test/resources/metadata/testshib-providers.xml
@@ -332,7 +332,7 @@
         SAML version/binding to use.
         -->
 
-            <AssertionConsumerService index="1" isDefault="true"
+            <AssertionConsumerService index="1"
                                       Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
                                       Location="https://sp.testshib.org/Shibboleth.sso/SAML2/POST"/>
             <AssertionConsumerService index="2"
@@ -353,7 +353,7 @@
 
             <!-- A couple additional assertion consumers for the registration webapp. -->
 
-            <AssertionConsumerService index="7"
+            <AssertionConsumerService index="7" isDefault="true"
                                       Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
                                       Location="https://www.testshib.org/Shibboleth.sso/SAML2/POST"/>
             <AssertionConsumerService index="8"


### PR DESCRIPTION
The `isDefault` attribute was not taken into account for an ACS definition.

This PR fixes this issue. One test has been updated to verify the behavior.