### PR TITLE
Allow MFA Triggers for Rest and Principal Attribute Per Application Return Multiple Providers

### DIFF
--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-principal-attribute/script.js
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-principal-attribute/script.js
@@ -1,0 +1,14 @@
+const puppeteer = require('puppeteer');
+
+const cas = require('../../cas.js');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+    await page.goto("https://localhost:8443/cas/login?service=https://example.com");
+    await cas.loginWith(page, "casuser", "Mellon");
+    await page.waitForTimeout(2000)
+    await cas.assertVisibility(page, '#mfa-gauth')
+    await cas.assertVisibility(page, '#mfa-webauthn')
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-principal-attribute/script.json
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-principal-attribute/script.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": "gauth,webauthn",
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.authn.attribute-repository.stub.attributes.memberof=staff",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services",
+    "--cas.authn.mfa.gauth.core.issuer=CASIssuer",
+    "--cas.authn.mfa.gauth.core.label=CASLabel",
+    "--cas.authn.mfa.core.provider-selection-enabled=true",
+    "--cas.audit.engine.enabled=false"
+  ]
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-principal-attribute/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-principal-attribute/services/Sample-1.json
@@ -1,0 +1,14 @@
+{
+  "@class": "org.apereo.cas.services.RegexRegisteredService",
+  "serviceId": "^(https|imaps)://.*",
+  "name": "Sample",
+  "id": 1,
+  "description": "Sample Service",
+  "evaluationOrder": 10000,
+  "multifactorPolicy" : {
+    "@class" : "org.apereo.cas.services.DefaultRegisteredServiceMultifactorPolicy",
+    "multifactorAuthenticationProviders" : [ "java.util.LinkedHashSet", [ "mfa-gauth", "mfa-webauthn" ] ],
+    "principalAttributeNameTrigger" : "memberof",
+    "principalAttributeValueToMatch" : "staff"
+  }
+}

--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/mfa/trigger/RegisteredServicePrincipalAttributeMultifactorAuthenticationTrigger.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/mfa/trigger/RegisteredServicePrincipalAttributeMultifactorAuthenticationTrigger.java
@@ -88,9 +88,11 @@ public class RegisteredServicePrincipalAttributeMultifactorAuthenticationTrigger
                 attributeValue != null && RegexUtils.matches(Pattern.compile(policy.getPrincipalAttributeValueToMatch()), attributeValue));
 
         if (result != null && !result.isEmpty()) {
-            return CollectionUtils.firstElement(result)
-                .map(value -> MultifactorAuthenticationUtils.getMultifactorAuthenticationProviderById(value.toString(), this.applicationContext))
-                .orElseGet(() -> unmatchedMultifactorAuthenticationTrigger(principal, registeredService));
+            val provider = multifactorAuthenticationProviderSelector.resolve(providers, registeredService, principal);
+            if (provider != null) {
+                LOGGER.debug("Selected multifactor authentication provider for this transaction is [{}]", provider);
+                return Optional.of(provider);
+            }
         }
 
         return unmatchedMultifactorAuthenticationTrigger(principal, registeredService);

--- a/core/cas-server-core-webflow-mfa/src/main/java/org/apereo/cas/web/flow/config/CasMultifactorAuthenticationWebflowConfiguration.java
+++ b/core/cas-server-core-webflow-mfa/src/main/java/org/apereo/cas/web/flow/config/CasMultifactorAuthenticationWebflowConfiguration.java
@@ -289,9 +289,14 @@ public class CasMultifactorAuthenticationWebflowConfiguration {
         public MultifactorAuthenticationTrigger restEndpointMultifactorAuthenticationTrigger(
             @Qualifier(MultifactorAuthenticationProviderResolver.BEAN_NAME)
             final MultifactorAuthenticationProviderResolver multifactorAuthenticationProviderResolver,
+            final MultifactorAuthenticationProviderSelector multifactorAuthenticationProviderSelector,
             final ConfigurableApplicationContext applicationContext,
             final CasConfigurationProperties casProperties) {
-            return new RestEndpointMultifactorAuthenticationTrigger(casProperties, multifactorAuthenticationProviderResolver, applicationContext);
+            return new RestEndpointMultifactorAuthenticationTrigger(
+                    casProperties,
+                    multifactorAuthenticationProviderResolver,
+                    multifactorAuthenticationProviderSelector,
+                    applicationContext);
         }
 
 


### PR DESCRIPTION
This will allow these mfa triggers to work properly when cas.authn.mfa.core.provider-selection-enabled = true , applied @jbanner6736 test case for Principal Attribute Per Application, /ci/tests/puppeteer/scenarios/mfa-provider-selection-trigger-principal-attribute . I wasn't sure on how to write a test for Rest, although we have been using it for a while now and no hiccups. I would gladly write a test for it, just need to some pointers on how to implement.

Service definition now works with, 

    "multifactorAuthenticationProviders" : [ "java.util.LinkedHashSet", [ "mfa-gauth", "mfa-webauthn" ] ],
    "principalAttributeNameTrigger" : "memberof",
    "principalAttributeValueToMatch" : "staff"

The rest endpoint can return multiple providers, comma-separated, 'mfa-gauth,mfa-webauthn'
 
Also, as noted by others when I was testing, mfa-webauthn has a webflow error when registering and then errors during forward to service, has flow exectution error as final flow destination, if you could please look into it. 

2022-03-23 12:37:54,517 WARN [org.apereo.cas.web.flow.executor.EncryptedTranscoder] - <java.util.Optional>
java.io.NotSerializableException: java.util.Optional

Forum link here [https://groups.google.com/a/apereo.org/g/cas-user/c/KQcalohFG6k](https://groups.google.com/a/apereo.org/g/cas-user/c/KQcalohFG6k)

Thanks!
