### PR TITLE
puppeteer build updates

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -9,6 +9,7 @@ env:
   GRADLE_BUILDCACHE_PSW: ${{ secrets.GRADLE_BUILDCACHE_PSW }}
   TERM: xterm-256color
   JDK_CURRENT: 11.0.11
+  SCENARIO_REGEX: ".*" # use this to limit which tests run
 
 on:
   push:
@@ -48,7 +49,7 @@ jobs:
     needs: [initialize]
     runs-on: ubuntu-latest
     outputs:
-      scenarios: ${{ steps.get-categories.outputs.scenarios }}
+      scenarios: ${{ steps.get-scenarios.outputs.scenarios }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -56,9 +57,9 @@ jobs:
         with:
           java-version: ${{ env.JDK_CURRENT }}
           distribution: 'adopt'
-      - id: print-categories
+      - id: print-scenarios
         run: ./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerScenarios | jq
-      - id: get-categories
+      - id: get-scenarios
         run: echo "::set-output name=scenarios::$(./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerScenarios)]}"
 
 ##########################################################################
@@ -72,6 +73,7 @@ jobs:
         os: [ubuntu-latest]
         scenario: ${{fromJSON(needs.puppeteer-scenarios.outputs.scenarios)}}
     name: ${{matrix.scenario}}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/ci/tests/ldap/run-ad-server.sh
+++ b/ci/tests/ldap/run-ad-server.sh
@@ -14,6 +14,12 @@
 # docker exec -it samba /bin/bash
 # The container also contains the ldap-utils package so users could be imported via LDIF files.
 
+docker ps | grep samba > /dev/null
+if [[ $? -eq 0 ]]; then
+  echo "Samba already running, run docker rm -f samba to get clean directory"
+  exit 0
+fi
+
 # Passing true as first argument will reset directory config and data
 RESET=${1:-false}
 

--- a/ci/tests/puppeteer/.npmrc
+++ b/ci/tests/puppeteer/.npmrc
@@ -1,0 +1,2 @@
+fetch-retry-maxtimeout = 120000
+fetch-retry-mintimeout = 20000

--- a/ci/tests/puppeteer/cas.js
+++ b/ci/tests/puppeteer/cas.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 
 const BROWSER_OPTIONS = {
     ignoreHTTPSErrors: true,
-    headless: process.env.CI === "true",
+    headless: process.env.CI === "true" || process.env.HEADLESS === "true",
     devtools: process.env.CI !== "true",
     defaultViewport: null,
     slowMo: process.env.CI === "true" ? 0 : 10,

--- a/ci/tests/puppeteer/run.sh
+++ b/ci/tests/puppeteer/run.sh
@@ -29,7 +29,8 @@ random=$(openssl rand -hex 8)
 
 if [[ ! -d "$PWD"/ci/tests/puppeteer/node_modules/puppeteer ]] ; then
   echo "Installing Puppeteer"
-  npm i --prefix "$PWD"/ci/tests/puppeteer puppeteer jsonwebtoken axios request
+  npm_install_cmd="npm i --prefix "$PWD"/ci/tests/puppeteer puppeteer jsonwebtoken axios request"
+  eval $npm_install_cmd || eval $npm_install_cmd || eval $npm_install_cmd
 else
   echo "Using existing Puppeteer modules..."
 fi

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -91,7 +91,8 @@ if (rootProject.tasks.findByName("puppeteerScenarios") == null) {
     rootProject.tasks.create(name: "puppeteerScenarios", description: "Display all available puppeteer scenarios") {
         doLast {
             def scenarios = new TreeSet<String>()
-            rootProject.file("ci/tests/puppeteer/scenarios").eachDir {
+            def scenarioMatchPattern = System.getenv().get("SCENARIO_REGEX") ?: ".*"
+            rootProject.file("ci/tests/puppeteer/scenarios").eachDirMatch(~scenarioMatchPattern) {
                 scenarios += it.getName()
             }
             println(groovy.json.JsonOutput.toJson(scenarios))


### PR DESCRIPTION
These are some changes I made related to running puppeteer tests locally on windows and on a fork (without running all tests). 

- make it easier to run a sub-set of the puppeteer tests on your own fork (via regex)
- allow running puppeteer tests as HEADLESS without setting CI=true (the x509 test now does ldap auth too but the certificate prompt was causing problems in non-headless mode)
- made puppeteer tests timeout after 15 minutes
- added REBUILD env variable that if set to false will use existing cas.war to run puppeteer test rather than building again
- fixed run.sh so it works on Windows MSYS2 bash when a path is passed (to a cert bundle or script) on the command line