### PR TITLE
Gradle File system watching

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,12 +8,12 @@ TIMEOUT=640000
 function build {
     ./gradlew clean --parallel
     echo -e "\n${GREEN}Building CAS. Please be patient as this might take a while...${NORMAL}\n"
-    ./gradlew assemble -x test -x check --no-watch-fs -DpublishReleases=true -DrepositoryUsername="$1" -DrepositoryPassword="$2"
+    ./gradlew assemble -x test -x check -watch-fs -DpublishReleases=true -DrepositoryUsername="$1" -DrepositoryPassword="$2"
 }
 
 function publish {
     echo -e "\n${GREEN}Publishing CAS. Please be patient as this might take a while...${NORMAL}\n"
-    ./gradlew publishToSonatype closeAndReleaseStagingRepository --no-watch-fs -DpublishReleases=true -DrepositoryUsername="$1" -DrepositoryPassword="$2" \
+    ./gradlew publishToSonatype closeAndReleaseStagingRepository -watch-fs -DpublishReleases=true -DrepositoryUsername="$1" -DrepositoryPassword="$2" \
       -DpublishReleases=true -DrepositoryUsername="$1" -DrepositoryPassword="$2" \
       -Dorg.gradle.internal.http.socketTimeout="${TIMEOUT}" \
       -Dorg.gradle.internal.http.connectionTimeout="${TIMEOUT}"  \


### PR DESCRIPTION
[File system watching](https://blog.gradle.org/introducing-file-system-watching). Since Gradle 6.5, File system watching was introduced which can help to avoid unnecessary I/O. This feature is the default since 7.0. For an older version, we can enable this feature by setting `org.gradle.vfs.watch=true`.
