### PR TITLE
Fix NullPointerException when X-CAS-PasswordExpirationDate header is not present for REST authentication.

### DIFF
--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -141,9 +141,9 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     protected List<MessageDescriptor> getWarnings(final HttpResponse authenticationResponse) {
         val messageDescriptors = new ArrayList<MessageDescriptor>(2);
 
-        val passwordExpirationDate = authenticationResponse.getFirstHeader(HEADER_NAME_CAS_PASSWORD_EXPIRATION_DATE).getValue();
+        val passwordExpirationDate = authenticationResponse.getFirstHeader(HEADER_NAME_CAS_PASSWORD_EXPIRATION_DATE);
         if (passwordExpirationDate != null) {
-            val days = Duration.between(Instant.now(Clock.systemUTC()), DateTimeUtils.convertToZonedDateTime(passwordExpirationDate)).toDays();
+            val days = Duration.between(Instant.now(Clock.systemUTC()), DateTimeUtils.convertToZonedDateTime(passwordExpirationDate.getValue())).toDays();
             messageDescriptors.add(new PasswordExpiringWarningMessageDescriptor(null, days));
         }
 


### PR DESCRIPTION
The remote REST endpoint can send warnings back to the CAS server using custom headers.  However, when the X-CAS-PasswordExpirationDate header is not present, a NullPointerException is thrown.