### PR TITLE
use node 14 for puppetteer tests for time being

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -27,6 +27,7 @@ on:
     branches:
       - master
       - '!**.**.**'
+      - pr-*
   pull_request:
     types: [ labeled ]
     branches:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -18,7 +18,9 @@ env:
   IMGUR_CLIENT_ID: ${{ secrets.IMGUR_CLIENT_ID }}
   TERM: xterm-256color
   JDK_CURRENT: 11.0.13
+  NODE_CURRENT: 14
   SCENARIO_REGEX: ".*" # Use this to limit which tests run
+
 
 on:
   push:
@@ -65,6 +67,11 @@ jobs:
       scenarios: ${{ steps.get-scenarios.outputs.scenarios }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_CURRENT }}
+          cache: 'npm'
+          cache-dependency-path: ci/tests/puppeteer/package-lock.json
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -68,7 +68,8 @@ jobs:
       scenarios: ${{ steps.get-scenarios.outputs.scenarios }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Set up Nodejs
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_CURRENT }}
           cache: 'npm'

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -18,7 +18,7 @@ env:
   IMGUR_CLIENT_ID: ${{ secrets.IMGUR_CLIENT_ID }}
   TERM: xterm-256color
   JDK_CURRENT: 11.0.13
-  NODE_CURRENT: 14
+  NODE_CURRENT: '14'
   SCENARIO_REGEX: ".*" # Use this to limit which tests run
 
 

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -27,7 +27,7 @@ on:
     branches:
       - master
       - '!**.**.**'
-      - pr-*
+      - 'pr-*'
   pull_request:
     types: [ labeled ]
     branches:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -68,12 +68,6 @@ jobs:
       scenarios: ${{ steps.get-scenarios.outputs.scenarios }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Nodejs
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_CURRENT }}
-          cache: 'npm'
-          cache-dependency-path: ./ci/tests/puppeteer/package.json
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -103,6 +97,12 @@ jobs:
         with:
           java-version: ${{ env.JDK_CURRENT }}
           distribution: 'temurin'
+      - name: Set up Nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_CURRENT }}
+          cache: 'npm'
+          cache-dependency-path: ./ci/tests/puppeteer/package.json
       - name: Initialize
         run: chmod -R 777 ./ci/*.sh
 #      - name: Setup tmate session

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_CURRENT }}
           cache: 'npm'
-          cache-dependency-path: ci/tests/puppeteer/package-lock.json
+          cache-dependency-path: ./ci/tests/puppeteer/package.json
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
Strapi 3.x doesn't work with Node 16 and Strapi 4.x OIDC support is currently broken but should be fixed in the next couple weeks. In the meantime, we can run the puppeteer tests with Node 14 and we will switch back to  Node 16 once Strapi 4.x OIDC is working. This adds caching for node_modules which appears to work, seems to be caching a 150MB of node_modules in the user's npm cache folder.