### PR TITLE
Fix the default URL in OAuth callback

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20CallbackAuthorizeEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20CallbackAuthorizeEndpointController.java
@@ -43,9 +43,10 @@ public class OAuth20CallbackAuthorizeEndpointController extends BaseOAuth20Contr
     public ModelAndView handleRequest(final HttpServletRequest request, final HttpServletResponse response) {
         val callback = new OAuth20CallbackLogic();
         val context = new JEEContext(request, response);
+        val defaultUrl = context.getRequestParameter(OAuth20Constants.REDIRECT_URI).orElse(context.getFullRequestURL());
         callback.perform(context, getConfigurationContext().getSessionStore(),
             getConfigurationContext().getOauthConfig(), (object, ctx) -> Boolean.FALSE,
-            context.getFullRequestURL(), Boolean.FALSE, Authenticators.CAS_OAUTH_CLIENT);
+                defaultUrl, Boolean.FALSE, Authenticators.CAS_OAUTH_CLIENT);
         val url = callback.getRedirectUrl();
         val manager = new ProfileManager(context, getConfigurationContext().getSessionStore());
         LOGGER.trace("OAuth callback URL is [{}]", url);

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20CallbackAuthorizeEndpointControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20CallbackAuthorizeEndpointControllerTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.oauth.web.endpoints;
 
 import org.apereo.cas.AbstractOAuth20Tests;
+import org.apereo.cas.support.oauth.OAuth20Constants;
 
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.view.RedirectView;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,7 +35,21 @@ public class OAuth20CallbackAuthorizeEndpointControllerTests extends AbstractOAu
     @Test
     public void verifyOperation() {
         val request = new MockHttpServletRequest();
+        request.addParameter(OAuth20Constants.CLIENT_ID, CLIENT_ID);
+        request.addParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         val response = new MockHttpServletResponse();
-        assertNotNull(callbackAuthorizeController.handleRequest(request, response));
+        val view = callbackAuthorizeController.handleRequest(request, response);
+        assertNotNull(view);
+        assertEquals(REDIRECT_URI, ((RedirectView) view.getView()).getUrl());
+    }
+
+    @Test
+    public void verifyOperationWithoutRedirectUri() {
+        val request = new MockHttpServletRequest();
+        request.addParameter(OAuth20Constants.CLIENT_ID, CLIENT_ID);
+        val response = new MockHttpServletResponse();
+        val view = callbackAuthorizeController.handleRequest(request, response);
+        assertNotNull(view);
+        assertEquals("http://localhost", ((RedirectView) view.getView()).getUrl());
     }
 }


### PR DESCRIPTION
In a regular OAuth authorize process, the default URL defined at the callback logic level is never used as the `OAuth20CallbackLogic` relies on the pac4j requested URL saved in the session (which is the /authorize URL).

Nonetheless, if I bookmark the /login URL during the OAuth authorize process and call it back later on, I'm redirected to the /callbackAuthorize URL without nothing in session for the pac4j requested URL.
So it loops to the /callbackAuthorize URL itself again and again as the default URL is defined to the /callbackAuthorize URL itself (`context.getFullRequestURL()`).

This PR proposes to use the `redirect_uri` instead of the /callbackAuthorize URL itself as the default URL. I can't say this will always work but I think it's better (to try to return to the client app) than the current setting which never works for this edge use case.
