### PR TITLE
fix RedisTicketRegistry.stream() problem

### DIFF
--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -95,12 +95,17 @@ public class RedisTicketRegistry extends AbstractTicketRegistry {
     public Stream<? extends Ticket> stream() {
         return getKeysStream()
             .map(redisKey -> {
-                val ticket = this.client.boundValueOps(redisKey).get();
-                if (ticket == null) {
-                    this.client.delete(redisKey);
+                try {
+                    val ticket = this.client.boundValueOps(redisKey).get();
+                    if (ticket == null) {
+                        this.client.delete(redisKey);
+                        return null;
+                    }
+                    return ticket;
+                } catch (final Exception e) {
+                    LOGGER.debug("Failed fetching [{}]. Message is: [{}]", redisKey, e.getMessage());
                     return null;
                 }
-                return ticket;
             })
             .filter(Objects::nonNull)
             .map(this::decodeTicket)

--- a/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/config/RedisTicketRegistryTestConfiguration.java
+++ b/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/config/RedisTicketRegistryTestConfiguration.java
@@ -1,0 +1,31 @@
+package org.apereo.cas.config;
+
+import org.apereo.cas.redis.core.RedisObjectFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+/**
+ * This is {@link RedisTicketRegistryTestConfiguration}.
+ *
+ * @author Fireborn Z
+ * @since 6.5.0
+ */
+@ConditionalOnBean(name = "redisTicketConnectionFactory")
+@Configuration(value = "RedisTicketRegistryTestConfiguration")
+public class RedisTicketRegistryTestConfiguration {
+    @Bean(name = {"stringRedisTemplate"})
+    @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+    @ConditionalOnMissingBean(name = "stringRedisTemplate")
+    public RedisTemplate<String, String> stringRedisTemplate(
+            @Qualifier("redisTicketConnectionFactory")
+            final RedisConnectionFactory redisTicketConnectionFactory) {
+        return RedisObjectFactory.newRedisTemplate(redisTicketConnectionFactory);
+    }
+}

--- a/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/BaseRedisSentinelTicketRegistryTests.java
+++ b/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/BaseRedisSentinelTicketRegistryTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.ticket.registry;
 
 import org.apereo.cas.config.RedisTicketRegistryConfiguration;
+import org.apereo.cas.config.RedisTicketRegistryTestConfiguration;
 import org.apereo.cas.ticket.Ticket;
 
 import lombok.Getter;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @SpringBootTest(classes = {
     RedisTicketRegistryConfiguration.class,
+    RedisTicketRegistryTestConfiguration.class,
     BaseTicketRegistryTests.SharedTestConfiguration.class
 })
 @EnableTransactionManagement
@@ -28,6 +30,10 @@ public abstract class BaseRedisSentinelTicketRegistryTests extends BaseTicketReg
     @Autowired
     @Qualifier("ticketRedisTemplate")
     protected RedisTemplate<String, Ticket> ticketRedisTemplate;
+
+    @Autowired
+    @Qualifier("stringRedisTemplate")
+    private RedisTemplate<String, String> stringRedisTemplate;
 
     @Autowired
     @Qualifier(TicketRegistry.BEAN_NAME)


### PR DESCRIPTION
This is a problem in our production environment. I use RedisTicketRegistry. However, for some reason, the RedisTicketRegistry keeps throwing a deserialization failure when featching a specific Ticket (This error data may be caused by other code problems). As a result, all methods invoked to RedisTicketRegistry.stream() throws that exception, affecting many core functions such as authentication and TGT cleaner.

My suggestion is adding a ```try-catch``` protection to improve the robustness in some extreme scenarios.

Test case result before this issue fixed:
```
RedisServerTicketRegistryTests > verifyStreamWithFaultTicketInjection() > org.apereo.cas.ticket.registry.RedisServerTicketRegistryTests.verifyStreamWithFaultTicketInjection()[1] FAILED
    java.lang.ClassCastException: class java.lang.String cannot be cast to class org.apereo.cas.ticket.Ticket (java.lang.String is in module java.base of loader 'bootstrap'; org.apereo.cas.ticket.Ticket is in unnamed module of loader 'app')
        at org.apereo.cas.ticket.registry.RedisTicketRegistry.lambda$stream$0(RedisTicketRegistry.java:98)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1621)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.ReduceOps$5.evaluateSequential(ReduceOps.java:257)
        at java.base/java.util.stream.ReduceOps$5.evaluateSequential(ReduceOps.java:248)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.count(ReferencePipeline.java:605)
        at org.apereo.cas.ticket.registry.RedisServerTicketRegistryTests.verifyStreamWithFaultTicketInjection(RedisServerTicketRegistryTests.java:98)
```