### PR TITLE
HTTPSandIMAPS-10000001.json is always copied from cas-server-webapp-r…

### DIFF
--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/config/CasServiceRegistryInitializationConfiguration.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/config/CasServiceRegistryInitializationConfiguration.java
@@ -108,7 +108,7 @@ public class CasServiceRegistryInitializationConfiguration {
             final CasConfigurationProperties casProperties,
             final ConfigurableApplicationContext applicationContext) {
             val registry = casProperties.getServiceRegistry().getJson();
-            if (ResourceUtils.doesResourceExist(registry.getLocation())) {
+            if (registry.getLocation().exists()) {
                 LOGGER.debug("Using JSON service registry location [{}] for embedded service definitions", registry.getLocation());
                 return registry.getLocation();
             }


### PR DESCRIPTION
HTTPSandIMAPS-10000001.json is always copied from cas-server-webapp-resources instead of user's own overlay project due to this issue.

Steps to reproduce this issue:
1. Clone the overlay project.
2. Add cas.serviceRegistry.core.initFromJson=true to application.properties.
3. Create services folder in src/main/resources and copy HTTPSandIMAPS-10000001.json here.
4. change **"serviceId" : "^(https|imaps)://.*"** to **"serviceId" : "^(https|http|imaps)://.*"** in HTTPSandIMAPS-10000001.json.
5. Start overlay project with trace log level.
You will see that some output looks like this "**Preparing classpath resource [URL [jar:file:/xxxxx/cas-overlay-template/build/libs/cas.war!/WEB-INF/lib/cas-server-webapp-resources-version.jar!/services/HTTPSandIMAPS-10000001.json]]**", It is because JsonServiceRegistryProperties.location is a folder, not a file. so IOUtils can not read anything from a folder, and its contentLength is always 0 byte.
```
//CasServiceRegistryInitializationConfiguration.java
if (ResourceUtils.doesResourceExist(registry.getLocation())) {
    LOGGER.debug("Using JSON service registry location [{}] for embedded service definitions", registry.getLocation());
    return registry.getLocation();
}

//ResourceUtils.java
public static boolean doesResourceExist(final Resource res) {
    if (res == null) {
        return false;
    }
    try {
        IOUtils.read(res.getInputStream(), new byte[1]);
        return res.contentLength() > 0;
    } catch (final FileNotFoundException e) {
        LOGGER.trace(e.getMessage());
        return false;
    } catch (final Exception e) {
        LOGGER.trace(e.getMessage(), e);
        return false;
    }
}
```