### PR TITLE
fix: Exception evaluating SpringEL expression: "'screen.pac4j.authn.' + rootCauseException.class.simpleName"

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnStopWebflow.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnStopWebflow.html
@@ -21,8 +21,10 @@
 
                 <p>
                     <i class="mdi mdi-alert fas fa-exclamation-triangle mr-2"></i>
-                    <span th:text="#{${'screen.pac4j.authn.' + rootCauseException.class.simpleName}}">
-                        Authentication response provided to CAS by the external identity provider cannot be accepted.</span>
+                    <span th:if="${rootCauseException}" th:text="#{${'screen.pac4j.authn.' + rootCauseException.class.simpleName}}">
+                      Authentication response provided to CAS by the external identity provider cannot be accepted.</span>
+                    <span th:unless="${rootCauseException}" th:text="#{screen.pac4j.authn.unknown}">
+                      Authentication response provided to CAS by the external identity provider cannot be accepted.</span>
                 </p>
                 
                 <div class="mdc-data-table table-responsive">


### PR DESCRIPTION
```
ERROR [org.apereo.cas.authentication.DefaultAuthenticationManager] - <[DelegatedClientAuthenticationHandler]: [org.pac4j.core.exception.TechnicalException: id cannot be blank / id cannot be blank]>
......
ERROR [org.thymeleaf.TemplateEngine] - <[THYMELEAF][https-jsse-nio-8443-exec-5] Exception processing template "delegated-authn/casDelegatedAuthnStopWebflow": Exception evaluating SpringEL expression: "'screen.pac4j.authn.' + rootCauseException.class.simpleName" (template: "delegated-authn/casDelegatedAuthnStopWebflow" - line 23, col 27)>

```

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
