### PR TITLE
Fix incorrect cty header value

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/EncodingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/EncodingUtils.java
@@ -530,7 +530,6 @@ public class EncodingUtils {
             jwe.setAlgorithmHeaderValue(algorithmHeaderValue);
             jwe.setEncryptionMethodHeaderParameter(encryptionMethodHeaderParameter);
             jwe.setKey(secretKeyEncryptionKey);
-            jwe.setContentTypeHeaderValue("JWT");
             jwe.setHeader("typ", "JWT");
 
             customHeaders.forEach((k, v) -> jwe.setHeader(k, v.toString()));


### PR DESCRIPTION
 cty 'JWT' for signed/encrypted/ nested JWT as ticket is not correct and doesn't follow RFC https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.12. Basically it make JWT validation fails as the snippet below based on jose4j try to demonstrates.

`
....
import org.jose4j.jws.JsonWebSignature;
import org.jose4j.jwt.JwtClaims;
import org.jose4j.jwt.consumer.InvalidJwtException;
import org.jose4j.jwt.consumer.JwtConsumer;
import org.jose4j.jwt.consumer.JwtConsumerBuilder;
import org.jose4j.keys.AesKey;
import org.jose4j.lang.JoseException;

       .....
        Key key = new AesKey(Base64.decodeBase64(encryptionJwtKey));

        JwtConsumer jwtConsumer = new JwtConsumerBuilder()
                .setExpectedIssuer("my-cas-url")
                .setRequireSubject()
                .setExpectedAudience("my-cas-service")
                .setDisableRequireSignature()
                .setEnableRequireEncryption()
                .setRequireExpirationTime()
                .setRequireIssuedAt()
                .setDecryptionKey(key)
                .build();

            // decrypt the JWT and process it to the Claims
            jwtConsumer.processToClaims("....decodedPayload....");
` 

JWTConsumer check if it's a nested JWT from cty header

`
                if (isNestedJwt(joseObject))
                {
                    workingJwt = payload;
                }
`

Unfortunately, content is not a JWT but a plain JSON...