### PR TITLE
Configuration: change load order (system properties and environment variables first)

### DIFF
--- a/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
+++ b/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
@@ -13,6 +13,7 @@ import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.env.SystemEnvironmentPropertySource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -24,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import static org.springframework.core.env.StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME;
-import static org.springframework.core.env.StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME;
 
 /**
  * This is {@link DefaultCasConfigurationPropertiesSourceLocator}.
@@ -176,19 +175,17 @@ public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfig
     }
 
     /**
-     * Returns a system property composed of environment variables and system properties.
+     * Returns a property source composed of system properties and environment variables.
      *
-     * <p>Properties present in system properties will
-     * take precedence over those in environment variables,
-     * similarly to spring boot behaviour.
+     * System properties take precedence over environment variables (similarly to spring boot behaviour).
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private PropertySource<?> loadEnvironmentAndSystemProperties() {
-        CompositePropertySource environmentAndSystemProperties = new CompositePropertySource("environmentAndSystemProperties");
+    private static PropertySource<?> loadEnvironmentAndSystemProperties() {
+        val environmentAndSystemProperties = new CompositePropertySource("environmentAndSystemProperties");
         environmentAndSystemProperties.addPropertySource(
-            new PropertiesPropertySource(SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME, System.getProperties()));
+            new PropertiesPropertySource(StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME, System.getProperties()));
         environmentAndSystemProperties.addPropertySource(
-            new SystemEnvironmentPropertySource(SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, (Map) System.getenv()));
+            new SystemEnvironmentPropertySource(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, (Map) System.getenv()));
         return environmentAndSystemProperties;
     }
 

--- a/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/DefaultCasConfigurationPropertiesSourceLocatorTests.java
+++ b/core/cas-server-core-configuration/src/test/java/org/apereo/cas/configuration/support/DefaultCasConfigurationPropertiesSourceLocatorTests.java
@@ -46,6 +46,7 @@ public class DefaultCasConfigurationPropertiesSourceLocatorTests {
         System.setProperty("spring.profiles.active", CasConfigurationPropertiesSourceLocator.PROFILE_STANDALONE + ",dev");
         System.setProperty("cas.standalone.configuration-directory", "src/test/resources/directory");
         System.setProperty("cas.standalone.configuration-file", "src/test/resources/standalone.properties");
+        System.setProperty("test.overriden-by-system-property", "from-system-properties");
     }
 
     @Autowired
@@ -104,5 +105,14 @@ public class DefaultCasConfigurationPropertiesSourceLocatorTests {
         val loader = configurationPropertiesLoaderFactory.getLoader(
             resourceLoader.getResource("classpath:/badyaml.yml"), "test");
         assertThrows(YAMLException.class, loader::load);
+    }
+
+    @Test
+    public void verifySystemPropertiesOverrideCasConfiguration() {
+        val source = casCoreBootstrapPropertySourceLocator.locate(environment);
+        assertTrue(source instanceof CompositePropertySource);
+
+        val composite = (CompositePropertySource) source;
+        assertEquals("from-system-properties", composite.getProperty("test.overriden-by-system-property"));
     }
 }

--- a/core/cas-server-core-configuration/src/test/resources/directory/application.yml
+++ b/core/cas-server-core-configuration/src/test/resources/directory/application.yml
@@ -5,3 +5,4 @@ test:
     cas: dirAppYml
   file: dirAppYml
   profile: dirAppYml
+  overriden-by-system-property: from-application-yml

--- a/docs/cas-server-documentation/configuration/Configuration-Management.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Management.md
@@ -53,9 +53,9 @@ are considered in the following order:
 1. Command line arguments, starting with `--` (e.g. `--server.port=9000`)
 2. Properties from `SPRING_APPLICATION_JSON` (inline JSON embedded in an environment variable/system property)
 3. JNDI attributes from `java:comp/env`.
-4. Java System properties.
+4. Configuration files (i.e. `application.properties|yml`) indicated by the [configuration server](#configuration-server) and profile.
 5. OS environment variables.
-6. Configuration files (i.e. `application.properties|yml`) indicated by the [configuration server](#configuration-server) and profile.
+6. Java System properties.
 
 <div class="alert alert-info"><strong>Managing Configuration</strong><p>In order to manage
 the CAS configuration, you should configure access


### PR DESCRIPTION
Hello,

**Summary**: This PR will change the load order of CAS configuration so that System properties and env variables
override CAS configuration files.

**Details**:

When I'm using CAS in a docker environment (with a docker-compose file), I stumbled
upon the fact that I could not override a variable already defined in /etc/cas/config/application.yml
from my docker-compose file (i.e I'm used to override the spring boot configuration with environment variables defined in the docker compose)

For instance, if I have:

{code}
version: '3'
services:
  cas:
    image: apereo/cas
    ports:
      - "8443:8443"
      - "8444:8444"
    volumes:
      - ./etc/cas/config:/etc/cas/config
    environment:
      - SERVER_PORT=8444
{code}

With my /etc/cas/config/application.yml being

{code}
server:
  port: 8443
{code}

The CAS will start at port 8443 (and not 8444 as I would expect from a Spring Boot app)

This PR will change the load order of CAS configuration so that System properties and env variables
override CAS configuration files.

N.B. I've added a unit test for checking system.properties configuration order, but I didn't found a good way to test environment variables ordering. I'll take any input gladly.