### PR TITLE
make maven publish repo variables type neutral

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,8 @@ env:
   JAVA_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
   GRADLE_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
   TERM: xterm-256color
-  SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-  SONATYPE_PWD: ${{ secrets.SONATYPE_PWD }}
+  REPOSITORY_USER: ${{ secrets.SONATYPE_USER }}
+  REPOSITORY_PWD: ${{ secrets.SONATYPE_PWD }}
   GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
   GRADLE_BUILDCACHE_USER: ${{ secrets.GRADLE_BUILDCACHE_USER }}
   GRADLE_BUILDCACHE_PSW: ${{ secrets.GRADLE_BUILDCACHE_PSW }}
@@ -96,8 +96,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Publish SNAPSHOTs
-        if: ${{ env.SONATYPE_USER != null && env.SONATYPE_PWD != null }}
-        run: ./gradlew -DpublishSnapshots=true --build-cache --configure-on-demand --no-daemon --parallel -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.http.connectionTimeout=180000 build publish -x test -x javadoc -x check -DsonatypeUsername="${SONATYPE_USER}" -DsonatypePassword="${SONATYPE_PWD}"
+        if: ${{ env.REPOSITORY_USER != null && env.REPOSITORY_PWD != null }}
+        run: ./gradlew -DpublishSnapshots=true --build-cache --configure-on-demand --no-daemon --parallel -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.http.connectionTimeout=180000 build publish -x test -x javadoc -x check -DrepositoryUsername="${REPOSITORY_USER}" -DrepositoryPassword="${REPOSITORY_PWD}"
 
           
 ##########################################################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,8 @@ env:
   JAVA_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
   GRADLE_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server"
   TERM: xterm-256color
-  REPOSITORY_USER: ${{ secrets.SONATYPE_USER }}
-  REPOSITORY_PWD: ${{ secrets.SONATYPE_PWD }}
+  REPOSITORY_USER: ${{ secrets.REPOSITORY_USER }}
+  REPOSITORY_PWD: ${{ secrets.REPOSITORY_PWD }}
   GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
   GRADLE_BUILDCACHE_USER: ${{ secrets.GRADLE_BUILDCACHE_USER }}
   GRADLE_BUILDCACHE_PSW: ${{ secrets.GRADLE_BUILDCACHE_PSW }}

--- a/build.gradle
+++ b/build.gradle
@@ -34,19 +34,23 @@ buildscript {
 ext {
     srcTagMap = new ConcurrentHashMap<File, Set<String>>()
 
-    sonatypeUsername = providers.systemProperty("sonatypeUsername").forUseAtConfigurationTime().getOrNull()
-    sonatypePassword = providers.systemProperty("sonatypePassword").forUseAtConfigurationTime().getOrNull()
+    repositoryUsername = providers.systemProperty("repositoryUsername").forUseAtConfigurationTime().getOrNull()
+    repositoryPassword = providers.systemProperty("repositoryPassword").forUseAtConfigurationTime().getOrNull()
 
     publishSnapshots = providers.systemProperty("publishSnapshots").forUseAtConfigurationTime().present
     publishReleases = providers.systemProperty("publishReleases").forUseAtConfigurationTime().present
-    
+
+    publishFlag = publishSnapshots || publishReleases
+
     skipBootifulArtifact = providers.systemProperty("skipBootifulArtifact").forUseAtConfigurationTime().present
     skipErrorProneCompiler = providers.systemProperty("skipErrorProneCompiler").forUseAtConfigurationTime().present
+
+    skipArtifactSigning = providers.systemProperty("skipArtifactSigning").forUseAtConfigurationTime().present
 
     enableRemoteDebugging = providers.systemProperty("enableRemoteDebugging").forUseAtConfigurationTime().present
     remoteDebuggingSuspend = providers.systemProperty("remoteDebuggingSuspend")
             .forUseAtConfigurationTime().getOrElse("false") == "true" ? "y" : "n"
-    generateGitProperties = publishReleases || publishSnapshots
+    generateGitProperties = publishFlag
             || providers.systemProperty("generateGitProperties").forUseAtConfigurationTime().present
 
     ci = System.getenv("CI") || providers.systemProperty("CI").forUseAtConfigurationTime().present
@@ -69,13 +73,13 @@ ext {
 }
 
 def isArtifactSigningRequired = {
-    return publishReleases
+    return publishReleases && !skipArtifactSigning
 }
 
 apply plugin: "io.codearte.nexus-staging"
 nexusStaging {
-    username = "${sonatypeUsername}"
-    password = "${sonatypePassword}"
+    username = "${repositoryUsername}"
+    password = "${repositoryPassword}"
     packageGroup = "org.apereo"
     stagingProfileId = "11d1ddbbdeae9d"
     numberOfRetries = 60
@@ -323,27 +327,27 @@ subprojects {
                 repositories {
                     if (rootProject.publishReleases) {
                         maven {
-                            name "Sonatype-Releases"
-                            url "${sonatypeRepositoryUrl}"
+                            name "CAS-Releases"
+                            url "${releaseRepositoryUrl}"
                             mavenContent {
                                 releasesOnly()
                             }
                             credentials {
-                                username "${sonatypeUsername}"
-                                password "${sonatypePassword}"
+                                username "${repositoryUsername}"
+                                password "${repositoryPassword}"
                             }
                         }
                     }
                     if (rootProject.publishSnapshots) {
                         maven {
-                            name "Sonatype-Snapshots"
-                            url "${sonatypeSnapshotsRepositoryUrl}"
+                            name "CAS-Snapshots"
+                            url "${snapshotsRepositoryUrl}"
                             mavenContent {
                                 snapshotsOnly()
                             }
                             credentials {
-                                username "${sonatypeUsername}"
-                                password "${sonatypePassword}"
+                                username "${repositoryUsername}"
+                                password "${repositoryPassword}"
                             }
                         }
                     }
@@ -359,7 +363,7 @@ subprojects {
 
     artifacts {
         tests testJar
-        if (rootProject.publishReleases || rootProject.publishSnapshots) {
+        if (rootProject.publishFlag) {
             archives sourcesJar
             archives javadocJar
             archives resourcesJar
@@ -531,7 +535,7 @@ subprojects {
     }
 }
 
-if (!gradle.startParameter.excludedTaskNames.contains("javadoc") || rootProject.publishReleases || rootProject.publishSnapshots) {
+if (!gradle.startParameter.excludedTaskNames.contains("javadoc") || rootProject.publishFlag) {
     tasks.withType(Javadoc) {
         source subprojects.collect { project -> project.sourceSets.main.allJava }
         destinationDir = new File(buildDir, "javadoc")
@@ -546,7 +550,7 @@ if (!gradle.startParameter.excludedTaskNames.contains("javadoc") || rootProject.
     }
 }
 
-if (rootProject.publishReleases || rootProject.publishSnapshots) {
+if (rootProject.publishFlag) {
     task rootSourcesJar(type: Jar, description: "Build JAR for the root CAS module") {
         archiveBaseName.set("${project.archivesBaseName}")
         from rootProject.file("src")
@@ -559,7 +563,7 @@ task gradleHome(description: "Display GRADLE_HOME environment variable") {
     }
 }
 
-if (rootProject.publishReleases || rootProject.publishSnapshots) {
+if (rootProject.publishFlag) {
     artifacts {
         archives aggregateJavadocsIntoJar
         archives rootSourcesJar

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ projectLicenseDistribution=repo
 projectIssueSystem=GitHub
 projectIssueUrl=https://github.com/apereo/cas/pulls
 
-sonatypeRepositoryUrl=https://oss.sonatype.org/service/local/staging/deploy/maven2/
-sonatypeSnapshotsRepositoryUrl=https://oss.sonatype.org/content/repositories/snapshots/
+releaseRepositoryUrl=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+snapshotsRepositoryUrl=https://oss.sonatype.org/content/repositories/snapshots/
 
 ###############################################################################################
 # Localized gradle settings to ensure modules can be loaded/configured as quickly as possible.

--- a/gradle/springboot.gradle
+++ b/gradle/springboot.gradle
@@ -1,6 +1,6 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
-if (project.ext.forceBootifulArtifact || (!rootProject.publishReleases && !rootProject.publishSnapshots && !rootProject.skipBootifulArtifact)) {
+if (project.ext.forceBootifulArtifact || (!rootProject.publishFlag && !rootProject.skipBootifulArtifact)) {
     //logger.info "Applying Spring Boot plugin to bootify web application artifact for project $project.name..."
 
     apply plugin: "org.springframework.boot"

--- a/gradle/webapp.gradle
+++ b/gradle/webapp.gradle
@@ -73,7 +73,7 @@ dependencies {
     }
 
     implementation libraries.springcloudconfigclient
-    if (!rootProject.publishReleases && !rootProject.publishSnapshots) {
+    if (!rootProject.publishFlag) {
         runtimeOnly libraries.springbootdevtools
     }
 

--- a/release.sh
+++ b/release.sh
@@ -8,12 +8,12 @@ TIMEOUT=640000
 function build {
     ./gradlew clean --parallel
     echo -e "\n${GREEN}Building CAS. Please be patient as this might take a while...${NORMAL}\n"
-    ./gradlew assemble -x test -x check --no-watch-fs -DpublishReleases=true -DsonatypeUsername="$1" -DsonatypePassword="$2"
+    ./gradlew assemble -x test -x check --no-watch-fs -DpublishReleases=true -DrepositoryUsername="$1" -DrepositoryPassword="$2"
 }
 
 function publish {
     echo -e "\n${GREEN}Publishing CAS. Please be patient as this might take a while...${NORMAL}\n"
-    ./gradlew publish closeAndReleaseRepository --no-watch-fs -DpublishReleases=true -DsonatypeUsername="$1" -DsonatypePassword="$2" \
+    ./gradlew publish closeAndReleaseRepository --no-watch-fs -DpublishReleases=true -DrepositoryUsername="$1" -DrepositoryPassword="$2" \
     -Dorg.gradle.internal.http.socketTimeout="${TIMEOUT}" -Dorg.gradle.internal.http.connectionTimeout="${TIMEOUT}"  \
     -Dorg.gradle.internal.publish.checksums.insecure=true
 }


### PR DESCRIPTION
This changes references to "sonatype" to "repository" so that it is easier to use the defined maven repos and gradle parameters when publishing to repositories other than Sonatype Nexus repositories. This also adds a variable called publishFlag that is true if either publishReleases or publishSnapshots are true because they are or'd together in several places. 

I was going to change the secret names in publish.yml but I decided to leave them as SONATYPE_USER and SONATYPE_PWD which means no change is needed if this merged. The workflow would be more generic if the secret names were REPOSITORY_USER and REPOSITORY_PWD. 