### PR TITLE
DynamoDB: Only set throughput for PROVISIONED billing mode

### DIFF
--- a/ci/tests/dynamodb/run-dynamodb-server.sh
+++ b/ci/tests/dynamodb/run-dynamodb-server.sh
@@ -4,7 +4,7 @@
 
 echo "Running DynamoDb docker image..."
 docker stop dynamodb-server || true && docker rm dynamodb-server || true
-docker run --rm -d -p 8000:8000 --name "dynamodb-server" amazon/dynamodb-local:1.13.6
+docker run --rm -d -p 8000:8000 --name "dynamodb-server" amazon/dynamodb-local:1.17.0
 
 docker ps | grep "dynamodb-server"
 retVal=$?


### PR DESCRIPTION
When creating DynamoDb tables with PAY_PER_REQUEST billing mode, the AWS API throws an exception if throughput (read capacity and write capacity) is populated in the create table request.  This error condition does not occur when testing against the dynamodb-local:1.13.6 docker image, but it does when running against DynamoDb in AWS.

With this change, throughput is only populated if billing mode is set to PROVISIONED.