### PR TITLE
Allow alternative identityProviderDiscoveryFeedControllers

### DIFF
--- a/support/cas-server-support-saml-idp-discovery/src/main/java/org/apereo/cas/config/SamlIdentityProviderDiscoveryConfiguration.java
+++ b/support/cas-server-support-saml-idp-discovery/src/main/java/org/apereo/cas/config/SamlIdentityProviderDiscoveryConfiguration.java
@@ -68,6 +68,7 @@ public class SamlIdentityProviderDiscoveryConfiguration {
 
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+    @ConditionalOnMissingBean(name = "identityProviderDiscoveryFeedController")
     public SamlIdentityProviderDiscoveryFeedController identityProviderDiscoveryFeedController(
         @Qualifier("samlIdentityProviderEntityParser")
         final Supplier<List<SamlIdentityProviderEntityParser>> samlIdentityProviderEntityParser, final CasConfigurationProperties casProperties,


### PR DESCRIPTION
- [] Brief description of changes applied
Add ConditionalOnMissingBean to the factory method for SamlIdentityProviderDiscoveryFeedController to allow alternative implementations. It might have been nicer to add an interface, implementations etc for a service that a standard FeedController uses but this is my first pull request and this simple change works for me.

- [] Test cases for all modified changes, where applicable
I don't think a test case would prove very much as it is just meta data for a standard mechanism.

- [] The same pull request targeted at the master branch, if applicable
This targets master but I would like to backport it to 6.5.x as we are already pretty late upgrading.

- [] Any documentation on how to configure, test
Standard feature already heavily used in CAS?

- [] Any possible limitations, side effects, etc
If somebody is already defining a bean with the same name it would have previously failed to start and now would try and do something?

- [] Reference any other pull requests that might be related
None

