### PR TITLE
oauth/oidc: token expiration policy attribute name

### DIFF
--- a/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
+++ b/docs/cas-server-documentation/installation/OAuth-OpenId-Authentication.md
@@ -239,7 +239,7 @@ whose token expiration policy is to deviate from the default configuration must 
   "accessTokenExpirationPolicy": {
     "@class": "org.apereo.cas.support.oauth.services.DefaultRegisteredServiceOAuthAccessTokenExpirationPolicy",
     "maxTimeToLive": "1000",
-    "timeToLive": "100"
+    "timeToKill": "100"
   }
 }
 ```
@@ -273,7 +273,7 @@ whose token expiration policy is to deviate from the default configuration must 
   "id" : 100,
   "accessTokenExpirationPolicy": {
     "@class": "org.apereo.cas.support.oauth.services.DefaultRegisteredServiceOAuthRefreshTokenExpirationPolicy",
-    "timeToLive": "100"
+    "timeToKill": "100"
   }
 }
 ```


### PR DESCRIPTION
Attribute name is invalid: documentation says timeToLive and cas search for timeToKill

https://github.com/apereo/cas/blob/b1a805429dcff00415a9a3b7d8ebfa6d01809afc/support/cas-server-support-oauth-services/src/main/java/org/apereo/cas/support/oauth/services/DefaultRegisteredServiceOAuthAccessTokenExpirationPolicy.java#L31

https://github.com/apereo/cas/blob/b1a805429dcff00415a9a3b7d8ebfa6d01809afc/support/cas-server-support-oauth-services/src/main/java/org/apereo/cas/support/oauth/services/DefaultRegisteredServiceOAuthRefreshTokenExpirationPolicy.java#L29

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
