### PR TITLE
avoid xmlsec snapshot that is no longer available

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -465,6 +465,7 @@ oktaSdkVersion=2.0.2
 ###############################
 opensamlVersion=4.1.1
 xmlSecToolVersion=3.0.0
+xmlSecVersion=2.3.0
 xercesVersion=2.12.1
 bouncyCastleVersion=1.69
 shibbolethUtilJavaSupportVersion=8.2.1

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1981,7 +1981,9 @@ ext.libraries = [
                     exclude(group: "org.opensaml", module: "opensaml-saml-api")
                     exclude(group: "org.opensaml", module: "opensaml-saml-impl")
                     exclude(group: "org.opensaml", module: "opensaml-core")
-
+                },
+                dependencies.create("org.apache.santuario:xmlsec:$xmlSecVersion") {
+                    exclude(group: "jakarta.xml.bind", module: "jakarta.xml.bind-api")
                 }
         ],
         pac4jcore               : [
@@ -3635,6 +3637,9 @@ ext.libraries = [
                     exclude(group: "org.apache.wss4j", module: "wss4j-ws-security-dom")
                     exclude(group: "org.jvnet.mimepull", module: "mimepull")
                     exclude(group: "org.apache.wss4j", module: "wss4j-ws-security-common")
+                },
+                dependencies.create("org.apache.santuario:xmlsec:$xmlSecVersion") {
+                    exclude(group: "jakarta.xml.bind", module: "jakarta.xml.bind-api")
                 }
         ],
         validationapi           : dependencies.create("javax.validation:validation-api:$javaxValidationVersion"),


### PR DESCRIPTION
I think the `wss4jVersion=2.5.0-SNAPSHOT` was trying to pull in xmlsec 2.3.0-SNAPSHOT which wasn't getting downloaded when I was trying to build. This sets the xmlsec version at the released 2.3.0 for both wss4j and opensaml. 
