### PR TITLE
Improve build speed by reusing computations from previous builds

### DIFF
--- a/ci/docs/publish.sh
+++ b/ci/docs/publish.sh
@@ -164,7 +164,7 @@ if [[ $generateData == "true" ]]; then
   docgen="docs/cas-server-documentation-processor/build/libs/casdocsgen.jar"
   printgreen "Generating documentation site data...\n"
   if [[ ! -f "$docgen" ]]; then
-    ./gradlew :docs:cas-server-documentation-processor:build --no-daemon -x check -x test -x javadoc --configure-on-demand --max-workers=8
+    ./gradlew :docs:cas-server-documentation-processor:build --daemon -x check -x test -x javadoc --configure-on-demand --max-workers=8
     if [ $? -eq 1 ]; then
       echo "Unable to build the documentation processor. Aborting..."
       exit 1

--- a/ci/init-build.sh
+++ b/ci/init-build.sh
@@ -29,8 +29,8 @@ echo -e "Setting build environment...\n"
 $SUDO mkdir -p /etc/cas/config /etc/cas/saml /etc/cas/services /tmp /temp
 
 echo -e "Configuring Gradle wrapper...\n"
-mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
+mkdir -p ~/.gradle && echo "org.gradle.daemon=true" >> ~/.gradle/gradle.properties
 chmod -R 777 ./gradlew
 echo "Gradle Home directory:"
-./gradlew gradleHome --no-daemon --version
+./gradlew gradleHome --daemon --version
 echo -e "Configured build environment\n"

--- a/ci/tests/oidc-conformance/run.sh
+++ b/ci/tests/oidc-conformance/run.sh
@@ -16,7 +16,7 @@ keytool -genkey -noprompt -alias cas -keyalg RSA -keypass changeit -storepass ch
 
 echo -e "\Building CAS with support for OpenID Connect..."
 ./gradlew :webapp:cas-server-webapp-tomcat:build -DskipNestedConfigMetadataGen=true -x check -x javadoc \
-  --no-daemon --build-cache --configure-on-demand --parallel -DcasModules="oidc,reports"
+  --daemon --build-cache --configure-on-demand --parallel -DcasModules="oidc,reports"
 mv "$PWD"/webapp/cas-server-webapp-tomcat/build/libs/cas-server-webapp-tomcat-*-SNAPSHOT.war "$PWD"/cas.war
 
 if [ $? -eq 1 ]; then

--- a/ci/tests/perf/perftests-jmeter.sh
+++ b/ci/tests/perf/perftests-jmeter.sh
@@ -16,7 +16,7 @@ function printgreen() {
 jmeterVersion=5.4.3
 gradle="./gradlew "
 gradleBuild=""
-gradleBuildOptions="--build-cache --configure-on-demand --no-daemon --parallel --max-workers=8 "
+gradleBuildOptions="--build-cache --configure-on-demand --daemon --parallel --max-workers=8 "
 webAppServerType="$1"
 testCategory="${2:-cas}"
 

--- a/ci/tests/perf/perftests-locust.sh
+++ b/ci/tests/perf/perftests-locust.sh
@@ -2,7 +2,7 @@
 
 gradle="./gradlew "
 gradleBuild=""
-gradleBuildOptions="--build-cache --configure-on-demand --no-daemon --parallel "
+gradleBuildOptions="--build-cache --configure-on-demand --daemon --parallel "
 webAppServerType="$1"
 
 echo -e "***********************************************"

--- a/ci/tests/puppeteer/run.sh
+++ b/ci/tests/puppeteer/run.sh
@@ -161,7 +161,7 @@ if [[ "${CI}" == "true" ]]; then
   printgreen "DEBUG flag is turned off while running CI"
   DEBUG=""
   printgreen "Gradle daemon is turned off while running CI"
-  DAEMON="--no-daemon"
+  DAEMON="--daemon"
 fi
 
 if [[ "${RERUN}" == "true" ]]; then

--- a/ci/tests/shell/run-shell.sh
+++ b/ci/tests/shell/run-shell.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 echo "Running Gradle build to determine CAS version..."
-casVersion=$(./gradlew casVersion --no-daemon -q)
+casVersion=$(./gradlew casVersion --daemon -q)
 
 echo "Building CAS command-line shell version $casVersion"
 ./gradlew :support:cas-server-support-shell:build -DskipNestedConfigMetadataGen=true \
-  -x check -x javadoc  --no-daemon --build-cache --configure-on-demand --parallel
+  -x check -x javadoc  --daemon --build-cache --configure-on-demand --parallel
 
 echo "Running CAS command-line shell version $casVersion"
 java -jar support/cas-server-support-shell/build/libs/cas-server-support-shell-${casVersion}.jar \

--- a/ci/tests/webapp/validate-bootadmin-webapp.sh
+++ b/ci/tests/webapp/validate-bootadmin-webapp.sh
@@ -2,7 +2,7 @@
 
 ./gradlew :webapp:cas-server-webapp-bootadmin-server:build \
   -DskipNestedConfigMetadataGen=true -x check -x javadoc \
-  --no-daemon --build-cache --configure-on-demand --parallel
+  --daemon --build-cache --configure-on-demand --parallel
   
 mv webapp/cas-server-webapp-bootadmin-server/build/libs/cas-server-webapp-bootadmin-server-*-SNAPSHOT.war \
   webapp/cas-server-webapp-bootadmin-server/build/libs/admin.war

--- a/ci/tests/webapp/validate-configserver-webapp.sh
+++ b/ci/tests/webapp/validate-configserver-webapp.sh
@@ -2,7 +2,7 @@
 
 ./gradlew :webapp:cas-server-webapp-config-server:build \
   -DskipNestedConfigMetadataGen=true -x check -x javadoc \
-  --no-daemon --build-cache --configure-on-demand --parallel
+  --daemon --build-cache --configure-on-demand --parallel
   
 mv webapp/cas-server-webapp-config-server/build/libs/cas-server-webapp-config-server-*-SNAPSHOT.war \
   webapp/cas-server-webapp-config-server/build/libs/casconfigserver.war

--- a/ci/tests/webapp/validate-embedded-webapp.sh
+++ b/ci/tests/webapp/validate-embedded-webapp.sh
@@ -62,7 +62,7 @@ testUrl() {
 echo "Building CAS server web application with ${webAppServerType}"
 ./gradlew :webapp:cas-server-webapp-"${webAppServerType}":build \
   -DskipNestedConfigMetadataGen=true -x check -x javadoc \
-  --no-daemon --build-cache --configure-on-demand --parallel
+  --daemon --build-cache --configure-on-demand --parallel
 
 mv webapp/cas-server-webapp-"${webAppServerType}"/build/libs/cas-server-webapp-"${webAppServerType}"-*-SNAPSHOT.war \
 webapp/cas-server-webapp-"${webAppServerType}"/build/libs/cas.war

--- a/ci/tests/webapp/validate-eurekaserver-webapp.sh
+++ b/ci/tests/webapp/validate-eurekaserver-webapp.sh
@@ -4,7 +4,7 @@ webAppServerType="$1"
 
 ./gradlew :webapp:cas-server-webapp-eureka-server:build \
   -DskipNestedConfigMetadataGen=true -x check -x javadoc \
-  --no-daemon --build-cache --configure-on-demand --parallel
+  --daemon --build-cache --configure-on-demand --parallel
 
 mv webapp/cas-server-webapp-eureka-server/build/libs/cas-server-webapp-eureka-server-*-SNAPSHOT.war \
   webapp/cas-server-webapp-eureka-server/build/libs/caseurekaserver.war

--- a/ci/tests/webapp/validate-external-webapp.sh
+++ b/ci/tests/webapp/validate-external-webapp.sh
@@ -54,7 +54,7 @@ clear
 echo -e "Building project ${project}..."
 ./gradlew :webapp:${project}:build \
   -DskipNestedConfigMetadataGen=true -x check -x javadoc -q \
-  --no-daemon --build-cache --configure-on-demand --parallel
+  --daemon --build-cache --configure-on-demand --parallel
 
 echo -e "Removing Apache Tomcat default web applications..."
 rm -Rf ${CATALINA_HOME}/webapps/examples ${CATALINA_HOME}/webapps/docs \

--- a/release.sh
+++ b/release.sh
@@ -46,7 +46,7 @@ echo -e "\t\tsigning.keyId=YOUR_KEY_ID"
 echo -e "\t\tsigning.password=YOUR_KEY_PASSWORD"
 echo -e "\t\tsigning.secretKeyRingFile=/path/to/.gnupg/secring.gpg"
 echo -e "\t- Disable the Gradle daemon and parallel processing via '~/.gradle/gradle.properties':"
-echo -e "\t\torg.gradle.daemon=false"
+echo -e "\t\torg.gradle.daemon=true"
 echo -e "\t\torg.gradle.parallel=false"
 echo -e "\nFor more information, please visit\n\thttps://apereo.github.io/cas/developer/Release-Process.html\n"
 

--- a/testcas.sh
+++ b/testcas.sh
@@ -45,7 +45,7 @@ parallel="--parallel "
 dryRun=""
 info=""
 gradleCmd="./gradlew"
-flags="--no-daemon --configure-on-demand --build-cache -x javadoc -x check -DskipNestedConfigMetadataGen=true -Dverbose=true "
+flags="--daemon --configure-on-demand --build-cache -x javadoc -x check -DskipNestedConfigMetadataGen=true -Dverbose=true "
 coverageTask=""
 
 while (( "$#" )); do


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
