### PR TITLE
update dependencies on 6.4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -518,7 +518,7 @@ subprojects {
         api libraries.quartz
         api libraries.bvalidator
         api libraries.groovy
-        api libraries.caffein
+        api libraries.caffeine
         api libraries.springcloud
         api libraries.springboot
         api libraries.springsecurity

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ targetCompatibility=11
 ###############################
 # Compiler/Utils versions
 ###############################
-lombokVersion=1.18.20
+lombokVersion=1.18.22
 aspectjVersion=1.9.7
 errorProneVersion=2.9.0
 errorproneJavacVersion=9+181-r4173-1
@@ -44,11 +44,11 @@ jaxbApiVersion=2.3.1
 jaxbRuntimeVersion=2.3.3
 istackVersion=4.0.1
 jythonVersion=2.7.2
-groovyVersion=3.0.8
-caffeinVersion=2.9.0
+groovyVersion=3.0.9
+caffeineVersion=2.9.2
 joolVersion=0.9.14
 jasyptVersion=1.9.3
-jodaTimeVersion=2.10.10
+jodaTimeVersion=2.10.13
 reflectionsVersion=0.9.11
 guavaVersion=30.1.1-jre
 semverVersion=3.1.0
@@ -62,8 +62,8 @@ apacheBValVersion=2.0.5
 ###############################
 # JUnit versions
 ###############################
-junitVersion=5.8.0-RC1
-junitPlatformVersion=1.8.0-RC1
+junitVersion=5.8.1
+junitPlatformVersion=1.8.1
 mockitoVersion=3.12.1
 objenesisVersion=3.2
 testContainersVersion=1.16.0
@@ -124,9 +124,9 @@ logbackVersion=1.3.0-alpha5
 ###############################
 # Spring versions
 ###############################
-springBootVersion=2.5.4
-springVersion=5.3.9
-springBootAdminVersion=2.5.0
+springBootVersion=2.5.6
+springVersion=5.3.12
+springBootAdminVersion=2.5.3
 
 ###############################
 # Spring Retry versions
@@ -136,7 +136,7 @@ springRetryVersion=1.3.1
 ###############################
 # Spring Integration versions
 ###############################
-springIntegrationVersion=5.5.3
+springIntegrationVersion=5.5.5
 
 ###############################
 # Spring Webflow versions
@@ -146,40 +146,40 @@ springWebflowVersion=2.5.1.RELEASE
 ###############################
 # Spring Data versions
 ###############################
-springDataCommonsVersion=2.5.4
-springDataMongoDbVersion=3.2.4
-springDataRedisVersion=2.5.4
-springDataCassandraVersion=3.2.4
+springDataCommonsVersion=2.5.6
+springDataMongoDbVersion=3.2.6
+springDataRedisVersion=2.5.6
+springDataCassandraVersion=3.2.6
 springDataCosmosDbVersion=2.0.3
 
 ###############################
 # Spring Security versions
 ###############################
-springSecurityVersion=5.5.2
-springSecurityRsaVersion=1.0.10.RELEASE
+springSecurityVersion=5.5.3
+springSecurityRsaVersion=1.0.11.RELEASE
 
 springShellVersion=2.0.1.RELEASE
 
 ###############################
 # Spring Cloud versions
 ###############################
-springCloudConfigVersion=3.0.4
-springCloudContextVersion=3.0.3
-springCloudCommonsVersion=3.0.3
+springCloudConfigVersion=3.0.5
+springCloudContextVersion=3.0.4
+springCloudCommonsVersion=3.0.4
 springCloudBusVersion=3.0.3
 
-springCloudVaultVersion=3.0.3
-springCloudZookeeperVersion=3.0.3
-springCloudSleuthVersion=3.0.3
-springCloudEurekaVersion=3.0.3
-springCloudConsulVersion=3.0.3
+springCloudVaultVersion=3.0.4
+springCloudZookeeperVersion=3.0.4
+springCloudSleuthVersion=3.0.4
+springCloudEurekaVersion=3.0.4
+springCloudConsulVersion=3.0.4
 springCloudAwsVersion=2.2.6.RELEASE
 
 ###############################
 # Spring WS versions
 ###############################
 springWsVersion=3.1.1
-springKafkaVersion=2.7.6
+springKafkaVersion=2.7.8
 
 wss4jVersion=2.5.0-SNAPSHOT
 wsdl4jVersion=1.6.3
@@ -194,7 +194,7 @@ curatorVersion=5.2.0
 ###############################
 # Ribbon/Eureka versions
 ###############################
-eurekaClientVersion=1.10.16
+eurekaClientVersion=1.10.17
 ribbonVersion=2.7.18
 
 ###############################
@@ -217,7 +217,7 @@ okhttp3Version=4.9.1
 ###############################
 # Redis versions
 ###############################
-redisLettuceVersion=6.1.4.RELEASE
+redisLettuceVersion=6.1.5.RELEASE
 
 ###############################
 # Database Versions
@@ -340,10 +340,10 @@ azureadVersion=1.6.7
 ###############################
 jsonVersion=20160810
 hjsonVersion=3.0.0
-jsoupVersion=1.14.2
+jsoupVersion=1.14.3
 jsonSmartVersion=2.4.7
 jsonassertVersion=1.5.0
-jacksonVersion=2.12.4
+jacksonVersion=2.13.0
 kotlinVersion=1.5.21
 
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -556,11 +556,11 @@ ext.libraries = [
                 dependencies.create("com.squareup.okio:okio:$okioVersion") {
                 }
         ],
-        caffein                 : [
-                dependencies.create("com.github.ben-manes.caffeine:caffeine:$caffeinVersion") {
+        caffeine                : [
+                dependencies.create("com.github.ben-manes.caffeine:caffeine:$caffeineVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 },
-                dependencies.create("com.github.ben-manes.caffeine:guava:$caffeinVersion") {
+                dependencies.create("com.github.ben-manes.caffeine:guava:$caffeineVersion") {
                     exclude(group: "com.google.guava", module: "guava")
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 }

--- a/gradle/overrides.gradle
+++ b/gradle/overrides.gradle
@@ -71,7 +71,7 @@ configurations.all {
                     details.useVersion("${couchbaseVersion}")
                 }
                 if (requested.group == "com.github.ben-manes.caffeine")  {
-                    details.useVersion("${caffeinVersion}")
+                    details.useVersion("${caffeineVersion}")
                 }
                 if (requested.group == "org.apache.logging.log4j")  {
                     details.useVersion("${log4jVersion}")
@@ -131,7 +131,7 @@ configurations.all {
 }
 
 ext["couchbase-client.version"] = ext["couchbaseVersion"]
-ext["caffeine.version"] = ext["caffeinVersion"]
+ext["caffeine.version"] = ext["caffeineVersion"]
 ext["commons-beanutils.version"] = ext["commonsBeansVersion"]
 ext["hazelcast.version"] = ext["hazelcastVersion"]
 ext["hibernate.version"] = ext["hibernateVersion"]


### PR DESCRIPTION
I want to update spring-boot, mainly b/c some CVEs for netty are showing up when I build CAS with latest 6.4.x and those dependencies come from spring boot. I mainly updated spring dependencies but I updated a few others without a good reason other than they seemed fairly safe. 