### PR TITLE
Backport: support duration for skew timeouts

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oidc/OidcProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oidc/OidcProperties.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.configuration.model.support.oidc;
 
+import org.apereo.cas.configuration.support.DurationCapable;
 import org.apereo.cas.configuration.support.RequiredProperty;
 import org.apereo.cas.configuration.support.RequiresModule;
 
@@ -44,8 +45,8 @@ public class OidcProperties implements Serializable {
     /**
      * Skew value used to massage the authentication issue instance.
      */
-    private int skew = 5;
-
+    @DurationCapable
+    private String skew = "PT5M";
     /**
      * Whether dynamic registration operates in {@code OPEN} or {@code PROTECTED} mode.
      */

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/BasePac4jOidcClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/oidc/BasePac4jOidcClientProperties.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.configuration.model.support.pac4j.oidc;
 
 import org.apereo.cas.configuration.model.support.pac4j.Pac4jIdentifiableClientProperties;
+import org.apereo.cas.configuration.support.DurationCapable;
 import org.apereo.cas.configuration.support.RequiredProperty;
 import org.apereo.cas.configuration.support.RequiresModule;
 
@@ -63,7 +64,8 @@ public abstract class BasePac4jOidcClientProperties extends Pac4jIdentifiableCli
     /**
      * Clock skew in order to account for drift, when validating id tokens.
      */
-    private int maxClockSkew;
+    @DurationCapable
+    private String maxClockSkew = "PT5S";
 
     /**
      * Custom parameters to send along in authZ requests, etc.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/SamlCoreProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/SamlCoreProperties.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.configuration.model.support.saml;
 
+import org.apereo.cas.configuration.support.DurationCapable;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import lombok.Getter;
@@ -25,7 +26,8 @@ public class SamlCoreProperties implements Serializable {
     /**
      * Skew allowance that controls the issue instance of the authentication.
      */
-    private int skewAllowance = 5;
+    @DurationCapable
+    private String skewAllowance = "PT30S";
 
     /**
      * Issue length that controls the validity period of the assertion.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPResponseProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPResponseProperties.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.configuration.model.support.saml.idp;
 
+import org.apereo.cas.configuration.support.DurationCapable;
 import org.apereo.cas.configuration.support.RequiresModule;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
@@ -40,7 +41,8 @@ public class SamlIdPResponseProperties implements Serializable {
      * Time unit in seconds used to skew authentication dates such
      * as valid-from and valid-until elements.
      */
-    private int skewAllowance = 15;
+    @DurationCapable
+    private String skewAllowance = "PT30S";
 
     /**
      * Whether error responses should be signed.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/DurationCapable.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/support/DurationCapable.java
@@ -1,0 +1,19 @@
+package org.apereo.cas.configuration.support;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This is {@link DurationCapable}.
+ *
+ * @author Linos Giannopoulos
+ * @since 6.3.5
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface DurationCapable {
+}

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorService.java
@@ -2,6 +2,7 @@ package org.apereo.cas.oidc.token;
 
 import org.apereo.cas.authentication.AuthenticationHandler;
 import org.apereo.cas.oidc.OidcConstants;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.services.OidcRegisteredService;
 import org.apereo.cas.support.oauth.OAuth20Constants;
 import org.apereo.cas.support.oauth.OAuth20ResponseTypes;
@@ -109,7 +110,7 @@ public class OidcIdTokenGeneratorService extends BaseIdTokenGeneratorService {
         expirationDate.addSeconds(timeoutInSeconds);
         claims.setExpirationTime(expirationDate);
         claims.setIssuedAtToNow();
-        claims.setNotBeforeMinutesInThePast(oidc.getSkew());
+        claims.setNotBeforeMinutesInThePast((float) Beans.newDuration(oidc.getCore().getSkew()).toMinutes());
         claims.setSubject(principal.getId());
 
         val mfa = getConfigurationContext().getCasProperties().getAuthn().getMfa();

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DefaultDelegatedClientFactory.java
@@ -676,7 +676,7 @@ public class DefaultDelegatedClientFactory implements DelegatedClientFactory<Ind
         if (StringUtils.isNotBlank(oidc.getPreferredJwsAlgorithm())) {
             cfg.setPreferredJwsAlgorithm(JWSAlgorithm.parse(oidc.getPreferredJwsAlgorithm().toUpperCase()));
         }
-        cfg.setMaxClockSkew(oidc.getMaxClockSkew());
+        cfg.setMaxClockSkew(Long.valueOf(Beans.newDuration(oidc.getMaxClockSkew()).toSeconds()).intValue());
         cfg.setDiscoveryURI(oidc.getDiscoveryUri());
         cfg.setCustomParams(oidc.getCustomParams());
         cfg.setLogoutUrl(oidc.getLogoutUrl());

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/authn/SamlProfileSamlAuthNStatementBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/authn/SamlProfileSamlAuthNStatementBuilder.java
@@ -2,6 +2,7 @@ package org.apereo.cas.support.saml.web.idp.profile.builders.authn;
 
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
 import org.apereo.cas.support.saml.SamlException;
 import org.apereo.cas.support.saml.SamlIdPUtils;
@@ -115,7 +116,7 @@ public class SamlProfileSamlAuthNStatementBuilder extends AbstractSaml20ObjectBu
 
             val skewAllowance = service.getSkewAllowance() > 0
                 ? service.getSkewAllowance()
-                : casProperties.getAuthn().getSamlIdp().getResponse().getSkewAllowance();
+                : Beans.newDuration(casProperties.getAuthn().getSamlIdp().getResponse().getSkewAllowance()).toSeconds();
             statement.setSessionNotOnOrAfter(dt.plusSeconds(skewAllowance).toInstant());
         }
         val subjectLocality = buildSubjectLocality(assertion, authnRequest, adaptor, binding);

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/conditions/SamlProfileSamlConditionsBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/conditions/SamlProfileSamlConditionsBuilder.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.saml.web.idp.profile.builders.conditions;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
 import org.apereo.cas.support.saml.SamlException;
 import org.apereo.cas.support.saml.services.SamlRegisteredService;
@@ -66,9 +67,9 @@ public class SamlProfileSamlConditionsBuilder extends AbstractSaml20ObjectBuilde
 
         var skewAllowance = service.getSkewAllowance() > 0
             ? service.getSkewAllowance()
-            : casProperties.getAuthn().getSamlIdp().getResponse().getSkewAllowance();
+            : Beans.newDuration(casProperties.getAuthn().getSamlIdp().getResponse().getSkewAllowance()).toSeconds();
         if (skewAllowance <= 0) {
-            skewAllowance = casProperties.getSamlCore().getSkewAllowance();
+            skewAllowance = Beans.newDuration(casProperties.getSamlCore().getSkewAllowance()).toSeconds();
         }
 
         val audienceUrls = new ArrayList<String>(2);

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/subject/SamlProfileSamlSubjectBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/subject/SamlProfileSamlSubjectBuilder.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.saml.web.idp.profile.builders.subject;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
 import org.apereo.cas.support.saml.SamlException;
 import org.apereo.cas.support.saml.SamlIdPUtils;
@@ -74,7 +75,7 @@ public class SamlProfileSamlSubjectBuilder extends AbstractSaml20ObjectBuilder i
                                  final MessageContext messageContext) throws SamlException {
 
         val assertion = Assertion.class.cast(casAssertion);
-        val validFromDate = ZonedDateTime.now(Clock.systemUTC());
+        val validFromDate = ZonedDateTime.now(ZoneOffset.UTC);
         LOGGER.trace("Locating the assertion consumer service url for binding [{}]", binding);
         val acs = SamlIdPUtils.determineEndpointForRequest(authnRequest, adaptor, binding);
         val location = StringUtils.isBlank(acs.getResponseLocation()) ? acs.getLocation() : acs.getResponseLocation();
@@ -91,7 +92,7 @@ public class SamlProfileSamlSubjectBuilder extends AbstractSaml20ObjectBuilder i
             ? null
             : validFromDate.plusSeconds(service.getSkewAllowance() > 0
                 ? service.getSkewAllowance()
-                : casProperties.getAuthn().getSamlIdp().getResponse().getSkewAllowance());
+                : Beans.newDuration(casProperties.getAuthn().getSamlIdp().getResponse().getSkewAllowance()).toSeconds());
 
         val subject = newSubject(subjectNameId, subjectConfNameId,
             service.isSkipGeneratingSubjectConfirmationRecipient() ? null : location,

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPProfileSingleLogoutMessageCreator.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPProfileSingleLogoutMessageCreator.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.saml.web.idp.profile.slo;
 
 import org.apereo.cas.configuration.model.support.saml.idp.SamlIdPProperties;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.logout.slo.SingleLogoutMessage;
 import org.apereo.cas.logout.slo.SingleLogoutMessageCreator;
 import org.apereo.cas.logout.slo.SingleLogoutRequestContext;
@@ -91,7 +92,7 @@ public class SamlIdPProfileSingleLogoutMessageCreator extends AbstractSaml20Obje
         val samlService = (SamlRegisteredService) request.getRegisteredService();
         val skewAllowance = samlService.getSkewAllowance() > 0
             ? samlService.getSkewAllowance()
-            : samlIdPProperties.getResponse().getSkewAllowance();
+            : Beans.newDuration(samlIdPProperties.getResponse().getSkewAllowance()).toSeconds();
 
         val issueInstant = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(skewAllowance);
 

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/authentication/SamlResponseBuilder.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/authentication/SamlResponseBuilder.java
@@ -4,6 +4,7 @@ import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.ProtocolAttributeEncoder;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.WebApplicationService;
+import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.saml.util.Saml10ObjectBuilder;
 import org.apereo.cas.util.CollectionUtils;
@@ -41,7 +42,7 @@ public class SamlResponseBuilder {
 
     private final int issueLength;
 
-    private final int skewAllowance;
+    private final String skewAllowance;
 
     private final ProtocolAttributeEncoder protocolAttributeEncoder;
 
@@ -55,9 +56,10 @@ public class SamlResponseBuilder {
      * @return the response
      */
     public Response createResponse(final String serviceId, final WebApplicationService service) {
+	val skew = Beans.newDuration(this.skewAllowance).toSeconds();
         return this.samlObjectBuilder.newResponse(
             this.samlObjectBuilder.generateSecureRandomId(),
-            ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(this.skewAllowance), serviceId, service);
+            ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(skew), serviceId, service);
     }
 
     /**

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10FailureResponseViewTests.java
@@ -37,7 +37,8 @@ public class Saml10FailureResponseViewTests extends AbstractOpenSamlTests {
     public void initialize() {
 
         val builder = new Saml10ObjectBuilder(this.configBean);
-        val samlResponseBuilder = new SamlResponseBuilder(builder, null, null, 0, 30,
+        val samlResponseBuilder = new SamlResponseBuilder(builder, null,
+            null, 0, "PT30S",
             new NoOpProtocolAttributeEncoder(), null);
         view = new Saml10FailureResponseView(new NoOpProtocolAttributeEncoder(), null,
             new DefaultArgumentExtractor(new SamlServiceFactory()),

--- a/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
+++ b/support/cas-server-support-saml/src/test/java/org/apereo/cas/support/saml/web/view/Saml10SuccessResponseViewTests.java
@@ -79,7 +79,8 @@ public class Saml10SuccessResponseViewTests extends AbstractOpenSamlTests {
 
         val protocolAttributeEncoder = new DefaultCasProtocolAttributeEncoder(mgmr, CipherExecutor.noOpOfStringToString());
         val builder = new Saml10ObjectBuilder(configBean);
-        val samlResponseBuilder = new SamlResponseBuilder(builder, "testIssuer", "whatever", 1000, 30,
+        val samlResponseBuilder = new SamlResponseBuilder(builder, "testIssuer",
+            "whatever", 1000, "PT30S",
             new NoOpProtocolAttributeEncoder(), mgmr);
         this.response = new Saml10SuccessResponseView(protocolAttributeEncoder,
             mgmr,


### PR DESCRIPTION
SAML responses validity is described by the `NotOnOrAfter` field under
the `SubjectConfirmationData`. This value was set to the authentication
date, therefore all SAML responses produced by CAS had a `NotOnOrAfter`
field that has already expired, shortly after the user authenticated.

By backporting the duration in skew timeouts, we should avoid the issue
at hand. A [relevant thread](https://groups.google.com/a/apereo.org/g/cas-user/c/zghyCmQ6WyE) in the users' mailing list, regarding this issue.

I've tried to test this in our staging environment, but it was impossible to find all the required dependencies that the overlay needs in order to re-compile all the components that I've changed for the backport.

If you can guide me through the process, or there's any documentation that I've missed around this, please let me know
