### PR TITLE
WIP - toggle between refreshable and one-time instantiation of pac4j clients

### DIFF
--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/RefreshableDelegatedClients.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/RefreshableDelegatedClients.java
@@ -12,7 +12,12 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * This is {@link RefreshableDelegatedClients}.
+ * This is {@link RefreshableDelegatedClients}, which shims {@link Clients}
+ * to rebuild any delegated clients when either {@link Clients#findClient(String) findClient}
+ * or {@link Clients#findAllClients() findAllClients} are called.
+ * In practice, this means that clients will be rebuilt for each request.
+ *
+ * @see org.apereo.cas.configuration.model.support.pac4j.Pac4jDelegatedAuthenticationCoreProperties#lazyInit
  *
  * @author Misagh Moayyed
  * @since 6.4.0

--- a/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/config/Pac4jAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j/src/main/java/org/apereo/cas/config/Pac4jAuthenticationEventExecutionPlanConfiguration.java
@@ -231,7 +231,21 @@ public class Pac4jAuthenticationEventExecutionPlanConfiguration {
         public Clients builtClients(final CasConfigurationProperties casProperties,
                                     @Qualifier("pac4jDelegatedClientFactory")
                                     final DelegatedClientFactory pac4jDelegatedClientFactory) {
-            return new RefreshableDelegatedClients(casProperties.getServer().getLoginUrl(), pac4jDelegatedClientFactory);
+            if (casProperties.getAuthn().getPac4j().getCore().isLazyInit()) {
+                LOGGER.info("Delegated clients will be dynamically initialized");
+                return new RefreshableDelegatedClients(casProperties.getServer().getLoginUrl(),
+                                                       pac4jDelegatedClientFactory);
+            } else {
+                val clients = pac4jDelegatedClientFactory.build();
+                LOGGER.debug("Built the following delegated clients: [{}]", clients);
+                if (clients.isEmpty()) {
+                    LOGGER.debug("No delegated authentication clients are defined and/or configured");
+                } else {
+                    LOGGER.info("Located and prepared [{}] delegated authentication client(s)", clients.size());
+
+                }
+                return new Clients(casProperties.getServer().getLoginUrl(), new ArrayList<>(clients));
+            }
         }
     }
 


### PR DESCRIPTION
A change was introduced in aa5c1c6bf0670f7189a2b1de43f971e52ccebfce to allow runtime refreshing of Pac4j clients. Unfortunately, this is extremely costly, particularly when running several delegated clients: with a CAS client, an OIDC client, and (particularly slow) two SAML clients, we are experiencing hot load times of over a second for `/cas/login` as every one of those clients are built from scratch for each login flow.
The other effect of this behavior is to render the `lazy-init` flag essentially useless, as the clients aren't being persisted and are as such effectively always lazy initialized.

This patch more or less restores the code as it existed previously, using `lazy-init` as a toggle between using `RefreshableDelegatedClients` vs a static list. Though this is not included in the PR, setting the default value for `lazy-init` to true would almost certainly reflect the behavior most end users hope for - losing a second or two during startup is nothing compared to default-enabled, persistent performance degradation across all requests.