### PR TITLE
WIP - close watch service before re-creating to release inotify watch resource

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcDefaultJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcDefaultJsonWebKeystoreGeneratorService.java
@@ -68,6 +68,9 @@ public class OidcDefaultJsonWebKeystoreGeneratorService implements OidcJsonWebKe
     public Resource generate() throws Exception {
         val resource = determineJsonWebKeystoreResource();
         if (ResourceUtils.isFile(resource) && isWatcherEnabled()) {
+            if (resourceWatcherService != null) {
+                resourceWatcherService.close();
+            }
             resourceWatcherService = new FileWatcherService(resource.getFile(),
                 file -> new Consumer<File>() {
                     @Override


### PR DESCRIPTION

I got this exception and CAS stopped working, probably because it wasn't able to load the JWKS file. This change closes any existing watch before creating another one. I marked this WIP b/c I can't figure how to write a test for it. 

```
2022-01-05 19:30:43,570 WARN [org.apereo.cas.oidc.jwks.OidcDefaultJsonWebKeystoreCacheLoader] - <User limit of inotify instances reached or too many open files>
java.io.IOException: User limit of inotify instances reached or too many open files
        at sun.nio.fs.LinuxWatchService.<init>(LinuxWatchService.java:62) ~[?:?]
        at sun.nio.fs.LinuxFileSystem.newWatchService(LinuxFileSystem.java:47) ~[?:?]
        at org.apereo.cas.util.io.PathWatcherService.<init>(PathWatcherService.java:59) ~[cas-server-core-util-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at org.apereo.cas.util.io.PathWatcherService.<init>(PathWatcherService.java:45) ~[cas-server-core-util-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at org.apereo.cas.util.io.FileWatcherService.<init>(FileWatcherService.java:26) ~[cas-server-core-util-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at org.apereo.cas.oidc.jwks.generator.OidcDefaultJsonWebKeystoreGeneratorService.generate(OidcDefaultJsonWebKeystoreGeneratorService.java:73) ~[cas-server-support-oidc-core-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at org.apereo.cas.oidc.jwks.OidcDefaultJsonWebKeystoreCacheLoader.generateJwksResource(OidcDefaultJsonWebKeystoreCacheLoader.java:153) ~[cas-server-support-oidc-core-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at org.apereo.cas.oidc.jwks.OidcDefaultJsonWebKeystoreCacheLoader.buildJsonWebKeySet(OidcDefaultJsonWebKeystoreCacheLoader.java:110) ~[cas-server-support-oidc-core-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at org.apereo.cas.oidc.jwks.OidcDefaultJsonWebKeystoreCacheLoader.load(OidcDefaultJsonWebKeystoreCacheLoader.java:33) ~[cas-server-support-oidc-core-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at org.apereo.cas.oidc.jwks.OidcDefaultJsonWebKeystoreCacheLoader.load(OidcDefaultJsonWebKeystoreCacheLoader.java:25) ~[cas-server-support-oidc-core-api-6.5.0-SNAPSHOT.jar!/:6.5.0-SNAPSHOT]
        at com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$2(LocalLoadingCache.java:141) ~[caffeine-2.9.2.jar!/:?]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$14(BoundedLocalCache.java:2438) ~[caffeine-2.9.2.jar!/:?]
        at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1940) ~[?:?]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2411) ~[caffeine-2.9.2.jar!/:?]
        at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2394) ~[caffeine-2.9.2.jar!/:?]
        at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:108) ~[caffeine-2.9.2.jar!/:?]
        at com.github.benmanes.caffeine.cache.LocalLoadingCache.get(LocalLoadingCache.java:54) ~[caffeine-2.9.2.jar!/:?]
```

I was able to recreate a leak with a puppeteer test by setting the cache to be really short and doing several OIDC logins. 
```
    "--cas.authn.oidc.jwks.file-system.jwks-file=file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
    "--cas.authn.oidc.jwks.core.jwks-cache-expiration=PT1S",
    "--cas.authn.oidc.jwks.file-system.watcher-enabled=true",
```
but I don't think that would worthwhile. 

I looked at all the other places where CAS calls `new FileWatcherService()` and they are all assigned in constructors and the classes are closeable or disposable and clean up the watchers. 