### PR TITLE
saml: Fix RelayState caching issue

### DIFF
--- a/ci/tests/puppeteer/scenarios/saml-relay-state-caching/init.sh
+++ b/ci/tests/puppeteer/scenarios/saml-relay-state-caching/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -e "Removing previous SAML metadata directory"
+rm -Rf "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/saml-md"

--- a/ci/tests/puppeteer/scenarios/saml-relay-state-caching/script.js
+++ b/ci/tests/puppeteer/scenarios/saml-relay-state-caching/script.js
@@ -1,0 +1,62 @@
+const puppeteer = require('puppeteer');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+(async () => {
+    const browser = await puppeteer.launch({
+        ignoreHTTPSErrors: true,
+        headless: true
+    });
+    const page = await browser.newPage();
+    await page.goto("https://samltest.id/upload.php");
+    // await page.waitForTimeout(1000)
+
+    const fileElement = await page.$("input[type=file]");
+    let metadata = path.join(__dirname, '/saml-md/idp-metadata.xml');
+    console.log("Metadata file: " + metadata);
+
+    await fileElement.uploadFile(metadata);
+    // await page.waitForTimeout(1000)
+
+    await click(page, "input[name='submit']")
+    await page.waitForNavigation();
+
+    // await page.waitForTimeout(1000)
+
+    let entityId = "https://samltest.id/saml/sp";
+    let url = "https://localhost:8443/cas/idp/profile/SAML2/Unsolicited/SSO";
+    url += `?providerId=${entityId}`;
+    url += "&target=https%3A%2F%2Flocalhost%3A8443%2Fcas%2Flogin";
+    url += "&time=60"
+
+    console.log("Navigating to " + url);
+    await page.goto(url);
+    await page.waitForTimeout(1000)
+
+    await page.type('#username', "casuser");
+    await page.type('#password', "Mellon");
+    await page.keyboard.press('Enter');
+    await page.waitForNavigation();
+    await page.waitForTimeout(2000);
+
+    const title = await page.title();
+    console.log(title);
+    assert(title === "CAS - Central Authentication Service")
+
+    let element = await page.$('#content div h2');
+    let header = await page.evaluate(element => element.textContent.trim(), element);
+    console.log(header)
+    assert(header === "Log In Successful")
+
+    let metadataDir = path.join(__dirname, '/saml-md');
+    fs.rmdirSync(metadataDir, { recursive: true });
+    
+    await browser.close();
+})();
+
+async function click(page, button) {
+    await page.evaluate((button) => {
+        document.querySelector(button).click();
+    }, button);
+}

--- a/ci/tests/puppeteer/scenarios/saml-relay-state-caching/script.json
+++ b/ci/tests/puppeteer/scenarios/saml-relay-state-caching/script.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": "saml-idp",
+  "properties": [
+    "--cas.authn.saml-idp.entity-id=https://cas.apereo.org/saml/idp/1",
+    "--cas.authn.saml-idp.metadata.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml-relay-state-caching/saml-md",
+    "--cas.saml-core.skew-allowance=5",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--logging.level.org.apereo.cas=debug",
+
+    "--cas.service-registry.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/saml-relay-state-caching/services"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/saml-relay-caching/init.sh"
+}

--- a/ci/tests/puppeteer/scenarios/saml-relay-state-caching/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/saml-relay-state-caching/services/Sample-1.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "https://samltest.id/.+",
+  "name" : "Sample",
+  "id" : 1,
+  "evaluationOrder" : 1,
+  "metadataLocation" : "https://samltest.id/saml/sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlIdPProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlIdPProfileHandlerController.java
@@ -458,7 +458,8 @@ public abstract class AbstractSamlIdPProfileHandlerController {
 
                     val binding = determineProfileBinding(authenticationContext, assertion);
                     LOGGER.debug("Using profile binding [{}] for service [{}]", binding, registeredService.getName());
-                    val relayState = SAMLBindingSupport.getRelayState(messageContext);
+                    val relayStateRequest = request.getParameter(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE);
+                    val relayState = relayStateRequest == null ? "" : relayStateRequest;
                     LOGGER.debug("Using relay-state value [{}]", relayState);
                     SAMLBindingSupport.setRelayState(authenticationContext.getRight(), relayState);
                     response.reset();

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/BaseSamlProfileSamlResponseBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/BaseSamlProfileSamlResponseBuilder.java
@@ -97,10 +97,12 @@ public abstract class BaseSamlProfileSamlResponseBuilder<T extends XMLObject> ex
 
         if (encodeResponse) {
             val context = new JEEContext(request, response);
-            val relayState = samlResponseBuilderConfigurationContext.getSessionStore()
+            val relayStateRequest = request.getParameter(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE);
+            val relayStateCache = samlResponseBuilderConfigurationContext.getSessionStore()
                 .get(context, SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE)
                 .map(Object::toString)
                 .orElse(SAMLBindingSupport.getRelayState(messageContext));
+            val relayState = relayStateRequest == null ? relayStateCache : relayStateRequest;
             LOGGER.trace("RelayState is [{}]", relayState);
             return encode(service, finalResponse, response, request, adaptor,
                 relayState, binding, authnRequest, assertion, messageContext);


### PR DESCRIPTION
There is a bug in 6.3.x currently, where SAML2's RelayState is falsely
cached and re-used alongside other SSO attributes, as an optimization.
An SP sends the RelayState alongside their SAML Authn request, and they
expect the same value by the idP, once the user has successfully
completed the SAML auth flow.

An example of RelayState is Github.com and Github Enterprise.
They both use RelayState to verify that the SAML response corresponds to a
valid SAML request (originating from Github itself).

The issue appears when one attempts to login to service A, and then they
attempt to login to service B, and service B relies on RelayState.
Service A's RelayState is cached and reused for service B, and that
breaks the SAML2 auth flow.

If we grab the RelayState from the request that's passed around, the
issue goes away.

Note that, I've crudely attempted to resolve the issue, there's probably a better way to do this, but my Java coding skills are not great :D (Maybe avoid caching RelayState altogether for a single SSO session?)
We've tested the fix, and it works in our staging env.

If you feel like the fix is okay, I'll add a few tests to avoid any regressions
