### PR TITLE
Create new OidcCustomScopePolicy in policyChain 6.4.x

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServiceRegistryListener.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/services/OidcServiceRegistryListener.java
@@ -2,6 +2,7 @@ package org.apereo.cas.oidc.services;
 
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.oidc.claims.BaseOidcScopeAttributeReleasePolicy;
+import org.apereo.cas.oidc.claims.OidcCustomScopeAttributeReleasePolicy;
 import org.apereo.cas.oidc.scopes.OidcAttributeReleasePolicyFactory;
 import org.apereo.cas.services.ChainingAttributeReleasePolicy;
 import org.apereo.cas.services.DenyAllAttributeReleasePolicy;
@@ -78,6 +79,7 @@ public class OidcServiceRegistryListener implements ServiceRegistryListener {
                     .stream()
                     .filter(t -> t.getScopeName().equals(givenScope.trim()))
                     .findFirst()
+                    .map(scope -> attributeReleasePolicyFactory.custom(scope.getScopeName(), scope.getAllowedAttributes()))
                     .ifPresent(userPolicy -> addAttributeReleasePolicy(policyChain, userPolicy, givenScope, oidcService));
             } else {
                 val scope = OidcConstants.StandardScopes.valueOf(givenScope.trim().toUpperCase());


### PR DESCRIPTION
For custom user defined OIDC scopes, the OidcServiceRegistryListener currently uses a single custom scope object.  This then results in the last service to be loaded is what is used for consent and attribute repositories for all services that use the custom scope.  

This PR ensures that a new custom scope object is created for each OIDC service that is registered and the configured consent and attribute repositories for that service are used.