### PR TITLE
make authy config conditional

### DIFF
--- a/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/AuthyConfiguration.java
+++ b/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/AuthyConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -38,6 +39,8 @@ import org.springframework.webflow.execution.Action;
  * @since 5.0.0
  */
 @Configuration("authyConfiguration")
+@ConditionalOnMultifactorTrustedDevicesEnabled(prefix = "cas.authn.mfa.authy")
+@ConditionalOnProperty(prefix="cas.authn.mfa.authy", name="api-key")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 public class AuthyConfiguration {
     private static final int WEBFLOW_CONFIGURER_ORDER = 100;
@@ -105,7 +108,6 @@ public class AuthyConfiguration {
      * The Authy multifactor trust configuration.
      */
     @ConditionalOnClass(value = MultifactorAuthnTrustConfiguration.class)
-    @ConditionalOnMultifactorTrustedDevicesEnabled(prefix = "cas.authn.mfa.authy")
     @Configuration("authyMultifactorTrustConfiguration")
     public class AuthyMultifactorTrustConfiguration {
 

--- a/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/support/authentication/AuthyAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-authy/src/main/java/org/apereo/cas/adaptors/authy/config/support/authentication/AuthyAuthenticationEventExecutionPlanConfiguration.java
@@ -17,6 +17,7 @@ import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.trusted.config.ConditionalOnMultifactorTrustedDevicesEnabled;
 
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -40,6 +41,7 @@ import org.springframework.webflow.execution.Action;
  */
 @Configuration("authyAuthenticationEventExecutionPlanConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnMultifactorTrustedDevicesEnabled(prefix = "cas.authn.mfa.authy")
 @ConditionalOnProperty(prefix="cas.authn.mfa.authy", name="api-key")
 public class AuthyAuthenticationEventExecutionPlanConfiguration {
 


### PR DESCRIPTION
This makes it so both of the following properties need to be set in order for authy to modify the webflow:
```
cas.authn.mfa.authy.trusted-device-enabled=true
cas.authn.mfa.authy.api-key=something
```
The `cas.authn.mfa.authy.trusted-device-enabled` defaults to true if not set so it can be set to false to disable authy even if an api-key is defined. 

