### PR TITLE
Ensure @Async annotations used along with interface

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -164,6 +164,7 @@ jobs:
       fail-fast: false
       matrix:
         check:
+          - CheckAsyncAnnotationInInterface
           - CheckDuplicateGradleConfiguration
           - CheckDuplicateTestConfiguration
           - CheckMissingClassInTestsSuite

--- a/ci/checks/CheckAsyncAnnotationInInterface.java
+++ b/ci/checks/CheckAsyncAnnotationInInterface.java
@@ -1,0 +1,49 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This is {@link CheckAsyncAnnotationInInterface}.
+ * Fail build if Async annotation is not in an interface.
+ * This ensures interface exists for Async classes so Spring can use JDK proxy instead of cglib proxy.
+ * @author Hal Deadman
+ * @since 6.5.0
+ */
+public class CheckAsyncAnnotationInInterface {
+    public static void main(final String[] args) throws Exception {
+        checkPattern(args[0]);
+    }
+
+    private static void print(final String message, final Object... args) {
+        //CHECKSTYLE:OFF
+        System.out.printf(message, args);
+        System.out.println();
+        //CHECKSTYLE:ON
+    }
+
+    private static String readFile(final Path file) {
+        try {
+            return Files.readString(file);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    protected static void checkPattern(final String arg) throws IOException {
+        var failBuild = new AtomicBoolean(false);
+        Files.walk(Paths.get(arg))
+            .filter(file -> Files.isRegularFile(file)
+                && file.toFile().getPath().matches(".*\\.java")
+                && !file.toFile().getPath().matches(".*Tests\\.java")
+                && readFile(file).contains("@Async")
+                && !readFile(file).contains("public interface"))
+            .forEach(file -> {
+                print("%s must have an interface that has Async annotation in interface", file);
+                failBuild.set(true);
+            });
+        if (failBuild.get()) {
+            System.exit(1);
+        }
+    }
+}

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasAuthenticationEventListener.java
@@ -17,8 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.common.web.ClientInfoHolder;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 import java.time.Instant;
 
@@ -58,8 +56,6 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleCasTicketGrantingTicketCreatedEvent(final CasTicketGrantingTicketCreatedEvent event) {
         if (this.casEventRepository != null) {
             val dto = prepareCasEvent(event);
@@ -71,8 +67,6 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleCasTicketGrantingTicketDeletedEvent(final CasTicketGrantingTicketDestroyedEvent event) {
         if (this.casEventRepository != null) {
             val dto = prepareCasEvent(event);
@@ -84,8 +78,6 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleCasAuthenticationTransactionFailureEvent(final CasAuthenticationTransactionFailureEvent event) {
         if (this.casEventRepository != null) {
             val dto = prepareCasEvent(event);
@@ -96,8 +88,6 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleCasAuthenticationPolicyFailureEvent(final CasAuthenticationPolicyFailureEvent event) {
         if (this.casEventRepository != null) {
             val dto = prepareCasEvent(event);
@@ -108,8 +98,6 @@ public class DefaultCasAuthenticationEventListener implements DefaultCasEventLis
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleCasRiskyAuthenticationDetectedEvent(final CasRiskyAuthenticationDetectedEvent event) {
         if (this.casEventRepository != null) {
             val dto = prepareCasEvent(event);

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultCasEventListener.java
@@ -6,6 +6,8 @@ import org.apereo.cas.support.events.authentication.adaptive.CasRiskyAuthenticat
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEvent;
 import org.apereo.cas.util.spring.CasEventListener;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultCasAuthenticationEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -19,6 +21,8 @@ public interface DefaultCasEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasTicketGrantingTicketCreatedEvent(CasTicketGrantingTicketCreatedEvent event);
 
     /**
@@ -26,6 +30,8 @@ public interface DefaultCasEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasTicketGrantingTicketDeletedEvent(CasTicketGrantingTicketDestroyedEvent event);
 
     /**
@@ -33,6 +39,8 @@ public interface DefaultCasEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasAuthenticationTransactionFailureEvent(CasAuthenticationTransactionFailureEvent event);
 
     /**
@@ -40,6 +48,8 @@ public interface DefaultCasEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasAuthenticationPolicyFailureEvent(CasAuthenticationPolicyFailureEvent event);
 
     /**
@@ -47,5 +57,7 @@ public interface DefaultCasEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasRiskyAuthenticationDetectedEvent(CasRiskyAuthenticationDetectedEvent event);
 }

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultLoggingCasEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/DefaultLoggingCasEventListener.java
@@ -10,8 +10,6 @@ import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEven
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 import static org.apereo.cas.util.serialization.MessageSanitizationUtils.*;
 
@@ -45,8 +43,6 @@ public class DefaultLoggingCasEventListener implements LoggingCasEventListener {
                                                    + "For principal: [{}]\nWith released attributes: [{}]";
 
     @Override
-    @EventListener
-    @Async
     public void logTicketGrantingTicketCreatedEvent(final CasTicketGrantingTicketCreatedEvent e) {
         val tgtId = sanitize(e.getId());
         LOGGER.debug(GRANTED_TGT_MSG,
@@ -58,22 +54,16 @@ public class DefaultLoggingCasEventListener implements LoggingCasEventListener {
     }
 
     @Override
-    @EventListener
-    @Async
     public void logAuthenticationTransactionFailureEvent(final CasAuthenticationTransactionFailureEvent e) {
         LOGGER.debug(AUTHN_TX_FAIL_MSG, e.getCredential(), e.getFailures());
     }
 
     @Override
-    @EventListener
-    @Async
     public void logAuthenticationPrincipalResolvedEvent(final CasAuthenticationPrincipalResolvedEvent e) {
         LOGGER.debug(PRINCIPAL_RESOLVED_MSG, e.getPrincipal().getId(), e.getPrincipal().getAttributes());
     }
 
     @Override
-    @EventListener
-    @Async
     public void logTicketGrantingTicketDestroyedEvent(final CasTicketGrantingTicketDestroyedEvent e) {
         val tgtId = sanitize(e.getId());
         LOGGER.debug(DESTROYED_TGT_MSG,
@@ -86,8 +76,6 @@ public class DefaultLoggingCasEventListener implements LoggingCasEventListener {
     }
 
     @Override
-    @EventListener
-    @Async
     public void logProxyTicketGrantedEvent(final CasProxyTicketGrantedEvent e) {
         val pgt = e.getProxyGrantingTicket();
         val pt = e.getProxyTicket();
@@ -106,8 +94,6 @@ public class DefaultLoggingCasEventListener implements LoggingCasEventListener {
     }
 
     @Override
-    @EventListener
-    @Async
     public void logServiceTicketGrantedEvent(final CasServiceTicketGrantedEvent e) {
         val serviceTicket = e.getServiceTicket();
         LOGGER.debug(CREATED_ST_MSG,
@@ -118,8 +104,6 @@ public class DefaultLoggingCasEventListener implements LoggingCasEventListener {
     }
 
     @Override
-    @EventListener
-    @Async
     public void logServiceTicketValidatedEvent(final CasServiceTicketValidatedEvent e) {
         val serviceTicket = e.getServiceTicket();
         val principal = serviceTicket.getTicketGrantingTicket().getAuthentication().getPrincipal();

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/LoggingCasEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/LoggingCasEventListener.java
@@ -8,6 +8,8 @@ import org.apereo.cas.support.events.ticket.CasServiceTicketValidatedEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEvent;
 import org.apereo.cas.util.spring.CasEventListener;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultLoggingCasEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -20,6 +22,8 @@ public interface LoggingCasEventListener extends CasEventListener {
      *
      * @param e the event
      */
+    @EventListener
+    @Async
     void logTicketGrantingTicketCreatedEvent(CasTicketGrantingTicketCreatedEvent e);
 
     /**
@@ -27,6 +31,8 @@ public interface LoggingCasEventListener extends CasEventListener {
      *
      * @param e the event
      */
+    @EventListener
+    @Async
     void logAuthenticationTransactionFailureEvent(CasAuthenticationTransactionFailureEvent e);
 
     /**
@@ -34,6 +40,8 @@ public interface LoggingCasEventListener extends CasEventListener {
      *
      * @param e the event
      */
+    @EventListener
+    @Async
     void logAuthenticationPrincipalResolvedEvent(CasAuthenticationPrincipalResolvedEvent e);
 
     /**
@@ -41,6 +49,8 @@ public interface LoggingCasEventListener extends CasEventListener {
      *
      * @param e the event
      */
+    @EventListener
+    @Async
     void logTicketGrantingTicketDestroyedEvent(CasTicketGrantingTicketDestroyedEvent e);
 
     /**
@@ -48,6 +58,8 @@ public interface LoggingCasEventListener extends CasEventListener {
      *
      * @param e the event
      */
+    @EventListener
+    @Async
     void logProxyTicketGrantedEvent(CasProxyTicketGrantedEvent e);
 
     /**
@@ -55,6 +67,8 @@ public interface LoggingCasEventListener extends CasEventListener {
      *
      * @param e the event
      */
+    @EventListener
+    @Async
     void logServiceTicketGrantedEvent(CasServiceTicketGrantedEvent e);
 
     /**
@@ -62,5 +76,7 @@ public interface LoggingCasEventListener extends CasEventListener {
      *
      * @param e the event
      */
+    @EventListener
+    @Async
     void logServiceTicketValidatedEvent(CasServiceTicketValidatedEvent e);
 }

--- a/core/cas-server-core-events-configuration-cloud-bus/src/main/java/org/apereo/cas/support/events/listener/CasCloudBusConfigurationEventListener.java
+++ b/core/cas-server-core-events-configuration-cloud-bus/src/main/java/org/apereo/cas/support/events/listener/CasCloudBusConfigurationEventListener.java
@@ -2,6 +2,8 @@ package org.apereo.cas.support.events.listener;
 
 import org.apereo.cas.util.spring.CasEventListener;
 import org.springframework.cloud.bus.event.RefreshRemoteApplicationEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultCasCloudBusConfigurationEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -15,5 +17,7 @@ public interface CasCloudBusConfigurationEventListener extends CasEventListener 
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleRefreshEvent(RefreshRemoteApplicationEvent event);
 }

--- a/core/cas-server-core-events-configuration-cloud-bus/src/main/java/org/apereo/cas/support/events/listener/DefaultCasCloudBusConfigurationEventListener.java
+++ b/core/cas-server-core-events-configuration-cloud-bus/src/main/java/org/apereo/cas/support/events/listener/DefaultCasCloudBusConfigurationEventListener.java
@@ -6,8 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.bus.event.RefreshRemoteApplicationEvent;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 /**
  * This is {@link DefaultCasCloudBusConfigurationEventListener}.
@@ -23,8 +21,6 @@ public class DefaultCasCloudBusConfigurationEventListener implements CasCloudBus
     private final ApplicationContext applicationContext;
 
     @Override
-    @EventListener
-    @Async
     public void handleRefreshEvent(final RefreshRemoteApplicationEvent event) {
         LOGGER.trace("Received event [{}]", event);
         configurationPropertiesEnvironmentManager.rebindCasConfigurationProperties(this.applicationContext);

--- a/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/CasConfigurationEventListener.java
+++ b/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/CasConfigurationEventListener.java
@@ -3,6 +3,8 @@ package org.apereo.cas.support.events.listener;
 import org.apereo.cas.support.events.config.CasConfigurationModifiedEvent;
 import org.apereo.cas.util.spring.CasEventListener;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultCasConfigurationEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -16,6 +18,8 @@ public interface CasConfigurationEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleRefreshEvent(EnvironmentChangeEvent event);
 
     /**
@@ -23,5 +27,7 @@ public interface CasConfigurationEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleConfigurationModifiedEvent(CasConfigurationModifiedEvent event);
 }

--- a/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
+++ b/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
@@ -10,8 +10,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesBindin
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,16 +33,12 @@ public class DefaultCasConfigurationEventListener implements CasConfigurationEve
     private final ApplicationContext applicationContext;
 
     @Override
-    @EventListener
-    @Async
     public void handleRefreshEvent(final EnvironmentChangeEvent event) {
         LOGGER.trace("Received event [{}]", event);
         rebind();
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleConfigurationModifiedEvent(final CasConfigurationModifiedEvent event) {
         if (event.isEligibleForContextRefresh()) {
             LOGGER.info("Received event [{}]. Refreshing CAS configuration...", event);

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/DefaultRegisteredServicesEventListener.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/DefaultRegisteredServicesEventListener.java
@@ -11,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 import java.util.Map;
 
@@ -32,22 +30,16 @@ public class DefaultRegisteredServicesEventListener implements RegisteredService
     private final CommunicationsManager communicationsManager;
 
     @Override
-    @EventListener
-    @Async
     public void handleRefreshEvent(final CasRegisteredServicesRefreshEvent event) {
         servicesManager.load();
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleEnvironmentChangeEvent(final EnvironmentChangeEvent event) {
         servicesManager.load();
     }
     
     @Override
-    @EventListener
-    @Async
     public void handleRegisteredServiceExpiredEvent(final CasRegisteredServiceExpiredEvent event) {
         val registeredService = event.getRegisteredService();
         val contacts = registeredService.getContacts();

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/RegisteredServicesEventListener.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/RegisteredServicesEventListener.java
@@ -5,6 +5,8 @@ import org.apereo.cas.support.events.service.CasRegisteredServicesRefreshEvent;
 import org.apereo.cas.util.spring.CasEventListener;
 
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultRegisteredServicesEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -19,6 +21,8 @@ public interface RegisteredServicesEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleRefreshEvent(CasRegisteredServicesRefreshEvent event);
 
     /**
@@ -26,6 +30,8 @@ public interface RegisteredServicesEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleEnvironmentChangeEvent(EnvironmentChangeEvent event);
 
     /**
@@ -33,6 +39,8 @@ public interface RegisteredServicesEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleRegisteredServiceExpiredEvent(CasRegisteredServiceExpiredEvent event);
 
 }

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultServiceRegistryInitializerEventListener.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/DefaultServiceRegistryInitializerEventListener.java
@@ -5,8 +5,6 @@ import org.apereo.cas.support.events.config.CasConfigurationModifiedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 /**
  * This is {@link DefaultServiceRegistryInitializerEventListener}.
@@ -20,16 +18,12 @@ public class DefaultServiceRegistryInitializerEventListener implements ServiceRe
     private final ServiceRegistryInitializer serviceRegistryInitializer;
 
     @Override
-    @EventListener
-    @Async
     public void handleRefreshEvent(final EnvironmentChangeEvent event) {
         LOGGER.trace("Received event [{}]", event);
         rebind();
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleConfigurationModifiedEvent(final CasConfigurationModifiedEvent event) {
         if (event.isEligibleForContextRefresh()) {
             rebind();

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ServiceRegistryInitializerEventListener.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/ServiceRegistryInitializerEventListener.java
@@ -3,6 +3,8 @@ package org.apereo.cas.services;
 import org.apereo.cas.support.events.config.CasConfigurationModifiedEvent;
 import org.apereo.cas.util.spring.CasEventListener;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultServiceRegistryInitializerEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -16,6 +18,8 @@ public interface ServiceRegistryInitializerEventListener extends CasEventListene
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleRefreshEvent(EnvironmentChangeEvent event);
 
     /**
@@ -23,5 +27,7 @@ public interface ServiceRegistryInitializerEventListener extends CasEventListene
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleConfigurationModifiedEvent(CasConfigurationModifiedEvent event);
 }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcDefaultJsonWebKeyStoreListener.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcDefaultJsonWebKeyStoreListener.java
@@ -6,8 +6,6 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jose4j.jwk.JsonWebKeySet;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 import java.util.Optional;
 
@@ -23,8 +21,6 @@ public class OidcDefaultJsonWebKeyStoreListener implements OidcJsonWebKeyStoreLi
     private final LoadingCache<OidcJsonWebKeyCacheKey, Optional<JsonWebKeySet>> oidcJsonWebKeystoreCache;
 
     @Override
-    @EventListener
-    @Async
     public void handleOidcJsonWebKeystoreModifiedEvent(final OidcJsonWebKeystoreModifiedEvent event) {
         LOGGER.debug("Detected change in [{}]. Will invalidate OIDC JWKS cache...", event.getFile());
         oidcJsonWebKeystoreCache.invalidateAll();

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeyStoreListener.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeyStoreListener.java
@@ -2,6 +2,8 @@ package org.apereo.cas.oidc.jwks;
 
 import org.apereo.cas.oidc.jwks.generator.OidcJsonWebKeystoreModifiedEvent;
 import org.apereo.cas.util.spring.CasEventListener;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code OidcJsonWebKeyStoreListenerImpl} to allow spring {@code @Async} support to use JDK proxy.
@@ -15,5 +17,7 @@ public interface OidcJsonWebKeyStoreListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleOidcJsonWebKeystoreModifiedEvent(OidcJsonWebKeystoreModifiedEvent event);
 }

--- a/support/cas-server-support-service-registry-stream/src/main/java/org/apereo/cas/services/CasServicesRegistryStreamingEventListener.java
+++ b/support/cas-server-support-service-registry-stream/src/main/java/org/apereo/cas/services/CasServicesRegistryStreamingEventListener.java
@@ -4,6 +4,8 @@ import org.apereo.cas.support.events.service.CasRegisteredServiceDeletedEvent;
 import org.apereo.cas.support.events.service.CasRegisteredServiceLoadedEvent;
 import org.apereo.cas.support.events.service.CasRegisteredServiceSavedEvent;
 import org.apereo.cas.util.spring.CasEventListener;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultCasServicesRegistryStreamingEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -17,6 +19,8 @@ public interface CasServicesRegistryStreamingEventListener extends CasEventListe
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasRegisteredServiceLoadedEvent(CasRegisteredServiceLoadedEvent event);
 
     /**
@@ -24,6 +28,8 @@ public interface CasServicesRegistryStreamingEventListener extends CasEventListe
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasRegisteredServiceSavedEvent(CasRegisteredServiceSavedEvent event);
 
     /**
@@ -31,5 +37,7 @@ public interface CasServicesRegistryStreamingEventListener extends CasEventListe
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleCasRegisteredServiceDeletedEvent(CasRegisteredServiceDeletedEvent event);
 }

--- a/support/cas-server-support-service-registry-stream/src/main/java/org/apereo/cas/services/DefaultCasServicesRegistryStreamingEventListener.java
+++ b/support/cas-server-support-service-registry-stream/src/main/java/org/apereo/cas/services/DefaultCasServicesRegistryStreamingEventListener.java
@@ -8,8 +8,6 @@ import org.apereo.cas.util.PublisherIdentifier;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 /**
  * This is {@link DefaultCasServicesRegistryStreamingEventListener}.
@@ -25,24 +23,18 @@ public class DefaultCasServicesRegistryStreamingEventListener implements CasServ
     private final PublisherIdentifier publisherIdentifier;
 
     @Override
-    @EventListener
-    @Async
     public void handleCasRegisteredServiceLoadedEvent(final CasRegisteredServiceLoadedEvent event) {
         LOGGER.trace("Received event [{}]", event);
         this.publisher.publish(event.getRegisteredService(), event, publisherIdentifier);
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleCasRegisteredServiceSavedEvent(final CasRegisteredServiceSavedEvent event) {
         LOGGER.trace("Received event [{}]", event);
         this.publisher.publish(event.getRegisteredService(), event, publisherIdentifier);
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleCasRegisteredServiceDeletedEvent(final CasRegisteredServiceDeletedEvent event) {
         LOGGER.trace("Received event [{}]", event);
         this.publisher.publish(event.getRegisteredService(), event, publisherIdentifier);

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/DefaultSurrogateAuthenticationEventListener.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/DefaultSurrogateAuthenticationEventListener.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 
 import java.util.Map;
 
@@ -30,15 +28,11 @@ public class DefaultSurrogateAuthenticationEventListener implements SurrogateAut
     private final CasConfigurationProperties casProperties;
 
     @Override
-    @EventListener
-    @Async
     public void handleSurrogateAuthenticationFailureEvent(final CasSurrogateAuthenticationFailureEvent event) {
         notify(event.getPrincipal(), event);
     }
 
     @Override
-    @EventListener
-    @Async
     public void handleSurrogateAuthenticationSuccessEvent(final CasSurrogateAuthenticationSuccessfulEvent event) {
         notify(event.getPrincipal(), event);
     }

--- a/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/SurrogateAuthenticationEventListener.java
+++ b/support/cas-server-support-surrogate-authentication/src/main/java/org/apereo/cas/authentication/event/SurrogateAuthenticationEventListener.java
@@ -3,6 +3,8 @@ package org.apereo.cas.authentication.event;
 import org.apereo.cas.support.events.authentication.surrogate.CasSurrogateAuthenticationFailureEvent;
 import org.apereo.cas.support.events.authentication.surrogate.CasSurrogateAuthenticationSuccessfulEvent;
 import org.apereo.cas.util.spring.CasEventListener;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 
 /**
  * Interface for {@code DefaultSurrogateAuthenticationEventListener} to allow spring {@code @Async} support to use JDK proxy.
@@ -16,6 +18,8 @@ public interface SurrogateAuthenticationEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleSurrogateAuthenticationFailureEvent(CasSurrogateAuthenticationFailureEvent event);
 
     /**
@@ -23,5 +27,7 @@ public interface SurrogateAuthenticationEventListener extends CasEventListener {
      *
      * @param event the event
      */
+    @EventListener
+    @Async
     void handleSurrogateAuthenticationSuccessEvent(CasSurrogateAuthenticationSuccessfulEvent event);
 }

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplication.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplication.java
@@ -19,8 +19,6 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -46,7 +44,7 @@ import java.time.Instant;
 @EnableScheduling
 @NoArgsConstructor
 @Slf4j
-public class CasWebApplication {
+public class CasWebApplication implements CasWebApplicationReadyListener {
 
     /**
      * Main entry point of the CAS web application.
@@ -64,13 +62,7 @@ public class CasWebApplication {
             .run(args);
     }
 
-    /**
-     * Handle application ready event.
-     *
-     * @param event the event
-     */
-    @EventListener
-    @Async
+    @Override
     public void handleApplicationReadyEvent(final ApplicationReadyEvent event) {
         AsciiArtUtils.printAsciiArtReady(LOGGER, StringUtils.EMPTY);
         LOGGER.info("Ready to process requests @ [{}]", DateTimeUtils.zonedDateTimeOf(Instant.ofEpochMilli(event.getTimestamp())));

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplicationReadyListener.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplicationReadyListener.java
@@ -1,0 +1,22 @@
+package org.apereo.cas.web;
+
+import org.apereo.cas.util.spring.CasEventListener;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+
+/**
+ * Interface for {@code CasWebApplication} to allow spring {@code @Async} support to use JDK proxy.
+ * @author Hal Deadman
+ * @since 6.5.0
+ */
+@FunctionalInterface
+public interface CasWebApplicationReadyListener extends CasEventListener {
+    /**
+     * Handle Application Ready Event.
+     * @param event ApplicationReadyEvent fired when application is ready
+     */
+    @EventListener
+    @Async
+    void handleApplicationReadyEvent(ApplicationReadyEvent event);
+}


### PR DESCRIPTION
The `CasWebApplication` recently got an `@Aysnc` annotation which required a cglib generated class  since there was no interface. This adds an interface to CasWebApplication and I moved the `@Async` annotations for other classes to the associated interface so it would be easy to add a "check" that ensures `@Async` annotations are in interfaces. I moved `@EventListener` annotation to the interface but it probably doesn't need to be there. 