### PR TITLE
Prepare for password management service election strategy

### DIFF
--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/PasswordManagementServiceProvider.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/PasswordManagementServiceProvider.java
@@ -1,0 +1,8 @@
+package org.apereo.cas.pm;
+
+import org.apereo.cas.services.RegisteredService;
+
+public interface PasswordManagementServiceProvider {
+
+    PasswordManagementService getPasswordChangeService(RegisteredService registeredService);
+}

--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/DefaultPasswordManagementServiceProvider.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/DefaultPasswordManagementServiceProvider.java
@@ -1,0 +1,32 @@
+package org.apereo.cas.pm.impl;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
+import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.util.crypto.CipherExecutor;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class DefaultPasswordManagementServiceProvider implements PasswordManagementServiceProvider {
+
+    private final List<PasswordManagementService> passwordManagementServices;
+
+    private final CasConfigurationProperties casProperties;
+
+    private final CipherExecutor passwordManagementCipherExecutor;
+
+    @Override
+    public PasswordManagementService getPasswordChangeService(RegisteredService registeredService) {
+        final Optional<PasswordManagementService> first = passwordManagementServices.stream().findFirst();
+
+        return first.orElseGet(() -> new NoOpPasswordManagementService(
+                passwordManagementCipherExecutor,
+                casProperties.getServer().getPrefix(),
+                casProperties.getAuthn().getPm()));
+    }
+}

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementForgotUsernameConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementForgotUsernameConfiguration.java
@@ -7,7 +7,7 @@ import org.apereo.cas.audit.AuditTrailRecordResolutionPlanConfigurer;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.notifications.CommunicationsManager;
-import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.web.flow.ForgotUsernameCaptchaWebflowConfigurer;
 import org.apereo.cas.pm.web.flow.ForgotUsernameWebflowConfigurer;
 import org.apereo.cas.pm.web.flow.actions.SendForgotUsernameInstructionsAction;
@@ -72,8 +72,7 @@ public class PasswordManagementForgotUsernameConfiguration {
     private ObjectProvider<FlowDefinitionRegistry> loginFlowDefinitionRegistry;
 
     @Autowired
-    @Qualifier(PasswordManagementService.DEFAULT_BEAN_NAME)
-    private ObjectProvider<PasswordManagementService> passwordManagementService;
+    private PasswordManagementServiceProvider passwordManagementServiceProvider;
 
     @Autowired
     @Qualifier("defaultPrincipalResolver")
@@ -84,7 +83,7 @@ public class PasswordManagementForgotUsernameConfiguration {
     @RefreshScope
     public Action sendForgotUsernameInstructionsAction() {
         return new SendForgotUsernameInstructionsAction(casProperties, communicationsManager.getObject(),
-            passwordManagementService.getObject(), defaultPrincipalResolver.getObject());
+                passwordManagementServiceProvider, defaultPrincipalResolver.getObject());
     }
 
     @ConditionalOnMissingBean(name = "forgotUsernameWebflowConfigurer")

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -5,7 +5,6 @@ import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.notifications.CommunicationsManager;
-import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.PasswordValidationService;
 import org.apereo.cas.pm.web.flow.PasswordManagementCaptchaWebflowConfigurer;
@@ -122,7 +121,7 @@ public class PasswordManagementWebflowConfiguration {
     private ObjectProvider<PasswordValidationService> passwordValidationService;
 
     @Autowired
-    @Qualifier(PasswordManagementService.DEFAULT_BEAN_NAME)
+    @Qualifier("passwordChangeServiceProvider")
     private PasswordManagementServiceProvider passwordManagementServiceProvider;
 
     @Bean

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/config/PasswordManagementWebflowConfiguration.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.notifications.CommunicationsManager;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.PasswordValidationService;
 import org.apereo.cas.pm.web.flow.PasswordManagementCaptchaWebflowConfigurer;
 import org.apereo.cas.pm.web.flow.PasswordManagementSingleSignOnParticipationStrategy;
@@ -122,7 +123,7 @@ public class PasswordManagementWebflowConfiguration {
 
     @Autowired
     @Qualifier(PasswordManagementService.DEFAULT_BEAN_NAME)
-    private ObjectProvider<PasswordManagementService> passwordManagementService;
+    private PasswordManagementServiceProvider passwordManagementServiceProvider;
 
     @Bean
     @RefreshScope
@@ -167,14 +168,14 @@ public class PasswordManagementWebflowConfiguration {
     @RefreshScope
     @Bean
     public Action initPasswordResetAction() {
-        return new InitPasswordResetAction(passwordManagementService.getObject());
+        return new InitPasswordResetAction(passwordManagementServiceProvider);
     }
 
     @ConditionalOnMissingBean(name = "passwordChangeAction")
     @RefreshScope
     @Bean
     public Action passwordChangeAction() {
-        return new PasswordChangeAction(passwordManagementService.getObject(), passwordValidationService.getObject());
+        return new PasswordChangeAction(passwordManagementServiceProvider, passwordValidationService.getObject());
     }
 
     @ConditionalOnMissingBean(name = "sendPasswordResetInstructionsAction")
@@ -182,8 +183,8 @@ public class PasswordManagementWebflowConfiguration {
     @RefreshScope
     public Action sendPasswordResetInstructionsAction() {
         return new SendPasswordResetInstructionsAction(casProperties, communicationsManager.getObject(),
-            passwordManagementService.getObject(), ticketRegistry.getObject(),
-            ticketFactory.getObject(), defaultPrincipalResolver.getObject());
+                passwordManagementServiceProvider, ticketRegistry.getObject(),
+                ticketFactory.getObject(), defaultPrincipalResolver.getObject());
     }
 
     @ConditionalOnMissingBean(name = "verifyPasswordResetRequestAction")
@@ -191,7 +192,7 @@ public class PasswordManagementWebflowConfiguration {
     @RefreshScope
     public Action verifyPasswordResetRequestAction() {
         return new VerifyPasswordResetRequestAction(casProperties,
-            passwordManagementService.getObject(), centralAuthenticationService.getObject());
+                passwordManagementServiceProvider, centralAuthenticationService.getObject());
     }
 
     @ConditionalOnMissingBean(name = "handlePasswordExpirationWarningMessagesAction")
@@ -209,15 +210,15 @@ public class PasswordManagementWebflowConfiguration {
             LOGGER.debug("Functionality to handle security questions for password management is not enabled");
             return new StaticEventExecutionAction("success");
         }
-        return new VerifySecurityQuestionsAction(passwordManagementService.getObject());
+        return new VerifySecurityQuestionsAction(passwordManagementServiceProvider);
     }
 
     @ConditionalOnMissingBean(name = "validatePasswordResetTokenAction")
     @Bean
     @RefreshScope
     public Action validatePasswordResetTokenAction() {
-        return new ValidatePasswordResetTokenAction(passwordManagementService.getObject(),
-            centralAuthenticationService.getObject());
+        return new ValidatePasswordResetTokenAction(passwordManagementServiceProvider,
+                centralAuthenticationService.getObject());
     }
 
     @ConditionalOnMissingBean(name = "passwordManagementWebflowConfigurer")

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/InitPasswordResetAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/InitPasswordResetAction.java
@@ -2,6 +2,7 @@ package org.apereo.cas.pm.web.flow.actions;
 
 import org.apereo.cas.authentication.credential.UsernamePasswordCredential;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowUtils;
 import org.apereo.cas.web.support.WebUtils;
 
@@ -22,7 +23,7 @@ import org.springframework.webflow.execution.RequestContext;
 @Slf4j
 @RequiredArgsConstructor
 public class InitPasswordResetAction extends AbstractAction {
-    private final PasswordManagementService passwordManagementService;
+    private final PasswordManagementServiceProvider passwordManagementServiceProvider;
 
     @Override
     protected Event doExecute(final RequestContext requestContext) {
@@ -33,7 +34,7 @@ public class InitPasswordResetAction extends AbstractAction {
             return error();
         }
 
-        val username = passwordManagementService.parseToken(token);
+        val username = getPasswordManagementService(requestContext).parseToken(token);
         if (StringUtils.isBlank(username)) {
             LOGGER.error("Password reset token could not be verified to determine username");
             return error();
@@ -43,5 +44,10 @@ public class InitPasswordResetAction extends AbstractAction {
         c.setUsername(username);
         WebUtils.putCredential(requestContext, c);
         return success();
+    }
+
+    private PasswordManagementService getPasswordManagementService(RequestContext requestContext) {
+        final var registeredService = WebUtils.getRegisteredService(requestContext);
+        return passwordManagementServiceProvider.getPasswordChangeService(registeredService);
     }
 }

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -4,6 +4,7 @@ import org.apereo.cas.CentralAuthenticationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.pm.PasswordManagementQuery;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.web.flow.PasswordManagementWebflowUtils;
 import org.apereo.cas.ticket.TicketState;
 import org.apereo.cas.ticket.TransientSessionTicket;
@@ -34,7 +35,7 @@ public class VerifyPasswordResetRequestAction extends BasePasswordManagementActi
 
     private final CasConfigurationProperties casProperties;
 
-    private final PasswordManagementService passwordManagementService;
+    private final PasswordManagementServiceProvider passwordManagementServiceProvider;
 
     private final CentralAuthenticationService centralAuthenticationService;
 
@@ -54,6 +55,7 @@ public class VerifyPasswordResetRequestAction extends BasePasswordManagementActi
             TicketState.class.cast(passwordResetTicket).update();
 
             val token = passwordResetTicket.getProperties().get(PasswordManagementWebflowUtils.FLOWSCOPE_PARAMETER_NAME_TOKEN).toString();
+            var passwordManagementService = getPasswordManagementService(requestContext);
             val username = passwordManagementService.parseToken(token);
 
             val query = PasswordManagementQuery.builder().username(username).build();
@@ -87,5 +89,10 @@ public class VerifyPasswordResetRequestAction extends BasePasswordManagementActi
                 centralAuthenticationService.deleteTicket(passwordResetTicket);
             }
         }
+    }
+
+    private PasswordManagementService getPasswordManagementService(RequestContext requestContext) {
+        final var registeredService = WebUtils.getRegisteredService(requestContext);
+        return passwordManagementServiceProvider.getPasswordChangeService(registeredService);
     }
 }

--- a/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/config/PasswordManagementConfiguration.java
+++ b/support/cas-server-support-pm/src/main/java/org/apereo/cas/pm/config/PasswordManagementConfiguration.java
@@ -10,8 +10,10 @@ import org.apereo.cas.notifications.CommunicationsManager;
 import org.apereo.cas.pm.DefaultPasswordValidationService;
 import org.apereo.cas.pm.PasswordHistoryService;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.PasswordResetTokenCipherExecutor;
 import org.apereo.cas.pm.PasswordValidationService;
+import org.apereo.cas.pm.impl.DefaultPasswordManagementServiceProvider;
 import org.apereo.cas.pm.impl.GroovyResourcePasswordManagementService;
 import org.apereo.cas.pm.impl.JsonResourcePasswordManagementService;
 import org.apereo.cas.pm.impl.NoOpPasswordManagementService;
@@ -37,6 +39,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.stream.Collectors;
 
 /**
  * This is {@link PasswordManagementConfiguration}.
@@ -93,6 +97,16 @@ public class PasswordManagementConfiguration implements InitializingBean {
             return new InMemoryPasswordHistoryService();
         }
         return new AmnesiacPasswordHistoryService();
+    }
+
+    @Bean
+    @Autowired
+    @ConditionalOnMissingBean(name = "passwordChangeServiceProvider")
+    public PasswordManagementServiceProvider passwordChangeServiceProvider(ObjectProvider<PasswordManagementService> passwordManagementServices) {
+        return new DefaultPasswordManagementServiceProvider(
+                passwordManagementServices.stream().collect(Collectors.toUnmodifiableList()),
+                casProperties,
+                passwordManagementCipherExecutor());
     }
 
     @ConditionalOnMissingBean(name = PasswordManagementService.DEFAULT_BEAN_NAME)

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/DefaultPasswordManagementServiceProviderTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/DefaultPasswordManagementServiceProviderTests.java
@@ -1,0 +1,39 @@
+package org.apereo.cas.pm.impl;
+
+import org.apereo.cas.config.CasCoreNotificationsConfiguration;
+import org.apereo.cas.config.CasCoreUtilConfiguration;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
+import org.apereo.cas.pm.config.PasswordManagementConfiguration;
+import org.apereo.cas.services.RegexRegisteredService;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(classes = {
+        RefreshAutoConfiguration.class,
+        PasswordManagementConfiguration.class,
+        MailSenderAutoConfiguration.class,
+        CasCoreNotificationsConfiguration.class,
+        CasCoreUtilConfiguration.class
+}, properties = {
+        "cas.authn.pm.core.enabled=true",
+        "cas.authn.pm.history.core.enabled=true",
+        "cas.authn.pm.core.policy-pattern=^Th!.+{8,10}"
+})
+@Tag("PasswordOps")
+class DefaultPasswordManagementServiceProviderTests {
+
+    @Autowired
+    private PasswordManagementServiceProvider passwordManagementServiceProvider;
+
+    @Test
+    void verifyReturnService() {
+        assertNotNull(passwordManagementServiceProvider.getPasswordChangeService(new RegexRegisteredService()));
+    }
+}

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/GroovyResourcePasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/GroovyResourcePasswordManagementServiceTests.java
@@ -6,7 +6,9 @@ import org.apereo.cas.config.CasCoreUtilConfiguration;
 import org.apereo.cas.pm.PasswordChangeRequest;
 import org.apereo.cas.pm.PasswordManagementQuery;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.config.PasswordManagementConfiguration;
+import org.apereo.cas.services.RegexRegisteredService;
 
 import lombok.val;
 import org.junit.jupiter.api.Tag;
@@ -17,7 +19,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is {@link GroovyResourcePasswordManagementServiceTests}.
@@ -26,13 +31,13 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 6.1.0
  */
 @SpringBootTest(classes = {
-    RefreshAutoConfiguration.class,
-    PasswordManagementConfiguration.class,
-    CasCoreNotificationsConfiguration.class,
-    CasCoreUtilConfiguration.class
+        RefreshAutoConfiguration.class,
+        PasswordManagementConfiguration.class,
+        CasCoreNotificationsConfiguration.class,
+        CasCoreUtilConfiguration.class
 }, properties = {
-    "cas.authn.pm.core.enabled=true",
-    "cas.authn.pm.groovy.location=classpath:/GroovyPasswordMgmt.groovy"
+        "cas.authn.pm.core.enabled=true",
+        "cas.authn.pm.groovy.location=classpath:/GroovyPasswordMgmt.groovy"
 })
 @Tag("Groovy")
 public class GroovyResourcePasswordManagementServiceTests {
@@ -40,6 +45,14 @@ public class GroovyResourcePasswordManagementServiceTests {
     @Autowired
     @Qualifier(PasswordManagementService.DEFAULT_BEAN_NAME)
     private PasswordManagementService passwordChangeService;
+
+    @Autowired
+    private PasswordManagementServiceProvider passwordManagementServiceProvider;
+
+    @Test
+    void verifyReturnService() {
+        assertNotNull(passwordManagementServiceProvider.getPasswordChangeService(new RegexRegisteredService()));
+    }
 
     @Test
     public void verifyFindEmail() {

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/impl/JsonResourcePasswordManagementServiceTests.java
@@ -24,8 +24,10 @@ import org.apereo.cas.logout.config.CasCoreLogoutConfiguration;
 import org.apereo.cas.pm.PasswordChangeRequest;
 import org.apereo.cas.pm.PasswordManagementQuery;
 import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.PasswordManagementServiceProvider;
 import org.apereo.cas.pm.PasswordValidationService;
 import org.apereo.cas.pm.config.PasswordManagementConfiguration;
+import org.apereo.cas.services.RegexRegisteredService;
 
 import lombok.val;
 import org.junit.jupiter.api.Tag;
@@ -39,7 +41,12 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This is {@link JsonResourcePasswordManagementServiceTests}.
@@ -79,6 +86,7 @@ import static org.junit.jupiter.api.Assertions.*;
     })
 @Tag("FileSystem")
 public class JsonResourcePasswordManagementServiceTests {
+
     @Autowired
     @Qualifier(PasswordManagementService.DEFAULT_BEAN_NAME)
     private PasswordManagementService passwordChangeService;
@@ -86,6 +94,14 @@ public class JsonResourcePasswordManagementServiceTests {
     @Autowired
     @Qualifier("passwordValidationService")
     private PasswordValidationService passwordValidationService;
+
+    @Autowired
+    private PasswordManagementServiceProvider passwordManagementServiceProvider;
+
+    @Test
+    void verifyReturnService() {
+        assertNotNull(passwordManagementServiceProvider.getPasswordChangeService(new RegexRegisteredService()));
+    }
 
     @Test
     public void verifyUserEmailCanBeFound() {


### PR DESCRIPTION
At the moment, we need to be able to configure what password manager is used for a given website. In the current solution, we have no influence on it. There is always one to load. The current PR is preparing space for further work and the configuration of this in RegisteredService. 

We already use similar implementation but in the custom way. We need  upgrade our instance to 6.4.x for the new things that we want too use. 

So i decide to move this implementation to core.