### PR TITLE
Username and password swapped in REST authentication

### DIFF
--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -80,8 +80,8 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
         var response = (HttpResponse) null;
         try {
             val exec = HttpUtils.HttpExecutionRequest.builder()
-                .basicAuthPassword(credential.getUsername())
-                .basicAuthUsername(credential.getPassword())
+                .basicAuthUsername(credential.getUsername())
+                .basicAuthPassword(credential.getPassword())
                 .method(HttpMethod.POST)
                 .url(properties.getUri())
                 .build();


### PR DESCRIPTION
When CAS delegates and submits authentication requests to a remote REST endpoint, the username and password is swapped in the Authorization header.