### PR TITLE
ci:tests: Extend mfa-provider-selection-sso to ensure SSO is reused

### DIFF
--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-sso-session/script.js
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-sso-session/script.js
@@ -64,5 +64,13 @@ const httpGet = (options) => {
     console.log(`Authentication context class ${context}`);
     assert(context === "[mfa-gauth]")
 
+    await page.goto("https://localhost:8443/cas/login?service=https://github.com/apereo/cas");
+    await page.waitForTimeout(500);
+    await page.waitForNavigation();
+
+    const url2 = await page.url()
+    console.log(`Page url: ${url2}`)
+    await cas.assertTicketParameter(page);
+
     await browser.close();
 })();


### PR DESCRIPTION
When multiple MFA providers are globally enabled and there's an SSO
active, it's not reused as we expect. This test makes sure that after
we've authenticated and sent back to the service, if we attempt to login
to the same service again, the SSO is reused.

The last `await page.waitForNavigation();` never returns since the
MFA provider selection menu is thrown at the user. If I am not mistaken, what's
expected here, is to redirect back to the service, since there's an active SSO that fulfills
the authentication requirements for the service.


This test covers what's described in https://github.com/apereo/cas/pull/5205.