### PR TITLE
Deserialization problem in PasswordExpiringWarningMessageDescriptor

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptor.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptor.java
@@ -4,6 +4,8 @@ import org.apereo.cas.DefaultMessageDescriptor;
 
 import java.io.Serializable;
 
+import lombok.NoArgsConstructor;
+
 /**
  * Message conveying account password expiration warning details.
  *
@@ -11,6 +13,7 @@ import java.io.Serializable;
  * @author Marvin S. Addison
  * @since 4.0.0
  */
+@NoArgsConstructor
 public class PasswordExpiringWarningMessageDescriptor extends DefaultMessageDescriptor {
     /**
      * Serialization version marker.

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptor.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptor.java
@@ -4,8 +4,6 @@ import org.apereo.cas.DefaultMessageDescriptor;
 
 import java.io.Serializable;
 
-import lombok.NoArgsConstructor;
-
 /**
  * Message conveying account password expiration warning details.
  *
@@ -13,7 +11,6 @@ import lombok.NoArgsConstructor;
  * @author Marvin S. Addison
  * @since 4.0.0
  */
-@NoArgsConstructor
 public class PasswordExpiringWarningMessageDescriptor extends DefaultMessageDescriptor {
     /**
      * Serialization version marker.
@@ -33,6 +30,13 @@ public class PasswordExpiringWarningMessageDescriptor extends DefaultMessageDesc
      */
     public PasswordExpiringWarningMessageDescriptor(final String defaultMsg, final long days) {
         super(CODE, defaultMsg, new Serializable[]{days});
+    }
+
+    /**
+     * No arg constructor needed for serialization.
+     */
+    public PasswordExpiringWarningMessageDescriptor() {
+        super(CODE);
     }
 
     public long getDaysToExpiration() {

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptorTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptorTests.java
@@ -20,4 +20,9 @@ public class PasswordExpiringWarningMessageDescriptorTests {
         assertEquals(30, d.getDaysToExpiration());
         assertEquals("DefaultMessage", d.getDefaultMessage());
     }
+
+    @Test
+    public void verifyEncoding() {
+        new PasswordExpiringWarningMessageDescriptor();
+    }
 }

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptorTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/support/password/PasswordExpiringWarningMessageDescriptorTests.java
@@ -22,7 +22,8 @@ public class PasswordExpiringWarningMessageDescriptorTests {
     }
 
     @Test
-    public void verifyEncoding() {
-        new PasswordExpiringWarningMessageDescriptor();
+    public void verifyNoArgsConstructor() {
+        val d = new PasswordExpiringWarningMessageDescriptor();
+        assertNotNull(d.getCode());
     }
 }


### PR DESCRIPTION
We see this exception in all users with password expiration warnings:

2022-02-03 16:36:58,450 ERROR [org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer] - <Cannot read/parse [{"@class":"org.apereo.cas.ticket.TicketGrantingTicketImpl","@id":1,"id":"TGT-20-bRfJ2NoWW-FyPv--1LdnWUJr-cuA0-sLx-VGCPV95s...] to deserialize into type [class org.apereo.cas.ticket.TicketGrantingTicketImpl]. This may be caused in the absence of a configuration/support module that knows how to interpret the fragment, specially if the fragment describes a CAS registered service definition. Internal parsing error is [Cannot construct instance of `org.apereo.cas.authentication.support.password.PasswordExpiringWarningMessageDescriptor` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)

It affects if using pwdPolicy in LDAP.

The fix seems simple as most of the other classes in org.apereo.cas.config.CasCoreAuthenticationComponentSerializationConfiguration seem to have a NoArgConstructor too.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
