### PR TITLE
Update SendForgotUsernameInstructionsAction.java

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
@@ -101,6 +101,7 @@ public class SendForgotUsernameInstructionsAction extends AbstractAction {
         if (StringUtils.isBlank(username)) {
             return getErrorEvent("username.missing", "No username could be located for the given email address", requestContext);
         }
+        query.username(username);
         if (sendForgotUsernameEmailToAccount(query, requestContext)) {
             return success();
         }


### PR DESCRIPTION
Set the username in query to it can be retrieved to generate the principal.

This class used to pass the username to sentForgotUsernameEmailToAccount but this was removed and the username is not set in the query parameter, thus the principalResolver can never create the appropriate person from the credentials.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
