### PR TITLE
thread-safe and printing type potential fix

### DIFF
--- a/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/AuthenticationException.java
+++ b/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/AuthenticationException.java
@@ -66,7 +66,7 @@ public class AuthenticationException extends RootCasException {
      */
     public AuthenticationException(final Map<String, Throwable> handlerErrors,
                                    final Map<String, AuthenticationHandlerExecutionResult> handlerSuccesses) {
-        this(String.format("%s errors, %s successes", handlerErrors.size(), handlerSuccesses.size()), handlerErrors, handlerSuccesses);
+        this(String.format("%d errors, %d successes", handlerErrors.size(), handlerSuccesses.size()), handlerErrors, handlerSuccesses);
     }
 
     /**

--- a/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/JsonResourceInterruptInquirer.java
+++ b/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/JsonResourceInterruptInquirer.java
@@ -56,9 +56,15 @@ public class JsonResourceInterruptInquirer extends BaseInterruptInquirer impleme
         final RequestContext requestContext) {
         readResourceForInterrupts();
         val user = authentication.getPrincipal().getId();
-        if (interrupts.containsKey(user)) {
-            return interrupts.get(user);
+        
+        InterruptResponse inquired_response = interrupts.get(user);
+        if (inquired_response) {
+            return inquired_response;
         }
+        // if (interrupts.containsKey(user)) {
+        //     return interrupts.get(user);
+        // }
+
         return InterruptResponse.none();
     }
 


### PR DESCRIPTION
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
This pull request is aiming at 2 minor changes for potential bugs concerns and safety concerns.
-The fix is based on the suggestion and reports generated by AWS Codeguru.
-1. Using %s instead of %d for size variable while size should be an int type, not String.
-2. Original code is not thread-safe enough. Even with ConcurrentHashMap, each access operation will lock the critical section, imagine the situation:
```java
if (interrupts.containsKey(user)) {
            return interrupts.get(user);
}
```
If after we call "containsKey(user)" and before we actually call get(), during the time the cs should already be released. And if other threads delete the user, get will return a null result. To prevent this corner case, what I am trying to do is to only call get once and directly see whether the get return null or not.
- There is no new feature implemented in the pull request so I did not provide any corresponding test case, original test cases should handle whether the modification is proper.