### PR TITLE
Fix DistributedJEESessionStore

### DIFF
--- a/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/pac4j/DistributedJEESessionStore.java
+++ b/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/pac4j/DistributedJEESessionStore.java
@@ -42,7 +42,7 @@ public class DistributedJEESessionStore implements SessionStore {
     @Override
     public Optional<String> getSessionId(final WebContext webContext, final boolean create) {
         var sessionId = fetchSessionIdFromContext(webContext);
-        if (StringUtils.isBlank(sessionId)) {
+        if (StringUtils.isBlank(sessionId) && create) {
             sessionId = UUID.randomUUID().toString();
             LOGGER.trace("Generated session id: [{}]", sessionId);
             
@@ -50,7 +50,7 @@ public class DistributedJEESessionStore implements SessionStore {
             cookieGenerator.addCookie(context.getNativeRequest(), context.getNativeResponse(), sessionId);
             context.setRequestAttribute(SESSION_ID_IN_REQUEST_ATTRIBUTE, sessionId);
         }
-        return Optional.of(sessionId);
+        return Optional.ofNullable(sessionId);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class DistributedJEESessionStore implements SessionStore {
     @Override
     public void set(final WebContext context, final String key, final Object value) {
         LOGGER.trace("Setting key: [{}]", key);
-        val sessionId = fetchSessionIdFromContext(context);
+        val sessionId = getSessionId(context, true).get();
 
         val properties = new HashMap<String, Serializable>();
         if (value instanceof Serializable) {
@@ -92,12 +92,14 @@ public class DistributedJEESessionStore implements SessionStore {
     @Override
     public boolean destroySession(final WebContext webContext) {
         val sessionId = fetchSessionIdFromContext(webContext);
-        val ticketId = TransientSessionTicketFactory.normalizeTicketId(sessionId);
-        this.centralAuthenticationService.deleteTicket(ticketId);
+        if (sessionId != null) {
+            val ticketId = TransientSessionTicketFactory.normalizeTicketId(sessionId);
+            this.centralAuthenticationService.deleteTicket(ticketId);
 
-        val context = JEEContext.class.cast(webContext);
-        cookieGenerator.removeCookie(context.getNativeResponse());
-        LOGGER.trace("Removes session cookie and ticket: [{}]", ticketId);
+            val context = JEEContext.class.cast(webContext);
+            cookieGenerator.removeCookie(context.getNativeResponse());
+            LOGGER.trace("Removes session cookie and ticket: [{}]", ticketId);
+        }
         return true;
     }
 
@@ -105,7 +107,7 @@ public class DistributedJEESessionStore implements SessionStore {
     public Optional getTrackableSession(final WebContext context) {
         val sessionId = fetchSessionIdFromContext(context);
         LOGGER.trace("Track sessionId: [{}]", sessionId);
-        return Optional.of(sessionId);
+        return Optional.ofNullable(sessionId);
     }
 
     @Override
@@ -132,17 +134,19 @@ public class DistributedJEESessionStore implements SessionStore {
             val context = JEEContext.class.cast(webContext);
             sessionId = cookieGenerator.retrieveCookieValue(context.getNativeRequest());
         }
-        LOGGER.trace("Generated session id: [{}]", sessionId);
+        LOGGER.trace("Fetched session id: [{}]", sessionId);
         return sessionId;
     }
 
     private TransientSessionTicket getTransientSessionTicketForSession(final WebContext context) {
         try {
             val sessionId = fetchSessionIdFromContext(context);
-            val ticketId = TransientSessionTicketFactory.normalizeTicketId(sessionId);
+            if (sessionId != null) {
+                val ticketId = TransientSessionTicketFactory.normalizeTicketId(sessionId);
 
-            LOGGER.trace("fetching ticket: [{}]", ticketId);
-            return centralAuthenticationService.getTicket(ticketId, TransientSessionTicket.class);
+                LOGGER.trace("fetching ticket: [{}]", ticketId);
+                return centralAuthenticationService.getTicket(ticketId, TransientSessionTicket.class);
+            }
         } catch (final Exception e) {
             LOGGER.trace(e.getMessage(), e);
         }

--- a/support/cas-server-support-pac4j-api/src/test/java/org/apereo/cas/integration/pac4j/DistributedJEESessionStoreTests.java
+++ b/support/cas-server-support-pac4j-api/src/test/java/org/apereo/cas/integration/pac4j/DistributedJEESessionStoreTests.java
@@ -43,7 +43,7 @@ public class DistributedJEESessionStoreTests {
     private TicketFactory ticketFactory;
 
     @Test
-    public void verifyOperation() {
+    public void verifyTracking() {
         val cookie = casProperties.getSessionReplication().getCookie();
         val cookieGenerator = CookieUtils.buildCookieRetrievingGenerator(cookie);
 
@@ -58,8 +58,22 @@ public class DistributedJEESessionStoreTests {
         assertFalse(store.renewSession(context));
         assertTrue(store.buildFromTrackableSession(context, "trackable-session").isPresent());
         assertTrue(store.getTrackableSession(context).isPresent());
+    }
 
+    @Test
+    public void verifySetGet() {
+        val cookie = casProperties.getSessionReplication().getCookie();
+        val cookieGenerator = CookieUtils.buildCookieRetrievingGenerator(cookie);
+
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+
+        val store = new DistributedJEESessionStore(centralAuthenticationService, ticketFactory, cookieGenerator);
+        val context = new JEEContext(request, response);
+
+        assertTrue(store.getSessionId(context, false).isEmpty());
         store.set(context, "attribute", "test");
+        assertTrue(store.getSessionId(context, false).isPresent());
         var value = store.get(context, "attribute");
         assertTrue(value.isPresent());
         assertEquals("test", value.get());


### PR DESCRIPTION
I have found an issue with the authentication delegation which comes from the `DistributedJEESessionStore`.

The source code has been refactored after the upgrade to pac4j v5 and there is a problem: the `set` operation should always create a session if it does not exist. Like in the `JEESessionStore`.

This PR fixes this issue. The tests have been updated accordingly.

Without this fix, before the authn delegation, the ticket used to save the session store is always `TST-null` (as `null` is the session id). It means that multiple new authentication processes will share the same ticket id and use the already existing session store (from another authn process).

You can check the issue with the following demo: https://github.com/casinthecloud/cas-pac4j-oauth-demo
- Set the version to v6.4.0-SNAPSHOT, build and run in a Tomcat
- Open the URL: http://localhost:8080/cas/login in one browser
- Open the second URL: http://localhost:8080/cas/login?service=http://localhost:8081 in another browser
- Click "CAS" on the first browser
- Same on the second browser
- Finish the authentication process on the first browser (user/pwd: jleleu/jleleu): the user is redirected to the service of the second browser (http://localhost:8081).
