### PR TITLE
Add missing @RefreshScope configuration

### DIFF
--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
@@ -117,6 +117,7 @@ public class CasOAuth20ThrottleConfiguration {
     public static class CasOAuth20ThrottleInterceptorConfiguration {
         @ConditionalOnMissingBean(name = "requiresAuthenticationAuthorizeInterceptor")
         @Bean
+        @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public HandlerInterceptor requiresAuthenticationAuthorizeInterceptor(
             @Qualifier("oauthSecConfig")
             final Config oauthSecConfig,

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcEndpointsConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcEndpointsConfiguration.java
@@ -149,6 +149,7 @@ public class OidcEndpointsConfiguration {
         }
 
         @Bean
+        @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public HandlerInterceptor oauthInterceptor(
             final ObjectProvider<List<AccessTokenGrantRequestExtractor>> accessTokenGrantRequestExtractors,
             final ObjectProvider<List<OAuth20AuthorizationRequestValidator>> oauthRequestValidators,


### PR DESCRIPTION
To make OAuth/OIDC interceptors refreshable as the `ticketRegistry` (they rely on) is.