### PR TITLE
Fix the auth_time claim in the OIDC support

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileDataCreator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileDataCreator.java
@@ -40,7 +40,7 @@ public class OidcUserProfileDataCreator extends DefaultOAuth20UserProfileDataCre
                 if (!map.containsKey(OidcConstants.CLAIM_SUB)) {
                     map.put(OidcConstants.CLAIM_SUB, principal.getId());
                 }
-                map.put(OidcConstants.CLAIM_AUTH_TIME, accessToken.getAuthentication().getAuthenticationDate().toEpochSecond());
+                map.put(OidcConstants.CLAIM_AUTH_TIME, accessToken.getTicketGrantingTicket().getAuthentication().getAuthenticationDate().toEpochSecond());
             } else {
                 map.keySet().retainAll(CollectionUtils.wrapList(OAuth20UserProfileViewRenderer.MODEL_ATTRIBUTE_ATTRIBUTES));
             }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/profile/OidcUserProfileDataCreatorTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/profile/OidcUserProfileDataCreatorTests.java
@@ -33,7 +33,7 @@ public class OidcUserProfileDataCreatorTests extends AbstractOidcTests {
         val accessToken = getAccessToken();
         val data = oidcUserProfileDataCreator.createFrom(accessToken, context);
         assertFalse(data.isEmpty());
-        assertTrue(data.containsKey(OidcConstants.CLAIM_AUTH_TIME));
+        assertEquals(accessToken.getTicketGrantingTicket().getAuthentication().getAuthenticationDate().toEpochSecond(), (long) data.get(OidcConstants.CLAIM_AUTH_TIME));
         assertTrue(data.containsKey(OidcConstants.CLAIM_SUB));
         assertTrue(data.containsKey(OAuth20UserProfileViewRenderer.MODEL_ATTRIBUTE_ID));
         assertTrue(data.containsKey(OAuth20UserProfileViewRenderer.MODEL_ATTRIBUTE_CLIENT_ID));


### PR DESCRIPTION
A few days ago, I submitted the PR: https://github.com/apereo/cas/pull/5185 to always have the same `auth_time` in all ID tokens (for the same session).

Though, it has introduced a small inconsistency between the `auth_time` of the ID token and the `auth_time` of the user profile endpoint.

"accessToken" endpoint response:

```json
{
   "access_token":"AT-6--HNfN3VYv7Bel28IwFu-fWol84taNSDN",
"id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImxhbGFsYSJ9.eyJqdGkiOiJUR1QtNi1oLURHclhVMUhFUVhqcTBIZjZPMlZiWmliaUhiQ0xVVjA1eXJFZ3BKckNhamN2UlhzUXdvdDB0YWUtOU5HZjVIQ1JNLWNhc3Rlc3QiLCJzaWQiOiI4ZWRiMWI3Y2VlZDY0N2ViNGU3NjEyZjE2MWYyMzVjZTVhYTdiNWIxIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2Nhcy9vaWRjIiwiYXVkIjoibXljbGllbnQiLCJleHAiOjE2MjUxNzc4NDAsImlhdCI6MTYyNTE0OTA0MCwibmJmIjoxNjI1MTQ4NzQwLCJzdWIiOiJqbGVsZXUiLCJjbGllbnRfaWQiOiJteWNsaWVudCIsImF1dGhfdGltZSI6MTYyNTE0OTAzOSwic3RhdGUiOiI5ZWJlNzg5MmI3Iiwibm9uY2UiOiIiLCJhdF9oYXNoIjoiRVRYSVZodDMzeTBjTkM2TThtQXhCQSIsImVtYWlsIjoibGVsZXVqQGdtYWlsLmNvbSIsImZhbWlseV9uYW1lIjoiTEVMRVUiLCJnZW5kZXIiOiJNYXNjdWxpbiIsIm5hbWUiOiJKw6lyw7RtZSIsIm5pY2tuYW1lIjoiasOpasOpQGV4YW1wbGUub3JnIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiamxlbGV1In0.CkI6jnTmLD0qO4kuemryM0OvPs2GrjXT2ZDKK-_c6IKQ3ACGUjrrDYrpK2SPwHl_0446mVJkl3WdX87d3utuyNeYXu1PgkeXus2j_CK5mGFdBW8Bwhm3ujXJxYUQF28LtNZ6QC1vgrAs-Bgrj0KajTW7kxEBT5mX1iU9Ao7DLAePiCSVl8N4QPps-CFabW3UY-_DCERWZGoNrv_xDxzwhwqnSQRjn3hSmLS5oo5sobbwUeQdXQCnIJaoRt5hX8ch5GvoKN56ZX-oSOVIamJfkcuInGfmFo6Cla-2eK9yNz78syhAYMyLhjHoguVejA3fImPKvrr3GeW2aSN1n3XJ5g",
   "refresh_token":"RT-6-6nhK3gg8fUUYbNce-nG4-eH6FfXUHpqo",
   "token_type":"bearer",
   "expires_in":28800,
   "scope":"email openid profile"
}
```

with the ID token:

```json
{
  "jti": "TGT-6-h-DGrXU1HEQXjq0Hf6O2VbZibiHbCLUV05yrEgpJrCajcvRXsQwot0tae-9NGf5HCRM-castest",
  "sid": "8edb1b7ceed647eb4e7612f161f235ce5aa7b5b1",
  "iss": "http://localhost:8080/cas/oidc",
  "aud": "myclient",
  "exp": 1625177840,
  "iat": 1625149040,
  "nbf": 1625148740,
  "sub": "jleleu",
  "client_id": "myclient",
  "auth_time": 1625149039,
  "state": "9ebe7892b7",
  "nonce": "",
  "at_hash": "ETXIVht33y0cNC6M8mAxBA",
  "email": "leleuj@gmail.com",
  "family_name": "LELEU",
  "gender": "Masculin",
  "name": "Jérôme",
  "nickname": "jéjé@example.org",
  "preferred_username": "jleleu"
}
```

"userinfo" endpoint response:

```json
{
   "sub":"jleleu",
   "service":"http://localhost:8081/callback?client_name=OidcClient",
   "auth_time":1625149040,
   "attributes":{
      "email":"leleuj@gmail.com",
      "family_name":"LELEU",
      "gender":"Masculin",
      "name":"Jérôme",
      "nickname":"jéjé@example.org"
   },
   "id":"jleleu",
   "client_id":"myclient"
}
```

You can see that the `auth_time` is  **slightly** different: 1625149039 vs 1625149040.

This PR fixes this issue by doing the same in both cases: using the TGT authentication date instead of the access token authentication date.
The test has been updated accordingly.
