### PR TITLE
Move Async methods off of CasWebApplication 

### DIFF
--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
@@ -3,6 +3,8 @@ package org.apereo.cas.config;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.tomcat.CasTomcatServletWebServerFactory;
 import org.apereo.cas.tomcat.CasTomcatServletWebServerFactoryCustomizer;
+import org.apereo.cas.web.CasWebApplicationReady;
+import org.apereo.cas.web.CasWebApplicationReadyListener;
 
 import org.apache.catalina.startup.Tomcat;
 import org.apache.coyote.http2.Http2Protocol;
@@ -18,6 +20,7 @@ import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerF
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 /**
  * This is {@link CasEmbeddedContainerTomcatConfiguration}.
@@ -30,6 +33,7 @@ import org.springframework.core.Ordered;
 @ConditionalOnClass(value = {Tomcat.class, Http2Protocol.class})
 @AutoConfigureBefore(ServletWebServerFactoryAutoConfiguration.class)
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
+@EnableAsync
 public class CasEmbeddedContainerTomcatConfiguration {
 
     @ConditionalOnMissingBean(name = "casServletWebServerFactory")
@@ -47,4 +51,10 @@ public class CasEmbeddedContainerTomcatConfiguration {
         final CasConfigurationProperties casProperties) {
         return new CasTomcatServletWebServerFactoryCustomizer(serverProperties, casProperties);
     }
+
+    @Bean
+    public CasWebApplicationReadyListener casWebApplicationReadyListener() {
+        return new CasWebApplicationReady();
+    }
+
 }

--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
@@ -3,8 +3,6 @@ package org.apereo.cas.config;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.tomcat.CasTomcatServletWebServerFactory;
 import org.apereo.cas.tomcat.CasTomcatServletWebServerFactoryCustomizer;
-import org.apereo.cas.web.CasWebApplicationReady;
-import org.apereo.cas.web.CasWebApplicationReadyListener;
 
 import org.apache.catalina.startup.Tomcat;
 import org.apache.coyote.http2.Http2Protocol;
@@ -20,7 +18,6 @@ import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerF
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 /**
  * This is {@link CasEmbeddedContainerTomcatConfiguration}.
@@ -33,7 +30,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @ConditionalOnClass(value = {Tomcat.class, Http2Protocol.class})
 @AutoConfigureBefore(ServletWebServerFactoryAutoConfiguration.class)
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
-@EnableAsync
 public class CasEmbeddedContainerTomcatConfiguration {
 
     @ConditionalOnMissingBean(name = "casServletWebServerFactory")
@@ -50,12 +46,6 @@ public class CasEmbeddedContainerTomcatConfiguration {
         final ServerProperties serverProperties,
         final CasConfigurationProperties casProperties) {
         return new CasTomcatServletWebServerFactoryCustomizer(serverProperties, casProperties);
-    }
-
-    @ConditionalOnMissingBean(name = "casWebApplicationReadyListener")
-    @Bean
-    public CasWebApplicationReadyListener casWebApplicationReadyListener() {
-        return new CasWebApplicationReady();
     }
 
 }

--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
@@ -47,5 +47,4 @@ public class CasEmbeddedContainerTomcatConfiguration {
         final CasConfigurationProperties casProperties) {
         return new CasTomcatServletWebServerFactoryCustomizer(serverProperties, casProperties);
     }
-
 }

--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
@@ -52,6 +52,7 @@ public class CasEmbeddedContainerTomcatConfiguration {
         return new CasTomcatServletWebServerFactoryCustomizer(serverProperties, casProperties);
     }
 
+    @ConditionalOnMissingBean(name = "casWebApplicationReadyListener")
     @Bean
     public CasWebApplicationReadyListener casWebApplicationReadyListener() {
         return new CasWebApplicationReady();

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/config/CasWebApplicationConfiguration.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/config/CasWebApplicationConfiguration.java
@@ -1,0 +1,32 @@
+package org.apereo.cas.config;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.web.CasWebApplicationReady;
+import org.apereo.cas.web.CasWebApplicationReadyListener;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * This is {@link CasWebApplicationConfiguration}.
+ *
+ * @author Hal Deadman
+ * @since 6.6.0
+ */
+@Configuration(value = "CasWebApplicationConfiguration", proxyBeanMethods = false)
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+@AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
+@EnableAsync
+public class CasWebApplicationConfiguration {
+
+    @ConditionalOnMissingBean(name = "casWebApplicationReadyListener")
+    @Bean
+    public CasWebApplicationReadyListener casWebApplicationReadyListener() {
+        return new CasWebApplicationReady();
+    }
+
+}

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplication.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplication.java
@@ -2,28 +2,20 @@ package org.apereo.cas.web;
 
 import org.apereo.cas.CasEmbeddedContainerUtils;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.util.AsciiArtUtils;
-import org.apereo.cas.util.DateTimeUtils;
 
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-
-import java.time.Instant;
 
 /**
  * This is {@link CasWebApplication} that houses the main method.
@@ -38,13 +30,11 @@ import java.time.Instant;
     MongoDataAutoConfiguration.class
 })
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@EnableAsync
 @EnableAspectJAutoProxy
 @EnableTransactionManagement
 @EnableScheduling
 @NoArgsConstructor
-@Slf4j
-public class CasWebApplication implements CasWebApplicationReadyListener {
+public class CasWebApplication {
 
     /**
      * Main entry point of the CAS web application.
@@ -62,9 +52,4 @@ public class CasWebApplication implements CasWebApplicationReadyListener {
             .run(args);
     }
 
-    @Override
-    public void handleApplicationReadyEvent(final ApplicationReadyEvent event) {
-        AsciiArtUtils.printAsciiArtReady(LOGGER, StringUtils.EMPTY);
-        LOGGER.info("Ready to process requests @ [{}]", DateTimeUtils.zonedDateTimeOf(Instant.ofEpochMilli(event.getTimestamp())));
-    }
 }

--- a/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplicationReady.java
+++ b/webapp/cas-server-webapp-init/src/main/java/org/apereo/cas/web/CasWebApplicationReady.java
@@ -1,0 +1,24 @@
+package org.apereo.cas.web;
+
+import org.apereo.cas.util.AsciiArtUtils;
+import org.apereo.cas.util.DateTimeUtils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+
+import java.time.Instant;
+
+/**
+ * @author Hal Deadman
+ * @since 6.6.0
+ */
+@Slf4j
+public class CasWebApplicationReady implements CasWebApplicationReadyListener {
+
+    @Override
+    public void handleApplicationReadyEvent(final ApplicationReadyEvent event) {
+        AsciiArtUtils.printAsciiArtReady(LOGGER, StringUtils.EMPTY);
+        LOGGER.info("Ready to process requests @ [{}]", DateTimeUtils.zonedDateTimeOf(Instant.ofEpochMilli(event.getTimestamp())));
+    }
+}

--- a/webapp/cas-server-webapp-init/src/main/resources/META-INF/spring.factories
+++ b/webapp/cas-server-webapp-init/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.config.CasWebApplicationConfiguration
 org.springframework.context.ApplicationContextInitializer=org.apereo.cas.context.CasApplicationContextInitializer


### PR DESCRIPTION
This moves the async application ready event method off of the CasWebApplication class. I think it may be confusing spring native but whether it is or not, I think it is better off in a bean. 