### PR TITLE
Authn delegation: fix post logout URL computation

### DIFF
--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationClientFinishLogoutAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationClientFinishLogoutAction.java
@@ -71,10 +71,12 @@ public class DelegatedAuthenticationClientFinishLogoutAction extends AbstractAct
                 .ifPresent(client -> {
                     LOGGER.debug("Located client from webflow state: [{}]", client);
                     val logoutRedirect = WebUtils.getLogoutRedirectUrl(requestContext, String.class);
-                    val validator = client.getLogoutValidator();
-                    validator.setPostLogoutURL(logoutRedirect);
-                    LOGGER.debug("Captured post logout url: [{}]", logoutRedirect);
-                    WebUtils.putLogoutRedirectUrl(requestContext, null);
+                    if (logoutRedirect != null) {
+                        val validator = client.getLogoutValidator();
+                        validator.setPostLogoutURL(logoutRedirect);
+                        LOGGER.debug("Captured post logout url: [{}]", logoutRedirect);
+                        WebUtils.putLogoutRedirectUrl(requestContext, null);
+                    }
                 });
         }
         return null;

--- a/support/cas-server-support-pac4j-webflow/src/test/java/org/apereo/cas/web/flow/DelegatedAuthenticationClientFinishLogoutActionTests.java
+++ b/support/cas-server-support-pac4j-webflow/src/test/java/org/apereo/cas/web/flow/DelegatedAuthenticationClientFinishLogoutActionTests.java
@@ -58,6 +58,21 @@ public class DelegatedAuthenticationClientFinishLogoutActionTests {
     }
 
     @Test
+    public void verifyOperationNoLogoutRedirectUrl() throws Exception {
+        val context = new MockRequestContext();
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, response));
+        WebUtils.putDelegatedAuthenticationClientName(context, "SAML2Client");
+        val samlClient = (SAML2Client) builtClients.findClient("SAML2Client").get();
+        samlClient.getLogoutValidator().setPostLogoutURL("https://google.com");
+        val result = delegatedAuthenticationClientFinishLogoutAction.execute(context);
+        assertNull(result);
+        assertEquals("https://google.com", samlClient.getLogoutValidator().getPostLogoutURL());
+        assertNull(WebUtils.getLogoutRedirectUrl(context, String.class));
+    }
+
+    @Test
     public void verifyOperationWithRelay() throws Exception {
         val context = new MockRequestContext();
         val request = new MockHttpServletRequest();


### PR DESCRIPTION
I noticed that the CAS `logoutRedirectUrl` overrides the pac4j default `postLogoutUrl` in the pac4j `LogoutValidator`.

I don't think this makes sense when the CAS `logoutRedirectUrl` is `null`.

This PR prevents this overrides in that case.
