### PR TITLE
[Documentation] Add missing consent properties (e.g. cas.consent.active, cas.consent.enabled, etc...)

### DIFF
--- a/docs/cas-server-documentation/integration/Attribute-Release-Consent-Activation.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Consent-Activation.md
@@ -57,9 +57,6 @@ selection. A sample chain of attribute consent polices follows:
   }
 }
 ```          
-## Configuration
-
-{% include casproperties.html properties="cas.consent" %}
 
 ## Activation via Groovy
 

--- a/docs/cas-server-documentation/integration/Attribute-Release-Consent-Activation.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Consent-Activation.md
@@ -57,6 +57,9 @@ selection. A sample chain of attribute consent polices follows:
   }
 }
 ```          
+## Configuration
+
+{% include casproperties.html properties="cas.consent" %}
 
 ## Activation via Groovy
 

--- a/docs/cas-server-documentation/integration/Attribute-Release-Consent.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Consent.md
@@ -24,10 +24,7 @@ Support is enabled by including the following module in the WAR Overlay:
 
 ## Configuration
 
-{% include casproperties.html properties="cas.consent.enabled" %}
-{% include casproperties.html properties="cas.consent.active" %}
-{% include casproperties.html properties="cas.consent.reminder" %}
-{% include casproperties.html properties="cas.consent.reminder-time-unit" %}
+{% include casproperties.html properties="cas.consent.enabled,cas.consent.active,cas.consent.reminder,cas.consent.reminder-time-unit" %}
 
 ## Actuator Endpoints
       

--- a/docs/cas-server-documentation/integration/Attribute-Release-Consent.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Consent.md
@@ -22,6 +22,13 @@ Support is enabled by including the following module in the WAR Overlay:
 
 {% include casmodule.html group="org.apereo.cas" module="cas-server-support-consent-webflow" %}
 
+## Configuration
+
+{% include casproperties.html properties="cas.consent.enabled" %}
+{% include casproperties.html properties="cas.consent.active" %}
+{% include casproperties.html properties="cas.consent.reminder" %}
+{% include casproperties.html properties="cas.consent.reminder-time-unit" %}
+
 ## Actuator Endpoints
       
 The following endpoints are provided by CAS:


### PR DESCRIPTION
From a quick algolia search in 6.4.x document, seems like `cas.consent.enabled`, `cas.consent.active` and properties at that level are missing in 6.4.x documentation.

For reference, in 6.3.x those properties are listed here:
* https://apereo.github.io/cas/6.3.x/configuration/Configuration-Properties.html#attribute-consent

And the `ConsentProperties` class specifying those properties in 6.4.x: 
* https://github.com/apereo/cas/blob/v6.4.0/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/consent/ConsentProperties.java

While I do think those properties are missing, I do not know how can I add back those properties to 6.4.x documentation since is quite different then before.

Judging from the 6.4.x documentation files, I reckon this line will add back the properties needed:
```
{% include casproperties.html properties="cas.consent" %}
```

Please see if the properties is indeed missing and see if this PR will help add them back, cheers!

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
