### PR TITLE
remove explicit destroy method from DisposableBean beans

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -16,7 +16,7 @@ env:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, pr-* ]
   pull_request:
     types: [ labeled ]
     branches: [ master ]

--- a/core/cas-server-core-web/src/main/java/org/apereo/cas/config/CasCoreHttpConfiguration.java
+++ b/core/cas-server-core-web/src/main/java/org/apereo/cas/config/CasCoreHttpConfiguration.java
@@ -4,7 +4,6 @@ import org.apereo.cas.authentication.CasSSLContext;
 import org.apereo.cas.authentication.DefaultCasSSLContext;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.support.Beans;
-import org.apereo.cas.util.http.HttpClient;
 import org.apereo.cas.util.http.SimpleHttpClient;
 import org.apereo.cas.util.http.SimpleHttpClientFactoryBean;
 
@@ -118,7 +117,7 @@ public class CasCoreHttpConfiguration {
             return c;
         }
 
-        private static HttpClient getHttpClient(final boolean redirectEnabled,
+        private static SimpleHttpClient getHttpClient(final boolean redirectEnabled,
                                                 final CasSSLContext casSslContext,
                                                 final HostnameVerifier hostnameVerifier,
                                                 final SSLConnectionSocketFactory trustStoreSslSocketFactory,
@@ -130,7 +129,7 @@ public class CasCoreHttpConfiguration {
         }
 
         @ConditionalOnMissingBean(name = "httpClient")
-        @Bean(destroyMethod = "destroy")
+        @Bean
         public FactoryBean<SimpleHttpClient> httpClient(
             @Qualifier("casSslContext")
             final CasSSLContext casSslContext,
@@ -144,8 +143,8 @@ public class CasCoreHttpConfiguration {
         }
 
         @ConditionalOnMissingBean(name = "noRedirectHttpClient")
-        @Bean(destroyMethod = "destroy")
-        public HttpClient noRedirectHttpClient(
+        @Bean
+        public SimpleHttpClient noRedirectHttpClient(
             @Qualifier("casSslContext")
             final CasSSLContext casSslContext,
             @Qualifier("hostnameVerifier")
@@ -158,8 +157,8 @@ public class CasCoreHttpConfiguration {
         }
 
         @ConditionalOnMissingBean(name = "supportsTrustStoreSslSocketFactoryHttpClient")
-        @Bean(destroyMethod = "destroy")
-        public HttpClient supportsTrustStoreSslSocketFactoryHttpClient(
+        @Bean
+        public SimpleHttpClient supportsTrustStoreSslSocketFactoryHttpClient(
             @Qualifier("casSslContext")
             final CasSSLContext casSslContext,
             @Qualifier("hostnameVerifier")

--- a/support/cas-server-support-service-registry-stream/src/main/java/org/apereo/cas/config/CasServicesStreamingConfiguration.java
+++ b/support/cas-server-support-service-registry-stream/src/main/java/org/apereo/cas/config/CasServicesStreamingConfiguration.java
@@ -44,7 +44,7 @@ public class CasServicesStreamingConfiguration {
     }
 
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
-    @Bean(destroyMethod = "destroy")
+    @Bean
     public RegisteredServiceReplicationStrategy registeredServiceReplicationStrategy(
         final CasConfigurationProperties casProperties,
         @Qualifier("registeredServiceDistributedCacheManager")


### PR DESCRIPTION
Spring-native currently sees the destroy method set explicitly on a bean definition and then goes looking for the method and doesn't find it on the `FactoryBean` interface. If I am not mistaken we shouldn't need to set the destroy method on the bean if the bean implements the `DisposableBean` interface. `SimpleHttpClient` and the non no-op impl of `RegisteredServiceReplicationStrategy ` both implement DisposableBean. 

Could we add a pattern like `pr-*` (for pull request) to some of the workflows so it is easier to run workflows on a fork? It might make it easier for contributors to run tests on their fork before submitting a PR. 