### PR TITLE
passwordless: phone and email should be optional on isRequestPassword

### DIFF
--- a/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/VerifyPasswordlessAccountAuthenticationAction.java
+++ b/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/VerifyPasswordlessAccountAuthenticationAction.java
@@ -30,14 +30,15 @@ public class VerifyPasswordlessAccountAuthenticationAction extends BaseCasWebflo
             return error();
         }
         val user = account.get();
+        if (user.isRequestPassword()) {
+            WebUtils.putPasswordlessAuthenticationAccount(requestContext, user);
+            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_PROMPT);
+        }
         if (StringUtils.isBlank(user.getPhone()) && StringUtils.isBlank(user.getEmail())) {
             WebUtils.addErrorMessageToContext(requestContext, "passwordless.error.invalid.user");
             return error();
         }
         WebUtils.putPasswordlessAuthenticationAccount(requestContext, user);
-        if (user.isRequestPassword()) {
-            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_PROMPT);
-        }
         return success();
     }
 }

--- a/support/cas-server-support-passwordless-webflow/src/test/resources/PasswordlessAccount.groovy
+++ b/support/cas-server-support-passwordless-webflow/src/test/resources/PasswordlessAccount.groovy
@@ -20,8 +20,6 @@ def run(Object[] args) {
         return PasswordlessUserAccount.builder()
                 .username("nouserinfo")
                 .name("CAS")
-                .email("casuser@example.org")
-                .phone("123-456-7890")
                 .requestPassword(true)
                 .build()
     }


### PR DESCRIPTION
When using passwordless authentication, uUser phone and email properties should be optional
if isRequestPassword() returns true

This issue affects CAS 6.5.0
