### PR TITLE
fix parsed services list

### DIFF
--- a/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
+++ b/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
@@ -6,6 +6,7 @@ import org.apereo.cas.util.HttpUtils;
 import org.apereo.cas.util.LoggingUtils;
 import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -136,7 +137,7 @@ public class RestfulServiceRegistry extends AbstractServiceRegistry {
             response = HttpUtils.execute(exec);
             if (response.getStatusLine().getStatusCode() == HttpStatus.OK.value()) {
                 val result = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
-                val services = (List<RegisteredService>) MAPPER.readValue(result, List.class);
+                val services = MAPPER.readValue(result, new TypeReference<ArrayList<RegisteredService>>() {});
                 services.stream()
                     .map(this::invokeServiceRegistryListenerPostLoad)
                     .filter(Objects::nonNull)


### PR DESCRIPTION
Hi,
I was trying to migrate from 6.3.7 to 6.4.3. I am using CAS with a RestServiceRegistery. Unfortunately trying this upgrade, now fetching the services from our rest resource is failing due to 
```
Unexpected token (START_OBJECT), expected VALUE_STRING: need JSON String that contains type id (for subtype of java.util.List)
```
I think enabling the default typing on the ObjectMapper, requires parsing the values by the referenced type. 
I have changed that implementation in this PR. Please let me know if there is a missing requirement that I need to enable my side to get this fixed.

I will adapt the test cases here if the proposed changes actually make sense to you.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
