### PR TITLE
Allow for multiple globally enabled mfa providers

### DIFF
--- a/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/accounts.json
+++ b/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/accounts.json
@@ -1,0 +1,29 @@
+{
+  "@class": "java.util.HashMap",
+  "casuser":
+  [
+    "java.util.ArrayList",
+    [
+      {
+        "@class": "org.apereo.cas.authentication.OneTimeTokenAccount",
+        "scratchCodes":
+        [
+          "java.util.ArrayList",
+          [
+            83766843,
+            11040740,
+            63605147,
+            62216081,
+            20207704
+          ]
+        ],
+        "id": 1,
+        "secretKey": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.ZXlKNmFYQWlPaUpFUlVZaUxDSmhiR2NpT2lKa2FYSWlMQ0psYm1NaU9pSkJNVEk0UTBKRExVaFRNalUySWl3aVkzUjVJam9pU2xkVUlpd2lkSGx3SWpvaVNsZFVJbjAuLlVwbEdMWll0emdLa1lGMVVpdkxtYlEuYzRVTVgzcXNhQkZoQlpNajlOeGJlZy5NTVFELWRYVUUteWJuN1FTcFQ4em1R.OIl6RACaRxgwwslnAAIAFaOKlf5iPuHhhTtjEQ-Odhz0p6XEf1YnMgYEf64cm8chaOZrcYej6cAS6DynHmXQOQ",
+        "validationCode": 999666,
+        "username": "casuser",
+        "name": "RecordName",
+        "registrationDate": 1607843237.905141
+      }
+    ]
+  ]
+}

--- a/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/script.js
+++ b/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/script.js
@@ -1,0 +1,33 @@
+const puppeteer = require('puppeteer');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch({
+        ignoreHTTPSErrors: true,
+        headless: true
+    });
+    const page = await browser.newPage();
+    await page.goto("https://localhost:8443/cas/login?service=https://example.org");
+
+    await page.type('#username', "casuser");
+    await page.type('#password', "Mellon");
+    await page.keyboard.press('Enter');
+    await page.waitForNavigation();
+
+    await page.waitForTimeout(9000);
+    const mfaGauth = await page.$('div#mfa-gauth');
+    const form = await mfaGauth.$('form');
+    await form.evaluate(form => form.submit());
+    await page.waitForTimeout(5000);
+
+    let element = await page.$('#login p');
+    await page.type('#token', "123456");
+    await page.keyboard.press('Enter');
+    await page.waitForNavigation();
+
+    await page.waitForTimeout(5000);
+    const html = await page.content();
+    console.log(html);
+    await browser.close();
+})();
+

--- a/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/script.json
+++ b/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/script.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": "yubikey,gauth",
+  "properties": [
+    "--cas.authn.mfa.yubikey.client-id=18420",
+    "--cas.authn.mfa.yubikey.secret-key=iBIehjui22aK8x82oe6qzGeb0As=",
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+    "--cas.authn.mfa.provider-selection-enabled=true",
+    "--cas.authn.mfa.global-provider-id=mfa-gauth,mfa-yubikey",
+
+    "--logging.level.org.apereo.cas=debug",
+    "--cas.service-registry.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/services",
+    "--cas.authn.mfa.gauth.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/accounts.json"
+  ]
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/mfa-global-multiple-providers/services/Sample-1.json
@@ -1,0 +1,10 @@
+{
+  "@class": "org.apereo.cas.services.RegexRegisteredService",
+  "serviceId": "https://example.org",
+  "name": "Sample",
+  "id": 1,
+  "description": "Sample Service",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/MultifactorAuthenticationUtils.java
@@ -4,6 +4,7 @@ import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.spring.ApplicationContextProvider;
+import org.apereo.cas.web.support.WebUtils;
 
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
@@ -71,6 +72,16 @@ public class MultifactorAuthenticationUtils {
         return context.map(ctx -> {
             LOGGER.trace("Reviewing current state [{}], event [{}] and transition [{}]",
                 ctx.getCurrentState(), ctx.getCurrentEvent(), ctx.getCurrentTransition());
+            val authentication = WebUtils.getAuthentication(ctx);
+            val authAttributes = authentication.getAttributes();
+            val ctxAttr = authAttributes.get("authnContextClass");
+            if (ctxAttr != null) {
+                val contexts = CollectionUtils.toCollection(ctxAttr);
+                val authnCtx = CollectionUtils.firstElement(contexts).get().toString();
+                if (authnCtx != null) {
+                        return new Event(authnCtx, authnCtx, attributesMap);
+                }
+            }
             val def = ctx.getMatchingTransition(event.getId());
             if (def == null) {
                 val msg = String.format("State [%s:%s:%s] does not have a matching transition for %s",


### PR DESCRIPTION
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
Currently there is an issue when multiple mfa providers are enabled
along with the selection menu. Even if there's an active SSO session for
the user, an exception is thrown, leading to a redirect to the login
page.

```
2021-07-23 13:27:06,476 DEBUG [org.apereo.cas.authentication.mfa.trigger.GlobalMultifactorAuthenticationTrigger] - <Attempting to globally activate [mfa-gauth,mfa-webauthn]>
2021-07-23 13:27:06,478 DEBUG [org.apereo.cas.authentication.mfa.trigger.GlobalMultifactorAuthenticationTrigger] - <Selected multifactor authentication provider for this transaction is [DefaultChainingMultifactorA
uthenticationProvider(multifactorAuthenticationProviders=[AbstractMultifactorAuthenticationProvider(bypassEvaluator=org.apereo.cas.authentication.bypass.DefaultChainingMultifactorAuthenticationBypassProvider@5538b
ce6, failureModeEvaluator=org.apereo.cas.authentication.DefaultMultifactorAuthenticationFailureModeEvaluator@25b5055a, failureMode=UNDEFINED, id=mfa-gauth, order=0), AbstractMultifactorAuthenticationProvider(bypas
sEvaluator=org.apereo.cas.authentication.bypass.DefaultChainingMultifactorAuthenticationBypassProvider@7dc2507a, failureModeEvaluator=org.apereo.cas.authentication.DefaultMultifactorAuthenticationFailureModeEvalua
tor@25b5055a, failureMode=UNDEFINED, id=mfa-webauthn, order=0)], failureModeEvaluator=org.apereo.cas.authentication.DefaultMultifactorAuthenticationFailureModeEvaluator@25b5055a)]>
2021-07-23 13:27:06,480 TRACE [org.apereo.cas.authentication.MultifactorAuthenticationUtils] - <Attempting to find a matching transition for event id [mfa-composite]>
2021-07-23 13:27:06,480 TRACE [org.apereo.cas.authentication.MultifactorAuthenticationUtils] - <Reviewing current state [[ActionState@4ae43566 id = 'initialAuthenticationRequestValidationCheck', flow = 'login', en
tryActionList = list[[EvaluateAction@dcab3a0 expression = verifyRequiredServiceAction, resultExpression = [null]]], exceptionHandlerSet = list[[empty]], actionList = list[[EvaluateAction@336e154c expression = init
ialAuthenticationRequestValidationAction, resultExpression = [null]]], transitions = list[[Transition@42c6de0b on = authenticationFailure, to = handleAuthenticationFailure], [Transition@29629c30 on = error, to = i
nitializeLoginForm], [Transition@71ed6d0f on = success, to = ticketGrantingTicketCheck], [Transition@32ead20b on = successWithWarnings, to = showAuthenticationWarningMessages], [Transition@46a874db on = mfa-gauth,
 to = mfa-gauth], [Transition@7b96f322 on = mfa-webauthn, to = mfa-webauthn]], exitActionList = list[[empty]]]], event [null] and transition [null]>
2021-07-23 13:27:06,481 TRACE [org.apereo.cas.audit.spi.principal.ThreadLocalAuditPrincipalResolver] - <Resolving principal at audit point [execution(Event org.apereo.cas.web.flow.resolver.impl.mfa.DefaultMultifac
torAuthenticationProviderWebflowEventResolver.resolveSingle(RequestContext))] with thrown exception [java.lang.NullPointerException]>
2021-07-23 13:27:06,482 TRACE [org.apereo.cas.audit.spi.FilterAndDelegateAuditTrailManager] - <Recording audit action context [org.apereo.inspektr.audit.AuditActionContext@61096c4a]>
2021-07-23 13:27:06,484 INFO [org.apereo.inspektr.audit.support.Slf4jLoggingAuditTrailManager] - <Audit trail record BEGIN
=============================================================
WHO: audit:unknown
WHAT: java.lang.NullPointerException
ACTION: AUTHENTICATION_EVENT
APPLICATION: CAS
WHEN: Fri Jul 23 13:27:06 EEST 2021
CLIENT IP ADDRESS: --
SERVER IP ADDRESS: --
=============================================================

>
2021-07-23 13:27:06,488 WARN [org.apereo.cas.web.flow.resolver.impl.DefaultCasDelegatingWebflowEventResolver] - <null>
2021-07-23 13:27:06,492 TRACE [org.apereo.cas.audit.spi.principal.ThreadLocalAuditPrincipalResolver] - <Resolving principal at audit point [execution(Event org.apereo.cas.web.flow.resolver.impl.RankedMultifactorAu
thenticationProviderWebflowEventResolver.resolveSingle(RequestContext))]>
2021-07-23 13:27:06,493 TRACE [org.apereo.cas.audit.spi.FilterAndDelegateAuditTrailManager] - <Recording audit action context [org.apereo.inspektr.audit.AuditActionContext@1c222f]>
2021-07-23 13:27:06,493 INFO [org.apereo.inspektr.audit.support.Slf4jLoggingAuditTrailManager] - <Audit trail record BEGIN
=============================================================
WHO: audit:unknown
WHAT: [event=error,timestamp=Fri Jul 23 13:27:06 EEST 2021,source=DefaultCasDelegatingWebflowEventResolver]
ACTION: AUTHENTICATION_EVENT_TRIGGERED
APPLICATION: CAS
WHEN: Fri Jul 23 13:27:06 EEST 2021
CLIENT IP ADDRESS: --
SERVER IP ADDRESS: --
=============================================================
```
If we swap `mfa-composite` for the authentication context that the TGT
has, the issue goes away.

This PR was done in the same vein as [this](https://github.com/apereo/cas/pull/5153) one.
There might be a better place to solve this issue that the one that leads to the exception but I am not sure where that might be.

I've also tried to include a puppeteer test but I am stuck at the point where I'm trying to log in using the TOTP provider.
What I want to achieve with this test is to have a user with an active TGT attempting to login to a service while having two mfa providers enabled -globally-. If I could somehow mock the user being logged in, that would be great but I could not find such an example in the other test cases.

Thanks a lot in advance!