### PR TITLE
Use correct path for the cookie encryption key

### DIFF
--- a/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/support/wsfederation/web/WsFederationCookieCipherExecutor.java
+++ b/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/support/wsfederation/web/WsFederationCookieCipherExecutor.java
@@ -24,7 +24,7 @@ public class WsFederationCookieCipherExecutor extends BaseStringCipherExecutor {
 
     @Override
     protected String getEncryptionKeySetting() {
-        return "cas.authn.wsfed[].cookie.encryption.key";
+        return "cas.authn.wsfed[].cookie.crypto.encryption.key";
     }
 
     @Override


### PR DESCRIPTION
If the key is given by the value `cas.authn.wsfed[0].cookie.encryption.key` it is not found and a warning is issued. If the key is given with the `crypto`-path added, the warning disappears.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
