### PR TITLE
fix trusted-mfa-redis: correctly get multiple devices per user

### DIFF
--- a/support/cas-server-support-trusted-mfa-redis/src/main/java/org/apereo/cas/trusted/authentication/storage/RedisMultifactorAuthenticationTrustStorage.java
+++ b/support/cas-server-support-trusted-mfa-redis/src/main/java/org/apereo/cas/trusted/authentication/storage/RedisMultifactorAuthenticationTrustStorage.java
@@ -83,10 +83,7 @@ public class RedisMultifactorAuthenticationTrustStorage extends BaseMultifactorA
         }
     }
 
-    @Override
-    public Set<? extends MultifactorAuthenticationTrustRecord> getAll() {
-        remove();
-        val keys = (Set<String>) this.redisTemplate.keys(getPatternRedisKey());
+    private Set<? extends MultifactorAuthenticationTrustRecord> getFromRedisKeys(final Set<String> keys) {
         if (keys != null) {
             return keys.stream()
                 .map(redisKey -> redisTemplate.boundValueOps(redisKey).get())
@@ -95,6 +92,13 @@ public class RedisMultifactorAuthenticationTrustStorage extends BaseMultifactorA
                 .collect(Collectors.toSet());
         }
         return new HashSet<>(0);
+    }
+
+    @Override
+    public Set<? extends MultifactorAuthenticationTrustRecord> getAll() {
+        remove();
+        val keys = (Set<String>) this.redisTemplate.keys(getPatternRedisKey());
+        return getFromRedisKeys(keys);
     }
 
     @Override
@@ -110,13 +114,7 @@ public class RedisMultifactorAuthenticationTrustStorage extends BaseMultifactorA
     public Set<? extends MultifactorAuthenticationTrustRecord> get(final String principal) {
         remove();
         val keys = redisTemplate.keys(buildRedisKeyForRecord(principal));
-        if (keys != null && !keys.isEmpty()) {
-            val redisKey = keys.iterator().next();
-            val results = (List<MultifactorAuthenticationTrustRecord>)
-                ObjectUtils.defaultIfNull(redisTemplate.boundValueOps(redisKey).get(), new ArrayList<>());
-            return new HashSet<>(results);
-        }
-        return new HashSet<>(0);
+        return getFromRedisKeys(keys);
     }
 
     @Override

--- a/support/cas-server-support-trusted-mfa-redis/src/test/java/org/apereo/cas/trusted/authentication/storage/RedisMultifactorAuthenticationTrustStorageTests.java
+++ b/support/cas-server-support-trusted-mfa-redis/src/test/java/org/apereo/cas/trusted/authentication/storage/RedisMultifactorAuthenticationTrustStorageTests.java
@@ -68,6 +68,17 @@ public class RedisMultifactorAuthenticationTrustStorageTests extends AbstractMul
     }
 
     @Test
+    public void verifyMultipleDevicesPerUser() {
+        getMfaTrustEngine().save(MultifactorAuthenticationTrustRecord.newInstance("casuser", "geography", "fingerprint"));
+        getMfaTrustEngine().save(MultifactorAuthenticationTrustRecord.newInstance("casuser", "geography bis", "fingerprint bis"));
+        getMfaTrustEngine().save(MultifactorAuthenticationTrustRecord.newInstance("casuser2", "geography2", "fingerprint2"));
+        
+        val records = getMfaTrustEngine().get("casuser");
+        assertEquals(2, records.size());
+    }
+
+
+    @Test
     public void verifyExpireByDate() {
         val r = MultifactorAuthenticationTrustRecord.newInstance("castest", "geography", "fingerprint");
         val now = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);


### PR DESCRIPTION
6.4.x backport of https://github.com/apereo/cas/pull/5293