### PR TITLE
cz translation - fix for required fields

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_cs.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_cs.properties
@@ -32,8 +32,8 @@ logo.title = j\u00EDt na str\u00E1nky Apereo
 password.expiration.loginsRemaining = Zb\u00FDv\u00E1 V\u00E1m {0} p\u0159ihl\u00E1\u0161en\u00ED, ne\u017E budete <strong>MUSET</strong> zm\u011Bnit sv\u00E9 heslo.
 password.expiration.warning         = Va\u0161e heslo vypr\u0161\u00ED za {0} dn\u00ED. <a href="{1}">Zm\u011B\u0148te pros\u00EDm ihned sv\u00E9 heslo</a>.
 
-required.password = Heslo je povinn\u00FD \u00FAdaj.
-required.username = U\u017Eivatelsk\u00E9 jm\u00E9no je povinn\u00FD \u00FAdaj.
+password.required = Heslo je povinn\u00FD \u00FAdaj.
+username.required = U\u017Eivatelsk\u00E9 jm\u00E9no je povinn\u00FD \u00FAdaj.
 
 screen.accountdisabled.heading          = Tento \u00FA\u010Det byl zak\u00E1z\u00E1n.
 screen.accountdisabled.message          = Pro obnoven\u00ED p\u0159\u00EDstupu kontaktujte pros\u00EDm sv\u00E9ho syst\u00E9mov\u00E9ho administr\u00E1tora.


### PR DESCRIPTION
fix for username.required and password.required like other languages.. (was required.username, required.password before - only in cz translation)


<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
