### PR TITLE
Refractor duplicate definition of singleLogoutServiceLogoutUrlBuilder as variable and function

### DIFF
--- a/core/cas-server-core-logout/src/main/java/org/apereo/cas/logout/config/CasCoreLogoutConfiguration.java
+++ b/core/cas-server-core-logout/src/main/java/org/apereo/cas/logout/config/CasCoreLogoutConfiguration.java
@@ -56,10 +56,6 @@ public class CasCoreLogoutConfiguration {
     private ObjectProvider<ServiceFactory> webApplicationServiceFactory;
 
     @Autowired
-    @Qualifier("singleLogoutServiceLogoutUrlBuilder")
-    private ObjectProvider<SingleLogoutServiceLogoutUrlBuilder> singleLogoutServiceLogoutUrlBuilder;
-
-    @Autowired
     @Qualifier("ticketRegistry")
     private ObjectProvider<TicketRegistry> ticketRegistry;
 
@@ -156,7 +152,7 @@ public class CasCoreLogoutConfiguration {
     @ConditionalOnMissingBean(name = "defaultLogoutRedirectionStrategy")
     public LogoutRedirectionStrategy defaultLogoutRedirectionStrategy() {
         return new DefaultLogoutRedirectionStrategy(webApplicationServiceFactory.getObject(),
-            casProperties.getLogout(), singleLogoutServiceLogoutUrlBuilder.getObject());
+            casProperties.getLogout(), singleLogoutServiceLogoutUrlBuilder());
     }
 
     @Bean


### PR DESCRIPTION
As title:

`singleLogoutServiceLogoutUrlBuilder` (used in `defaultLogoutRedirectionStrategy`)  is being defined as variable while it is already available as function in the same class.

Suggestion:

- Remove `singleLogoutServiceLogoutUrlBuilder` variable
- Change `defaultLogoutRedirectionStrategy` to use the `singleLogoutServiceLogoutUrlBuilder` function instead of the varaible

See if is an applicable change, thanks.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
