### PR TITLE
Reset password:  Allow Password Reset Links to optionally be not one time use

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/ResetPasswordManagementProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/ResetPasswordManagementProperties.java
@@ -68,6 +68,11 @@ public class ResetPasswordManagementProperties implements Serializable {
      */
     private long expirationMinutes = 1;
 
+    /**
+     * Should the password expiration links be single use.
+     */
+    private boolean singleUseLink = true;
+    
     public ResetPasswordManagementProperties() {
         mail.setAttributeName("mail");
         mail.setText("Reset your password via this link: %s");

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -50,11 +50,14 @@ public class VerifyPasswordResetRequestAction extends BasePasswordManagementActi
             val tst = centralAuthenticationService.getTicket(transientTicket, TransientSessionTicket.class);
             val token = tst.getProperties().get(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN).toString();
             val username = passwordManagementService.parseToken(token);
-            centralAuthenticationService.deleteTicket(tst.getId());
+            val pm = casProperties.getAuthn().getPm();
+
+            if (pm.getReset().isSingleUseLink()) {
+                centralAuthenticationService.deleteTicket(tst.getId());
+            }
 
             val query = PasswordManagementQuery.builder().username(username).build();
             PasswordManagementWebflowUtils.putPasswordResetToken(requestContext, token);
-            val pm = casProperties.getAuthn().getPm();
             if (pm.getReset().isSecurityQuestionsEnabled()) {
                 val questions = canonicalizeSecurityQuestions(passwordManagementService.getSecurityQuestions(query));
                 if (questions.isEmpty()) {


### PR DESCRIPTION
Because of the prevalence of Office 365 and it's Advanced Threat Protection (along with other email virus scanners), I'm proposing allowing the password reset links to optionally be not one time use and for the tickets to expire as per the default timescales.  ATP automatically visits the url to check for issues, invalidating the ticket before the user has a chance to click on the link.  As we are sending the emails to multiple third-party organizations we can't mandate that all of them disable ATP for our urls.

This is achieved by adding a new PasswordManagementReset property singleUseLink - which default to true (current behavior)

Within VerifyPasswordResetAction it now checks to see if the new property is true and if so deletes the ticket, otherwise it doesn't.

I'd like to add an additional test to VerifyPasswordResetActionTest to show that if the property is set to false that that the ticket is not deleted.  This would be based on verifyAction, but would set the new property to false and then check that the ticket is still present on return

I can use assertNotNull(transientService.getTicket(ticket)) to validate the ticket presence but don't know how to manipulate the settings from within the test - guidance would be appreciated.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
