### PR TITLE
Make BeanPostProcessor static

### DIFF
--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
@@ -101,7 +101,7 @@ public class CasCoreUtilConfiguration {
     public static class CasCoreUtilEssentialConfiguration {
         @Bean
         @ConditionalOnMissingBean(name = "casBeanValidationPostProcessor")
-        public BeanPostProcessor casBeanValidationPostProcessor() {
+        public static BeanPostProcessor casBeanValidationPostProcessor() {
             return new BeanValidationPostProcessor();
         }
 

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/config/CasCoreUtilConfiguration.java
@@ -99,6 +99,12 @@ public class CasCoreUtilConfiguration {
     @Configuration(value = "CasCoreUtilEssentialConfiguration", proxyBeanMethods = false)
     @EnableConfigurationProperties(CasConfigurationProperties.class)
     public static class CasCoreUtilEssentialConfiguration {
+
+        /**
+         * Create casBeanValidationPostProcessor bean.
+         * Note that {@code BeanPostProcessor} beans should be static.
+         * @return the BeanValidationPostProcessor
+         */
         @Bean
         @ConditionalOnMissingBean(name = "casBeanValidationPostProcessor")
         public static BeanPostProcessor casBeanValidationPostProcessor() {


### PR DESCRIPTION
I am running into an error trying to build CAS with spring native that might be due to early bean initialization. One cause of that apparently is non-static BeanPostProcessor beans: https://stackoverflow.com/questions/68830586/should-we-use-spring-bean-with-static-method

https://github.com/spring-projects/spring-boot/issues/29747#issuecomment-1036322721

I don't know if it is worth adding a check for this because CAS doesn't seem to use these BeanPostProcessor  or BeanFactoryPostProcessor much. 