### PR TITLE
pac4j >= 5.1.4 requires nimbus oidc >= 9.14

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -451,7 +451,7 @@ textMagicVersion=2.0.1423
 # JWT versions
 ###############################
 nimbusJoseVersion=9.12.1
-nimbusOidcVersion=9.13
+nimbusOidcVersion=9.14
 jose4jVersion=0.7.9
 
 ###############################


### PR DESCRIPTION
Cf
https://github.com/pac4j/pac4j/pull/1986
https://github.com/pac4j/pac4j/commit/bb241edc86e995715ec7a40efcf1c6b7ca4185a8
https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/commits/38f6959d698313b1b88993ae1f02d7b6f72fa5a8

