### PR TITLE
Fix reveal password button on mobile

### DIFF
--- a/ci/tests/puppeteer/scenarios/reveal-password/script.js
+++ b/ci/tests/puppeteer/scenarios/reveal-password/script.js
@@ -1,0 +1,31 @@
+const puppeteer = require('puppeteer');
+const assert = require('assert');
+const cas = require('../../cas.js');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+    await page.goto("https://localhost:8443/cas/login");
+
+    await cas.type(page, "#username", "casuser");
+    await cas.type(page, "#password", "Mellon");
+  
+    let pwd = await page.$('.pwd');
+    let pwdType = await page.evaluate(pwd => pwd.type, pwd);
+    console.log(`password input type is ${pwdType}`);
+    assert(pwdType === "password");
+  
+    console.log('click button to reveal password');
+    await page.click('.reveal-password');
+    pwdType = await page.evaluate(pwd => pwd.type, pwd);
+    console.log(`password input type is ${pwdType}`);
+    assert(pwdType === "text");
+
+    console.log('click button to unreveal password');
+    await page.click('.reveal-password');
+    pwdType = await page.evaluate(pwd => pwd.type, pwd);
+    console.log(`password input type is ${pwdType}`);
+    assert(pwdType === "password");
+  
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/reveal-password/script.json
+++ b/ci/tests/puppeteer/scenarios/reveal-password/script.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": "core"
+}

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
@@ -189,15 +189,14 @@ function resourceLoadedSuccessfully() {
         $('#fm1 input[name="username"]').focus();
 
         let $revealpassword = $('.reveal-password');
-        $revealpassword.mouseup(function (ev) {
-            $('.pwd').attr('type', 'password');
-            $(".reveal-password-icon").removeClass("mdi mdi-eye-off").addClass("mdi mdi-eye");
-            ev.preventDefault();
-        })
-
         $revealpassword.mousedown(function (ev) {
-            $('.pwd').attr('type', 'text');
-            $(".reveal-password-icon").removeClass("mdi mdi-eye").addClass("mdi mdi-eye-off");
+            if($('.pwd').attr('type')!='text') {
+                $('.pwd').attr('type', 'text');
+                $(".reveal-password-icon").removeClass("mdi mdi-eye").addClass("mdi mdi-eye-off");
+            } else {
+                $('.pwd').attr('type', 'password');
+                $(".reveal-password-icon").removeClass("mdi mdi-eye-off").addClass("mdi mdi-eye");
+            }
             ev.preventDefault();
         });
 


### PR DESCRIPTION
On mobile, the "reveal password" button doesn't working.
This issue is described here : 
https://www.mail-archive.com/cas-user@apereo.org/msg11852.html
With this PR, we propose to modify the behaviorof this button on desktop so that it also works on mobile.
With this commit, you have to click once to see the password, and another time to hide it.