### PR TITLE
Adding test for multiple mfa providers with triggers, it will fail

### DIFF
--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/script.js
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/script.js
@@ -1,0 +1,14 @@
+const puppeteer = require('puppeteer');
+
+const cas = require('../../cas.js');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+    await page.goto("https://localhost:8443/cas/login?service=https://example.com");
+    await cas.loginWith(page, "casuser", "Mellon");
+    await page.waitForTimeout(2000)
+    await cas.assertVisibility(page, '#mfa-gauth')
+    await cas.assertVisibility(page, '#mfa-webauthn')
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/script.json
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/script.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": "gauth,webauthn",
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.authn.attribute-repository.stub.attributes.memberof=staff"
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services",
+    "--cas.authn.mfa.gauth.core.issuer=CASIssuer",
+    "--cas.authn.mfa.gauth.core.label=CASLabel",
+    "--cas.authn.mfa.core.provider-selection-enabled=true",
+    "--cas.audit.engine.enabled=false"
+  ]
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/script.json
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/script.json
@@ -5,7 +5,7 @@
     "--cas.server.prefix=${cas.server.name}/cas",
 
     "--cas.service-registry.core.init-from-json=true",
-    "--cas.authn.attribute-repository.stub.attributes.memberof=staff"
+    "--cas.authn.attribute-repository.stub.attributes.memberof=staff",
     "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services",
     "--cas.authn.mfa.gauth.core.issuer=CASIssuer",
     "--cas.authn.mfa.gauth.core.label=CASLabel",

--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-attr/services/Sample-1.json
@@ -1,0 +1,14 @@
+{
+  "@class": "org.apereo.cas.services.RegexRegisteredService",
+  "serviceId": "^(https|imaps)://.*",
+  "name": "Sample",
+  "id": 1,
+  "description": "Sample Service",
+  "evaluationOrder": 10000,
+  "multifactorPolicy" : {
+    "@class" : "org.apereo.cas.services.DefaultRegisteredServiceMultifactorPolicy",
+    "multifactorAuthenticationProviders" : [ "java.util.LinkedHashSet", [ "mfa-gauth", "mfa-webauthn" ] ],
+    "principalAttributeNameTrigger" : "memberof",
+    "principalAttributeValueToMatch" : "staff"
+  }
+}


### PR DESCRIPTION
Added test for mfa provider selection with multiple providers and trigger, ci/test/puppeteer/mfa-provider-selection-trigger-attr

This test should fail in the current state because I have noticed that when using multiple mfa providers in a service plus any triggers will completely disable mfa all together and let the user sign in.

End result should let the user decide which MFA to use and only if trigger matches.