### PR TITLE
In the OidcWellKnownEndpointController file, change the "/**/" in the mapping to "/*/"

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/discovery/OidcWellKnownEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/discovery/OidcWellKnownEndpointController.java
@@ -44,7 +44,7 @@ public class OidcWellKnownEndpointController extends BaseOidcController {
      */
     @GetMapping(value = {
         '/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.WELL_KNOWN_URL,
-        "/**/" + OidcConstants.WELL_KNOWN_URL
+        "/*/" + OidcConstants.WELL_KNOWN_URL
     }, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<OidcServerDiscoverySettings> getWellKnownDiscoveryConfiguration(final HttpServletRequest request,
                                                                                           final HttpServletResponse response) {
@@ -60,7 +60,7 @@ public class OidcWellKnownEndpointController extends BaseOidcController {
      */
     @GetMapping(value = {
         '/' + OidcConstants.BASE_OIDC_URL + '/' + OidcConstants.WELL_KNOWN_OPENID_CONFIGURATION_URL,
-        "/**/" + OidcConstants.WELL_KNOWN_OPENID_CONFIGURATION_URL}, produces = MediaType.APPLICATION_JSON_VALUE)
+        "/*/" + OidcConstants.WELL_KNOWN_OPENID_CONFIGURATION_URL}, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<OidcServerDiscoverySettings> getWellKnownOpenIdDiscoveryConfiguration(final HttpServletRequest request,
                                                                                                 final HttpServletResponse response) {
         return getOidcServerDiscoveryResponse(request, response, OidcConstants.WELL_KNOWN_OPENID_CONFIGURATION_URL);


### PR DESCRIPTION
When the project is updated to version 6.5, it cannot be started. The error is "Invalid mapping on handler class OidcWellKnownEndpointController ...". It is found that the path wildcard has changed after spring is upgraded to 5.3. The official explanation is "In Spring MVC, the path was previously analyzed by AntPathMatcher, but it was changed to use PathPatternParser introduced in WebFlux from Spring 5.3.0."

In the CAS project, there are too many dependencies and I can't download them, so I can't install the modified dependencies locally. Here, I will mention the problems and solutions first. I hope you can help me. Thank you very much.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
