### PR TITLE
Fix bootstrap margins - backport to CAS 6.4

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/acceptto/casAccepttoRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/acceptto/casAccepttoRegistrationView.html
@@ -25,7 +25,7 @@
             </ol>
 
             <div class="d-flex justify-content-center">
-                <a href="https://itunes.apple.com/us/app/acceptto-itsme/id893534370?mt=8" target="_blank" class="mr-2">
+                <a href="https://itunes.apple.com/us/app/acceptto-itsme/id893534370?mt=8" target="_blank" class="me-2">
                     <img src="https://s3-us-west-2.amazonaws.com/acceptto-log-and-graphics/Asset+14.png" alt="App Store"
                         title="App Store" width="151.25" height="50">
                 </a>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/admin/casAdminLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/admin/casAdminLoginView.html
@@ -14,7 +14,7 @@
     <div layout:fragment="content" class="row">
         <section class="col-lg-6 offset-lg-3 col-xs-12">
             <div class="card-header text-center d-flex justify-content-center mb-4">
-                <h2 th:text="#{cas.login.pagetitle}" class="mr-2">Login</h2>
+                <h2 th:text="#{cas.login.pagetitle}" class="me-2">Login</h2>
                 <i class="mdi mdi-shield-lock-outline"></i>
             </div>
             <form name="fm1" th:action="@{/adminlogin}" method="post">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/aup/casAcceptableUsagePolicyView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/aup/casAcceptableUsagePolicyView.html
@@ -31,7 +31,7 @@
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
                 <input type="hidden" name="_eventId" value="submit"/>
                 <div class="form-actions d-flex">
-                    <button class="mdc-button mdc-button--raised mr-2"
+                    <button class="mdc-button mdc-button--raised me-2"
                             name="submit"
                             id="aupSubmit"
                             accesskey="s">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/consent/casConsentView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/consent/casConsentView.html
@@ -184,7 +184,7 @@
                         Show the consent screen, as a reminder, in the event that there is no change to the collection of attributes released to {0}.
                     </p>
                     <div class="d-flex mt-2">
-                        <div class="mr-2">
+                        <div class="me-2">
 
                             <label for="reminder" class="mdc-text-field mdc-text-field--outlined">
                                 <input class="mdc-text-field__input"
@@ -241,7 +241,7 @@
             </section>
             <hr class="my-4"/>
             <section class="cas-section form-actions mt-4 d-flex justify-content-center">
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                         name="confirm"
                         id="confirm"
                         accesskey="l"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnStopWebflow.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnStopWebflow.html
@@ -19,7 +19,7 @@
                     cause of the issue.</p>
 
                 <p>
-                    <i class="mdi mdi-alert mr-2"></i>
+                    <i class="mdi mdi-alert me-2"></i>
                     <span th:if="${rootCauseException}" th:text="#{${'screen.pac4j.authn.' + rootCauseException.class.simpleName}}">
                       Authentication response provided to CAS by the external identity provider cannot be accepted.</span>
                     <span th:unless="${rootCauseException}" th:text="#{screen.pac4j.authn.unknown}">
@@ -56,16 +56,16 @@
             </div>
             <br/>
             <div class="d-flex">
-                <a id="loginLink" class="mdc-button mdc-button--raised mr-2" th:href="@{/login}">
+                <a id="loginLink" class="mdc-button mdc-button--raised me-2" th:href="@{/login}">
                     <span class="mdc-button__label" th:text="#{screen.pac4j.unauthz.login}">Back to CAS</span>
                 </a>
-                <a id="appLink" class="mdc-button mdc-button--raised mr-2" th:href="${service}">
+                <a id="appLink" class="mdc-button mdc-button--raised me-2" th:href="${service}">
                     <span class="mdc-button__label" th:text="#{screen.pac4j.unauthz.gotoapp}">Goto Application</span>
                 </a>
                 <form method="post" id="fm1">
                     <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
                     <input type="hidden" name="_eventId" value="retry"/>
-                    <button id="retryButton" class="mdc-button mdc-button--raised mr-2" name="retry" accesskey="r">
+                    <button id="retryButton" class="mdc-button mdc-button--raised me-2" name="retry" accesskey="r">
                         <span class="mdc-button__label" th:text="#{screen.pac4j.button.retry}">Try Again</span>
                     </button>
                 </form>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/forgot-username/casForgotUsernameSendInfoView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/forgot-username/casForgotUsernameSendInfoView.html
@@ -57,7 +57,7 @@
 
                             <div class="mdc-card__actions p-4">
                                 <button
-                                    class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button mr-2"
+                                    class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button me-2"
                                     accesskey="s" th:value="#{screen.pm.button.submit}" type="submit" value="SUBMIT">
                                     <span class="mdc-button__label" th:text="#{screen.pm.button.submit}">Submit</span>
                                 </button>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/footer.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/footer.html
@@ -1,5 +1,5 @@
 <footer class="py-4 d-flex justify-content-center cas-footer">
-    <span id="copyright" th:utext="#{copyright}" class="mr-2 d-inline-block">Copyright Date Apereo, Inc</span>
-    <span class="mr-2 d-inline-block">Powered by <a href="https://github.com/apereo/cas">Apereo CAS</a></span>
+    <span id="copyright" th:utext="#{copyright}" class="me-2 d-inline-block">Copyright Date Apereo, Inc</span>
+    <span class="me-2 d-inline-block">Powered by <a href="https://github.com/apereo/cas">Apereo CAS</a></span>
     <code class="version" th:text="${T(org.apereo.cas.util.CasVersion).getVersion() + ' ' + T(org.apereo.cas.util.CasVersion).getDateTime()}"></code>
 </footer>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pwdupdateform.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pwdupdateform.html
@@ -141,7 +141,7 @@
             <div class="cas-field">
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
                 <input type="hidden" name="_eventId" value="submit"/>
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                         name="submit"
                         accesskey="s"
                         th:value="#{screen.pm.button.submit}"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/webAuthnLogin.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/webAuthnLogin.html
@@ -92,7 +92,7 @@
                 </div>
             </div>
             <div class="d-flex justify-content-center flex-column align-items-center">
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                         name="authnButton" id="authnButton" accesskey="a" type="button">
                     <i class="mdi mdi-fingerprint"></i>
                     <span id="authnButtonText" class="mdc-button__label"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorConfirmRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorConfirmRegistrationView.html
@@ -20,13 +20,13 @@
                         <h4 class="d-flex align-items-center">
                             <ul style="list-style: none">
                                 <code>
-                                <li><i class="mdi mdi-laptop mr-2"></i>
+                                <li><i class="mdi mdi-laptop me-2"></i>
                                     <span th:id="${'name-' + device.name}" th:utext="${device.name}">Device Name</span>
                                 </li>
-                                <li><i class="mdi mdi-account-clock mr-2"></i>
+                                <li><i class="mdi mdi-account-clock me-2"></i>
                                     <span th:utext="${device.registrationDate}">Device Date</span>
                                 </li>
-                                <li><i class="mdi mdi-account-details mr-2"></i>
+                                <li><i class="mdi mdi-account-details me-2"></i>
                                     <span th:id="${'id-' + device.id}" th:utext="${device.id}">Device Id</span>
                                 </li>
                                 </code>
@@ -53,7 +53,7 @@
                 <p th:utext="#{screen.authentication.gauth.reganotherdevice}"></p>
                 <input type="hidden" name="_eventId_register" value="Register"/>
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
-                <button id="register" class="mdc-button mdc-button--raised mr-2" name="register" accesskey="r" value="Register">
+                <button id="register" class="mdc-button mdc-button--raised me-2" name="register" accesskey="r" value="Register">
                     <span class="mdc-button__label" th:text="#{screen.welcome.button.register}">Register</span>
                 </button>
             </form>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorLoginView.html
@@ -82,7 +82,7 @@
             <form method="post" id="fm3">
                 <input type="hidden" name="_eventId_select" value="select"/>
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
-                <button id="selectDeviceButton" class="mdc-button mdc-button--raised mr-2" accesskey="s">
+                <button id="selectDeviceButton" class="mdc-button mdc-button--raised me-2" accesskey="s">
                     <span class="mdc-button__label" th:text="#{screen.authentication.gauth.selectdevice}">Select Device</span>
                 </button>
             </form>
@@ -94,7 +94,7 @@
             <p th:utext="#{screen.authentication.gauth.reganotherdevice}"></p>
             <input type="hidden" name="_eventId_register" value="register"/>
             <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
-            <button class="mdc-button mdc-button--raised mr-2" id="register" type="submit" name="register" accesskey="r" value="Register">
+            <button class="mdc-button mdc-button--raised me-2" id="register" type="submit" name="register" accesskey="r" value="Register">
                 <span class="mdc-button__label" th:text="#{screen.welcome.button.register}">Register</span>
             </button>
         </form>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
@@ -95,7 +95,7 @@
                             </div>
                         </div>
                         <footer class="mdc-dialog__actions">
-                            <button class="mdc-button mdc-button--raised mr-2" name="registerButton" id="registerButton">
+                            <button class="mdc-button mdc-button--raised me-2" name="registerButton" id="registerButton">
                                 <span class="mdc-button__label" th:text="#{screen.welcome.button.register}">Register</span>
                             </button>
                             <button type="button" class="mdc-button mdc-button--outlined"
@@ -162,10 +162,10 @@
         </table>
         <div class="d-flex flex-column align-items-center">
             <div class="d-flex justify-content-center">
-                <button class="mdc-button mdc-button--raised mr-2" name="confirm" id="confirm" accesskey="f" value="Confirm">
+                <button class="mdc-button mdc-button--raised me-2" name="confirm" id="confirm" accesskey="f" value="Confirm">
                     <span class="mdc-button__label" th:text="#{screen.welcome.button.confirm}">Confirm</span>
                 </button>
-                <button class="mdc-button mdc-button--raised mr-2" name="print" accesskey="p" type="button"
+                <button class="mdc-button mdc-button--raised me-2" name="print" accesskey="p" type="button"
                         onclick="window.print();">
                     <span class="mdc-button__label" th:text="#{screen.welcome.button.print}">Print</span>
                 </button>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
@@ -39,7 +39,7 @@
             <div class="alert alert-info">
                 <p id="interruptMessage" th:utext="${interrupt.message}">interrupt.message</p>
                 <div id="interruptLinks" th:if="${interrupt.links}">
-                    <a class="mdc-button mr-2"
+                    <a class="mdc-button me-2"
                        th:each="link : ${interrupt.links}"
                        th:text="${link.key}"
                        th:href="${link.value}">
@@ -76,7 +76,7 @@
             <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
             <input type="hidden" name="_eventId" value="proceed" />
             <div class="form-actions d-flex">
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                     name="proceed"
                     id="proceed"
                     type="submit"
@@ -85,7 +85,7 @@
                 </button>
 
                 <span th:if="${interruptTriggerMode == 'AFTER_AUTHENTICATION'}">
-                    <a class="mdc-button mdc-button--raised mr-2" id="login" name="login" th:href="${service?.id} ?: @{/login}">
+                    <a class="mdc-button mdc-button--raised me-2" id="login" name="login" th:href="${service?.id} ?: @{/login}">
                         <span class="mdc-button__label" th:text="#{screen.error.page.loginagain}">Login Again</span>
                     </a>
                 </span>
@@ -93,7 +93,7 @@
         </form>
 
         <div th:if="${interrupt.block}">
-            <a class="mdc-button mdc-button--raised mr-2" id="cancel" name="cancel" th:href="@{/login}">
+            <a class="mdc-button mdc-button--raised me-2" id="cancel" name="cancel" th:href="@{/login}">
 
                 <span th:if="${interruptTriggerMode == 'AFTER_AUTHENTICATION'}" class="mdc-button__label"
                       th:text="#{screen.interrupt.btn.cancel}">Cancel</span>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginMessageView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginMessageView.html
@@ -18,7 +18,7 @@
                </li>
             </ul>
             <div class="cas-field d-flex">
-               <form method="post" id="form" class="mr-2" th:action="@{/login}">
+               <form method="post" id="form" class="me-2" th:action="@{/login}">
                   <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
                   <input type="hidden" name="_eventId" value="proceed" />
                   <button class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa-trusted-devices/casMfaRegisterDeviceView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa-trusted-devices/casMfaRegisterDeviceView.html
@@ -41,7 +41,7 @@
 
                 <div><p>How long should we remember this device?</p></div>
                 <div class="d-flex mt-2">
-                    <div id="expirationField" class="mr-2" style="display:none">
+                    <div id="expirationField" class="me-2" style="display:none">
                         <label for="expiration" class="mdc-text-field mdc-text-field--outlined">
                             <input class="mdc-text-field__input"
                                    type="number"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casCompositeMfaProviderSelectionView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casCompositeMfaProviderSelectionView.html
@@ -18,7 +18,7 @@
                 <div th:id="${provider}" th:each="provider: ${mfaSelectableProviders}" class="border-bottom py-4">
                     <form name="fm1" method="post" th:action="@{/login}">
                         <h4 class="d-flex align-items-center">
-                            <i class="mdi mdi-laptop mr-2"></i>
+                            <i class="mdi mdi-laptop me-2"></i>
                             <span th:utext="#{'cas.mfa.providerselection.' + ${provider}}">Provider name goes
                                 here</span>
                         </h4>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casPasswordUpdateSuccessView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casPasswordUpdateSuccessView.html
@@ -18,7 +18,7 @@
             <form method="post" id="form" class="fm-v clearfix" th:action="@{/login}">
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
                 <input type="hidden" name="_eventId" value="proceed" />
-                <button class="mdc-button mdc-button--raised mr-2" name="continue" accesskey="l" type="submit"
+                <button class="mdc-button mdc-button--raised me-2" name="continue" accesskey="l" type="submit"
                     value="Login">
                     <span class="mdc-button__label" th:text="#{screen.welcome.button.login}">Log In</span>
                 </button>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casResetPasswordVerifyQuestionsView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casResetPasswordVerifyQuestionsView.html
@@ -57,7 +57,7 @@
                                     <td class="mdc-data-table__cell"></td>
                                     <td class="mdc-data-table__cell">
                                         <button
-                                            class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button mr-2"
+                                            class="mdc-button mdc-button--raised mdc-card__action mdc-card__action--button me-2"
                                             accesskey="s"
                                             th:attr="data-processing-text=#{screen.welcome.button.loginwip}"
                                             th:value="#{screen.pm.button.submit}" type="submit" value="SUBMIT">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/protocol/oidc/confirm.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/protocol/oidc/confirm.html
@@ -15,7 +15,7 @@
     </div>
 
     <div id="dynamic" th:if="${dynamic}" class="my-2 banner banner-warning d-flex align-items-center">
-        <i class="mdi mdi-alert mr-2"></i>
+        <i class="mdi mdi-alert me-2"></i>
         <strong th:utext="#{screen.oidc.confirm.dynamic(${dynamicTime})}"/>
     </div>
     <div id="scopes" th:unless="${#sets.isEmpty(scopes)}">
@@ -59,7 +59,7 @@
     <h3 class="strong border-bottom pb-2 mt-4"
         th:text="#{screen.oauth.confirm.message(${serviceName})}"/>
     <div class="d-flex">
-        <a class="mdc-button mdc-button--raised mr-2"
+        <a class="mdc-button mdc-button--raised me-2"
            id="allow"
            name="allow"
            th:href="@{${callbackUrl}}">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/simple-mfa/casSimpleMfaLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/simple-mfa/casSimpleMfaLoginView.html
@@ -62,7 +62,7 @@
                 </button>
             </section>
             <div class="d-flex">
-                <button class="mdc-button mdc-button--raised mr-2" accesskey="s">
+                <button class="mdc-button mdc-button--raised me-2" accesskey="s">
                     <span class="mdc-button__label" th:text="#{screen.welcome.button.login}">Login</span>
                 </button>
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/surrogate/casSurrogateAuthnListView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/surrogate/casSurrogateAuthnListView.html
@@ -34,7 +34,7 @@
                 <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
                 <input type="hidden" name="_eventId" value="submit" />
                 <div class="d-flex">
-                    <button class="mdc-button mdc-button--raised mr-2" id="submit" name="submit" accesskey="l"
+                    <button class="mdc-button mdc-button--raised me-2" id="submit" name="submit" accesskey="l"
                         th:value="#{screen.welcome.button.login}" value="Login">
                         <span class="mdc-button__label" th:text="#{screen.welcome.button.login}">Login</span>
                     </button>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/webauthn/casWebAuthnRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/webauthn/casWebAuthnRegistrationView.html
@@ -104,7 +104,7 @@
                     </div>
                 </section>
 
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                         name="registerButton" id="registerButton" accesskey="r" type="button">
                     <span class="mdc-button__label" th:text="#{screen.welcome.button.register}">Register Device</span>
                 </button>
@@ -118,7 +118,7 @@
                         memory on the authenticator and not on the CAS server.
                     </p>
                 </section>
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                         name="registerDiscoverableCredentialButton"
                         id="registerDiscoverableCredentialButton" accesskey="d" type="button">
                         <span class="mdc-button__label"
@@ -126,13 +126,13 @@
                 </button>
 
                 <!--
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                         id="logoutButton" disabled="disabled" name="logout"
                         accesskey="l" type="button" onclick="javascript:logout();">
                 <span class="mdc-button__label"
                       th:text="#{screen.welcome.button.logout}">Logout</span>
                 </button>
-                <button class="mdc-button mdc-button--raised mr-2"
+                <button class="mdc-button mdc-button--raised me-2"
                         id="deregisterButton" name="deregister"
                         accesskey="d" type="button" onclick="javascript:deregister();">
                 <span class="mdc-button__label"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/yubikey/casYubiKeyLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/yubikey/casYubiKeyLoginView.html
@@ -71,7 +71,7 @@
             <p th:utext="#{screen.authentication.yubikey.reganotherdevice}"></p>
             <input type="hidden" name="_eventId_register" value="register"/>
             <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
-            <button class="mdc-button mdc-button--raised mr-2" type="submit" name="register" accesskey="r" value="Register">
+            <button class="mdc-button mdc-button--raised me-2" type="submit" name="register" accesskey="r" value="Register">
                 <span class="mdc-button__label" th:text="#{screen.welcome.button.register}">Register</span>
             </button>
         </form>


### PR DESCRIPTION
Since Bootstrap 5.x, margin-right syntax moved from mr- to me- , cf. https://getbootstrap.com/docs/5.1/utilities/spacing/#margin-and-padding)