### PR TITLE
passwordless: phone and email should be optional on isRequestPassword

### DIFF
--- a/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/VerifyPasswordlessAccountAuthenticationAction.java
+++ b/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/VerifyPasswordlessAccountAuthenticationAction.java
@@ -30,14 +30,15 @@ public class VerifyPasswordlessAccountAuthenticationAction extends BaseCasWebflo
             return error();
         }
         val user = account.get();
+        if (user.isRequestPassword()) {
+            WebUtils.putPasswordlessAuthenticationAccount(requestContext, user);
+            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_PROMPT);
+        }
         if (StringUtils.isBlank(user.getPhone()) && StringUtils.isBlank(user.getEmail())) {
             WebUtils.addErrorMessageToContext(requestContext, "passwordless.error.invalid.user");
             return error();
         }
         WebUtils.putPasswordlessAuthenticationAccount(requestContext, user);
-        if (user.isRequestPassword()) {
-            return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_PROMPT);
-        }
         return success();
     }
 }

--- a/support/cas-server-support-passwordless-webflow/src/test/java/org/apereo/cas/web/flow/VerifyPasswordlessAccountAuthenticationActionTests.java
+++ b/support/cas-server-support-passwordless-webflow/src/test/java/org/apereo/cas/web/flow/VerifyPasswordlessAccountAuthenticationActionTests.java
@@ -68,6 +68,12 @@ public class VerifyPasswordlessAccountAuthenticationActionTests extends BasePass
         assertEquals(CasWebflowConstants.TRANSITION_ID_PROMPT, verifyPasswordlessAccountAuthenticationAction.execute(context).getId());
     }
 
+    @Test
+    public void verifyRequestPasswordForUserWithoutEmailOrPhone() throws Exception {
+        val context = getRequestContext("needs-password-user-without-email-or-phone");
+        assertEquals(CasWebflowConstants.TRANSITION_ID_PROMPT, verifyPasswordlessAccountAuthenticationAction.execute(context).getId());
+    }
+
     private static RequestContext getRequestContext(final String username) {
         val request = new MockHttpServletRequest();
         val exec = new MockFlowExecutionContext(new MockFlowSession(new Flow(CasWebflowConfigurer.FLOW_ID_LOGIN)));

--- a/support/cas-server-support-passwordless-webflow/src/test/resources/PasswordlessAccount.groovy
+++ b/support/cas-server-support-passwordless-webflow/src/test/resources/PasswordlessAccount.groovy
@@ -26,6 +26,14 @@ def run(Object[] args) {
                 .build()
     }
 
+    if (username.equals("needs-password-user-without-email-or-phone")) {
+        return PasswordlessUserAccount.builder()
+                .username("nouserinfo")
+                .name("CAS")
+                .requestPassword(true)
+                .build()
+    }
+
     return PasswordlessUserAccount.builder()
             .email("casuser@example.org")
             .phone("123-456-7890")


### PR DESCRIPTION
Passwordless authentication: User phone and email properties should be optional
if isRequestPassword() returns true

Affects: CAS 6.5
