### PR TITLE
Fix parsed list from a rest resource

### DIFF
--- a/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
+++ b/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
@@ -136,7 +136,7 @@ public class RestfulServiceRegistry extends AbstractServiceRegistry {
             response = HttpUtils.execute(exec);
             if (response.getStatusLine().getStatusCode() == HttpStatus.OK.value()) {
                 val result = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
-                val services = (List<RegisteredService>) MAPPER.readValue(result, List.class);
+                val services = MAPPER.readValue(result, TypeReference<ArrayList<RegisteredService>>() {});
                 services.stream()
                     .map(this::invokeServiceRegistryListenerPostLoad)
                     .filter(Objects::nonNull)


### PR DESCRIPTION
Hi,
I was trying to migrate from 6.3.7 to 6.4.3. I am using CAS with a RestServiceRegistery. Unfortunately trying this upgrade, now fetching the services from our rest resource is failing due to
```
Unexpected token (START_OBJECT), expected VALUE_STRING: need JSON String that contains type id (for subtype of java.util.List)
```
I think enabling the default typing on the ObjectMapper, requires parsing the values by the referenced type.
I have changed that implementation in this PR. Please let me know if there is a missing requirement that I need to enable my side to get this fixed.

I will adapt the test cases here if the proposed changes actually make sense to you.