### PR TITLE
Fix OIDC UserInfo in JWT format

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-profile-jwt-format/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-profile-jwt-format/script.js
@@ -1,0 +1,64 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    const redirectUrl = "https://github.com/apereo/cas";
+
+    let url = `https://localhost:8443/cas/oidc/authorize?response_type=code&client_id=client&scope=openid%20email%20profile%20address%20phone&redirect_uri=${redirectUrl}&nonce=3d3a7457f9ad3&state=1735fd6c43c14`;
+
+    console.log(`Navigating to ${url}`);
+    await cas.goto(page, url);
+    await cas.loginWith(page, "casuser", "Mellon");
+    await page.waitForTimeout(1000)
+    await cas.click(page, "#allow");
+    await page.waitForNavigation();
+
+    let code = await cas.assertParameter(page, "code");
+    console.log(`OAuth code ${code}`);
+
+    let accessTokenParams = "client_id=client&";
+    accessTokenParams += "client_secret=secret&";
+    accessTokenParams += "grant_type=authorization_code&";
+    accessTokenParams += `redirect_uri=${redirectUrl}`;
+
+    let accessTokenUrl = `https://localhost:8443/cas/oidc/token?${accessTokenParams}&code=${code}`;
+    console.log(`Calling ${accessTokenUrl}`);
+
+    let accessToken = null;
+    await cas.doPost(accessTokenUrl, "", {
+        'Content-Type': "application/json"
+    }, async res => {
+        console.log(res.data);
+        assert(res.data.access_token !== null);
+
+        accessToken = res.data.access_token;
+        console.log(`Received access token ${accessToken}`);
+
+        console.log("Decoding ID token...");
+        let decoded = await cas.decodeJwt(res.data.id_token);
+
+        assert(decoded.sub !== null)
+        assert(decoded["preferred_username"] == null)
+    }, error => {
+        throw `Operation failed to obtain access token: ${error}`;
+    });
+
+    assert(accessToken != null, "Access Token cannot be null")
+
+    let profileUrl = `https://localhost:8443/cas/oidc/profile?access_token=${accessToken}`;
+    console.log(`Calling user profile ${profileUrl}`);
+    await cas.doPost(profileUrl, "", {
+        'Accept': "application/jwt"
+    }, res => {
+        console.log(res.data);
+        assert(res.data != null)
+    }, error => {
+        throw `Operation failed: ${error}`;
+    });
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-profile-jwt-format/script.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-profile-jwt-format/script.json
@@ -1,0 +1,24 @@
+{
+  "dependencies": "oidc",
+  "properties": [
+    "--cas.audit.engine.enabled=false",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--cas.authn.attribute-repository.stub.attributes.email=casuser@apereo.org",
+    "--cas.authn.attribute-repository.stub.attributes.name=CAS",
+    "--cas.authn.attribute-repository.stub.attributes.gender=female",
+    "--cas.authn.attribute-repository.stub.attributes.preferred_username=casuser",
+
+    "--cas.authn.oauth.code.remove-related-access-tokens=true",
+    "--cas.authn.oauth.core.user-profile-view-type=FLAT",
+    
+    "--cas.authn.oidc.core.issuer=https://localhost:8443/cas/oidc",
+    "--cas.authn.oidc.core.include-id-token-claims=false",
+    "--cas.authn.oidc.jwks.file-system.jwks-file=file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services"
+  ]
+}

--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-profile-jwt-format/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-profile-jwt-format/services/Sample-1.json
@@ -1,0 +1,14 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client",
+  "clientSecret": "secret",
+  "serviceId": ".*",
+  "name": "Sample",
+  "id": 1,
+  "description": "Sample Service",
+  "evaluationOrder": 10000,
+  "scopes" : [ "java.util.HashSet", [ "openid", "profile", "email" ] ],
+  "supportedResponseTypes": [ "java.util.HashSet", [ "code" ] ],
+  "jwks": "file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
+  "userInfoSigningAlg": "RS256"
+}

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/profile/OidcUserProfileEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/profile/OidcUserProfileEndpointController.java
@@ -32,7 +32,7 @@ public class OidcUserProfileEndpointController extends OAuth20UserProfileEndpoin
     @GetMapping(value = {
         '/' + OidcConstants.BASE_OIDC_URL + '/' + OAuth20Constants.PROFILE_URL,
         "/**/" + OidcConstants.PROFILE_URL
-    }, produces = MediaType.APPLICATION_JSON_VALUE)
+    }, produces = { MediaType.APPLICATION_JSON_VALUE, OidcConstants.CONTENT_TYPE_JWT })
     @Override
     public ResponseEntity<String> handleGetRequest(final HttpServletRequest request,
                                                    final HttpServletResponse response) throws Exception {
@@ -47,7 +47,7 @@ public class OidcUserProfileEndpointController extends OAuth20UserProfileEndpoin
     @PostMapping(value = {
         '/' + OidcConstants.BASE_OIDC_URL + '/' + OAuth20Constants.PROFILE_URL,
         "/**/" + OidcConstants.PROFILE_URL
-    }, produces = MediaType.APPLICATION_JSON_VALUE)
+    }, produces = { MediaType.APPLICATION_JSON_VALUE, OidcConstants.CONTENT_TYPE_JWT })
     @Override
     public ResponseEntity<String> handlePostRequest(final HttpServletRequest request,
                                                     final HttpServletResponse response) throws Exception {


### PR DESCRIPTION
The OIDC UserInfo endpoint can return a signed/encrypted JWT.

Some clients may send the `"Accept": "application/jwt"` header in the request to meet the response type.
Currently, the endpoint is only defined as producing JSON.
So Spring returns a 406 HTTP error.

This PR fixes the problem by adding the JWT format in addition to the JSON format.

I couldn't find any good unit test to confirm the fix, so I added an integration test for that.
