### PR TITLE
Enable static resources versioning

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/application.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/application.properties
@@ -195,3 +195,8 @@ spring.jpa.open-in-view=false
 # Default strategy for matching request paths against
 # registered Spring MVC handler mappings
 spring.mvc.pathmatch.matching-strategy=ant-path-matcher
+
+##
+# Static resources hash-based versioning
+spring.web.resources.chain.strategy.content.enabled=true
+spring.web.resources.chain.strategy.content.paths=/images/**,/css/**,/js/**


### PR DESCRIPTION
I'm not sure, but it seems to me that it would be good idea to enable by default the static resources versioning.

The configuration is described in:
https://docs.spring.io/spring-boot/docs/current/reference/html/web.html#web.servlet.spring-mvc.static-content
