### PR TITLE
Update addCookieHeaderToResponse method from private to protected

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
@@ -185,7 +185,7 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator implements 
         return c;
     }
 
-    private Cookie addCookieHeaderToResponse(final Cookie cookie,
+    protected Cookie addCookieHeaderToResponse(final Cookie cookie,
                                              final HttpServletResponse response) {
         val builder = new StringBuilder();
         builder.append(String.format("%s=%s;", cookie.getName(), cookie.getValue()));


### PR DESCRIPTION
## Brief description of changes applied

Change the `addCookieHeaderToResponse` method from `private` to `protected`

Which will allow customization on `samesite=none` for compatibility for legacy browser 

## Reason

* Some of our cookie need to be configured as `samesite=none`. 
* However with the current CAS implementation in `addCookieHeaderToResponse` method. 
  * It will break some legacy browser (e.g. Chrome 51 to Chrome 66, iOS 12, etc) so they cannot login
  * https://www.chromium.org/updates/same-site/incompatible-clients
* I understand that CAS should not be supporting legacy browser by default, so I don't think it is proper to submit our customization. 
* However I would like this `addCookieHeaderToResponse` to be set to `protected` so we can add in our customization for support of legacy browser ourselves.

Many thanks.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
