### PR TITLE
hazelcast upgraded to 5.1 (fix for CVE-2022-0265)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -204,7 +204,7 @@ mongoDriverVersion=4.4.2
 ###############################
 # Hazelcast Versions
 ###############################
-hazelcastVersion=5.0.2
+hazelcastVersion=5.1
 hazelcastAwsVersion=3.4
 hazelcastAzureVersion=2.1.2
 hazelcastZooKeeperVersion=4.0.2


### PR DESCRIPTION
Hazelcast 5.0.2 has a high CVE with id CVE-2022-0265 which is fixed in 5.1. This is basically a backport from master.