### PR TITLE
OIDC: Fix the auth_time claim in ID tokens

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorService.java
@@ -94,7 +94,8 @@ public class OidcIdTokenGeneratorService extends BaseIdTokenGeneratorService<Oid
 
         val claims = new JwtClaims();
 
-        val jwtId = getJwtId(accessToken.getTicketGrantingTicket());
+        val tgt = accessToken.getTicketGrantingTicket();
+        val jwtId = getJwtId(tgt);
         claims.setJwtId(jwtId);
         claims.setClaim(OidcConstants.CLAIM_SESSIOND_ID, DigestUtils.sha(jwtId));
 
@@ -121,7 +122,7 @@ public class OidcIdTokenGeneratorService extends BaseIdTokenGeneratorService<Oid
         }
 
         claims.setStringClaim(OAuth20Constants.CLIENT_ID, service.getClientId());
-        claims.setClaim(OidcConstants.CLAIM_AUTH_TIME, accessToken.getAuthentication().getAuthenticationDate().toEpochSecond());
+        claims.setClaim(OidcConstants.CLAIM_AUTH_TIME, tgt.getAuthentication().getAuthenticationDate().toEpochSecond());
 
         if (attributes.containsKey(OAuth20Constants.STATE)) {
             claims.setClaim(OAuth20Constants.STATE, attributes.get(OAuth20Constants.STATE).get(0));

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorServiceTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorServiceTests.java
@@ -107,7 +107,7 @@ public class OidcIdTokenGeneratorServiceTests extends AbstractOidcTests {
         val claims = oidcTokenSigningAndEncryptionService.decode(idToken, Optional.ofNullable(registeredService));
         assertNotNull(claims);
         assertTrue(claims.hasClaim(OIDC_CLAIM_EMAIL));
-        assertTrue(claims.hasClaim(OidcConstants.CLAIM_AUTH_TIME));
+        assertEquals(authentication.getAuthenticationDate().toEpochSecond(), (long) claims.getClaimValue(OidcConstants.CLAIM_AUTH_TIME));
         assertTrue(claims.hasClaim(OIDC_CLAIM_NAME));
         assertTrue(claims.hasClaim(OIDC_CLAIM_PHONE_NUMBER));
         assertEquals("casuser@example.org", claims.getStringClaimValue(OIDC_CLAIM_EMAIL));


### PR DESCRIPTION
I have a client app (pac4j) integrated via the OIDC protocol with a CAS server.

I have this service definition:

```json
{
  "@class" : "org.apereo.cas.services.OidcRegisteredService",
  "clientId": "myclient",
  "clientSecret": "mysecret",
  "serviceId" : "^http://localhost:.*",
  "name": "OIDC",
  "id": 1,
  "scopes" : [ "java.util.HashSet",
    [ "openid", "email", "profile" ]
  ],
  "generateRefreshToken": true
}
```

I perform an authorization code flow login and receive an ID token, an access token and a refresh token.

I use this command to receive a new access token and ID token:

```shell
curl -XPOST -H "Authorization: Basic bXljbGllbnQ6bXlzZWNyZXQ=" 'http://localhost:8080/cas/oidc/token?grant_type=refresh_token&refresh_token=XXXXX'
```

The ID tokens have different values for the `auth_time` claim.

In the OIDC spec (https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse), it is defined that the `auth_time` should always be the time of the original authentication for the refresh: `if the ID Token contains an auth_time Claim, its value MUST represent the time of the original authentication - not the time that the new ID token is issued,`

This PR fixes the issue by using the authentication date of the TGT instead of the authentication date of the access token. A test has been updated to verify the change.
