### PR TITLE
Upgrade to pac4j v5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -256,8 +256,8 @@ commonsCollectionsVersion=4.4
 ###############################
 # Pac4j versions
 ###############################
-pac4jSpringWebmvcVersion=5.0.0
-pac4jVersion=5.1.5
+pac4jSpringWebmvcVersion=5.1.0
+pac4jVersion=5.2.0
 ###############################
 # ACME versions
 ###############################

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2018,7 +2018,7 @@ ext.libraries = [
                     exclude(group: "org.cryptacular", module: "cryptacular")
 
                 },
-                dependencies.create("org.pac4j:pac4j-core:$pac4jVersion") {
+                dependencies.create("org.pac4j:pac4j-jee:$pac4jVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     exclude(group: "joda-time", module: "joda-time")
                     exclude(group: "commons-codec", module: "commons-codec")


### PR DESCRIPTION
The `pac4j-jee` artifact must be pulled instead of the `pac4j-core` artifact.