### PR TITLE
add SAML2 Response ID to audit message

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolver.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolver.java
@@ -50,7 +50,7 @@ public class SamlResponseAuditResourceResolver extends ReturnValueAsStringResour
         val values = new HashMap<>();
         values.put("issuer", response.getIssuer().getValue());
         values.put("destination", response.getDestination());
-        values.put("ID", response.getID());
+        values.put("responseId", response.getID());
         return new String[]{auditFormat.serialize(values)};
     }
 

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolver.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolver.java
@@ -50,6 +50,7 @@ public class SamlResponseAuditResourceResolver extends ReturnValueAsStringResour
         val values = new HashMap<>();
         values.put("issuer", response.getIssuer().getValue());
         values.put("destination", response.getDestination());
+        values.put("ID", response.getID());
         return new String[]{auditFormat.serialize(values)};
     }
 

--- a/support/cas-server-support-saml-idp-web/src/test/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolverTests.java
+++ b/support/cas-server-support-saml-idp-web/src/test/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolverTests.java
@@ -59,6 +59,9 @@ public class SamlResponseAuditResourceResolverTests {
         var result = r.resolveFrom(mock(JoinPoint.class), response);
         assertNotNull(result);
         assertTrue(result.length > 0);
+        assertTrue(result[0].contains("https://idp.example.org"));
+        assertTrue(result[0].contains("https://sp.example.org"));
+        assertTrue(result[0].contains("_123456789"));
 
         val envelope = mock(Envelope.class);
         val body = mock(Body.class);

--- a/support/cas-server-support-saml-idp-web/src/test/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolverTests.java
+++ b/support/cas-server-support-saml-idp-web/src/test/java/org/apereo/cas/support/saml/web/idp/audit/SamlResponseAuditResourceResolverTests.java
@@ -54,6 +54,7 @@ public class SamlResponseAuditResourceResolverTests {
         when(issuer.getValue()).thenReturn("https://idp.example.org");
         when(response.getIssuer()).thenReturn(issuer);
         when(response.getDestination()).thenReturn("https://sp.example.org");
+        when(response.getID()).thenReturn("_123456789");
 
         var result = r.resolveFrom(mock(JoinPoint.class), response);
         assertNotNull(result);


### PR DESCRIPTION
add SAML2 Response ID to audit message to facilitate traceability

Ex : 
{
  "who" : "xxx",
  "what" : "{\"destination\":\"xxx\",**\"ID\":\"_1268972478599884800\"**,\"issuer\":\"xxx\"}",
  "action" : "SAML2_RESPONSE_CREATED",
  "application" : "cas",
  "when" : "Wed Nov 17 14:53:55 CET 2021",
  "clientIpAddress" : "0:0:0:0:0:0:0:1",
  "serverIpAddress" : "xxx"
}