### PR TITLE
Exclude initToken and nextToken from SpnegoCredential JSON Serialization

### DIFF
--- a/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredential.java
+++ b/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredential.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.spnego.authentication.principal;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apereo.cas.authentication.Credential;
 import org.apereo.cas.authentication.principal.Principal;
 
@@ -45,12 +46,14 @@ public class SpnegoCredential implements Credential {
      * The SPNEGO Init Token.
      */
     @ToString.Exclude
+    @JsonIgnore
     private byte[] initToken;
 
     /**
      * The SPNEGO Next Token.
      */
     @ToString.Exclude
+    @JsonIgnore
     private byte[] nextToken;
 
     /**

--- a/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredentialsTests.java
+++ b/support/cas-server-support-spnego/src/test/java/org/apereo/cas/support/spnego/authentication/principal/SpnegoCredentialsTests.java
@@ -1,12 +1,18 @@
 package org.apereo.cas.support.spnego.authentication.principal;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
 
 import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -42,4 +48,22 @@ public class SpnegoCredentialsTests {
         val hash2 = credential.hashCode();
         assertNotEquals(hash1, hash2);
     }
+
+    @Test
+    public void verifyToStringWithToken() {
+        val credentials = new SpnegoCredential(new byte[16]);
+        credentials.setNextToken(new byte[16]);
+        assertThat(credentials.toString(), not(containsString("initToken")));
+        assertThat(credentials.toString(), not(containsString("nextToken")));
+    }
+
+    @Test
+    public void verifyJsonWithToken() throws JsonProcessingException {
+        val credentials = new SpnegoCredential(new byte[16]);
+        credentials.setNextToken(new byte[16]);
+        ObjectMapper objectMapper = new ObjectMapper();
+        assertThat(objectMapper.writeValueAsString(credentials), not(containsString("initToken")));
+        assertThat(objectMapper.writeValueAsString(credentials), not(containsString("nextToken")));
+    }
+
 }


### PR DESCRIPTION
Remove `initToken`and `nextToken` binary attributes from `SpnegoCredential` JSON Serialization.

These attributes pollute audit log when formatted in JSON because of their huge size
and finally it is maybe sensible information we want to hide in audit log.

This was fixed by [PR 4897](https://github.com/apereo/cas/pull/4897) but this is no longer the case (bug exists in 6.4.4.2)