### PR TITLE
Open some CAS classes

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/OAuth20DefaultAccessTokenFactory.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/accesstoken/OAuth20DefaultAccessTokenFactory.java
@@ -88,7 +88,13 @@ public class OAuth20DefaultAccessTokenFactory implements OAuth20AccessTokenFacto
         return OAuth20AccessToken.class;
     }
 
-    private ExpirationPolicy determineExpirationPolicyForService(final OAuthRegisteredService registeredService) {
+    /**
+     * Determine the expiration policy for the registered service.
+     *
+     * @param registeredService the registered service
+     * @return the expiration policy
+     */
+    protected ExpirationPolicy determineExpirationPolicyForService(final OAuthRegisteredService registeredService) {
         if (registeredService != null && registeredService.getAccessTokenExpirationPolicy() != null) {
             val policy = registeredService.getAccessTokenExpirationPolicy();
             val maxTime = policy.getMaxTimeToLive();

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedClientAuthenticationAction.java
@@ -52,7 +52,10 @@ import java.util.stream.Stream;
 @Slf4j
 @Getter
 public class DelegatedClientAuthenticationAction extends AbstractAuthenticationAction {
-    private final DelegatedClientAuthenticationConfigurationContext configContext;
+    /**
+     * The configuration context.
+     */
+    protected final DelegatedClientAuthenticationConfigurationContext configContext;
 
     private final DelegatedClientAuthenticationWebflowManager delegatedClientAuthenticationWebflowManager;
 

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorSendTokenAction.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorSendTokenAction.java
@@ -49,7 +49,16 @@ public class CasSimpleMultifactorSendTokenAction extends AbstractMultifactorAuth
 
     private final CasSimpleMultifactorTokenCommunicationStrategy tokenCommunicationStrategy;
 
-    private static boolean isSmsSent(final CommunicationsManager communicationsManager,
+    /**
+     * Send a SMS.
+     *
+     * @param communicationsManager the communication manager
+     * @param properties the properties
+     * @param principal the principal
+     * @param token the token
+     * @return whether the SMS has been sent.
+     */
+    protected boolean isSmsSent(final CommunicationsManager communicationsManager,
                                      final CasSimpleMultifactorAuthenticationProperties properties,
                                      final Principal principal,
                                      final Ticket token) {
@@ -63,7 +72,17 @@ public class CasSimpleMultifactorSendTokenAction extends AbstractMultifactorAuth
         return false;
     }
 
-    private static boolean isMailSent(final CommunicationsManager communicationsManager,
+    /**
+     * Send an email.
+     *
+     * @param communicationsManager the communication manager
+     * @param properties the properties
+     * @param principal the principal
+     * @param token the token
+     * @param requestContext the request context
+     * @return whether the email has been sent.
+     */
+    protected boolean isMailSent(final CommunicationsManager communicationsManager,
                                       final CasSimpleMultifactorAuthenticationProperties properties,
                                       final Principal principal, final Ticket token,
                                       final RequestContext requestContext) {
@@ -78,7 +97,15 @@ public class CasSimpleMultifactorSendTokenAction extends AbstractMultifactorAuth
         return false;
     }
 
-    private static boolean isNotificationSent(final CommunicationsManager communicationsManager,
+    /**
+     * Send a notification.
+     *
+     * @param communicationsManager the communication manager
+     * @param principal the principal
+     * @param token the token
+     * @return whether the notification has been sent.
+     */
+    protected boolean isNotificationSent(final CommunicationsManager communicationsManager,
                                               final Principal principal,
                                               final Ticket token) {
         return communicationsManager.isNotificationSenderDefined()
@@ -115,7 +142,14 @@ public class CasSimpleMultifactorSendTokenAction extends AbstractMultifactorAuth
         return error();
     }
 
-    private CasSimpleMultifactorAuthenticationTicket getOrCreateToken(final RequestContext requestContext, final Principal principal) {
+    /**
+     * Get or create a token.
+     *
+     * @param requestContext the request context
+     * @param principal the principal
+     * @return the token
+     */
+    protected CasSimpleMultifactorAuthenticationTicket getOrCreateToken(final RequestContext requestContext, final Principal principal) {
         return Optional.ofNullable(WebUtils.getSimpleMultifactorAuthenticationToken(requestContext, CasSimpleMultifactorAuthenticationTicket.class))
             .filter(token -> !token.isExpired())
             .orElseGet(() -> {


### PR DESCRIPTION
For customisations:
- I want to override the `OAuth20DefaultAccessTokenFactory` class to use a specific principal attribute as the access token identifier
- I want to override the `DelegatedClientAuthenticationAction` class to perform some initial operations when the login webflow starts and I need to access the `casProperties` which is already in the `configContext`
- I want to override the `CasSimpleMultifactorSendTokenAction` to send a SMS only with a token without the prefix.

Will backport.
