### PR TITLE
Add workflows for publishing private releases from forks to aws/github package repositories

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,0 +1,93 @@
+name: Publish Fork Release to Azure Artifacts Repository
+env:
+  JAVA_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
+  GRADLE_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
+  TERM: xterm-256color
+  REPOSITORY_USER: ${{ secrets.ARTIFACTS_REPOSITORY_USER }}
+  REPOSITORY_PWD: ${{ secrets.ARTIFACTS_REPOSITORY_PWD }}
+  REPOSITORY_URL: ${{ secrets.ARTIFACTS_REPOSITORY_URL }}
+  RUBY_VERSION: 2.6
+  JDK_CURRENT: 11.0.11
+  TIMEOUT: 640000
+
+##########################################################################
+
+# Trigger on four digit tags where the fourth digit differentiates build from official builds
+on:
+  push:
+    tags:
+      - 6.*.*.*
+      - 7.*.*.*
+
+##########################################################################
+
+jobs:
+
+  ##########################################################################
+
+  initialize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: ls ./ci && chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+
+  ##########################################################################
+
+  cache:
+    runs-on: ubuntu-latest
+    needs: [initialize]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+      - uses: actions/checkout@v2
+      - name: Download Dependencies
+        run: ./gradlew --build-cache --configure-on-demand --no-daemon downloadDependencies --parallel --refresh-dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+  ##########################################################################
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: [cache]
+    continue-on-error: false
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Output Config
+        run: echo "username=${REPOSITORY_USER} releaseRepositoryUrl=${REPOSITORY_URL} on tag ${{ github.ref }} Token Length is [$(echo -n REPOSITORY_PWD | wc -c)] Tag is ${GITHUB_REF/refs\/tags\//}"
+        if: ${{ env.REPOSITORY_USER != null && env.REPOSITORY_PWD != null && env.REPOSITORY_URL != null }}
+      - name: Publish Release to GH Package Repository
+        run: ./gradlew -DpublishReleases=true -DskipArtifactSigning=true --parallel --build-cache --configure-on-demand --no-daemon -Dorg.gradle.internal.http.socketTimeout="${TIMEOUT}" -Dorg.gradle.internal.http.connectionTimeout="${TIMEOUT}"  build publish -x test -x javadoc -x check -PrepositoryUsername=${REPOSITORY_USER} -PrepositoryPassword=${REPOSITORY_PWD} -PreleaseRepositoryUrl=${REPOSITORY_URL} -Pversion=${GITHUB_REF/refs\/tags\//}
+        if: ${{ env.REPOSITORY_USER != null && env.REPOSITORY_PWD != null && env.REPOSITORY_URL != null }}

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -7,7 +7,7 @@ env:
   REPOSITORY_PWD: ${{ secrets.ARTIFACTS_REPOSITORY_PWD }}
   REPOSITORY_URL: ${{ secrets.ARTIFACTS_REPOSITORY_URL }}
   RUBY_VERSION: 2.6
-  JDK_CURRENT: 11.0.11
+  JDK_CURRENT: 11.0.12
   TIMEOUT: 640000
 
 ##########################################################################
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: ls ./ci && chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
 
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
       - uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
       - uses: actions/cache@v2

--- a/.github/workflows/publish-aws.yml
+++ b/.github/workflows/publish-aws.yml
@@ -1,0 +1,110 @@
+name: Publish Fork Release to AWS CodeArtifact
+# This can be used to publish a release from a CAS fork to an AWS CodeArtifact private repository.
+# Workflow is triggered by four digit tags.
+# Requires secrets:
+# CODE_ARTIFACT_DOMAIN and CODE_ARTIFACT_URL determined when the repository is created.
+# CODE_ARTIFACT_AWS_ACCESS_KEY_ID and CODE_ARTIFACT_AWS_SECRET_ACCESS_KEY should be for user with publish rights on repo
+# CODE_ARTIFACT_REGION is region where the CodeArtifact repository exists
+
+env:
+  JAVA_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
+  GRADLE_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
+  TERM: xterm-256color
+  REPO_OWNER: ${{ github.repository_owner }}
+  RUBY_VERSION: 2.6
+  JDK_CURRENT: 11.0.11
+  CODE_ARTIFACT_DOMAIN: ${{ secrets.CODE_ARTIFACT_DOMAIN }}
+  CODE_ARTIFACT_URL: ${{ secrets.CODE_ARTIFACT_URL }}
+
+##########################################################################
+
+# Trigger on four digit tags where the fourth digit differentiates build from official builds
+on:
+  push:
+    tags:
+      - 6.*.*.*
+      - 7.*.*.*
+
+##########################################################################
+
+jobs:
+
+  ##########################################################################
+
+  initialize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: ls ./ci && chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+
+  ##########################################################################
+
+  cache:
+    runs-on: ubuntu-latest
+    needs: [initialize]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+      - uses: actions/checkout@v2
+      - name: Download Dependencies
+        run: ./gradlew --build-cache --configure-on-demand --no-daemon downloadDependencies --parallel --refresh-dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+  ##########################################################################
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: [cache]
+    continue-on-error: false
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.CODE_ARTIFACT_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CODE_ARTIFACT_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.CODE_ARTIFACT_REGION }}
+      - name: Publish Release to AWS CodeArtifact Package Repository
+        run: |
+          export CODE_ARTIFACT_OWNER=${{ steps.aws-credentials.outputs.aws-account-id }}
+          echo "CodeArtifact owner length is $(echo -n $CODE_ARTIFACT_OWNER | wc -c)"
+          echo "CodeArtifact domain length is: $(echo -n CODE_ARTIFACT_DOMAIN | wc -c)"
+          export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain ${CODE_ARTIFACT_DOMAIN} --domain-owner ${{ steps.aws-credentials.outputs.aws-account-id }} --query authorizationToken --output text`
+          echo "Auth Token Length: $(echo -n $CODEARTIFACT_AUTH_TOKEN | wc -c)"
+          echo "CodeArtifact URL Length: $(echo -n $CODE_ARTIFACT_URL | wc -c)"
+          ./gradlew -DpublishReleases=true -DskipArtifactSigning=true --parallel --build-cache --configure-on-demand --no-daemon -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.http.connectionTimeout=180000 build publish -x test -x javadoc -x check -PrepositoryUsername=aws -PrepositoryPassword=${CODEARTIFACT_AUTH_TOKEN} -PreleaseRepositoryUrl=${CODE_ARTIFACT_URL} -Pversion=${GITHUB_REF/refs\/tags\//}
+        if: ${{ env.CODE_ARTIFACT_URL != null && env.CODE_ARTIFACT_DOMAIN != null}}

--- a/.github/workflows/publish-aws.yml
+++ b/.github/workflows/publish-aws.yml
@@ -12,7 +12,7 @@ env:
   TERM: xterm-256color
   REPO_OWNER: ${{ github.repository_owner }}
   RUBY_VERSION: 2.6
-  JDK_CURRENT: 11.0.11
+  JDK_CURRENT: 11.0.12
   CODE_ARTIFACT_DOMAIN: ${{ secrets.CODE_ARTIFACT_DOMAIN }}
   CODE_ARTIFACT_URL: ${{ secrets.CODE_ARTIFACT_URL }}
 
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: ls ./ci && chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
 
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
       - uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
       - uses: actions/cache@v2

--- a/.github/workflows/publish-gpr.yml
+++ b/.github/workflows/publish-gpr.yml
@@ -1,0 +1,100 @@
+name: Publish Fork Release to Github Package Repository
+# As of July 2021 this workflow fails with 409 Conflict error on seemingly random packages or associated files (e.g. *.md5).
+# With as many packages as CAS publishes your odds of successfully publishing a release
+# to Github Packages are low, possibly zero.
+# The CAS shell jar is skipped because it fails with 400 error, presumably because it is too big for GPR. (~120MB)
+# GitHub automatically creates a GITHUB_TOKEN secret to use in your workflow and by default it has read/write to
+# packages when triggered to run on a a fork (but not when triggered by a fork to run on main repo).
+
+env:
+  JAVA_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
+  GRADLE_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
+  TERM: xterm-256color
+  REPO_OWNER: ${{ github.repository_owner }}
+  RUBY_VERSION: 2.6
+  JDK_CURRENT: 11.0.11
+  TIMEOUT: 640000
+
+##########################################################################
+
+# Trigger on four digit tags where the fourth digit differentiates build from official builds
+on:
+  push:
+    tags:
+      - 6.*.*.*
+      - 7.*.*.*
+
+##########################################################################
+
+jobs:
+
+##########################################################################
+
+  initialize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: ls ./ci && chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+
+##########################################################################
+
+  cache:
+    runs-on: ubuntu-latest
+    needs: [initialize]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+      - uses: actions/checkout@v2
+      - name: Download Dependencies
+        run: ./gradlew --build-cache --configure-on-demand --no-daemon downloadDependencies --parallel --refresh-dependencies
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+            
+##########################################################################
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: [cache]
+    continue-on-error: false
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'adopt'
+      - name: Initialize
+        run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Output Config
+        run: echo "username=${GITHUB_ACTOR} releaseRepositoryUrl=https://maven.pkg.github.com/${GITHUB_REPOSITORY} on tag ${{ github.ref }} Token Length is [$(echo -n $GITHUB_TOKEN | wc -c)] Tag is ${GITHUB_REF/refs\/tags\//}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Release to GH Package Repository
+        run: ./gradlew -DpublishReleases=true -DskipArtifactSigning=true -DpublishMinimalArtifacts=true --build-cache --configure-on-demand --no-daemon -Dorg.gradle.internal.http.socketTimeout="${TIMEOUT}" -Dorg.gradle.internal.http.connectionTimeout="${TIMEOUT}"  build publish -x test -x javadoc -x check -PrepositoryUsername=${GITHUB_ACTOR} -PrepositoryPassword=${GITHUB_TOKEN} -PreleaseRepositoryUrl=https://maven.pkg.github.com/${GITHUB_REPOSITORY} -Pversion=${GITHUB_REF/refs\/tags\//}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-gpr.yml
+++ b/.github/workflows/publish-gpr.yml
@@ -12,7 +12,7 @@ env:
   TERM: xterm-256color
   REPO_OWNER: ${{ github.repository_owner }}
   RUBY_VERSION: 2.6
-  JDK_CURRENT: 11.0.11
+  JDK_CURRENT: 11.0.12
   TIMEOUT: 640000
 
 ##########################################################################
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: ls ./ci && chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
 
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
       - uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ env.JDK_CURRENT }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Initialize
         run: chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
       - uses: actions/cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-##########################################################################
+  ##########################################################################
 
   initialize:
     needs: [cancel-previous-runs]
@@ -49,7 +49,7 @@ jobs:
       - name: Initialize
         run: ls ./ci && chmod -R 777 ./ci/*.sh && ./ci/init-build.sh
 
-##########################################################################
+  ##########################################################################
 
   cache:
     runs-on: ubuntu-latest
@@ -72,8 +72,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-            
-##########################################################################
+
+  ##########################################################################
 
   publish-snapshots:
     runs-on: ubuntu-latest
@@ -99,8 +99,8 @@ jobs:
         if: ${{ env.REPOSITORY_USER != null && env.REPOSITORY_PWD != null }}
         run: ./gradlew -DpublishSnapshots=true --build-cache --configure-on-demand --no-daemon --parallel -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.http.connectionTimeout=180000 build publish -x test -x javadoc -x check -DrepositoryUsername="${REPOSITORY_USER}" -DrepositoryPassword="${REPOSITORY_PWD}"
 
-          
-##########################################################################
+
+  ##########################################################################
 
   publish-docs:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ ext {
 
     publishFlag = publishSnapshots || publishReleases
 
+    publishMinimalArtifacts = providers.systemProperty("publishMinimalArtifacts").forUseAtConfigurationTime().present
+
     skipBootifulArtifact = providers.systemProperty("skipBootifulArtifact").forUseAtConfigurationTime().present
     skipErrorProneCompiler = providers.systemProperty("skipErrorProneCompiler").forUseAtConfigurationTime().present
 
@@ -309,10 +311,12 @@ subprojects {
                         logger.info "Project ${project.name} should be published as a JAR"
                         mavenJava(MavenPublication) {
                             from components.java
-                            artifact tasks['sourcesJar']
-                            artifact tasks['resourcesJar']
-                            artifact tasks['javadocJar']
-                            artifact tasks['testJar']
+                            if (!rootProject.publishMinimalArtifacts) {
+                                artifact tasks['sourcesJar']
+                                artifact tasks['resourcesJar']
+                                artifact tasks['javadocJar']
+                                artifact tasks['testJar']
+                            }
 
                             pom {
                                 createPom(it, project)
@@ -363,7 +367,7 @@ subprojects {
 
     artifacts {
         tests testJar
-        if (rootProject.publishFlag) {
+        if (rootProject.publishFlag && !rootProject.publishMinimalArtifacts) {
             archives sourcesJar
             archives javadocJar
             archives resourcesJar
@@ -433,7 +437,7 @@ subprojects {
         project.buildDate != null || !project.buildJarFile.exists()
     }
 
-    if (projectShouldBePublished(project)) {
+    if (projectRequiresLombok(project)) {
         apply plugin: "io.franzbecker.gradle-lombok"
         lombok {
             version = "$lombokVersion"
@@ -563,7 +567,7 @@ task gradleHome(description: "Display GRADLE_HOME environment variable") {
     }
 }
 
-if (rootProject.publishFlag) {
+if (rootProject.publishFlag && !rootProject.publishMinimalArtifacts) {
     artifacts {
         archives aggregateJavadocsIntoJar
         archives rootSourcesJar
@@ -640,7 +644,15 @@ task verifyRequiredJavaVersion {
 boolean projectShouldBePublished(Project project) {
     def publishable = !["api", "core", "docs", "support", "webapp"].contains(project.name)
             && !project.getPath().contains("cas-server-documentation")
+    if ("${releaseRepositoryUrl}".contains("github.com") && project.getPath().contains("cas-server-support-shell")) {
+        // shell is too big for github
+        publishable = false
+    }
     project.ext.publishable = publishable
 }
 
+boolean projectRequiresLombok(Project project) {
+    return !["api", "core", "docs", "support", "webapp"].contains(project.name)
+            && !project.getPath().contains("cas-server-documentation")
+}
 


### PR DESCRIPTION
This adds two github action workflows, intended mainly for use in forks, one for publishing a tagged release from a fork to github package repo (which doesn't work, or hasn't yet worked) and one to publish to AWS CodeArtifact (which works). The Github Package Repo workflow fails with random 409 conflict errors but I figure it might have some value as an easy to recreate the problem so Github could fix the problem. With 250+ packages in CAS, every publish will likely fail. The AWS workflow seems to work reliably (or at least hasn't failed for two releases since I got it working) although it requires more work on the AWS side (creating repo and user with rights to the repo, generating an access key, and then creating secrets on the fork doing the publishing). 

I think this might encourage contributions to CAS, and increase use of the latest under development release branch, since users could contribute something and get to use it immediately in their own tagged release (from their fork) rather than having to use a snapshot release (which I often do but which entails some risk). I might still use the snapshots since they only go to development environments but having ability to do production releases from a non-snapshot or use a tag when the snapshot is currently broken for me has value. Forks wouldn't want to maintain significant uncontributed changes so the incentive to contribute would still be there. 

The workflows are currently setup to trigger on a four digit tag like `6.4.0.1` but that could be changed if we wanted to encourage a different convention, but someone could edit the workflow on their fork to do whatever. Since the repositories would be private I don't know if it matters. I suppose Github package repo (if it worked) might default to public but I can't imagine someone using some other fork's release. 

If you don't want the broken github workflow I can remove that and if don't think this belongs in the main repo since it would mainly be used from forks, that is fine, but I don't think it would add any overhead to the main CI since the workflow only triggers on a particular tag format. I can also document how to set this up or at least the existence of the workflows. 

![image](https://user-images.githubusercontent.com/1556777/125178490-6a13a500-e1b3-11eb-956b-157da6a331bd.png)

Here is a run of the AWS CodeArtifact workflow:
https://github.com/hdeadman/cas/actions/runs/1018600538

