### PR TITLE
Fix preserve url anchor

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
@@ -74,7 +74,7 @@ function showGeoPosition(position) {
 function preserveAnchorTagOnForm() {
     $('#fm1').submit(() => {
         let location = self.document.location;
-        let hash = decodeURIComponent(location.hash);
+        let hash = location.hash;
 
         if (hash !== undefined && hash != '' && hash.indexOf('#') === -1) {
             hash = `#${hash}`;

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
@@ -74,15 +74,13 @@ function showGeoPosition(position) {
 function preserveAnchorTagOnForm() {
     $('#fm1').submit(() => {
         let location = self.document.location;
-        let hash = location.hash;
 
         let action = $('#fm1').attr('action');
         if (action === undefined) {
             action = location.href;
         } else {
-            action += location.search;
+            action += location.search + location.hash;
         }
-        action += hash;
         $('#fm1').attr('action', action);
 
     });

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
@@ -84,11 +84,7 @@ function preserveAnchorTagOnForm() {
         if (action === undefined) {
             action = location.href;
         } else {
-            let qidx = location.href.indexOf('?');
-            if (qidx !== -1) {
-                let queryParams = location.href.substring(qidx);
-                action += queryParams;
-            }
+            action += location.search;
         }
         action += hash;
         $('#fm1').attr('action', action);

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/cas.js
@@ -76,10 +76,6 @@ function preserveAnchorTagOnForm() {
         let location = self.document.location;
         let hash = location.hash;
 
-        if (hash !== undefined && hash != '' && hash.indexOf('#') === -1) {
-            hash = `#${hash}`;
-        }
-
         let action = $('#fm1').attr('action');
         if (action === undefined) {
             action = location.href;


### PR DESCRIPTION
Since CAS 5.2, hash param in url is added twice to login submit url. Example of resulting url: #foo=bar#foo=bar

The regression comes from commit https://github.com/apereo/cas/commit/984dfaf00eee4ad50467e83fc19ff932d429e8ff (*) , "queryParams" is added to "action". Then "hash" is added to "action". The issue is that "queryParams" contains both the query params AND the hash.

This pull request uses `location.search` to fix the issue.
It has been tested in production (for CAS protocol).


(*) backported to 5.2 5.3 6.0 https://github.com/apereo/cas/commit/52d5fb26e794fe1694dfa5606aa297e920a0aac8
