### PR TITLE
Additional Check for Validating Issuer URL based on Paths

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/util/OidcRequestSupport.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/util/OidcRequestSupport.java
@@ -1,5 +1,16 @@
 package org.apereo.cas.oidc.util;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.oidc.OidcConstants;
@@ -9,28 +20,18 @@ import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.web.cookie.CasCookieBuilder;
-
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
-import org.apache.http.client.utils.URIBuilder;
 import org.pac4j.core.context.JEEContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.profile.BasicUserProfile;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
-
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import org.springframework.util.Assert;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.val;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is {@link OidcRequestSupport}.
@@ -41,214 +42,234 @@ import java.util.stream.Collectors;
 @Slf4j
 @RequiredArgsConstructor
 public class OidcRequestSupport {
-    private final CasCookieBuilder ticketGrantingTicketCookieGenerator;
+  private final CasCookieBuilder ticketGrantingTicketCookieGenerator;
 
-    private final TicketRegistrySupport ticketRegistrySupport;
+  private final TicketRegistrySupport ticketRegistrySupport;
 
-    private final OidcIssuerService oidcIssuerService;
+  private final OidcIssuerService oidcIssuerService;
 
-    /**
-     * Gets oidc prompt from authorization request.
-     *
-     * @param url the url
-     * @return the oidc prompt from authorization request
-     */
-    @SneakyThrows
-    public static Set<String> getOidcPromptFromAuthorizationRequest(final @NonNull String url) {
-        return new URIBuilder(url).getQueryParams().stream()
-            .filter(p -> OidcConstants.PROMPT.equals(p.getName()))
-            .map(param -> param.getValue().split(" "))
-            .flatMap(Arrays::stream)
-            .collect(Collectors.toSet());
+  /**
+   * Gets oidc prompt from authorization request.
+   *
+   * @param url the url
+   * @return the oidc prompt from authorization request
+   */
+  @SneakyThrows
+  public static Set<String> getOidcPromptFromAuthorizationRequest(final @NonNull String url) {
+    return new URIBuilder(url).getQueryParams().stream()
+        .filter(p -> OidcConstants.PROMPT.equals(p.getName()))
+        .map(param -> param.getValue().split(" ")).flatMap(Arrays::stream)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Gets oidc prompt from authorization request.
+   *
+   * @param context the context
+   * @return the oidc prompt from authorization request
+   */
+  public static Set<String> getOidcPromptFromAuthorizationRequest(final WebContext context) {
+    return getOidcPromptFromAuthorizationRequest(context.getFullRequestURL());
+  }
+
+  /**
+   * Gets oidc max age from authorization request.
+   *
+   * @param context the context
+   * @return the oidc max age from authorization request
+   */
+  @SneakyThrows
+  public static Optional<Long> getOidcMaxAgeFromAuthorizationRequest(final WebContext context) {
+    val builderContext = new URIBuilder(context.getFullRequestURL());
+    return builderContext.getQueryParams().stream()
+        .filter(p -> OidcConstants.MAX_AGE.equals(p.getName())).map(p -> Optional.of(p.getValue()))
+        .findFirst().orElseGet(() -> context.getRequestParameter(OidcConstants.MAX_AGE))
+        .map(param -> {
+          val maxAge = NumberUtils.toLong(param, -1);
+          return Optional.of(maxAge);
+        }).orElse(Optional.empty());
+  }
+
+  /**
+   * Is authentication profile available?.
+   *
+   * @param context the context
+   * @param sessionStore the session store
+   * @return the optional user profile
+   */
+  public static Optional<UserProfile> isAuthenticationProfileAvailable(final JEEContext context,
+      final SessionStore sessionStore) {
+    val manager = new ProfileManager(context, sessionStore);
+    return manager.getProfile();
+  }
+
+  /**
+   * Gets redirect url with error.
+   *
+   * @param originalRedirectUrl the original redirect url
+   * @param errorCode the error code
+   * @param webContext the web context
+   * @return the redirect url with error
+   */
+  @SneakyThrows
+  public static String getRedirectUrlWithError(final String originalRedirectUrl,
+      final String errorCode, final WebContext webContext) {
+    val uriBuilder =
+        new URIBuilder(originalRedirectUrl).addParameter(OAuth20Constants.ERROR, errorCode);
+    webContext.getRequestParameter(OAuth20Constants.STATE)
+        .ifPresent(st -> uriBuilder.addParameter(OAuth20Constants.STATE, st));
+    return uriBuilder.build().toASCIIString();
+  }
+
+  /**
+   * Remove oidc prompt from authorization request.
+   *
+   * @param url the url
+   * @param prompt the prompt
+   * @return the string
+   */
+  @SneakyThrows
+  public static String removeOidcPromptFromAuthorizationRequest(final String url,
+      final String prompt) {
+    val uriBuilder = new URIBuilder(url);
+    val newParams = uriBuilder.getQueryParams().stream().filter(
+        p -> !OidcConstants.PROMPT.equals(p.getName()) || !p.getValue().equalsIgnoreCase(prompt))
+        .collect(Collectors.toList());
+    return uriBuilder.removeQuery().addParameters(newParams).build().toASCIIString();
+  }
+
+  /**
+   * Is cas authentication old for max age authorization request boolean.
+   *
+   * @param context the context
+   * @param authenticationDate the authentication date
+   * @return true/false
+   */
+  public static boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(
+      final WebContext context, final ZonedDateTime authenticationDate) {
+    val maxAge = getOidcMaxAgeFromAuthorizationRequest(context);
+    if (maxAge.isPresent() && maxAge.get() > 0) {
+      val now = ZonedDateTime.now(ZoneOffset.UTC).toEpochSecond();
+      val authTime = authenticationDate.toEpochSecond();
+      val diffInSeconds = now - authTime;
+      if (diffInSeconds > maxAge.get()) {
+        LOGGER.info("Authentication is too old: [{}] and was created [{}] seconds ago.", authTime,
+            diffInSeconds);
+        return true;
+      }
     }
+    return false;
+  }
 
-    /**
-     * Gets oidc prompt from authorization request.
-     *
-     * @param context the context
-     * @return the oidc prompt from authorization request
-     */
-    public static Set<String> getOidcPromptFromAuthorizationRequest(final WebContext context) {
-        return getOidcPromptFromAuthorizationRequest(context.getFullRequestURL());
+  /**
+   * Is cas authentication old for max age authorization request?
+   *
+   * @param context the context
+   * @param authentication the authentication
+   * @return true/false
+   */
+  public static boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(
+      final WebContext context, final Authentication authentication) {
+    return isCasAuthenticationOldForMaxAgeAuthorizationRequest(context,
+        authentication.getAuthenticationDate());
+  }
+
+  /**
+   * Is cas authentication old for max age authorization request?
+   *
+   * @param context the context
+   * @param profile the profile
+   * @return true/false
+   */
+  public static boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(
+      final WebContext context, final BasicUserProfile profile) {
+    var authTime = profile
+        .getAttribute(CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_AUTHENTICATION_DATE);
+    if (authTime == null) {
+      authTime = profile.getAuthenticationAttribute(
+          CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_AUTHENTICATION_DATE);
     }
-
-    /**
-     * Gets oidc max age from authorization request.
-     *
-     * @param context the context
-     * @return the oidc max age from authorization request
-     */
-    @SneakyThrows
-    public static Optional<Long> getOidcMaxAgeFromAuthorizationRequest(final WebContext context) {
-        val builderContext = new URIBuilder(context.getFullRequestURL());
-        return builderContext.getQueryParams()
-            .stream()
-            .filter(p -> OidcConstants.MAX_AGE.equals(p.getName()))
-            .map(p -> Optional.of(p.getValue()))
-            .findFirst()
-            .orElseGet(() -> context.getRequestParameter(OidcConstants.MAX_AGE))
-            .map(param -> {
-                val maxAge = NumberUtils.toLong(param, -1);
-                return Optional.of(maxAge);
-            })
-            .orElse(Optional.empty());
+    if (authTime == null) {
+      return false;
     }
+    val dt =
+        ZonedDateTime.parse(CollectionUtils.toCollection(authTime).iterator().next().toString());
+    return isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, dt);
+  }
 
-    /**
-     * Is authentication profile available?.
-     *
-     * @param context      the context
-     * @param sessionStore the session store
-     * @return the optional user profile
-     */
-    public static Optional<UserProfile> isAuthenticationProfileAvailable(final JEEContext context, final SessionStore sessionStore) {
-        val manager = new ProfileManager(context, sessionStore);
-        return manager.getProfile();
-    }
+  /**
+   * Is cas authentication available and old for max age authorization request?
+   *
+   * @param context the context
+   * @return true/false
+   */
+  public boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(final WebContext context) {
+    return isCasAuthenticationAvailable(context)
+        .filter(a -> isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, a)).isPresent();
+  }
 
-    /**
-     * Gets redirect url with error.
-     *
-     * @param originalRedirectUrl the original redirect url
-     * @param errorCode           the error code
-     * @param webContext          the web context
-     * @return the redirect url with error
-     */
-    @SneakyThrows
-    public static String getRedirectUrlWithError(final String originalRedirectUrl, final String errorCode,
-                                                 final WebContext webContext) {
-        val uriBuilder = new URIBuilder(originalRedirectUrl).addParameter(OAuth20Constants.ERROR, errorCode);
-        webContext.getRequestParameter(OAuth20Constants.STATE).ifPresent(st -> uriBuilder.addParameter(OAuth20Constants.STATE, st));
-        return uriBuilder.build().toASCIIString();
-    }
+  /**
+   * Is cas authentication available?
+   *
+   * @param context the context
+   * @return the optional authn
+   */
+  public Optional<Authentication> isCasAuthenticationAvailable(final WebContext context) {
+    val webContext = (JEEContext) context;
+    if (webContext != null) {
+      val tgtId =
+          ticketGrantingTicketCookieGenerator.retrieveCookieValue(webContext.getNativeRequest());
 
-    /**
-     * Remove oidc prompt from authorization request.
-     *
-     * @param url    the url
-     * @param prompt the prompt
-     * @return the string
-     */
-    @SneakyThrows
-    public static String removeOidcPromptFromAuthorizationRequest(final String url, final String prompt) {
-        val uriBuilder = new URIBuilder(url);
-        val newParams = uriBuilder.getQueryParams()
-            .stream()
-            .filter(p -> !OidcConstants.PROMPT.equals(p.getName()) || !p.getValue().equalsIgnoreCase(prompt))
-            .collect(Collectors.toList());
-        return uriBuilder
-            .removeQuery()
-            .addParameters(newParams)
-            .build()
-            .toASCIIString();
-    }
-
-    /**
-     * Is cas authentication old for max age authorization request boolean.
-     *
-     * @param context            the context
-     * @param authenticationDate the authentication date
-     * @return true/false
-     */
-    public static boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(final WebContext context,
-                                                                              final ZonedDateTime authenticationDate) {
-        val maxAge = getOidcMaxAgeFromAuthorizationRequest(context);
-        if (maxAge.isPresent() && maxAge.get() > 0) {
-            val now = ZonedDateTime.now(ZoneOffset.UTC).toEpochSecond();
-            val authTime = authenticationDate.toEpochSecond();
-            val diffInSeconds = now - authTime;
-            if (diffInSeconds > maxAge.get()) {
-                LOGGER.info("Authentication is too old: [{}] and was created [{}] seconds ago.",
-                    authTime, diffInSeconds);
-                return true;
-            }
+      if (StringUtils.isNotBlank(tgtId)) {
+        val authentication = ticketRegistrySupport.getAuthenticationFrom(tgtId);
+        if (authentication != null) {
+          return Optional.of(authentication);
         }
-        return false;
+      }
+    }
+    return Optional.empty();
+  }
+
+
+  /**
+   * Is valid issuer for endpoint.
+   *
+   * @param webContext the web context
+   * @param endpoint the endpoint
+   * @return true /false
+   */
+  public boolean isValidIssuerForEndpoint(final JEEContext webContext, final String endpoint) {
+    val requestUrl = webContext.getNativeRequest().getRequestURL().toString();
+    val issuerFromRequestUrl =
+        StringUtils.removeEnd(StringUtils.remove(requestUrl, '/' + endpoint), "/");
+    val definedIssuer = oidcIssuerService.determineIssuer(Optional.empty());
+
+    val definedIssuerWithSlash = StringUtils.appendIfMissing(definedIssuer, "/");
+
+    val result = definedIssuer.equalsIgnoreCase(issuerFromRequestUrl)
+        || issuerFromRequestUrl.startsWith(definedIssuerWithSlash)
+        || isIssuerPathMatching(issuerFromRequestUrl, definedIssuerWithSlash);
+    FunctionUtils.doIf(!result,
+        o -> LOGGER.trace("Configured issuer [{}] defined does not match the request issuer [{}]",
+            o, issuerFromRequestUrl))
+        .accept(definedIssuer);
+    return result;
+  }
+
+  private boolean isIssuerPathMatching(String requestIssuer, String definedIssuer) {
+    Assert.notNull(requestIssuer, "Request Issuer URL cannot be NULL");
+    Assert.notNull(definedIssuer, "Defined Issuer URL cannot be NULL");
+
+    boolean result = false;
+    try {
+      URL urlIssuerFromRequest = new URL(requestIssuer);
+      URL urlDefinedIssuer = new URL(definedIssuer);
+
+      result = urlIssuerFromRequest.getPath().equalsIgnoreCase(urlDefinedIssuer.getPath());
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException(e.getMessage(), e);
     }
 
-    /**
-     * Is cas authentication old for max age authorization request?
-     *
-     * @param context        the context
-     * @param authentication the authentication
-     * @return true/false
-     */
-    public static boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(final WebContext context,
-                                                                              final Authentication authentication) {
-        return isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, authentication.getAuthenticationDate());
-    }
-
-    /**
-     * Is cas authentication old for max age authorization request?
-     *
-     * @param context the context
-     * @param profile the profile
-     * @return true/false
-     */
-    public static boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(final WebContext context,
-                                                                              final BasicUserProfile profile) {
-        var authTime = profile.getAttribute(CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_AUTHENTICATION_DATE);
-        if (authTime == null) {
-            authTime = profile.getAuthenticationAttribute(CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_AUTHENTICATION_DATE);
-        }
-        if (authTime == null) {
-            return false;
-        }
-        val dt = ZonedDateTime.parse(CollectionUtils.toCollection(authTime).iterator().next().toString());
-        return isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, dt);
-    }
-
-    /**
-     * Is cas authentication available and old for max age authorization request?
-     *
-     * @param context the context
-     * @return true/false
-     */
-    public boolean isCasAuthenticationOldForMaxAgeAuthorizationRequest(final WebContext context) {
-        return isCasAuthenticationAvailable(context)
-            .filter(a -> isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, a))
-            .isPresent();
-    }
-
-    /**
-     * Is cas authentication available?
-     *
-     * @param context the context
-     * @return the optional authn
-     */
-    public Optional<Authentication> isCasAuthenticationAvailable(final WebContext context) {
-        val webContext = (JEEContext) context;
-        if (webContext != null) {
-            val tgtId = ticketGrantingTicketCookieGenerator.retrieveCookieValue(webContext.getNativeRequest());
-
-            if (StringUtils.isNotBlank(tgtId)) {
-                val authentication = ticketRegistrySupport.getAuthenticationFrom(tgtId);
-                if (authentication != null) {
-                    return Optional.of(authentication);
-                }
-            }
-        }
-        return Optional.empty();
-    }
-
-
-    /**
-     * Is valid issuer for endpoint.
-     *
-     * @param webContext the web context
-     * @param endpoint   the endpoint
-     * @return true /false
-     */
-    public boolean isValidIssuerForEndpoint(final JEEContext webContext, final String endpoint) {
-        val requestUrl = webContext.getNativeRequest().getRequestURL().toString();
-        val issuerFromRequestUrl = StringUtils.removeEnd(StringUtils.remove(requestUrl, '/' + endpoint), "/");
-        val definedIssuer = oidcIssuerService.determineIssuer(Optional.empty());
-
-        val definedIssuerWithSlash = StringUtils.appendIfMissing(definedIssuer, "/");
-        val result = definedIssuer.equalsIgnoreCase(issuerFromRequestUrl)
-                     || issuerFromRequestUrl.startsWith(definedIssuerWithSlash);
-        FunctionUtils.doIf(!result, o -> LOGGER.trace("Configured issuer [{}] defined does not match the request issuer [{}]",
-            o, issuerFromRequestUrl)).accept(definedIssuer);
-        return result;
-    }
+    return result;
+  }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcRequestSupportTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcRequestSupportTests.java
@@ -1,5 +1,15 @@
 package org.apereo.cas.oidc.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.UUID;
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.oidc.OidcConstants;
@@ -7,8 +17,6 @@ import org.apereo.cas.oidc.issuer.OidcIssuerService;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.web.cookie.CasCookieBuilder;
-
-import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.context.JEEContext;
@@ -18,13 +26,7 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.util.Pac4jConstants;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import lombok.val;
 
 /**
  * @author David Rodriguez
@@ -33,160 +35,186 @@ import static org.mockito.Mockito.*;
 @Tag("OIDC")
 public class OidcRequestSupportTests {
 
-    protected static JEEContext getContextForEndpoint(final String endpoint) {
-        val request = new MockHttpServletRequest();
-        request.setScheme("https");
-        request.setServerName("sso.example.org");
-        request.setServerPort(8443);
-        request.setRequestURI("/cas/oidc/" + endpoint);
-        val response = new MockHttpServletResponse();
-        return new JEEContext(request, response);
-    }
+  protected static JEEContext getContextForEndpoint(final String endpoint) {
+    val request = new MockHttpServletRequest();
+    request.setScheme("https");
+    request.setServerName("sso.example.org");
+    request.setServerPort(8443);
+    request.setRequestURI("/cas/oidc/" + endpoint);
+    val response = new MockHttpServletResponse();
+    return new JEEContext(request, response);
+  }
 
-    @Test
-    public void verifyRemovePrompt() {
-        val url = "https://tralala.whapi.com/something?" + OidcConstants.PROMPT + '=' + OidcConstants.PROMPT_CONSENT;
-        val request = OidcRequestSupport.removeOidcPromptFromAuthorizationRequest(url, OidcConstants.PROMPT_CONSENT);
-        assertFalse(request.contains(OidcConstants.PROMPT));
-    }
+  @Test
+  public void verifyRemovePrompt() {
+    val url = "https://tralala.whapi.com/something?" + OidcConstants.PROMPT + '='
+        + OidcConstants.PROMPT_CONSENT;
+    val request = OidcRequestSupport.removeOidcPromptFromAuthorizationRequest(url,
+        OidcConstants.PROMPT_CONSENT);
+    assertFalse(request.contains(OidcConstants.PROMPT));
+  }
 
-    @Test
-    public void verifyOidcPrompt() {
-        val url = "https://tralala.whapi.com/something?" + OidcConstants.PROMPT + "=value1";
-        val authorizationRequest = OidcRequestSupport.getOidcPromptFromAuthorizationRequest(url);
-        assertEquals("value1", authorizationRequest.toArray()[0]);
-    }
+  @Test
+  public void verifyOidcPrompt() {
+    val url = "https://tralala.whapi.com/something?" + OidcConstants.PROMPT + "=value1";
+    val authorizationRequest = OidcRequestSupport.getOidcPromptFromAuthorizationRequest(url);
+    assertEquals("value1", authorizationRequest.toArray()[0]);
+  }
 
-    @Test
-    public void verifyOidcPromptFromContext() {
-        val url = "https://tralala.whapi.com/something?" + OidcConstants.PROMPT + "=value1";
-        val context = mock(WebContext.class);
-        when(context.getFullRequestURL()).thenReturn(url);
-        val authorizationRequest = OidcRequestSupport.getOidcPromptFromAuthorizationRequest(context);
-        assertEquals("value1", authorizationRequest.toArray()[0]);
-    }
+  @Test
+  public void verifyOidcPromptFromContext() {
+    val url = "https://tralala.whapi.com/something?" + OidcConstants.PROMPT + "=value1";
+    val context = mock(WebContext.class);
+    when(context.getFullRequestURL()).thenReturn(url);
+    val authorizationRequest = OidcRequestSupport.getOidcPromptFromAuthorizationRequest(context);
+    assertEquals("value1", authorizationRequest.toArray()[0]);
+  }
 
-    @Test
-    public void verifyOidcMaxAgeTooOld() {
-        val context = mock(WebContext.class);
-        when(context.getFullRequestURL()).thenReturn("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=1");
-        val authenticationDate = ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(5);
-        assertTrue(OidcRequestSupport.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, authenticationDate));
+  @Test
+  public void verifyOidcMaxAgeTooOld() {
+    val context = mock(WebContext.class);
+    when(context.getFullRequestURL())
+        .thenReturn("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=1");
+    val authenticationDate = ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(5);
+    assertTrue(OidcRequestSupport.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context,
+        authenticationDate));
 
-        val authn = CoreAuthenticationTestUtils.getAuthentication("casuser", authenticationDate);
-        assertTrue(OidcRequestSupport.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, authn));
+    val authn = CoreAuthenticationTestUtils.getAuthentication("casuser", authenticationDate);
+    assertTrue(
+        OidcRequestSupport.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, authn));
 
-        val profile = new CommonProfile();
-        profile.setClientName("OIDC");
-        profile.setId("casuser");
-        profile.addAuthenticationAttribute(CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_AUTHENTICATION_DATE, authenticationDate);
-        assertTrue(OidcRequestSupport.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, profile));
-    }
+    val profile = new CommonProfile();
+    profile.setClientName("OIDC");
+    profile.setId("casuser");
+    profile.addAuthenticationAttribute(
+        CasProtocolConstants.VALIDATION_CAS_MODEL_ATTRIBUTE_NAME_AUTHENTICATION_DATE,
+        authenticationDate);
+    assertTrue(
+        OidcRequestSupport.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context, profile));
+  }
 
-    @Test
-    public void verifyOidcMaxAgeTooOldForContext() {
-        val authenticationDate = ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(5);
-        val authn = CoreAuthenticationTestUtils.getAuthentication("casuser", authenticationDate);
+  @Test
+  public void verifyOidcMaxAgeTooOldForContext() {
+    val authenticationDate = ZonedDateTime.now(ZoneOffset.UTC).minusSeconds(5);
+    val authn = CoreAuthenticationTestUtils.getAuthentication("casuser", authenticationDate);
 
-        val request = new MockHttpServletRequest();
-        request.setRequestURI("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=1");
-        val response = new MockHttpServletResponse();
-        val context = new JEEContext(request, response);
+    val request = new MockHttpServletRequest();
+    request.setRequestURI("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=1");
+    val response = new MockHttpServletResponse();
+    val context = new JEEContext(request, response);
 
-        val builder = mock(CasCookieBuilder.class);
-        when(builder.retrieveCookieValue(any())).thenReturn(UUID.randomUUID().toString());
-        val registrySupport = mock(TicketRegistrySupport.class);
-        when(registrySupport.getAuthenticationFrom(anyString())).thenReturn(authn);
-        val support = new OidcRequestSupport(builder, registrySupport, mock(OidcIssuerService.class));
-        assertTrue(support.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context));
-    }
+    val builder = mock(CasCookieBuilder.class);
+    when(builder.retrieveCookieValue(any())).thenReturn(UUID.randomUUID().toString());
+    val registrySupport = mock(TicketRegistrySupport.class);
+    when(registrySupport.getAuthenticationFrom(anyString())).thenReturn(authn);
+    val support = new OidcRequestSupport(builder, registrySupport, mock(OidcIssuerService.class));
+    assertTrue(support.isCasAuthenticationOldForMaxAgeAuthorizationRequest(context));
+  }
 
-    @Test
-    public void verifyOidcMaxAge() {
-        val context = mock(WebContext.class);
-        when(context.getFullRequestURL()).thenReturn("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=1000");
-        val age = OidcRequestSupport.getOidcMaxAgeFromAuthorizationRequest(context);
-        assertTrue(age.isPresent());
-        assertEquals((long) age.get(), 1000);
+  @Test
+  public void verifyOidcMaxAge() {
+    val context = mock(WebContext.class);
+    when(context.getFullRequestURL())
+        .thenReturn("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=1000");
+    val age = OidcRequestSupport.getOidcMaxAgeFromAuthorizationRequest(context);
+    assertTrue(age.isPresent());
+    assertEquals((long) age.get(), 1000);
 
-        when(context.getFullRequestURL()).thenReturn("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=NA");
-        val age2 = OidcRequestSupport.getOidcMaxAgeFromAuthorizationRequest(context);
-        assertTrue(age2.isPresent());
-        assertEquals((long) age2.get(), -1);
+    when(context.getFullRequestURL())
+        .thenReturn("https://tralala.whapi.com/something?" + OidcConstants.MAX_AGE + "=NA");
+    val age2 = OidcRequestSupport.getOidcMaxAgeFromAuthorizationRequest(context);
+    assertTrue(age2.isPresent());
+    assertEquals((long) age2.get(), -1);
 
-        when(context.getFullRequestURL()).thenReturn("https://tralala.whapi.com/something?");
-        val age3 = OidcRequestSupport.getOidcMaxAgeFromAuthorizationRequest(context);
-        assertFalse(age3.isPresent());
-    }
+    when(context.getFullRequestURL()).thenReturn("https://tralala.whapi.com/something?");
+    val age3 = OidcRequestSupport.getOidcMaxAgeFromAuthorizationRequest(context);
+    assertFalse(age3.isPresent());
+  }
 
-    @Test
-    public void verifyAuthnProfile() {
-        val request = new MockHttpServletRequest();
-        request.setRequestURI("https://www.example.org");
-        request.setQueryString("param=value");
-        val context = new JEEContext(request, new MockHttpServletResponse());
-        val profile = new CommonProfile();
-        context.setRequestAttribute(Pac4jConstants.USER_PROFILES,
-            CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
-        assertTrue(OidcRequestSupport.isAuthenticationProfileAvailable(context, JEESessionStore.INSTANCE).isPresent());
-    }
+  @Test
+  public void verifyAuthnProfile() {
+    val request = new MockHttpServletRequest();
+    request.setRequestURI("https://www.example.org");
+    request.setQueryString("param=value");
+    val context = new JEEContext(request, new MockHttpServletResponse());
+    val profile = new CommonProfile();
+    context.setRequestAttribute(Pac4jConstants.USER_PROFILES,
+        CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
+    assertTrue(OidcRequestSupport
+        .isAuthenticationProfileAvailable(context, JEESessionStore.INSTANCE).isPresent());
+  }
 
-    @Test
-    public void verifyGetRedirectUrlWithError() {
-        val request = new MockHttpServletRequest();
-        request.setScheme("https");
-        request.setServerName("example.org");
-        request.addParameter("state", "123456");
-        request.setServerPort(443);
-        val context = new JEEContext(request, new MockHttpServletResponse());
-        val expectedUrlWithError = context.getRequestURL() + "?error=login_required&state=123456";
-        assertEquals(expectedUrlWithError,
-            OidcRequestSupport.getRedirectUrlWithError(context.getRequestURL(), OidcConstants.LOGIN_REQUIRED, context));
-    }
+  @Test
+  public void verifyGetRedirectUrlWithError() {
+    val request = new MockHttpServletRequest();
+    request.setScheme("https");
+    request.setServerName("example.org");
+    request.addParameter("state", "123456");
+    request.setServerPort(443);
+    val context = new JEEContext(request, new MockHttpServletResponse());
+    val expectedUrlWithError = context.getRequestURL() + "?error=login_required&state=123456";
+    assertEquals(expectedUrlWithError, OidcRequestSupport
+        .getRedirectUrlWithError(context.getRequestURL(), OidcConstants.LOGIN_REQUIRED, context));
+  }
 
-    @Test
-    public void validateStaticIssuer() {
-        val issuerService = mock(OidcIssuerService.class);
-        val staticIssuer = "https://sso.example.org:8443/cas/oidc";
-        when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
-        val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
-            mock(TicketRegistrySupport.class), issuerService);
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("authorize"), "authorize"));
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("profile"), "profile"));
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("logout"), "logout"));
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("realms/authorize"), "authorize"));
-    }
+  @Test
+  public void validateStaticIssuer() {
+    val issuerService = mock(OidcIssuerService.class);
+    val staticIssuer = "https://sso.example.org:8443/cas/oidc";
+    when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
+    val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
+        mock(TicketRegistrySupport.class), issuerService);
+    assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("authorize"), "authorize"));
+    assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("profile"), "profile"));
+    assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("logout"), "logout"));
+    assertTrue(
+        support.isValidIssuerForEndpoint(getContextForEndpoint("realms/authorize"), "authorize"));
+  }
 
-    @Test
-    public void validateDynamicIssuer() {
-        val issuerService = mock(OidcIssuerService.class);
-        val staticIssuer = "https://sso.example.org:8443/cas/oidc/custom/fawnoos/issuer";
-        when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
-        val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
-            mock(TicketRegistrySupport.class), issuerService);
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("custom/fawnoos/issuer/authorize"), "authorize"));
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("custom/fawnoos/issuer/profile"), "profile"));
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("custom/fawnoos/issuer/oidcAuthorize"), "oidcAuthorize"));
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("custom/fawnoos/issuer"), "unknown"));
-    }
+  @Test
+  public void validateDynamicIssuer() {
+    val issuerService = mock(OidcIssuerService.class);
+    val staticIssuer = "https://sso.example.org:8443/cas/oidc/custom/fawnoos/issuer";
+    when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
+    val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
+        mock(TicketRegistrySupport.class), issuerService);
+    assertTrue(support.isValidIssuerForEndpoint(
+        getContextForEndpoint("custom/fawnoos/issuer/authorize"), "authorize"));
+    assertTrue(support.isValidIssuerForEndpoint(
+        getContextForEndpoint("custom/fawnoos/issuer/profile"), "profile"));
+    assertTrue(support.isValidIssuerForEndpoint(
+        getContextForEndpoint("custom/fawnoos/issuer/oidcAuthorize"), "oidcAuthorize"));
+    assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("custom/fawnoos/issuer"),
+        "unknown"));
+  }
 
-    @Test
-    public void validateDynamicIssuerForLogout() {
-        val issuerService = mock(OidcIssuerService.class);
-        val staticIssuer = "https://sso.example.org:8443/cas/oidc";
-        when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
-        val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
-            mock(TicketRegistrySupport.class), issuerService);
-        assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("logout"), "oidcLogout"));
-    }
+  @Test
+  public void validateDynamicIssuerForLogout() {
+    val issuerService = mock(OidcIssuerService.class);
+    val staticIssuer = "https://sso.example.org:8443/cas/oidc";
+    when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
+    val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
+        mock(TicketRegistrySupport.class), issuerService);
+    assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("logout"), "oidcLogout"));
+  }
 
-    @Test
-    public void validateIssuerMismatch() {
-        val issuerService = mock(OidcIssuerService.class);
-        val staticIssuer = "https://sso.example.org:8443/cas/openid-connect";
-        when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
-        val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
-            mock(TicketRegistrySupport.class), issuerService);
-        assertFalse(support.isValidIssuerForEndpoint(getContextForEndpoint("logout"), "oidcLogout"));
-    }
+  @Test
+  public void validateIssuerMismatch() {
+    val issuerService = mock(OidcIssuerService.class);
+    val staticIssuer = "https://sso.example.org:8443/cas/openid-connect";
+    when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
+    val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
+        mock(TicketRegistrySupport.class), issuerService);
+    assertFalse(support.isValidIssuerForEndpoint(getContextForEndpoint("logout"), "oidcLogout"));
+  }
+
+  @Test
+  public void validateIsValidIssuerForEndpoint() {
+    val issuerService = mock(OidcIssuerService.class);
+    val staticIssuer = "https://cas:8901/cas/oidc";
+    when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
+    val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
+        mock(TicketRegistrySupport.class), issuerService);
+    assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("jwks"), "jwks"));
+  }
 }


### PR DESCRIPTION
Implementation enhancement in 6.4.x seems not to cater for cases where CAS is behind gateway and inter microservice need to happen based on CAS's registered DNS name in docker network. I have introduced additional check to bypass host and port name check and compare only cas/oidc path to validate the check.

I am unsure why this check was introduced in 6.4.x while 6.3.x was not perform such checks. Your feedback will be much appreciated. Thanks.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
