### PR TITLE
Fix reading entityId in Saml attribute release policies

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/BaseSamlRegisteredServiceAttributeReleasePolicy.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/BaseSamlRegisteredServiceAttributeReleasePolicy.java
@@ -42,10 +42,14 @@ public abstract class BaseSamlRegisteredServiceAttributeReleasePolicy extends Re
     private static final long serialVersionUID = -3301632236702329694L;
 
     @SneakyThrows
-    private static String getEntityIdFromRequest(final HttpServletRequest request) {
+    private static String getEntityIdFromRequest(final HttpServletRequest request, final Service service) {
         val entityId = request.getParameter(SamlProtocolConstants.PARAMETER_ENTITY_ID);
         if (StringUtils.isNotBlank(entityId)) {
             return entityId;
+        }
+        val entityIdAttribute = service.getAttributes().get(SamlProtocolConstants.PARAMETER_ENTITY_ID);
+        if (entityIdAttribute != null && entityIdAttribute.size() > 0) {
+            return (String) entityIdAttribute.get(0);
         }
         val svcParam = request.getParameter(CasProtocolConstants.PARAMETER_SERVICE);
         if (StringUtils.isNotBlank(svcParam)) {
@@ -89,7 +93,7 @@ public abstract class BaseSamlRegisteredServiceAttributeReleasePolicy extends Re
             val samlRegisteredService = (SamlRegisteredService) registeredService;
 
             val request = HttpRequestUtils.getHttpServletRequestFromRequestAttributes();
-            val entityId = getEntityIdFromRequest(request);
+            val entityId = getEntityIdFromRequest(request, selectedService);
             val applicationContext = ApplicationContextProvider.getApplicationContext();
             val resolver = applicationContext.getBean(SamlRegisteredServiceCachingMetadataResolver.DEFAULT_BEAN_NAME,
                 SamlRegisteredServiceCachingMetadataResolver.class);


### PR DESCRIPTION
This patch fixes the following error:

```
cas_1    | DEBUG [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Initiating attributes release phase for principal [rom3314] accessing service [AbstractWebApplicationService(id=https://aai.pionier.net.pl/test/module.php/saml/sp/metadata.php/default-sp, originalUrl=https://aai.pionier.net.pl/test/module.php/saml/sp/metadata.php/default-sp, artifactId=null, principal=null, source=null, loggedOutAlready=false, format=XML, attributes={SigAlg=[http://www.w3.org/2001/04/xmldsig-more#rsa-sha256], entityId=[https://aai.pionier.net.pl/test/module.php/saml/sp/metadata.php/default-sp], SAMLRequest=[nZJBb9swDIX/iqG7LUeNF0dIAmQNhgVo1yBOd9hlYC2mESBLnkh327+fnGxYu0MOOwmg+B4/PnBB0Llerwc++T1+G5A4+9E5T/r8sRRD9DoAWdIeOiTNrW7W93daFaXuY+DQBideSa4rgAgj2+BFtt0sxdeqvsF5bWBWwbQ1tVHz2ZMyM2XqSkHVqptKVaqeVFMlss8YKSmXIhklOdGAW08MnlOpVJO8rPNyepjMdflOT+svItukbawHPqtOzD1pKV14tr4YupaK3skWSFrTy7TK0TqUI6mSezQ2YsuyaR5Etv4DfRs8DR3GBuOLbfFxf/fXFsAWfeqxGAuPPHpzGi+7YAaHRX/q5RiPpMurchgBUtXgEQbHOfUi2/0O9L31xvrn61k+XZpIfzwcdvnuoTmI1WL01uds4uo/0DpkMMDwD9lCvvZdXG7mUyLabnbB2fZn9iHEDvg68FixJj+eWzVH8GTRcwrYufD9NiIwLgXHAYVcXUa+vczVLw==], RelayState=[https://aai.pionier.net.pl/test/attributes.php], Signature=[WV07y0CHUAq70StFfjgnFXSd6im9lPfZU5epYR82niDDArWXMLbIGNao0wIHiWZkHBBjK3hRhQOn6sm75P0uoK/30QbEP738sx1lpXstA4f7jiMg4M+NW7psKKG225H4gm4mtOmcDGgh2LCnw++7ThtzaxthHYGQ7as0x3eEa+LU69OfXRpzQhODNyYUHD39htDTeaPLiXkKbppjr43h6wS8TpKUMBwEa3cCqlJhmlPA7P5YXTRJ3LAVHNAYCiVewsiSG00fuoJ3sGzyUclf6iqyGM4326CQLhZgiwWET0CaKNEwDODDPNVTXaMj5JO1lT1WjgEixsqm8C1kgdl7Yw==]})] defined by registered service [https://aai\.pionier\.net\.pl/test/.*]...
cas_1    | TRACE [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Locating principal attributes for [test]
cas_1    | DEBUG [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Using principal attribute repository [DefaultPrincipalAttributesRepository()] to retrieve attributes
cas_1    | DEBUG [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Found principal attributes [{...}] for [test]
cas_1    | TRACE [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Retrieving attribute definition store and attribute definitions...
cas_1    | TRACE [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Finding requested attribute definitions [[eduPersonPrincipalName, eduPersonTargetedID, mail, displayName, givenName, sn, eduPersonScopedAffiliation]]
cas_1    | WARN [org.apereo.cas.authentication.attribute.AttributeDefinitionStore] Unable to produce or determine attributes values for attribute definition [SamlIdPAttributeDefinition(super=DefaultAttributeDefinition(key=eduPersonScopedAffiliation, name=eduPersonScopedAffiliation, scoped=false, encrypted=false, attribute=null, patternFormat=null, script=null, canonicalizationMode=null), friendlyName=eduPersonScopedAffiliation, urn=urn:oid:1.3.6.1.4.1.5923.1.1.1.9)]
cas_1    | WARN [org.apereo.cas.authentication.attribute.AttributeDefinitionStore] Unable to produce or determine attributes values for attribute definition [SamlIdPAttributeDefinition(super=DefaultAttributeDefinition(key=eduPersonTargetedID, name=eduPersonTargetedID, scoped=false, encrypted=false, attribute=null, patternFormat=null, script=null, canonicalizationMode=null), friendlyName=eduPersonTargetedID, urn=urn:oid:1.3.6.1.4.1.5923.1.1.1.10)]
cas_1    | TRACE [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Resolved principal attributes [{...}] for [test] from attribute definition store
cas_1    | TRACE [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Updating principal attributes repository cache for [test] with [{...}]
cas_1    | TRACE [org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy] Calling attribute policy [RefedsRSAttributeReleasePolicy] to process attributes for [rom3314]
cas_1    | TRACE [org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade] Adapting SAML metadata for CAS service [aai_pionier_net_pl_test] issued by [null]
cas_1    | ERROR [org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade] Entity ID cannot be null or empty
cas_1    | net.shibboleth.utilities.java.support.logic.ConstraintViolationException: Entity ID cannot be null or empty
cas_1    |      at net.shibboleth.utilities.java.support.logic.Constraint.isNotNull(Constraint.java:307) ~[java-support-8.2.1.jar!/:?]
cas_1    |      at org.opensaml.core.criterion.EntityIdCriterion.<init>(EntityIdCriterion.java:39) ~[opensaml-core-4.1.1.jar!/:?]
cas_1    |      at org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade.get(SamlRegisteredServiceServiceProviderMetadataFacade.java:98) ~[cas-server-support-saml-idp-core-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.support.saml.services.idp.metadata.SamlRegisteredServiceServiceProviderMetadataFacade.get(SamlRegisteredServiceServiceProviderMetadataFacade.java:74) ~[cas-server-support-saml-idp-core-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.support.saml.services.BaseSamlRegisteredServiceAttributeReleasePolicy.getAttributesInternal(BaseSamlRegisteredServiceAttributeReleasePolicy.java:96) ~[cas-server-support-saml-idp-core-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.services.AbstractRegisteredServiceAttributeReleasePolicy.getAttributes(AbstractRegisteredServiceAttributeReleasePolicy.java:95) ~[cas-server-core-authentication-attributes-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.services.ChainingAttributeReleasePolicy.lambda$getAttributes$1(ChainingAttributeReleasePolicy.java:67) ~[cas-server-core-authentication-attributes-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[?:?]
cas_1    |      at java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:357) ~[?:?]
cas_1    |      at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:485) ~[?:?]
cas_1    |      at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
cas_1    |      at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
cas_1    |      at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
cas_1    |      at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
cas_1    |      at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497) ~[?:?]
cas_1    |      at org.apereo.cas.services.ChainingAttributeReleasePolicy.getAttributes(ChainingAttributeReleasePolicy.java:65) ~[cas-server-core-authentication-attributes-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.support.saml.web.idp.profile.AbstractSamlIdPProfileHandlerController.buildCasAssertion(AbstractSamlIdPProfileHandlerController.java:196) ~[cas-server-support-saml-idp-web-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.support.saml.web.idp.profile.AbstractSamlIdPProfileHandlerController.buildResponseBasedSingleSignOnSession(AbstractSamlIdPProfileHandlerController.java:380) ~[cas-server-support-saml-idp-web-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.support.saml.web.idp.profile.AbstractSamlIdPProfileHandlerController.initiateAuthenticationRequest(AbstractSamlIdPProfileHandlerController.java:355) ~[cas-server-support-saml-idp-web-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.support.saml.web.idp.profile.AbstractSamlIdPProfileHandlerController.handleSsoPostProfileRequest(AbstractSamlIdPProfileHandlerController.java:652) ~[cas-server-support-saml-idp-web-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apereo.cas.support.saml.web.idp.profile.sso.SSOSamlIdPPostProfileHandlerController.handleSaml2ProfileSsoRedirectRequest(SSOSamlIdPPostProfileHandlerController.java:45) ~[cas-server-support-saml-idp-web-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
cas_1    |      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
cas_1    |      at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
cas_1    |      at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
cas_1    |      at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282) ~[spring-core-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:485) ~[spring-cloud-context-3.0.3.jar!/:3.0.3]
cas_1    |      at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:750) ~[spring-aop-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:692) ~[spring-aop-5.3.9.jar!/:5.3.9]
cas_1    |      at org.apereo.cas.support.saml.web.idp.profile.sso.SSOSamlIdPPostProfileHandlerController$$EnhancerBySpringCGLIB$$287acdf4.handleSaml2ProfileSsoRedirectRequest(<generated>) ~[cas-server-support-saml-idp-web-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
cas_1    |      at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
cas_1    |      at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
cas_1    |      at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
cas_1    |      at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:197) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:141) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:106) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1064) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at javax.servlet.http.HttpServlet.service(HttpServlet.java:645) ~[javax.servlet-api-4.0.1.jar!/:4.0.1]
cas_1    |      at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc-5.3.9.jar!/:5.3.9]
cas_1    |      at javax.servlet.http.HttpServlet.service(HttpServlet.java:750) ~[javax.servlet-api-4.0.1.jar!/:4.0.1]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:228) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apereo.cas.web.support.AuthenticationCredentialsThreadLocalBinderClearingFilter.doFilter(AuthenticationCredentialsThreadLocalBinderClearingFilter.java:28) ~[cas-server-core-web-api-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apereo.cas.web.support.filters.RequestParameterPolicyEnforcementFilter.doFilter(RequestParameterPolicyEnforcementFilter.java:401) ~[cas-server-core-web-api-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apereo.cas.web.support.filters.ResponseHeadersEnforcementFilter.doFilter(ResponseHeadersEnforcementFilter.java:200) ~[cas-server-core-web-api-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apereo.cas.web.support.filters.AddResponseHeadersFilter.doFilter(AddResponseHeadersFilter.java:64) ~[cas-server-core-web-api-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:204) ~[spring-security-web-5.5.1.jar!/:5.5.1]
cas_1    |      at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:183) ~[spring-security-web-5.5.1.jar!/:5.5.1]
cas_1    |      at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:358) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:271) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:96) ~[spring-boot-actuator-2.5.2.jar!/:2.5.2]
cas_1    |      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apereo.cas.logging.web.ThreadContextMDCServletFilter.doFilter(ThreadContextMDCServletFilter.java:99) ~[cas-server-core-logging-6.4.0-RC6.jar!/:6.4.0-RC6]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apereo.inspektr.common.web.ClientInfoThreadLocalFilter.doFilter(ClientInfoThreadLocalFilter.java:66) ~[inspektr-common-1.8.15.GA.jar!/:1.8.15.GA]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.3.9.jar!/:5.3.9]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:190) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:163) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:542) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:143) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:687) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:769) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:357) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:382) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:893) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1723) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
cas_1    |      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
cas_1    |      at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.50.jar!/:9.0.50]
cas_1    |      at java.lang.Thread.run(Thread.java:834) [?:?]
```