### PR TITLE
Do not generate pac4j CSRF token

### DIFF
--- a/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
+++ b/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
@@ -49,6 +49,7 @@ import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
+import org.pac4j.core.matching.matcher.DefaultMatchers;
 import org.pac4j.http.client.direct.HeaderClient;
 import org.pac4j.springframework.web.SecurityInterceptor;
 import org.springframework.beans.factory.FactoryBean;
@@ -266,6 +267,7 @@ public class CasOAuthUmaConfiguration implements WebMvcConfigurer {
         val config = new Config(OAuth20Utils.casOAuthCallbackUrl(casProperties.getServer().getPrefix()), headerClient);
         config.setSessionStore(oauthDistributedSessionStore.getObject());
         val interceptor = new SecurityInterceptor(config, clients, JEEHttpActionAdapter.INSTANCE);
+        interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
         interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
         return interceptor;
     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
@@ -14,6 +14,7 @@ import org.pac4j.core.client.Client;
 import org.pac4j.core.client.DirectClient;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
+import org.pac4j.core.matching.matcher.DefaultMatchers;
 import org.pac4j.springframework.web.SecurityInterceptor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +70,7 @@ public class CasOAuth20ThrottleConfiguration {
     public HandlerInterceptor requiresAuthenticationAuthorizeInterceptor() {
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(),
             Authenticators.CAS_OAUTH_CLIENT, JEEHttpActionAdapter.INSTANCE);
+        interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
         interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
         return interceptor;
     }
@@ -84,6 +86,7 @@ public class CasOAuth20ThrottleConfiguration {
             .map(Client::getName)
             .collect(Collectors.joining(","));
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(), clients, JEEHttpActionAdapter.INSTANCE);
+        interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
         interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
         return interceptor;
     }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -97,6 +97,7 @@ import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.credentials.extractor.BearerAuthExtractor;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
 import org.pac4j.core.http.url.UrlResolver;
+import org.pac4j.core.matching.matcher.DefaultMatchers;
 import org.pac4j.http.client.direct.DirectFormClient;
 import org.pac4j.http.client.direct.HeaderClient;
 import org.pac4j.springframework.web.SecurityInterceptor;
@@ -252,6 +253,7 @@ public class OidcConfiguration {
     public HandlerInterceptor requiresAuthenticationAuthorizeInterceptor() {
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(),
             Authenticators.CAS_OAUTH_CLIENT, JEEHttpActionAdapter.INSTANCE);
+        interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
         interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
         interceptor.setSecurityLogic(new OidcAuthenticationAuthorizeSecurityLogic());
         return interceptor;

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcEndpointsConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcEndpointsConfiguration.java
@@ -56,6 +56,7 @@ import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
+import org.pac4j.core.matching.matcher.DefaultMatchers;
 import org.pac4j.springframework.web.SecurityInterceptor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -216,6 +217,7 @@ public class OidcEndpointsConfiguration {
             Authenticators.CAS_OAUTH_CLIENT_DIRECT_FORM,
             Authenticators.CAS_OAUTH_CLIENT_USER_FORM);
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(), clients, JEEHttpActionAdapter.INSTANCE);
+        interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
         interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
         return interceptor;
     }
@@ -224,6 +226,7 @@ public class OidcEndpointsConfiguration {
     public HandlerInterceptor requiresAuthenticationClientConfigurationInterceptor() {
         val clients = String.join(",", OidcConstants.CAS_OAUTH_CLIENT_CONFIG_ACCESS_TOKEN_AUTHN);
         val interceptor = new SecurityInterceptor(oauthSecConfig.getObject(), clients, JEEHttpActionAdapter.INSTANCE);
+        interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
         interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
         return interceptor;
     }


### PR DESCRIPTION
By default, in pac4j, a CSRF token is generated (by the default `csrfToken` matcher).

In the CAS server, this is useless. This PR removes this CSRF token generation by forcing the default matchers to `DefaultMatchers.SECURITYHEADERS` only.