### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ disruptorVersion=3.4.4
 inspektrVersion=1.8.17.GA
 sentryRavenVersion=8.0.3
 splunkLoggingVersion=1.11.2
-log4jVersion=2.16.0
+log4jVersion=2.17.0
 logbackVersion=1.2.9
 ###############################
 # Spring versions


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105