### PR TITLE
use released versions of loggers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -100,13 +100,13 @@ springDocVersion=1.5.12
 ###############################
 # Logging versions
 ###############################
-slf4jVersion=2.0.0-alpha2
+slf4jVersion=1.7.32
 disruptorVersion=3.4.4
 inspektrVersion=1.8.16.GA
 sentryRavenVersion=8.0.3
 splunkLoggingVersion=1.11.0
 log4jVersion=2.14.1
-logbackVersion=1.3.0-alpha10
+logbackVersion=1.2.6
 ###############################
 # Spring versions
 ###############################

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1618,7 +1618,7 @@ ext.libraries = [
                 dependencies.create("org.apache.logging.log4j:log4j-web:$log4jVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 },
-                dependencies.create("org.apache.logging.log4j:log4j-slf4j18-impl:$log4jVersion") {
+                dependencies.create("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                 },
                 dependencies.create("org.apache.logging.log4j:log4j-layout-template-json:$log4jVersion") {


### PR DESCRIPTION
Trying #5261 again, this time changing log4j-slf4j18-impl to log4j-slf4j-impl. `pupcas actuator-endpoint-reports` passed locally. 

I don't think using spring boot 2.6.0 will help with current logging issue I am seeing with spring-native. I believe I previously downgraded the loggers locally and got past this:

```
Unexpected problem occured during version sanity check
Reported exception:
java.lang.AbstractMethodError: Receiver class ch.qos.logback.classic.spi.LogbackServiceProvider does not define or inherit an implementation of the resolved method 'abstract java.lang.String getRequesteApiVersion()' of interface org.slf4j.spi.SLF4JServiceProvider.
        at org.slf4j.LoggerFactory.versionSanityCheck(LoggerFactory.java:297)
        at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:141)
        at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:421)
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:407)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:356)
        at org.apache.commons.logging.LogAdapter$Slf4jAdapter.createLocationAwareLog(LogAdapter.java:130)
        at org.apache.commons.logging.LogAdapter.createLog(LogAdapter.java:91)
        at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:67)
        at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:59)
        at org.springframework.core.env.AbstractEnvironment.<init>(AbstractEnvironment.java:105)
        at org.springframework.core.env.AbstractEnvironment.<init>(AbstractEnvironment.java:124)
        at org.springframework.core.env.StandardEnvironment.<init>(StandardEnvironment.java:68)
        at org.springframework.aot.build.GenerateBootstrapCommand.call(GenerateBootstrapCommand.java:89)
        at org.springframework.aot.build.GenerateBootstrapCommand.call(GenerateBootstrapCommand.java:42)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
        at picocli.CommandLine.access$1300(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
        at picocli.CommandLine.execute(CommandLine.java:2078)
        at org.springframework.aot.build.GenerateBootstrapCommand.main(GenerateBootstrapCommand.java:108)
Exception in thread "main" java.lang.NoClassDefFoundError: org/slf4j/impl/StaticLoggerBinder
        at org.springframework.boot.logging.logback.LogbackLoggingSystem.getLoggerContext(LogbackLoggingSystem.java:293)
        at org.springframework.boot.logging.logback.LogbackLoggingSystem.initialize(LogbackLoggingSystem.java:128)
        at org.springframework.aot.build.GenerateBootstrapCommand.call(GenerateBootstrapCommand.java:94)
        at org.springframework.aot.build.GenerateBootstrapCommand.call(GenerateBootstrapCommand.java:42)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
        at picocli.CommandLine.access$1300(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
        at picocli.CommandLine.execute(CommandLine.java:2078)
        at org.springframework.aot.build.GenerateBootstrapCommand.main(GenerateBootstrapCommand.java:108)
Caused by: java.lang.ClassNotFoundException: org.slf4j.impl.StaticLoggerBinder
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 12 more
```

I foresee lots of other issues ahead regarding spring-native and don't see the slf4j/logback alphas as being worth early adoption but maybe they are doing something for somebody. It's not a big deal not time critical if you want to wait. 
