### PR TITLE
Take as AUP accepted when true in principal attribute #5287

### DIFF
--- a/support/cas-server-support-aup-core/src/main/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-core/src/main/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepository.java
@@ -41,11 +41,12 @@ public class DefaultAcceptableUsagePolicyRepository extends BaseAcceptableUsageP
             throw new AuthenticationException("No authentication could be found in the current context");
         }
         val principal = authentication.getPrincipal();
+                
         if (map.containsKey(key)) {
-            val accepted = (boolean) map.getOrDefault(key, Boolean.FALSE) || isUsagePolicyAcceptedBy(principal);
-            return new AcceptableUsagePolicyStatus(accepted, principal);
+            return new AcceptableUsagePolicyStatus((boolean) map.getOrDefault(key, Boolean.FALSE), principal);
         }
-        return AcceptableUsagePolicyStatus.denied(principal);
+        
+        return new AcceptableUsagePolicyStatus(isUsagePolicyAcceptedBy(principal), principal);
     }
 
     @Override

--- a/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepositoryTests.java
+++ b/support/cas-server-support-aup-webflow/src/test/java/org/apereo/cas/aup/DefaultAcceptableUsagePolicyRepositoryTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.aup;
 
+import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.authentication.AuthenticationException;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.configuration.model.support.aup.AcceptableUsagePolicyProperties;
@@ -10,6 +11,7 @@ import org.apereo.cas.web.support.WebUtils;
 
 import lombok.Getter;
 import lombok.val;
+import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +22,7 @@ import org.springframework.mock.web.MockServletContext;
 import org.springframework.webflow.context.servlet.ServletExternalContext;
 import org.springframework.webflow.test.MockRequestContext;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -72,6 +75,21 @@ public class DefaultAcceptableUsagePolicyRepositoryTests extends BaseAcceptableU
         val properties = new AcceptableUsagePolicyProperties();
         properties.getInMemory().setScope(InMemoryAcceptableUsagePolicyProperties.Scope.GLOBAL);
         verifyAction(properties);
+    }
+
+    @Test
+    public void verifyActionAcceptedGlobal() {
+        val properties = new AcceptableUsagePolicyProperties();
+        properties.getInMemory().setScope(InMemoryAcceptableUsagePolicyProperties.Scope.GLOBAL);
+        val context = getRequestContext();
+        val repo = getRepositoryInstance(properties);
+        val authentication = CoreAuthenticationTestUtils.getAuthentication();
+        authentication.getPrincipal().getAttributes().put(
+                properties.getCore().getAupAttributeName(),
+                Collections.singletonList("true"));
+        WebUtils.putAuthentication(authentication, context);
+        WebUtils.putTicketGrantingTicketInScopes(context, "TGT-12345");
+        assertTrue(repo.verify(context).isAccepted());
     }
 
     @Test


### PR DESCRIPTION
Hi,
I have found that using the default implementation requires de user to accept he policy. It is so even if the value passed in the aupAccepted is true (which is done during the attribute resolution). I think that this is not the excepted behaviour.

I propose doing something like what is shown in this PR.

Best regards,
Miguel