### PR TITLE
Wildcard service/cache issue fix.

### DIFF
--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -19,7 +19,6 @@ import org.springframework.context.ApplicationEvent;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -98,11 +97,11 @@ public abstract class AbstractServicesManager implements ServicesManager {
 
         val candidates = getCandidateServicesToMatch(service.getId());
         var foundService = configurationContext.getRegisteredServiceLocators()
-                .stream()
-                .map(locator -> locator.locate(candidates, service))
-                .filter(candidate -> candidate != null && validateRegisteredService(candidate) != null)
-                .findFirst()
-                .orElse(null);
+            .stream()
+            .map(locator -> locator.locate(candidates, service))
+            .filter(candidate -> validateRegisteredService(candidate) != null)
+            .findFirst()
+            .orElse(null);
 
         if (foundService == null) {
             val serviceRegistry = configurationContext.getServiceRegistry();

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/AbstractServicesManager.java
@@ -98,11 +98,11 @@ public abstract class AbstractServicesManager implements ServicesManager {
 
         val candidates = getCandidateServicesToMatch(service.getId());
         var foundService = configurationContext.getRegisteredServiceLocators()
-            .stream()
-            .map(locator -> locator.locate(candidates, service))
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+                .stream()
+                .map(locator -> locator.locate(candidates, service))
+                .filter(candidate -> candidate != null && validateRegisteredService(candidate) != null)
+                .findFirst()
+                .orElse(null);
 
         if (foundService == null) {
             val serviceRegistry = configurationContext.getServiceRegistry();

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -196,11 +196,10 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
      *      match {@code https://*.test.edu} is executed first.
      * </ul>
      * Failure is caused by "promotion" through the services cache. When the non-{@code https://prod.test.edu} request
-     * is matched, it is added to the cache <em>before</em> its associated environments were evaluated in
-     * {@code AbstractServicesManager#validateRegisteredService(RegisteredService)}: it ends up in cache even though it
-     * doesn't match the current environment. Subsequently, <em>all</em> requests matching {@code https://*.test.edu}
-     * will return {@code null} because they are validated against {@code https://*.test.edu}, which is not associated
-     * with {@code current-env}.
+     * is matched, it is added to the cache <em>before</em> its associated environments were evaluated: it ends up in
+     * cache even though it doesn't match the current environment. Subsequently, <em>all</em> requests matching
+     * {@code https://*.test.edu} will return {@code null} because they are validated against
+     * {@code https://*.test.edu}, which is not associated with {@code current-env}.
      *
      * This test verifies that the above situation does not occur. Requests for {@code https://prod.test.edu} should
      * return a valid service regardless of whether a request for {@code https://[anything else].test.edu} comes in

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -16,10 +16,7 @@ import org.springframework.context.support.StaticApplicationContext;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -180,16 +177,91 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         loadingThread.join();
     }
 
+    /**
+     * Verify that a service which is <strong>not</strong> associated with the current environment ({@code current-env}
+     * in this test) is not incorrectly selected due to "promotion" through the services cache. Scenario is as follows:
+     * <ul>
+     *      <li/> Active environment is {@code current-env}.
+     *      <li/> Service {@code https://prod.test.edu} associated with {@code current-env}, low
+     *      {@code evaluationOrder}.
+     *      <li/> Service {@code https://*.test.edu} <strong>not</strong> associated with {@code current-env}, high
+     *      {@code evaluationOrder}.
+     *      <li/> {@code https://prod.test.edu} is matched correctly <em>if</em> no request for some other domain which
+     *      would match {@code https://*.test.edu} is executed first.
+     *      <li/> {@code https://prod.test.edu} fails to match <em>if</em> a request for some other domain which would
+     *      match {@code https://*.test.edu} is executed first.
+     * </ul>
+     * Failure is caused by "promotion" through the services cache. When the non-{@code https://prod.test.edu} request
+     * is matched, it is added to the cache <em>before</em> its associated environments were evaluated in
+     * {@code validateRegisteredService()}: it ends up in cache even though it doesn't match the current environment.
+     * Subsequently, <em>all</em> requests matching {@code https://*.test.edu} will return {@code null} because they are
+     * validated against {@code https://*.test.edu}, which is not associated with {@code current-env}.
+     *
+     * This test verifies that the above situation does not occur. Requests for {@code https://prod.test.edu} should
+     * return a valid service regardless of whether a request for {@code https://[anything else].test.edu} comes in
+     * first. A service which is not associated with the current environment should not interfere.
+     */
+    @Test
+    public void verifyInvalidServiceNotPromotedByCache() {
+        val applicationContext = new StaticApplicationContext();
+        applicationContext.refresh();
+        val cache = Caffeine.newBuilder().expireAfterWrite(Duration.ofDays(1000L)).<Long, RegisteredService>build();
+        val config = ServicesManagerConfigurationContext.builder()
+                .serviceRegistry(serviceRegistry)
+                .applicationContext(applicationContext)
+                .environments(Collections.singleton("current-env"))
+                .registeredServiceLocators(Collections.singletonList(new DefaultServicesManagerRegisteredServiceLocator()))
+                .servicesCache(cache)
+                .build();
+        val manager = new DefaultServicesManager(config);
+
+        /* Service "https://prod.test.edu", low evaluationOrder (high priority), active in "current-env". */
+        val prodTestEduService = new RegexRegisteredService();
+        prodTestEduService.setServiceId("https://prod\\.test\\.edu.*");
+        prodTestEduService.setId(RandomUtils.nextLong());
+        prodTestEduService.setName("Specific Subdomain Service");
+        prodTestEduService.setEvaluationOrder(0);
+        prodTestEduService.setEnvironments(new HashSet<>(Collections.singleton("current-env")));
+
+        /* Service "https://*.test.edu", high evaluationOrder (low priority), NOT active in "current-env". */
+        val anyTestEduService = new RegexRegisteredService();
+        anyTestEduService.setServiceId("https://[^.]+\\.test\\.edu.*");
+        anyTestEduService.setId(RandomUtils.nextLong());
+        anyTestEduService.setName("Any Subdomain Service");
+        anyTestEduService.setEvaluationOrder(1000);
+        anyTestEduService.setEnvironments(new HashSet<>(Collections.singleton("non-current-env")));
+
+        /* Initialize the service manager. */
+        serviceRegistry.save(prodTestEduService);
+        serviceRegistry.save(anyTestEduService);
+        manager.load();
+
+        /* This case always worked: request for https://prod.test.edu before any request for
+        https://[anything else].test.edu. */
+        var foundService = manager.findServiceBy(serviceFactory.createService("https://prod.test.edu"));
+        assertSame(prodTestEduService, foundService);
+
+        /* Now clear the cache and try the previous failure case: request for https://prod.test.edu comes after any
+        request for https://[anything else].test.edu. Previously this would fail because https://*.test.edu matches
+        https://prod.test.edu and exists in cache even though it is not associated with current-env. Null would have
+        been returned. */
+        cache.invalidateAll();
+        foundService = manager.findServiceBy(serviceFactory.createService("https://not-prod.test.edu"));
+        assertNull(foundService);
+        foundService = manager.findServiceBy(serviceFactory.createService("https://prod.test.edu"));
+        assertSame(prodTestEduService, foundService);
+    }
+
     protected ServicesManager getServicesManagerInstance() {
         val applicationContext = new StaticApplicationContext();
         applicationContext.refresh();
 
         val context = ServicesManagerConfigurationContext.builder()
-            .serviceRegistry(serviceRegistry)
-            .applicationContext(applicationContext)
-            .environments(new HashSet<>(0))
-            .servicesCache(Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(2)).build())
-            .build();
+                .serviceRegistry(serviceRegistry)
+                .applicationContext(applicationContext)
+                .environments(new HashSet<>(0))
+                .servicesCache(Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(2)).build())
+                .build();
         return new DefaultServicesManager(context);
     }
 
@@ -201,7 +273,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
 
     protected boolean isServiceInCache(final String serviceId, final long id) {
         return servicesManager.getAllServices()
-            .stream()
-            .anyMatch(r -> serviceId != null ? r.getServiceId().equals(serviceId) : r.getId() == id);
+                .stream()
+                .anyMatch(r -> serviceId != null ? r.getServiceId().equals(serviceId) : r.getId() == id);
     }
 }

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -220,7 +220,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
             .build();
         val manager = new DefaultServicesManager(config);
 
-        // Service "https://prod.test.edu", low evaluationOrder (high priority), active in "current-env".
+        /* Service "https://prod.test.edu", low evaluationOrder (high priority), active in "current-env". */
         val prodTestEduService = new RegexRegisteredService();
         prodTestEduService.setServiceId("https://prod\\.test\\.edu.*");
         prodTestEduService.setId(RandomUtils.nextLong());
@@ -228,7 +228,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         prodTestEduService.setEvaluationOrder(0);
         prodTestEduService.setEnvironments(new HashSet<>(Collections.singleton("current-env")));
 
-        // Service "https://*.test.edu", high evaluationOrder (low priority), NOT active in "current-env".
+        /* Service "https://*.test.edu", high evaluationOrder (low priority), NOT active in "current-env". */
         val anyTestEduService = new RegexRegisteredService();
         anyTestEduService.setServiceId("https://[^.]+\\.test\\.edu.*");
         anyTestEduService.setId(RandomUtils.nextLong());
@@ -236,19 +236,21 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         anyTestEduService.setEvaluationOrder(1000);
         anyTestEduService.setEnvironments(new HashSet<>(Collections.singleton("non-current-env")));
 
-        // Initialize the service manager.
+        /* Initialize the service manager. */
         serviceRegistry.save(prodTestEduService);
         serviceRegistry.save(anyTestEduService);
         manager.load();
 
-        // Always worked: request for https://prod.test.edu before any request for https://[anything else].test.edu.
+        /* Always worked: request for https://prod.test.edu before any request for https://[anything else].test.edu. */
         var foundService = manager.findServiceBy(serviceFactory.createService("https://prod.test.edu"));
         assertSame(prodTestEduService, foundService);
 
-        // Now clear the cache and try the previous failure case: request for https://prod.test.edu comes after any
-        // request for https://[anything else].test.edu. Previously this would fail because https://*.test.edu matches
-        // https://prod.test.edu and exists in cache even though it is not associated with current-env. Null would have
-        // been returned.
+        /*
+         * Now clear the cache and try the previous failure case: request for https://prod.test.edu comes after any
+         * request for https://[anything else].test.edu. Previously this would fail because https://*.test.edu matches
+         * https://prod.test.edu and exists in cache even though it is not associated with current-env. Null would have
+         * been returned.
+         */
         cache.invalidateAll();
         foundService = manager.findServiceBy(serviceFactory.createService("https://not-prod.test.edu"));
         assertNull(foundService);

--- a/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
+++ b/core/cas-server-core-services/src/test/java/org/apereo/cas/services/AbstractServicesManagerTests.java
@@ -16,7 +16,11 @@ import org.springframework.context.support.StaticApplicationContext;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -183,9 +187,9 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
      * <ul>
      *      <li/> Active environment is {@code current-env}.
      *      <li/> Service {@code https://prod.test.edu} associated with {@code current-env}, low
-     *      {@code evaluationOrder}.
+     *      {@link RegisteredService#getEvaluationOrder()}.
      *      <li/> Service {@code https://*.test.edu} <strong>not</strong> associated with {@code current-env}, high
-     *      {@code evaluationOrder}.
+     *      {@link RegisteredService#getEvaluationOrder()}.
      *      <li/> {@code https://prod.test.edu} is matched correctly <em>if</em> no request for some other domain which
      *      would match {@code https://*.test.edu} is executed first.
      *      <li/> {@code https://prod.test.edu} fails to match <em>if</em> a request for some other domain which would
@@ -193,9 +197,10 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
      * </ul>
      * Failure is caused by "promotion" through the services cache. When the non-{@code https://prod.test.edu} request
      * is matched, it is added to the cache <em>before</em> its associated environments were evaluated in
-     * {@code validateRegisteredService()}: it ends up in cache even though it doesn't match the current environment.
-     * Subsequently, <em>all</em> requests matching {@code https://*.test.edu} will return {@code null} because they are
-     * validated against {@code https://*.test.edu}, which is not associated with {@code current-env}.
+     * {@code AbstractServicesManager#validateRegisteredService(RegisteredService)}: it ends up in cache even though it
+     * doesn't match the current environment. Subsequently, <em>all</em> requests matching {@code https://*.test.edu}
+     * will return {@code null} because they are validated against {@code https://*.test.edu}, which is not associated
+     * with {@code current-env}.
      *
      * This test verifies that the above situation does not occur. Requests for {@code https://prod.test.edu} should
      * return a valid service regardless of whether a request for {@code https://[anything else].test.edu} comes in
@@ -207,15 +212,15 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         applicationContext.refresh();
         val cache = Caffeine.newBuilder().expireAfterWrite(Duration.ofDays(1000L)).<Long, RegisteredService>build();
         val config = ServicesManagerConfigurationContext.builder()
-                .serviceRegistry(serviceRegistry)
-                .applicationContext(applicationContext)
-                .environments(Collections.singleton("current-env"))
-                .registeredServiceLocators(Collections.singletonList(new DefaultServicesManagerRegisteredServiceLocator()))
-                .servicesCache(cache)
-                .build();
+            .serviceRegistry(serviceRegistry)
+            .applicationContext(applicationContext)
+            .environments(Collections.singleton("current-env"))
+            .registeredServiceLocators(Collections.singletonList(new DefaultServicesManagerRegisteredServiceLocator()))
+            .servicesCache(cache)
+            .build();
         val manager = new DefaultServicesManager(config);
 
-        /* Service "https://prod.test.edu", low evaluationOrder (high priority), active in "current-env". */
+        // Service "https://prod.test.edu", low evaluationOrder (high priority), active in "current-env".
         val prodTestEduService = new RegexRegisteredService();
         prodTestEduService.setServiceId("https://prod\\.test\\.edu.*");
         prodTestEduService.setId(RandomUtils.nextLong());
@@ -223,7 +228,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         prodTestEduService.setEvaluationOrder(0);
         prodTestEduService.setEnvironments(new HashSet<>(Collections.singleton("current-env")));
 
-        /* Service "https://*.test.edu", high evaluationOrder (low priority), NOT active in "current-env". */
+        // Service "https://*.test.edu", high evaluationOrder (low priority), NOT active in "current-env".
         val anyTestEduService = new RegexRegisteredService();
         anyTestEduService.setServiceId("https://[^.]+\\.test\\.edu.*");
         anyTestEduService.setId(RandomUtils.nextLong());
@@ -231,20 +236,19 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         anyTestEduService.setEvaluationOrder(1000);
         anyTestEduService.setEnvironments(new HashSet<>(Collections.singleton("non-current-env")));
 
-        /* Initialize the service manager. */
+        // Initialize the service manager.
         serviceRegistry.save(prodTestEduService);
         serviceRegistry.save(anyTestEduService);
         manager.load();
 
-        /* This case always worked: request for https://prod.test.edu before any request for
-        https://[anything else].test.edu. */
+        // Always worked: request for https://prod.test.edu before any request for https://[anything else].test.edu.
         var foundService = manager.findServiceBy(serviceFactory.createService("https://prod.test.edu"));
         assertSame(prodTestEduService, foundService);
 
-        /* Now clear the cache and try the previous failure case: request for https://prod.test.edu comes after any
-        request for https://[anything else].test.edu. Previously this would fail because https://*.test.edu matches
-        https://prod.test.edu and exists in cache even though it is not associated with current-env. Null would have
-        been returned. */
+        // Now clear the cache and try the previous failure case: request for https://prod.test.edu comes after any
+        // request for https://[anything else].test.edu. Previously this would fail because https://*.test.edu matches
+        // https://prod.test.edu and exists in cache even though it is not associated with current-env. Null would have
+        // been returned.
         cache.invalidateAll();
         foundService = manager.findServiceBy(serviceFactory.createService("https://not-prod.test.edu"));
         assertNull(foundService);
@@ -257,11 +261,11 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
         applicationContext.refresh();
 
         val context = ServicesManagerConfigurationContext.builder()
-                .serviceRegistry(serviceRegistry)
-                .applicationContext(applicationContext)
-                .environments(new HashSet<>(0))
-                .servicesCache(Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(2)).build())
-                .build();
+            .serviceRegistry(serviceRegistry)
+            .applicationContext(applicationContext)
+            .environments(new HashSet<>(0))
+            .servicesCache(Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(2)).build())
+            .build();
         return new DefaultServicesManager(context);
     }
 
@@ -273,7 +277,7 @@ public abstract class AbstractServicesManagerTests<T extends ServicesManager> {
 
     protected boolean isServiceInCache(final String serviceId, final long id) {
         return servicesManager.getAllServices()
-                .stream()
-                .anyMatch(r -> serviceId != null ? r.getServiceId().equals(serviceId) : r.getId() == id);
+            .stream()
+            .anyMatch(r -> serviceId != null ? r.getServiceId().equals(serviceId) : r.getId() == id);
     }
 }


### PR DESCRIPTION
Fixes an issue where a service with a wildcard regex (such as `https://*.test.edu`) can interfere with a higher-priority (lower `evaluationOrder`) service with a regex which would also match the wildcard (such as `https://prod.test.edu`.) This occurred even if the service with the wildcard regex should not be active in the current environment.

The issue was caused by inadvertent "promotion" through the services cache, which is populated with a service *before* the service's environment is validated.

See `AbstractServicesManagerTests.verifyInvalidServiceNotPromotedByCache()` for details.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test
- [x] Any possible limitations, side effects, etc
- [x] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
