### PR TITLE
Build performance tweaks

### DIFF
--- a/api/cas-server-core-api-configuration-model/build.gradle
+++ b/api/cas-server-core-api-configuration-model/build.gradle
@@ -34,6 +34,7 @@ if (!skipConfigurationMetadata) {
         args buildDir, projectDir.canonicalPath
     }
 
-    compileJava.inputs.files(processResources)
+    compileJava.inputs.files(processResources).withPropertyName("processResources")
+        .withPathSensitivity(PathSensitivity.RELATIVE).ignoreEmptyDirectories()
     jar.dependsOn(generateConfigurationMetadata)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -390,7 +390,6 @@ subprojects {
         }
     }
 
-    ext.buildDate = null
     ext.buildJarFile = new File(project.buildDir, "libs/${project.name}-${project.version}.jar")
 
     [compileTestJava, compileJava].each {
@@ -419,15 +418,6 @@ subprojects {
             casCompilerArgs.add("-XDcompilePolicy=byfile")
         }
         it.options.compilerArgs += casCompilerArgs
-    }
-
-    def currentTime = java.time.ZonedDateTime.now(ZoneId.systemDefault())
-    compileJava.doLast {
-        buildDate = currentTime
-    }
-
-    tasks.jar.onlyIf {
-        project.buildDate != null || !project.buildJarFile.exists()
     }
 
     if (projectRequiresLombok(project)) {

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ ext {
             .forUseAtConfigurationTime().getOrElse("false") == "true" ? "y" : "n"
     generateGitProperties = publishFlag
             || providers.systemProperty("generateGitProperties").forUseAtConfigurationTime().present
+    generateTimestamps = publishFlag
+        || providers.systemProperty("generateTimestamps").forUseAtConfigurationTime().present
 
     ci = System.getenv("CI") || providers.systemProperty("CI").forUseAtConfigurationTime().present
 
@@ -435,8 +437,12 @@ subprojects {
                     "Automatic-Module-Name": project.name,
                     "Implementation-Title": project.name,
                     "Implementation-Vendor": project.group,
-                    "Created-By": project.group,
-                    "Implementation-Date": java.time.ZonedDateTime.now(ZoneId.systemDefault()),
+                    "Created-By": project.group)
+            if (generateTimestamps) {
+                // Only generate timestamps when enabled, as they cause every build to update the JAR.
+                attributes("Implementation-Date": java.time.ZonedDateTime.now(ZoneId.systemDefault()))
+            }
+            attributes(
                     "Specification-Version": "${-> project.ext.has("gitProps") ? project.ext.gitProps['git.commit.id'] : 'N/A'}",
                     "Implementation-Version": project.version)
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ snapshotsRepositoryUrl=https://oss.sonatype.org/content/repositories/snapshots/
 ################################################################################################
 org.gradle.configureondemand=true
 org.gradle.caching=true
-org.gradle.vfs.watch=true
+org.gradle.parallel=true
 org.gradle.jvmargs=-Xms1024m -Xmx4048m -XX:SoftRefLRUPolicyMSPerMB=0 -noverify -XX:TieredStopAtLevel=1
 
 #################################################

--- a/gradle/springboot.gradle
+++ b/gradle/springboot.gradle
@@ -22,7 +22,14 @@ if (project.ext.forceBootifulArtifact || (!rootProject.publishFlag && !rootProje
 
     springBoot {
         mainClassName = project.ext.mainClassName
-        buildInfo()
+        buildInfo {
+            properties {
+                if (!rootProject.generateTimestamps) {
+                    // Only generate timestamps when enabled, as they cause every build to update JARs/WARs.
+                    time = null
+                }
+            }
+        }
     }
 
     if (plugins.hasPlugin("war")) {
@@ -38,8 +45,12 @@ if (project.ext.forceBootifulArtifact || (!rootProject.publishFlag && !rootProje
                         "Automatic-Module-Name": project.name,
                         "Implementation-Title": project.name,
                         "Implementation-Vendor": project.group,
-                        "Created-By": project.group,
-                        "Implementation-Date": java.time.ZonedDateTime.now(),
+                        "Created-By": project.group)
+                if (rootProject.generateTimestamps) {
+                    // Only generate timestamps when enabled, as they cause every build to update the WAR.
+                    attributes("Implementation-Date": java.time.ZonedDateTime.now())
+                }
+                attributes(
                         "Specification-Version": "${-> project.ext.has("gitProps") ? project.ext.gitProps['git.commit.id'] : 'N/A'}",
                         "Implementation-Version": project.version)
             }


### PR DESCRIPTION
# Details

I did an evaluation of the CAS build using Gradle Enterprise, and came across a few changes that I believe will improve the performance of the build.

* Enable parallel execution by default (`org.gradle.parallel=true`)
* Remove explicit setting of `org.gradle.vfs.watch=true` property (Gradle now enabled this by default)
* Address an issue with a declared task input that caused problems with cacheability
* Remove an unneeded optimization to avoid JAR assembly
* Add a `generateTimestamps` flag to the build, allowing for better UP-TO-DATE and build cache compatibility
