### PR TITLE
Hazelcast integer properties

### DIFF
--- a/support/cas-server-support-hazelcast-discovery-aws/src/main/java/org/apereo/cas/hz/HazelcastAwsDiscoveryStrategy.java
+++ b/support/cas-server-support-hazelcast-discovery-aws/src/main/java/org/apereo/cas/hz/HazelcastAwsDiscoveryStrategy.java
@@ -41,7 +41,9 @@ public class HazelcastAwsDiscoveryStrategy implements HazelcastDiscoveryStrategy
             properties.put(HazelcastAwsDiscoveryProperties.AWS_DISCOVERY_HOST_HEADER, aws.getHostHeader());
         }
         if (aws.getPort() > 0) {
-            properties.put(HazelcastAwsDiscoveryProperties.AWS_DISCOVERY_PORT, aws.getPort());
+            properties.put(
+                    HazelcastAwsDiscoveryProperties.AWS_DISCOVERY_PORT,
+                    Integer.toString(aws.getPort()));
         }
         if (StringUtils.hasText(aws.getRegion())) {
             properties.put(HazelcastAwsDiscoveryProperties.AWS_DISCOVERY_REGION, aws.getRegion());

--- a/support/cas-server-support-hazelcast-discovery-aws/src/test/java/org/apereo/cas/hz/HazelcastAwsDiscoveryStrategyTests.java
+++ b/support/cas-server-support-hazelcast-discovery-aws/src/test/java/org/apereo/cas/hz/HazelcastAwsDiscoveryStrategyTests.java
@@ -2,15 +2,20 @@ package org.apereo.cas.hz;
 
 import org.apereo.cas.configuration.model.support.hazelcast.HazelcastClusterProperties;
 
+import com.hazelcast.aws.AwsDiscoveryStrategyFactory;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.NetworkConfig;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * This is {@link HazelcastAwsDiscoveryStrategyTests}.
@@ -36,6 +41,21 @@ public class HazelcastAwsDiscoveryStrategyTests {
         aws.setTagKey("TagKey");
         aws.setTagValue("TagValue");
 
-        assertNotNull(strategy.get(properties, mock(JoinConfig.class), mock(Config.class), mock(NetworkConfig.class)));
+        Optional<DiscoveryStrategyConfig> result = strategy.get(properties, mock(JoinConfig.class), mock(Config.class), mock(NetworkConfig.class));
+        assertNotNull(result);
+        assertTrue(result.isPresent());
+
+        Map<String, Comparable> discoveryProperties = result.get().getProperties();
+        for (val propertyDefinition: new AwsDiscoveryStrategyFactory().getConfigurationProperties()) {
+            val value = discoveryProperties.get(propertyDefinition.key());
+            if (value == null) {
+                assertTrue(propertyDefinition.optional(),
+                        "Property " + propertyDefinition.key() + " is not optional and should be given");
+            } else {
+                assertDoesNotThrow(() -> propertyDefinition.typeConverter().convert(value),
+                        "Property " + propertyDefinition.key() + " has invalid value '" + value + "'");
+            }
+        }
+
     }
 }

--- a/support/cas-server-support-hazelcast-discovery-jclouds/src/main/java/org/apereo/cas/hz/HazelcastJCloudsDiscoveryStrategy.java
+++ b/support/cas-server-support-hazelcast-discovery-jclouds/src/main/java/org/apereo/cas/hz/HazelcastJCloudsDiscoveryStrategy.java
@@ -43,7 +43,9 @@ public class HazelcastJCloudsDiscoveryStrategy implements HazelcastDiscoveryStra
             properties.put(HazelcastJCloudsDiscoveryProperties.JCLOUDS_DISCOVERY_IDENTITY, jclouds.getIdentity());
         }
         if (jclouds.getPort() > 0) {
-            properties.put(HazelcastJCloudsDiscoveryProperties.JCLOUDS_DISCOVERY_HZ_PORT, jclouds.getPort());
+            properties.put(
+                    HazelcastJCloudsDiscoveryProperties.JCLOUDS_DISCOVERY_HZ_PORT,
+                    Integer.toString(jclouds.getPort()));
         }
         if (StringUtils.hasText(jclouds.getProvider())) {
             properties.put(HazelcastJCloudsDiscoveryProperties.JCLOUDS_DISCOVERY_PROVIDER, jclouds.getProvider());

--- a/support/cas-server-support-hazelcast-discovery-kubernetes/src/main/java/org/apereo/cas/hz/HazelcastKubernetesDiscoveryStrategy.java
+++ b/support/cas-server-support-hazelcast-discovery-kubernetes/src/main/java/org/apereo/cas/hz/HazelcastKubernetesDiscoveryStrategy.java
@@ -32,7 +32,9 @@ public class HazelcastKubernetesDiscoveryStrategy implements HazelcastDiscoveryS
             properties.put(KubernetesProperties.SERVICE_DNS.key(), kube.getServiceDns());
         }
         if (kube.getServiceDnsTimeout() > 0) {
-            properties.put(KubernetesProperties.SERVICE_DNS_TIMEOUT.key(), kube.getServiceDnsTimeout());
+            properties.put(
+                    KubernetesProperties.SERVICE_DNS_TIMEOUT.key(),
+                    Integer.toString(kube.getServiceDnsTimeout()));
         }
         if (StringUtils.hasText(kube.getServiceName())) {
             properties.put(KubernetesProperties.SERVICE_NAME.key(), kube.getServiceName());
@@ -55,7 +57,9 @@ public class HazelcastKubernetesDiscoveryStrategy implements HazelcastDiscoveryS
         properties.put(KubernetesProperties.RESOLVE_NOT_READY_ADDRESSES.key(), kube.isResolveNotReadyAddresses());
         properties.put(KubernetesProperties.USE_NODE_NAME_AS_EXTERNAL_ADDRESS.key(), kube.isUseNodeNameAsExternalAddress());
         if (kube.getApiRetries() > 0) {
-            properties.put(KubernetesProperties.KUBERNETES_API_RETIRES.key(), kube.getApiRetries());
+            properties.put(
+                    KubernetesProperties.KUBERNETES_API_RETIRES.key(),
+                    Integer.toString(kube.getApiRetries()));
         }
 
         if (StringUtils.hasText(kube.getKubernetesMaster())) {
@@ -68,7 +72,9 @@ public class HazelcastKubernetesDiscoveryStrategy implements HazelcastDiscoveryS
             properties.put(KubernetesProperties.KUBERNETES_CA_CERTIFICATE.key(), kube.getCaCertificate());
         }
         if (kube.getServicePort() > 0) {
-            properties.put(KubernetesProperties.SERVICE_PORT.key(), kube.getServicePort());
+            properties.put(
+                    KubernetesProperties.SERVICE_PORT.key(),
+                    Integer.toString(kube.getServicePort()));
         }
         return Optional.of(new DiscoveryStrategyConfig(new HazelcastKubernetesDiscoveryStrategyFactory(), properties));
     }

--- a/support/cas-server-support-hazelcast-discovery-kubernetes/src/test/java/org/apereo/cas/hz/HazelcastKubernetesDiscoveryStrategyTests.java
+++ b/support/cas-server-support-hazelcast-discovery-kubernetes/src/test/java/org/apereo/cas/hz/HazelcastKubernetesDiscoveryStrategyTests.java
@@ -5,14 +5,18 @@ import org.apereo.cas.configuration.model.support.hazelcast.HazelcastClusterProp
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategyFactory;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * This is {@link HazelcastKubernetesDiscoveryStrategyTests}.
@@ -36,8 +40,26 @@ public class HazelcastKubernetesDiscoveryStrategyTests {
         kb.setServiceLabelName(id);
         kb.setServiceLabelValue(id);
         kb.setServiceName(id);
+        kb.setApiRetries(3);
+        kb.setServicePort(1234);
         val hz = new HazelcastKubernetesDiscoveryStrategy();
         val result = hz.get(cluster, mock(JoinConfig.class), mock(Config.class), mock(NetworkConfig.class));
+
         assertNotNull(result);
+        assertTrue(result.isPresent());
+        Map<String, Comparable> properties = result.get().getProperties();
+        Collection<PropertyDefinition> configurationProperties = new HazelcastKubernetesDiscoveryStrategyFactory()
+                .getConfigurationProperties();
+        for (val propertyDefinition : configurationProperties) {
+            val value = properties.get(propertyDefinition.key());
+            if (value == null) {
+                assertTrue(propertyDefinition.optional(),
+                        "Property " + propertyDefinition.key() + " is not Optional and should be given");
+            } else {
+                assertDoesNotThrow(
+                        () -> propertyDefinition.typeConverter().convert(value),
+                        "Property " + propertyDefinition.key() + " has invalid value '"+value+"'");
+            }
+        }
     }
 }

--- a/support/cas-server-support-hazelcast-discovery-swarm/src/main/java/org/apereo/cas/hz/HazelcastDockerSwarmDiscoveryStrategy.java
+++ b/support/cas-server-support-hazelcast-discovery-swarm/src/main/java/org/apereo/cas/hz/HazelcastDockerSwarmDiscoveryStrategy.java
@@ -56,7 +56,8 @@ public class HazelcastDockerSwarmDiscoveryStrategy implements HazelcastDiscovery
 
         val props = new Properties();
         props.put("serviceName", dnsProvider.getServiceName());
-        props.put("servicePort", dnsProvider.getServicePort());
+        props.put("servicePort",
+                Integer.toString(dnsProvider.getServicePort()));
         memberAddressProviderConfig.setImplementation(new DockerDNSRRMemberAddressProvider(props));
 
         val properties = new HashMap<String, Comparable>();
@@ -91,7 +92,9 @@ public class HazelcastDockerSwarmDiscoveryStrategy implements HazelcastDiscovery
             properties.put("skip-verify-ssl", memberProvider.isSkipVerifySsl());
         }
         if (memberProvider.getHazelcastPeerPort() > 0) {
-            properties.put("hazelcast-peer-port", memberProvider.getHazelcastPeerPort());
+            properties.put(
+                    "hazelcast-peer-port",
+                    Integer.toString(memberProvider.getHazelcastPeerPort()));
         }
         val cfg = new DiscoveryStrategyConfig(new DockerSwarmDiscoveryStrategyFactory(), properties);
         try {


### PR DESCRIPTION
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
# Problem description
When setting up a hazelcast ticket registry on kubernetes I noticed, that I couldn't provide a valid value for `api-retries`. I always got an exception like the following one:

```
Caused by: java.lang.IllegalArgumentException: Cannot convert to integer
            at com.hazelcast.config.properties.PropertyTypeConverter$3.convert(PropertyTypeConverter.java:60) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.spi.discovery.impl.DiscoveryServicePropertiesUtil.prepareProperties(DiscoveryServicePropertiesUtil.java:72) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.spi.discovery.impl.DefaultDiscoveryService.buildDiscoveryStrategy(DefaultDiscoveryService.java:194) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.spi.discovery.impl.DefaultDiscoveryService.loadDiscoveryStrategies(DefaultDiscoveryService.java:141) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.spi.discovery.impl.DefaultDiscoveryService.<init>(DefaultDiscoveryService.java:58) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider.newDiscoveryService(DefaultDiscoveryServiceProvider.java:29) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.instance.impl.Node.createDiscoveryService(Node.java:343) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.instance.impl.Node.<init>(Node.java:269) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.instance.impl.HazelcastInstanceImpl.createNode(HazelcastInstanceImpl.java:148) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.instance.impl.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:117) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.instance.impl.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:211) ~[hazelcast-4.2.2.jar:4.2.2]
            at com.hazelcast.instance.impl.HazelcastInstanceFactory.getOrCreateHazelcastInstance(HazelcastInstanceFactory.java:108) ~[hazelcast-4.2.2.jar:4.2.2]
            at org.apereo.cas.config.HazelcastTicketRegistryConfiguration.casTicketRegistryHazelcastInstance(HazelcastTicketRegistryConfiguration.java:67) ~[classes/:6.4.5]
            at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
            at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
            at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
            at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
```

# Solution

The problem here was, that the property has to be given as a String encoded integer value, as it will be decoded by a Hazelcast `PropertyTypeConverter`, which expects String values for all (but Boolean) values.

This PR will encode all integer values of the various *HazelcastXDiscoveryStrategy* classes. As they all seem to be effected by the same problem.

> **Note**: I have adapted the tests to my best knowledge and they all pass (except Docker Swarm), but only the Kubernetes part has been tested in a complete setup.

## Docker Swarm

The code for Docker Swarm still throws exceptions when run with the adapted code, as as the initialization of `SwarmMemberAddressProvider` inside `HazelcastDockerSwarmDiscoveryStrategy#getDiscoveryStrategyConfigViaMemberAddressProvider()` is looking for more system properties than I was willing to simulate here.

What I find strangest is that the test done with `./testcas.sh --category hazelcast ` succeeds even when the exception is shown.

## Side note

It probably would be nice, if the `PropertyTypeConverter`s from Hazelcast would be a bit more open to re-use a value, when it is already in the correct destination type given.