### PR TITLE
Fix SPNEGO in case of failure

### DIFF
--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/ClearWebflowCredentialAction.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/ClearWebflowCredentialAction.java
@@ -20,7 +20,6 @@ import org.springframework.webflow.execution.RequestContext;
  * @author Misagh Moayyed
  * @since 5.0.0
  */
-
 @Slf4j
 public class ClearWebflowCredentialAction extends AbstractAction {
 
@@ -35,15 +34,11 @@ public class ClearWebflowCredentialAction extends AbstractAction {
             return null;
         }
 
-        val credential = WebUtils.getCredential(requestContext);
         WebUtils.removeCredential(requestContext);
         if (current.equalsIgnoreCase(CasWebflowConstants.TRANSITION_ID_AUTHENTICATION_FAILURE)
             || current.equalsIgnoreCase(CasWebflowConstants.TRANSITION_ID_ERROR)) {
             LOGGER.trace("Current event signaled a failure. Recreating credentials instance from the context");
             WebUtils.createCredential(requestContext);
-            if (credential != null) {
-                WebUtils.putCredentialIntoScope(requestContext.getFlashScope(), credential);
-            }
         }
         return null;
     }


### PR DESCRIPTION
I'm currently upgrading a CAS server using SPNEGO from v6.1 to v6.4.

In case of a SPNEGO failure, the login page was properly displayed in v6.1.

In v6.4.0-SNAPSHOT (or RC5), I get the following exception:

```java
ERROR [org.thymeleaf.TemplateEngine] - <[THYMELEAF][http-nio-8080-exec-1] Exception processing template "login/casLoginView": Error during execution of processor 'org.thymeleaf.spring5.processor.SpringInputGeneralFieldTagProcessor' (template: "fragments/loginform" - line 68, col 40)>
org.thymeleaf.exceptions.TemplateProcessingException: Error during execution of processor
...
Caused by: org.springframework.beans.NotReadablePropertyException: Invalid property 'username' of bean class [org.apereo.cas.support.spnego.authentication.principal.SpnegoCredential]: Bean property 'username' is not readable or has an invalid getter method: Does the return type of the getter match the parameter type of the setter?
```

It comes from the change made in `ClearWebflowCredentialAction`: https://github.com/apereo/cas/commit/a420b6e033a308624d40493533c8080392ddc998
It now saves the previous credential in the flash scope so the login page finds a `SpneogCredential` without a `username` property instead of a `UsernamePasswordCredential`.

This PR reverts this change in `ClearWebflowCredentialAction` to fix the problem. Though, some new changes may be needed related to the original commit: "fix NPE in password-change flows".
