### PR TITLE
Better shibboleth compatibility

### DIFF
--- a/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/AbstractSamlObjectBuilder.java
+++ b/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/AbstractSamlObjectBuilder.java
@@ -35,6 +35,7 @@ import org.opensaml.core.xml.schema.impl.XSIntegerBuilder;
 import org.opensaml.core.xml.schema.impl.XSStringBuilder;
 import org.opensaml.core.xml.schema.impl.XSURIBuilder;
 import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.NameIDType;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
@@ -307,6 +308,11 @@ public abstract class AbstractSamlObjectBuilder implements Serializable {
             attrValueObj.setTextContent(mapper.writeValueAsString(value));
             LOGGER.trace(LOG_MESSAGE_ATTR_CREATED, attrValueObj);
             return attrValueObj;
+        }
+
+        if (NameIDType.class.getSimpleName().equalsIgnoreCase(valueType)) {
+            LOGGER.trace(LOG_MESSAGE_ATTR_CREATED, value);
+            return (NameIDType) value;
         }
 
         val builder = new XSAnyBuilder();

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/nameid/SamlProfileSamlNameIdBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/nameid/SamlProfileSamlNameIdBuilder.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.saml.web.idp.profile.builders.nameid;
 
 import org.apereo.cas.authentication.principal.PersistentIdGenerator;
+import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
 import org.apereo.cas.support.saml.SamlException;
 import org.apereo.cas.support.saml.SamlIdPUtils;
@@ -41,9 +42,13 @@ public class SamlProfileSamlNameIdBuilder extends AbstractSaml20ObjectBuilder im
 
     private final PersistentIdGenerator persistentIdGenerator;
 
-    public SamlProfileSamlNameIdBuilder(final OpenSamlConfigBean configBean, final PersistentIdGenerator persistentIdGenerator) {
+    private final CasConfigurationProperties casProperties;
+
+    public SamlProfileSamlNameIdBuilder(final OpenSamlConfigBean configBean, final PersistentIdGenerator persistentIdGenerator,
+                                        final CasConfigurationProperties casProperties) {
         super(configBean);
         this.persistentIdGenerator = persistentIdGenerator;
+        this.casProperties = casProperties;
     }
 
     /**
@@ -176,7 +181,10 @@ public class SamlProfileSamlNameIdBuilder extends AbstractSaml20ObjectBuilder im
             if (StringUtils.isNotBlank(service.getNameIdQualifier())) {
                 nameid.setNameQualifier(service.getNameIdQualifier());
             } else {
-                val issuer = SamlIdPUtils.getIssuerFromSamlObject(authnRequest);
+                var issuer = SamlIdPUtils.getIssuerFromSamlObject(authnRequest);
+                if (StringUtils.equals(parseAndBuildRequiredNameIdFormat(service), NameIDType.PERSISTENT)) {
+                    issuer = casProperties.getAuthn().getSamlIdp().getCore().getEntityId();
+                }
                 nameid.setNameQualifier(issuer);
             }
             if (StringUtils.isNotBlank(service.getServiceProviderNameIdQualifier())) {

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPConfiguration.java
@@ -261,7 +261,7 @@ public class SamlIdPConfiguration {
     @RefreshScope
     public SamlProfileObjectBuilder<NameID> samlProfileSamlNameIdBuilder() {
         return new SamlProfileSamlNameIdBuilder(openSamlConfigBean.getObject(),
-            shibbolethCompatiblePersistentIdGenerator.getObject());
+            shibbolethCompatiblePersistentIdGenerator.getObject(), casProperties);
     }
 
     @ConditionalOnMissingBean(name = "samlProfileSamlConditionsBuilder")


### PR DESCRIPTION
- [x] Brief description of changes applied
- Set NameIDQualifier to entityID of IdP for persistent name format. See https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf line 2493-2500
- Added an additional value type check (NameIDType) to correctly format NameID attribute n SAML response. See https://wiki.geant.org/display/eduGAIN/IDP+Attribute+Profile+and+Recommended+Attributes#IDPAttributeProfileandRecommendedAttributes-HowtotestthereleaseoftherecommendedattributestotheExampleServiceProvider

- [x] Test cases for all modified changes, where applicable
- none
- [x] The same pull request targeted at the master branch, if applicable
- done
- [x] Any documentation on how to configure, test
- PR for gh-pages follows
- [x] Any possible limitations, side effects, etc
- To release an eduPersonTargetedID as attribute value, the attribute as to be an instance of NameIDImpl. The following Groovy Attribute Release Policy shows an example.
```
    def nameIDBuilder = new NameIDBuilder()
    def nameID = nameIDBuilder.buildObject();
    nameID.setFormat(registeredService.getRequiredNameIdFormat().trim());
    nameID.setNameQualifier(nameIdQualifier);
    nameID.setSPNameQualifier(serviceProviderNameIdQualifier);
    nameID.setValue(persistentId);
```
But this can lead to a StackOverflowError in consent screen, because of an error in marshalling nameID. `owner` property is a self-pointer. Maybe this can be fixed in a better way.
- [x] Reference any other pull requests that might be related
- none