### PR TITLE
use released versions of loggers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,13 +100,13 @@ springDocVersion=1.5.12
 ###############################
 # Logging versions
 ###############################
-slf4jVersion=2.0.0-alpha2
+slf4jVersion=1.7.32
 disruptorVersion=3.4.4
 inspektrVersion=1.8.16.GA
 sentryRavenVersion=8.0.3
 splunkLoggingVersion=1.11.0
 log4jVersion=2.14.1
-logbackVersion=1.3.0-alpha10
+logbackVersion=1.2.6
 ###############################
 # Spring versions
 ###############################


### PR DESCRIPTION
Backs off the alpha versions of slf4j and logback which I don't think were doing much for CAS. In order to make progress on spring-native which has some support for logback, I think it is important to use the same versions of slf4j and logback that spring-native samples are working with. We probably need to wait for spring-boot 2.6.0 to come out so we can use the same version of spring-boot as spring-native's main branch but once that is out I am hoping to move past logger issues and onto other issues... 