### PR TITLE
remove deprecated method calls in redis code

### DIFF
--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -169,13 +169,13 @@ public class RedisObjectFactory {
             config.setTestOnReturn(pool.isTestOnReturn());
             config.setTestOnCreate(pool.isTestOnCreate());
             if (pool.getMinEvictableIdleTimeMillis() > 0) {
-                config.setMinEvictableIdleTimeMillis(pool.getMinEvictableIdleTimeMillis());
+                config.setMinEvictableIdleTime(Duration.ofMillis(pool.getMinEvictableIdleTimeMillis()));
             }
             if (pool.getNumTestsPerEvictionRun() > 0) {
                 config.setNumTestsPerEvictionRun(pool.getNumTestsPerEvictionRun());
             }
             if (pool.getSoftMinEvictableIdleTimeMillis() > 0) {
-                config.setSoftMinEvictableIdleTimeMillis(pool.getSoftMinEvictableIdleTimeMillis());
+                config.setSoftMinEvictableIdleTime(Duration.ofMillis(pool.getSoftMinEvictableIdleTimeMillis()));
             }
             poolingClientConfig.poolConfig(config);
             LOGGER.trace("Redis configuration: the pool is configured to [{}]", config);


### PR DESCRIPTION
This change removes a couple deprecations but the right fix would probably be to change the property names to not contain the "millis" suffix and use the CAS duration syntax for the property. Not sure if it is too late for 6.4 to change property names. 




