### PR TITLE
fix ResourceUtils.doesResourceExist to detect directory on windows

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ResourceUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ResourceUtils.java
@@ -89,6 +89,8 @@ public class ResourceUtils {
     /**
      * Does resource exist?
      *
+     * On Windows, reading one byte from a directory does not return length greater than zero so an explicit directory
+     * check is needed.
      * @param res the res
      * @return true/false
      */
@@ -97,6 +99,9 @@ public class ResourceUtils {
             return false;
         }
         try {
+            if (FileUtils.isDirectory(res.getFile())) {
+                return true;
+            }
             IOUtils.read(res.getInputStream(), new byte[1]);
             return res.contentLength() > 0;
         } catch (final FileNotFoundException e) {

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ResourceUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ResourceUtils.java
@@ -99,7 +99,7 @@ public class ResourceUtils {
             return false;
         }
         try {
-            if (FileUtils.isDirectory(res.getFile())) {
+            if (res.isFile() && FileUtils.isDirectory(res.getFile())) {
                 return true;
             }
             IOUtils.read(res.getInputStream(), new byte[1]);

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/ResourceUtilsTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/ResourceUtilsTests.java
@@ -86,6 +86,10 @@ public class ResourceUtilsTests {
         val path = Files.createTempDirectory("castest-");
         assertTrue(ResourceUtils.doesResourceExist(ResourceUtils.getResourceFrom(path.toString())));
         FileUtils.forceDelete(path.toFile());
+        val nonFileResourceMissing = ResourceUtils.getRawResourceFrom("classpath:doesnotexist.json");
+        assertDoesNotThrow(() -> ResourceUtils.doesResourceExist(nonFileResourceMissing));
+        val nonFileExists = ResourceUtils.getRawResourceFrom("classpath:log4j2-test.xml");
+        assertDoesNotThrow(() -> ResourceUtils.doesResourceExist(nonFileExists));
     }
 
 

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/ResourceUtilsTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/ResourceUtilsTests.java
@@ -11,7 +11,9 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.UrlResource;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -75,4 +77,16 @@ public class ResourceUtilsTests {
         FileUtils.write(new File(file, Objects.requireNonNull(res.getFilename())), "data", StandardCharsets.UTF_8);
         assertNotNull(ResourceUtils.exportClasspathResourceToFile(file, res));
     }
+
+    /**
+     * Check that doesResourceExist validates existence of directory.
+     */
+    @Test
+    public void verifyResourceExistsDetectsFolder() throws IOException {
+        val path = Files.createTempDirectory("castest-");
+        assertTrue(ResourceUtils.doesResourceExist(ResourceUtils.getResourceFrom(path.toString())));
+        FileUtils.forceDelete(path.toFile());
+    }
+
+
 }


### PR DESCRIPTION
I debugged and figured out why init-from-json wasn't working on Windows... The ResourceUtils.doesResourceExist() method was returning false for a directory that existed and it was moving on to create a services folder in temp directory and using the default service in that. I might look into whether the puppeteer tests could run on windows in Github Actions... I think msys2 is available, hopefully jq is installed, then it would just have to skip tests that require docker which would be doable.