### PR TITLE
Additional Check for Validating Issuer URL based on Paths

### DIFF
--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcRequestSupportTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/util/OidcRequestSupportTests.java
@@ -189,4 +189,14 @@ public class OidcRequestSupportTests {
             mock(TicketRegistrySupport.class), issuerService);
         assertFalse(support.isValidIssuerForEndpoint(getContextForEndpoint("logout"), "oidcLogout"));
     }
+
+    @Test
+    public void validateIsValidIssuerForEndpoint() {
+      val issuerService = mock(OidcIssuerService.class);
+      val staticIssuer = "https://cas:8901/cas/oidc";
+      when(issuerService.determineIssuer(any())).thenReturn(staticIssuer);
+      val support = new OidcRequestSupport(mock(CasCookieBuilder.class),
+          mock(TicketRegistrySupport.class), issuerService);
+      assertTrue(support.isValidIssuerForEndpoint(getContextForEndpoint("jwks"), "jwks"));
+    }
 }


### PR DESCRIPTION
Request Issuer URL vs. Defined Issuer URL matching criteria enhanced to also allow path lookup as one of the criterion.
The existing enhancement done in 6.4.x has caused problem when CAS is deployed as a container behind a gateway. Microservices behind that gateway will attempt to GET JWKS by making a GET call to CAS using its DNS name and port number within docker network which will not match the issuer property cas.authn.oidc.core.issuer in cas properties
This mismatch means that JWT cannot be verified/validated by microservice.

e.g.
server.port=8901
cas.server.name=https://foo:8082 (where foo is hostname where gateway is running)
cas.authn.oidc.core.issuer=${cas.server.name}/cas/oidc

The above means if the request for JWKS url is made from outside the gateway as https://foo:8082/cas/oidc/jwks --> It will be success

However, if the request is made for JWKS url from within docker network where CAS is registered as service called cas, https://cas:8901/cas/oidc/jwks --> It will fail

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
