### PR TITLE
Fix cache busting on login/logout webflows

### DIFF
--- a/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/DefaultLoginWebflowConfigurerTests.java
+++ b/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/DefaultLoginWebflowConfigurerTests.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.web.support.CasLocaleChangeInterceptor;
+
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.servlet.resource.ResourceUrlProviderExposingInterceptor;
 import org.springframework.webflow.context.ExternalContextHolder;
 import org.springframework.webflow.context.servlet.ServletExternalContext;
 import org.springframework.webflow.engine.EndState;
@@ -38,6 +41,10 @@ public class DefaultLoginWebflowConfigurerTests extends BaseWebflowConfigurerTes
     @Test
     public void verifyOperation() {
         assertFalse(casWebflowExecutionPlan.getWebflowConfigurers().isEmpty());
+        val interceptors = casWebflowExecutionPlan.getWebflowInterceptors();
+        assertEquals(2, interceptors.size());
+        assertTrue(interceptors.stream().anyMatch(interceptor -> interceptor instanceof CasLocaleChangeInterceptor));
+        assertTrue(interceptors.stream().anyMatch(interceptor -> interceptor instanceof ResourceUrlProviderExposingInterceptor));
         val flow = (Flow) this.loginFlowDefinitionRegistry.getFlowDefinition(CasWebflowConfigurer.FLOW_ID_LOGIN);
         assertNotNull(flow);
         assertTrue(flow.containsState(CasWebflowConstants.STATE_ID_VIEW_LOGIN_FORM));

--- a/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/DefaultLogoutWebflowConfigurerTests.java
+++ b/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/DefaultLogoutWebflowConfigurerTests.java
@@ -1,8 +1,11 @@
 package org.apereo.cas.web.flow;
 
+import org.apereo.cas.web.support.CasLocaleChangeInterceptor;
+
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.resource.ResourceUrlProviderExposingInterceptor;
 import org.springframework.webflow.engine.Flow;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,6 +22,10 @@ public class DefaultLogoutWebflowConfigurerTests extends BaseWebflowConfigurerTe
     @Test
     public void verifyOperation() {
         assertFalse(casWebflowExecutionPlan.getWebflowConfigurers().isEmpty());
+        val interceptors = casWebflowExecutionPlan.getWebflowInterceptors();
+        assertEquals(2, interceptors.size());
+        assertTrue(interceptors.stream().anyMatch(interceptor -> interceptor instanceof CasLocaleChangeInterceptor));
+        assertTrue(interceptors.stream().anyMatch(interceptor -> interceptor instanceof ResourceUrlProviderExposingInterceptor));
         val flow = (Flow) this.logoutFlowDefinitionRegistry.getFlowDefinition(CasWebflowConfigurer.FLOW_ID_LOGOUT);
         assertNotNull(flow);
         assertTrue(flow.containsState(CasWebflowConstants.STATE_ID_TERMINATE_SESSION));


### PR DESCRIPTION
The Spring cache busting does not work on login/logout webflows: JS/CSS files do not have a version in their names.

Configuration example:
```
spring.web.resources.chain.strategy.content.enabled: true
spring.web.resources.chain.strategy.content.paths: /**
```

The `ResourceUrlProviderExposingInterceptor` interceptor is missing (to populate the `ResourceUrlProvider` in the HTTP request to be used by the `ResourceUrlEncodingFilter`).

This PR fixes this issue.
