### PR TITLE
fix strapi puppeteer test

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-login-strapi/init.sh
+++ b/ci/tests/puppeteer/scenarios/oidc-login-strapi/init.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -e
 set -m
-
+STRAPI_VERSION=3.6.8
 SCENARIO="oidc-login-strapi"
 STRAPI_FOLDER=${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/strapi
 PROJECT=getstarted
 if [[ ! -d $STRAPI_FOLDER/$PROJECT ]] ; then
   mkdir -p $STRAPI_FOLDER
   cd $STRAPI_FOLDER
-  yarn create strapi-app $PROJECT --quickstart --no-run
+  npx create-strapi-app@v$STRAPI_VERSION $PROJECT --quickstart --no-run
   cd -
 fi
 


### PR DESCRIPTION
Strapi came out with 4.0 release and I think it has some pretty significant changes. I believe strapi still supports CAS but I haven't had time to play with it so I am pinning this test to strapi 3.6.8 until I can update the test to work with 4.0.0. This uses npx to install the strapi app instead of yarn b/c yarn doesn't seem to let you specify a version, or I don't know how to do it. 