### PR TITLE
Stacking session-mongo, mongo-service-, mongo-ticket-registry 6.4.x

### DIFF
--- a/support/cas-server-support-mongo-service-registry/src/main/java/org/apereo/cas/config/MongoDbServiceRegistryConfiguration.java
+++ b/support/cas-server-support-mongo-service-registry/src/main/java/org/apereo/cas/config/MongoDbServiceRegistryConfiguration.java
@@ -47,9 +47,7 @@ public class MongoDbServiceRegistryConfiguration {
     @Qualifier("sslContext")
     private ObjectProvider<SSLContext> sslContext;
 
-    @ConditionalOnMissingBean(name = "mongoDbServiceRegistryTemplate")
-    @Bean
-    public MongoTemplate mongoDbServiceRegistryTemplate() {
+    private MongoTemplate mongoDbServiceRegistryTemplate() {
         val mongo = casProperties.getServiceRegistry().getMongo();
         val factory = new MongoDbConnectionFactory(sslContext.getObject());
 

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
@@ -55,10 +55,7 @@ public class MongoDbTicketRegistryConfiguration {
         return registry;
     }
 
-    @ConditionalOnMissingBean(name = "mongoDbTicketRegistryTemplate")
-    @Bean
-    @RefreshScope
-    public MongoTemplate mongoDbTicketRegistryTemplate() {
+    private MongoTemplate mongoDbTicketRegistryTemplate() {
         val factory = new MongoDbConnectionFactory(sslContext.getObject());
         val mongo = casProperties.getTicket().getRegistry().getMongo();
         return factory.buildMongoTemplate(mongo);


### PR DESCRIPTION
Stacking modules

cas-server-support-session-mongo
cas-server-support-mongo-service-registry
cas-server-support-mongo-ticket-registry

leads to autoconfiguration issues as outlined in this cas-user group post https://groups.google.com/a/apereo.org/g/cas-user/c/L0dAv358Lxo

It might be fixed in an overlay project by e.g. disabling and overwriting MongoDbServiceRegistryConfiguration.java and MongoDbTicketRegistryConfiguration.java, but a better solution without code duplication might be not publishing the MongoTemplate beans at all.


<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
