### PR TITLE
OIDC: fix missing amr claim in ID token

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20CasAuthenticationBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20CasAuthenticationBuilder.java
@@ -110,12 +110,16 @@ public class OAuth20CasAuthenticationBuilder {
         val nonce = context.getRequestParameter(OAuth20Constants.NONCE).map(String::valueOf).orElse(StringUtils.EMPTY);
         LOGGER.debug("OAuth [{}] is [{}], and [{}] is [{}]", OAuth20Constants.STATE, state, OAuth20Constants.NONCE, nonce);
 
+        val builder = DefaultAuthenticationBuilder.newInstance();
+        val authenticationAttributes = profile.getAuthenticationAttributes();
+        authenticationAttributes.forEach((k, v) -> builder.addAttribute(k, v));
+
         /*
          * pac4j UserProfile.getPermissions() and getRoles() returns UnmodifiableSet which Jackson Serializer
          * happily serializes to json but is unable to deserialize.
          * We have to transform those to HashSet to avoid such a problem
          */
-        return DefaultAuthenticationBuilder.newInstance()
+        return builder
             .addAttribute("permissions", new LinkedHashSet<>(profile.getPermissions()))
             .addAttribute("roles", new LinkedHashSet<>(profile.getRoles()))
             .addAttribute("scopes", scopes)

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20CasAuthenticationBuilderTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20CasAuthenticationBuilderTests.java
@@ -1,15 +1,20 @@
 package org.apereo.cas.support.oauth.authenticator;
 
 import org.apereo.cas.CasProtocolConstants;
+import org.apereo.cas.services.RegisteredServiceTestUtils;
+import org.apereo.cas.support.oauth.OAuth20Constants;
 
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.pac4j.cas.profile.CasProfile;
 import org.pac4j.core.context.JEEContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -27,7 +32,7 @@ public class OAuth20CasAuthenticationBuilderTests extends BaseOAuth20Authenticat
     private OAuth20CasAuthenticationBuilder authenticationBuilder;
 
     @Test
-    public void verifyOperation() {
+    public void verifyOperationByService() {
         val request = new MockHttpServletRequest();
         request.addHeader("X-".concat(CasProtocolConstants.PARAMETER_SERVICE), service.getServiceId());
         val ctx = new JEEContext(request, new MockHttpServletResponse());
@@ -35,4 +40,23 @@ public class OAuth20CasAuthenticationBuilderTests extends BaseOAuth20Authenticat
         assertNotNull(result);
     }
 
+    @Test
+    public void verifyOperationToBuild() {
+        val profile = new CasProfile();
+        profile.setId("casuser");
+        profile.addAuthenticationAttribute("clazz", "high");
+        profile.addAttribute("cn", "casuser");
+
+        val request = new MockHttpServletRequest();
+        request.addParameter(OAuth20Constants.STATE, UUID.randomUUID().toString());
+        request.addParameter(OAuth20Constants.NONCE, UUID.randomUUID().toString());
+        request.addParameter(OAuth20Constants.ACR_VALUES, "mfa-dummy");
+        request.addHeader("X-".concat(CasProtocolConstants.PARAMETER_SERVICE), service.getServiceId());
+        val ctx = new JEEContext(request, new MockHttpServletResponse());
+        val result = authenticationBuilder.build(profile, service,
+                ctx, RegisteredServiceTestUtils.getService());
+        assertNotNull(result);
+        assertTrue(result.getPrincipal().getAttributes().containsKey("cn"));
+        assertTrue(result.getAttributes().containsKey("clazz"));
+    }
 }


### PR DESCRIPTION
For the record as the 6.3.x stream is now in SPM.