### PR TITLE
Don't use Delegated Authentication when service cannot be determined

### DIFF
--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/validation/DelegatedAuthenticationAccessStrategyHelper.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/validation/DelegatedAuthenticationAccessStrategyHelper.java
@@ -81,7 +81,7 @@ public class DelegatedAuthenticationAccessStrategyHelper {
                                                   final HttpServletRequest request) {
         if (service == null || StringUtils.isBlank(service.getId())) {
             LOGGER.debug("Can not evaluate delegated authentication policy without a service");
-            return true;
+            return false;
         }
 
         if (StringUtils.isBlank(clientName)) {

--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -8,6 +8,7 @@ import org.apereo.cas.authentication.principal.provision.RestfulDelegatedClientU
 import org.apereo.cas.pac4j.clients.DefaultDelegatedClientIdentityProviderRedirectionStrategyTests;
 import org.apereo.cas.pac4j.clients.GroovyDelegatedClientIdentityProviderRedirectionStrategyTests;
 import org.apereo.cas.pac4j.discovery.DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests;
+import org.apereo.cas.validation.DelegatedAuthenticationAccessStrategyHelperTests;
 import org.apereo.cas.validation.DelegatedAuthenticationServiceTicketValidationAuthorizerTests;
 import org.apereo.cas.web.DelegatedClientIdentityProviderConfigurationFactoryTests;
 import org.apereo.cas.web.flow.DelegatedAuthenticationSingleSignOnParticipationStrategyTests;
@@ -33,7 +34,8 @@ import org.junit.platform.suite.api.Suite;
     GroovyDelegatedClientUserProfileProvisionerTests.class,
     DelegatedAuthenticationSingleSignOnParticipationStrategyTests.class,
     ChainingDelegatedClientUserProfileProvisionerTests.class,
-    RestfulDelegatedClientUserProfileProvisionerTests.class
+    RestfulDelegatedClientUserProfileProvisionerTests.class,
+    DelegatedAuthenticationAccessStrategyHelperTests.class
 })
 @Suite
 public class AllTestsSuite {

--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/validation/DelegatedAuthenticationAccessStrategyHelperTests.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/validation/DelegatedAuthenticationAccessStrategyHelperTests.java
@@ -1,0 +1,108 @@
+package org.apereo.cas.validation;
+
+
+import org.apereo.cas.audit.AuditableExecution;
+import org.apereo.cas.audit.AuditableExecutionResult;
+import org.apereo.cas.authentication.principal.Service;
+import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.services.RegisteredServiceAccessStrategy;
+import org.apereo.cas.services.ServicesManager;
+
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DelegatedAuthenticationAccessStrategyHelper}.
+ *
+ * @author Stefan Reiterer
+ * @since 6.5
+ */
+@Tag("Delegation")
+public class DelegatedAuthenticationAccessStrategyHelperTests {
+
+    @Test
+    public void isDelegatedClientAuthorizedForServiceIsNull() {
+        val serviceManager = mock(ServicesManager.class);
+        val delegatedAuthenticationPolicyEnforcer = mock(AuditableExecution.class);
+
+        DelegatedAuthenticationAccessStrategyHelper delegatedAuthenticationAccessStrategyHelper =
+                new DelegatedAuthenticationAccessStrategyHelper(serviceManager, delegatedAuthenticationPolicyEnforcer);
+
+        val httpServletRequest = mock(HttpServletRequest.class);
+
+        /*
+        Without service delegated authentication policy cannot be evaluated and so Delegated Auth. should not be
+        authorized for the given client-name
+         */
+        assertFalse(
+                delegatedAuthenticationAccessStrategyHelper.isDelegatedClientAuthorizedFor(
+                        "myClientName", null, httpServletRequest));
+    }
+
+    @Test
+    public void isDelegatedClientAuthorizedForServiceIdIsEmpty() {
+        val serviceManager = mock(ServicesManager.class);
+        val delegatedAuthenticationPolicyEnforcer = mock(AuditableExecution.class);
+
+        DelegatedAuthenticationAccessStrategyHelper delegatedAuthenticationAccessStrategyHelper =
+                new DelegatedAuthenticationAccessStrategyHelper(serviceManager, delegatedAuthenticationPolicyEnforcer);
+
+        val httpServletRequest = mock(HttpServletRequest.class);
+        val service = mock(Service.class);
+        when(service.getId()).thenReturn(StringUtils.EMPTY);
+
+        /*
+        Without service delegated authentication policy cannot be evaluated and so Delegated Auth. should not be
+        authorized for the given client-name
+         */
+        assertFalse(
+                delegatedAuthenticationAccessStrategyHelper.isDelegatedClientAuthorizedFor(
+                        "myClientName", service, httpServletRequest));
+    }
+
+    @Test
+    public void isDelegatedClientAuthorizedForKnownService() {
+        val serviceManager = mock(ServicesManager.class);
+        val delegatedAuthenticationPolicyEnforcer = mock(AuditableExecution.class);
+
+        DelegatedAuthenticationAccessStrategyHelper delegatedAuthenticationAccessStrategyHelper =
+                new DelegatedAuthenticationAccessStrategyHelper(serviceManager, delegatedAuthenticationPolicyEnforcer);
+
+        val httpServletRequest = mock(HttpServletRequest.class);
+        val service = mock(Service.class);
+        when(service.getId()).thenReturn("serviceId");
+
+        var registeredService = mock(RegisteredService.class);
+        var accessStrategy = mock(RegisteredServiceAccessStrategy.class);
+        when(serviceManager.findServiceBy(Mockito.eq(service))).thenReturn(registeredService);
+        when(registeredService.getAccessStrategy()).thenReturn(accessStrategy);
+        when(accessStrategy.isServiceAccessAllowed()).thenReturn(true);
+
+        var auditableExecutionResult = mock(AuditableExecutionResult.class);
+        when(delegatedAuthenticationPolicyEnforcer.execute(any())).thenReturn(auditableExecutionResult);
+        when(auditableExecutionResult.isExecutionFailure()).thenReturn(false);
+
+        assertTrue(
+                delegatedAuthenticationAccessStrategyHelper.isDelegatedClientAuthorizedFor(
+                        "myClientName", service, httpServletRequest));
+
+        verify(delegatedAuthenticationPolicyEnforcer, times(1)).execute(any());
+        verify(auditableExecutionResult, times(1)).isExecutionFailure();
+        verify(serviceManager, times(1)).findServiceBy(Mockito.eq(service));
+        verify(serviceManager, times(1)).findServiceBy(Mockito.eq(service));
+        verify(accessStrategy, times(1)).isServiceAccessAllowed();
+    }
+}


### PR DESCRIPTION
When /cas/login is called, it is evaluated which Delegated Authentication configuration (client-name) has to be applied based on the service parameter passed. If no service parameter is passed, the handler with the first available client name is used. Even if other handlers are configured apart from Delegated Authentication (e.g. LDAP).
If Delegated Authentication is used on a call to /cas/login without a service parameter, then an error occurs after authentication. If alternatively a handler for e.g. LDAP is configured, the login works without problems.

This pull request fixes the problem that DelegatedAuthenticationAccessStrategyHelper#isDelegatedClientAuthorizedFor returns true even if the Delegated Authentication policy cannot be evaluated due to the missing service parameter.

Note: re-opened pull requests for PR 5218 (this time it contains unit tests)
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
