### PR TITLE
add puppeteer test with strapi oidc app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ webapp/resources/static/js/*-bundle.js
 **/.sts4-cache/*
 ci/tests/puppeteer/overlay
 ci/tests/puppeteer/package*.json
+ci/tests/puppeteer/**/strapi
+ci/tests/puppeteer/**/*.jwks

--- a/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/init.sh
+++ b/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/init.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+set -m
+
+STRAPI_FOLDER=${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/strapi
+PROJECT=getstarted
+if [[ ! -d $STRAPI_FOLDER/$PROJECT ]] ; then
+  mkdir -p $STRAPI_FOLDER
+  cd $STRAPI_FOLDER
+  yarn create strapi-app $PROJECT --quickstart --no-run
+  cd -
+fi
+
+# copy server.js with URL for strapi defined
+cp ${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/strapi-custom/server.js $STRAPI_FOLDER/$PROJECT/config/server.js
+# copy SSO provider bootstrap.js with CAS defaults pre-configured for this test deployment
+mkdir -p $STRAPI_FOLDER/$PROJECT/extensions/users-permissions/config/functions
+cp ${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/strapi-custom/bootstrap.js $STRAPI_FOLDER/$PROJECT/extensions/users-permissions/config/functions
+
+# install node modules for strapi app
+cd $STRAPI_FOLDER/$PROJECT
+yarn install
+
+# copy over user-permissions-actions.js from installed app b/c bootstrap.js references it by relative path
+cp $STRAPI_FOLDER/$PROJECT/node_modules/strapi-plugin-users-permissions/config/users-permissions-actions.js $STRAPI_FOLDER/$PROJECT/extensions/users-permissions/config
+
+# run without SSL verification in order to call CAS via https and not worry about SSL trust
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn develop &
+pid=$!
+echo "Waiting for Strapi start up in background"
+until curl -k -L --output /dev/null --silent --fail http://localhost:1337; do
+  echo -n '.'
+  sleep 1
+done
+echo "Strapi Ready - PID: $pid"
+
+if [[ "$SKIP_REGISTRATION" != "true" ]]; then
+  # register strapi administrator user
+  DATA='{"email":"admin@example.org","password":"P@ssw0rd","firstname":"Strapi","lastname":"Admin"}'
+  echo $DATA > .admin.txt
+  cat .admin.txt
+  # allow error in case already registered
+  set +e
+  curl -X POST -H "Content-Type: application/json" http://localhost:1337/admin/register-admin --data @./.admin.txt
+  rm .admin.txt
+fi
+
+# let strapi keep running
+disown -h %1
+
+cd -

--- a/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/script.js
+++ b/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/script.js
@@ -1,0 +1,34 @@
+const puppeteer = require('puppeteer');
+const assert = require('assert');
+const cas = require('../../cas.js');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+    await page.goto("https://localhost:8443/cas/login");
+
+    await cas.loginWith(page, "casuser", "Mellon");
+
+    await cas.assertTicketGrantingCookie(page);
+    
+    const title = await page.title();
+    console.log(title)
+    assert(title === "CAS - Central Authentication Service")
+
+    const header = await cas.innerText(page, '#content div h2');
+    console.log(header)
+    assert(header === "Log In Successful")
+    // hit strapi endpoint that triggers CAS login to get JWT
+    await page.goto("http://localhost:1337/connect/cas", {waitUntil: 'networkidle2'});
+    let element = await page.$('body pre');
+    if (element == null) {
+        let element = await page.$('body div main');
+        let errorpage = await page.evaluate(element => element.textContent.trim(), element);
+        console.log(errorpage)
+        assert(false);
+    }
+    let jwt = await page.evaluate(element => element.textContent.trim(), element);
+    console.log(jwt);
+    assert(jwt.includes("jwt"));
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/script.json
+++ b/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/script.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": "oidc,json-service-registry",
+  "properties": [
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services",
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+    "--cas.authn.oidc.core.issuer=${cas.server.name}/cas/oidc",
+    "--cas.authn.attribute-repository.stub.attributes.email=casuser@apereo.org",
+    "--cas.authn.attribute-repository.stub.id=STUB",
+    "--cas.authn.oidc.jwks.jwks-file=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/keystore.jwks",
+    "--logging.level.org.apereo.cas=DEBUG",
+    "--logging.level.org.apereo.services.persondir=DEBUG",
+    "--cas.authn.oauth.user-profile-view-type=FLAT"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/init.sh"
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/services/Strapi-1.json
+++ b/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/services/Strapi-1.json
@@ -1,0 +1,23 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "strapi",
+  "clientSecret": "strapisecret",
+  "bypassApprovalPrompt": true,
+  "serviceId": "http://localhost:1337/.*",
+  "name": "Strapi",
+  "id": 1,
+  "description": "Sample Service",
+  "evaluationOrder": 1,
+  "scopes" : [ "java.util.HashSet", [ "profile", "email" ] ],
+  "supportedResponseTypes": [ "java.util.HashSet", [ "code", "token", "id_token token", "id_token" ] ],
+  "supportedGrantTypes": [ "java.util.HashSet", [ "client_credentials", "refresh_token", "authorization_code" ] ],
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllowedAttributeReleasePolicy",
+    "allowedAttributes" : [ "java.util.ArrayList", [ "email", "username" ] ],
+    "consentPolicy": {
+      "@class": "org.apereo.cas.services.consent.DefaultRegisteredServiceConsentPolicy",
+      "includeOnlyAttributes": ["java.util.LinkedHashSet", ["email", "username"]],
+      "status": "TRUE"
+    }    
+  }
+}

--- a/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/strapi-custom/bootstrap.js
+++ b/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/strapi-custom/bootstrap.js
@@ -1,0 +1,234 @@
+'use strict';
+
+/**
+ * An asynchronous bootstrap function that runs before
+ * your application gets started.
+ *
+ * This gives you an opportunity to set up your data model,
+ * run jobs, or perform some special logic.
+ */
+const _ = require('lodash');
+const uuid = require('uuid/v4');
+
+const usersPermissionsActions = require('../users-permissions-actions');
+
+module.exports = async () => {
+  const pluginStore = strapi.store({
+    environment: '',
+    type: 'plugin',
+    name: 'users-permissions',
+  });
+
+  const grantConfig = {
+    email: {
+      enabled: true,
+      icon: 'envelope',
+    },
+    discord: {
+      enabled: false,
+      icon: 'discord',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/discord/callback`,
+      scope: ['identify', 'email'],
+    },
+    facebook: {
+      enabled: false,
+      icon: 'facebook-square',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/facebook/callback`,
+      scope: ['email'],
+    },
+    google: {
+      enabled: false,
+      icon: 'google',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/google/callback`,
+      scope: ['email'],
+    },
+    github: {
+      enabled: false,
+      icon: 'github',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/github/callback`,
+      scope: ['user', 'user:email'],
+    },
+    microsoft: {
+      enabled: false,
+      icon: 'windows',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/microsoft/callback`,
+      scope: ['user.read'],
+    },
+    twitter: {
+      enabled: false,
+      icon: 'twitter',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/twitter/callback`,
+    },
+    instagram: {
+      enabled: false,
+      icon: 'instagram',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/instagram/callback`,
+      scope: ['user_profile'],
+    },
+    vk: {
+      enabled: false,
+      icon: 'vk',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/vk/callback`,
+      scope: ['email'],
+    },
+    twitch: {
+      enabled: false,
+      icon: 'twitch',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/twitch/callback`,
+      scope: ['user:read:email'],
+    },
+    linkedin: {
+      enabled: false,
+      icon: 'linkedin',
+      key: '',
+      secret: '',
+      callback: `${strapi.config.server.url}/auth/linkedin/callback`,
+      scope: ['r_liteprofile', 'r_emailaddress'],
+    },
+    cognito: {
+      enabled: false,
+      icon: 'aws',
+      key: '',
+      secret: '',
+      subdomain: 'my.subdomain.com',
+      callback: `${strapi.config.server.url}/auth/cognito/callback`,
+      scope: ['email', 'openid', 'profile'],
+    },
+    reddit: {
+      enabled: false,
+      icon: 'reddit',
+      key: '',
+      secret: '',
+      state: true,
+      callback: `${strapi.config.server.url}/auth/reddit/callback`,
+      scope: ['identity'],
+    },
+    auth0: {
+      enabled: false,
+      icon: '',
+      key: '',
+      secret: '',
+      subdomain: 'my-tenant.eu',
+      callback: `${strapi.config.server.url}/auth/auth0/callback`,
+      scope: ['openid', 'email', 'profile'],
+    },
+    cas: {
+      enabled: true,
+      icon: 'book',
+      key: 'strapi',
+      secret: 'strapisecret',
+      callback: `${strapi.config.server.url}/auth/cas/callback`,
+      scope: ['openid email'], // scopes should be space delimited
+      subdomain: 'localhost:8443/cas',
+    },
+  };
+  const prevGrantConfig = (await pluginStore.get({ key: 'grant' })) || {};
+  // store grant auth config to db
+  // when plugin_users-permissions_grant is not existed in db
+  // or we have added/deleted provider here.
+  if (!prevGrantConfig || !_.isEqual(_.keys(prevGrantConfig), _.keys(grantConfig))) {
+    // merge with the previous provider config.
+    _.keys(grantConfig).forEach(key => {
+      if (key in prevGrantConfig) {
+        grantConfig[key] = _.merge(grantConfig[key], prevGrantConfig[key]);
+      }
+    });
+    await pluginStore.set({ key: 'grant', value: grantConfig });
+  }
+
+  if (!(await pluginStore.get({ key: 'email' }))) {
+    const value = {
+      reset_password: {
+        display: 'Email.template.reset_password',
+        icon: 'sync',
+        options: {
+          from: {
+            name: 'Administration Panel',
+            email: 'no-reply@strapi.io',
+          },
+          response_email: '',
+          object: 'Reset password',
+          message: `<p>We heard that you lost your password. Sorry about that!</p>
+
+<p>But don’t worry! You can use the following link to reset your password:</p>
+<p><%= URL %>?code=<%= TOKEN %></p>
+
+<p>Thanks.</p>`,
+        },
+      },
+      email_confirmation: {
+        display: 'Email.template.email_confirmation',
+        icon: 'check-square',
+        options: {
+          from: {
+            name: 'Administration Panel',
+            email: 'no-reply@strapi.io',
+          },
+          response_email: '',
+          object: 'Account confirmation',
+          message: `<p>Thank you for registering!</p>
+
+<p>You have to confirm your email address. Please click on the link below.</p>
+
+<p><%= URL %>?confirmation=<%= CODE %></p>
+
+<p>Thanks.</p>`,
+        },
+      },
+    };
+
+    await pluginStore.set({ key: 'email', value });
+  }
+
+  if (!(await pluginStore.get({ key: 'advanced' }))) {
+    const value = {
+      unique_email: true,
+      allow_register: true,
+      email_confirmation: false,
+      email_reset_password: null,
+      email_confirmation_redirection: null,
+      default_role: 'authenticated',
+    };
+
+    await pluginStore.set({ key: 'advanced', value });
+  }
+
+  await strapi.plugins['users-permissions'].services.userspermissions.initialize();
+
+  if (!_.get(strapi.plugins['users-permissions'], 'config.jwtSecret')) {
+    const jwtSecret = uuid();
+    _.set(strapi.plugins['users-permissions'], 'config.jwtSecret', jwtSecret);
+
+    strapi.reload.isWatching = false;
+
+    await strapi.fs.writePluginFile(
+        'users-permissions',
+        'config/jwt.js',
+        `module.exports = {\n  jwtSecret: process.env.JWT_SECRET || '${jwtSecret}'\n};`
+    );
+
+    strapi.reload.isWatching = true;
+  }
+
+  await strapi.admin.services.permission.actionProvider.registerMany(
+      usersPermissionsActions.actions
+  );
+};

--- a/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/strapi-custom/server.js
+++ b/ci/tests/puppeteer/scenarios/external-app-strapi-oidc/strapi-custom/server.js
@@ -1,0 +1,10 @@
+module.exports = ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: env('', 'http://localhost:1337'),
+  admin: {
+    auth: {
+      secret: env('ADMIN_JWT_SECRET', 'example-token'),
+    },
+  },
+});


### PR DESCRIPTION
This test installs strapi (a nodejs application) and configures it to use CAS for login via OIDC and then the puppeteer test hits endpoint in strapi that does OIDC login with CAS and returns a JWT which can then be used to hit strapi endpoints. Installing and starting strapi application takes about 2-3 minutes. There is an init.sh script that installs strapi and it copies a "bootstrap.js" file into the installed app with values pre-configured. Rather that checking in that file I could probably use the one from the installed app and do few `sed` commands to configure the clientid, clientsecret and enable the CAS auth provider. 