### PR TITLE
Password Management: Forgot Username correctly set and check for Principal

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
@@ -121,7 +121,10 @@ public class SendForgotUsernameInstructionsAction extends AbstractAction {
         val credential = new BasicIdentifiableCredential();
         credential.setId(query.getUsername());
         val person = principalResolver.resolve(credential);
-        FunctionUtils.doIfNotNull(person, principal -> parameters.put("principal", principal));
+        if (person == null || person.getClass().equals(NullPrincipal.class) {
+            return false;
+        }
+        parameters.put("principal", principal)
         val reset = casProperties.getAuthn().getPm().getForgotUsername().getMail();
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
         val body = EmailMessageBodyBuilder.builder().properties(reset)

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
@@ -101,6 +101,7 @@ public class SendForgotUsernameInstructionsAction extends AbstractAction {
         if (StringUtils.isBlank(username)) {
             return getErrorEvent("username.missing", "No username could be located for the given email address", requestContext);
         }
+        query.username(username);
         if (sendForgotUsernameEmailToAccount(query, requestContext)) {
             return success();
         }


### PR DESCRIPTION
As discussed in PR:5200 the Send Forgot Username functionality has two issues.

1. The username, whilst retrieved, is never passed into the method that constructs the email to be sent
2. When the principal is retrieved the method never checks that it's either null or a NullPrincipal (indicating a principal wasn't found).

The proposed changes correctly set the username and ensure that the principal is valid.

Without the username fix the change to the principal validation by itself will cause the current tests to fail (as a principal is never currently able to be found).  This failure would be correct (and would have potentially highlighted the issue earlier).
