### PR TITLE
Take as AUP accepted when true in principal attribute

### DIFF
--- a/support/cas-server-support-aup-core/src/main/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-core/src/main/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepository.java
@@ -41,11 +41,12 @@ public class DefaultAcceptableUsagePolicyRepository extends BaseAcceptableUsageP
             throw new AuthenticationException("No authentication could be found in the current context");
         }
         val principal = authentication.getPrincipal();
+                
         if (map.containsKey(key)) {
-            val accepted = (boolean) map.getOrDefault(key, Boolean.FALSE) || isUsagePolicyAcceptedBy(principal);
-            return new AcceptableUsagePolicyStatus(accepted, principal);
+            return new AcceptableUsagePolicyStatus((boolean) map.getOrDefault(key, Boolean.FALSE), principal);
         }
-        return AcceptableUsagePolicyStatus.denied(principal);
+        
+        return new AcceptableUsagePolicyStatus(isUsagePolicyAcceptedBy(principal), principal);
     }
 
     @Override


### PR DESCRIPTION
Hi,
I have found that using the default implementation requires de user to accept he policy. It is so even if the value passed in the aupAccepted is true (which is done during the attribute resolution). I think that this is not the excepted behaviour. 

I propose doing something like what is shown in this PR.

Best regards,
Miguel
