### PR TITLE
Fix SingleSignOnSessionsEndpoint.destroySsoSession

### DIFF
--- a/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
+++ b/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
@@ -145,6 +145,7 @@ public class SingleSignOnSessionsEndpoint extends BaseCasActuatorEndpoint {
             sessionsMap.put(STATUS, HttpServletResponse.SC_OK);
             sessionsMap.put(TICKET_GRANTING_TICKET, ticketGrantingTicket);
             sessionsMap.put("singleLogoutRequests", sloRequests);
+            centralAuthenticationService.deleteTicket(ticketGrantingTicket);
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
             sessionsMap.put(STATUS, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
After calling destroySsoSession, TGT still exists in database.
Tested with MongoDB ticket registry.
There was no problem with CAS 6.1.
I don't know the real fix but this patch fixed the problem for me.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
