### PR TITLE
Allow to encode scratch codes for MFA Google Auth

### DIFF
--- a/api/cas-server-core-api-util/src/main/java/org/apereo/cas/util/crypto/CipherExecutor.java
+++ b/api/cas-server-core-api-util/src/main/java/org/apereo/cas/util/crypto/CipherExecutor.java
@@ -60,6 +60,15 @@ public interface CipherExecutor<I, O> {
     /**
      * Factory method.
      *
+     * @return Strongly -typed Noop {@code CipherExecutor Number -> Number}
+     */
+    static CipherExecutor<Number, Number> noOpOfNumberToNumber() {
+        return NoOpCipherExecutor.INSTANCE;
+    }
+
+    /**
+     * Factory method.
+     *
      * @return Strongly -typed Noop {@code CipherExecutor Serializable -> String}
      */
     static CipherExecutor<Serializable, String> noOpOfSerializableToString() {

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/OneTimeTokenAccount.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/OneTimeTokenAccount.java
@@ -21,6 +21,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Transient;
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -63,11 +64,11 @@ public class OneTimeTokenAccount implements Serializable, Comparable<OneTimeToke
     @JsonProperty("validationCode")
     private int validationCode;
 
-    @ElementCollection
+    @ElementCollection(targetClass = BigInteger.class)
     @CollectionTable(name = TABLE_NAME_SCRATCH_CODES, joinColumns = @JoinColumn(name = "id"))
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "bigint", precision = 255, scale = 0)
     @Builder.Default
-    private List<Integer> scratchCodes = new ArrayList<>(0);
+    private List<Number> scratchCodes = new ArrayList<>(0);
 
     @Column(nullable = false)
     @JsonProperty("username")

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/JasyptNumberCipherExecutor.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/JasyptNumberCipherExecutor.java
@@ -3,6 +3,7 @@ package org.apereo.cas.util.cipher;
 import org.apereo.cas.util.crypto.CipherExecutor;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jasypt.util.numeric.AES256IntegerNumberEncryptor;
@@ -16,6 +17,7 @@ import java.security.Security;
  * @author Misagh Moayyed
  * @since 6.6.0
  */
+@Slf4j
 public class JasyptNumberCipherExecutor implements CipherExecutor<Number, Number> {
     static {
         Security.addProvider(new BouncyCastleProvider());
@@ -42,6 +44,11 @@ public class JasyptNumberCipherExecutor implements CipherExecutor<Number, Number
     @Override
     public Number decode(final Number value, final Object[] parameters) {
         val input = new BigInteger(value.toString());
-        return this.jasyptInstance.decrypt(input);
+        try {
+            return this.jasyptInstance.decrypt(input);
+        } catch (final org.jasypt.exceptions.EncryptionOperationNotPossibleException e) {
+            LOGGER.warn("Unable to decode number. Returning input value", e);
+            return value;
+        }
     }
 }

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/cipher/JasyptNumberCipherExecutorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/cipher/JasyptNumberCipherExecutorTests.java
@@ -36,4 +36,13 @@ public class JasyptNumberCipherExecutorTests {
         val encoded = cipher.encode(randomNumber);
         assertEquals(randomNumber, cipher.decode(encoded).intValue());
     }
+
+    @Test
+    public void verifyDecodeTwice() throws Exception {
+        val cipher = new JasyptNumberCipherExecutor(UUID.randomUUID().toString(), "My Cipher");
+        val randomNumber = RandomUtils.nextInt(0, 9999999);
+        val encoded = cipher.encode(randomNumber);
+        val decoded = cipher.decode(cipher.decode(encoded));
+        assertEquals(randomNumber, decoded.intValue());
+    }
 }

--- a/docs/cas-server-documentation/release_notes/RC2.md
+++ b/docs/cas-server-documentation/release_notes/RC2.md
@@ -104,6 +104,24 @@ CAS may also allow individual end-users to update certain aspects of their accou
 
 <img width="100%" alt="image" src="https://user-images.githubusercontent.com/1205228/160280056-ec2244f1-acb3-44fb-93cc-ee3ac5e541e6.png">
 
+### Google Authenticator Scratch Codes
+
+CAS now allows to encrypt the Google Authenticator scratch codes to protect their values.
+
+This is enabled when the following key is set: `cas.authn.mfa.gauth.core.scratch-codes.encryption.key`.
+
+You must notice that while the encrypted scratch codes are still numbers, they are bigger ones.
+
+So the `scratch_codes` column in the `scratch_codes` table in the database needs to be updated.
+
+For example for PostgreSQL, you must run this SQL command to alter the column from an `int4` to a `numeric`:
+
+```sql
+ALTER TABLE scratch_codes ALTER COLUMN scratch_codes TYPE numeric USING scratch_codes::numeric;
+```
+
+This should be very similar for other databases: you need to migrate the column type from "integer" to "numeric".
+
 ## Other Stuff
       
 - Minor UI improvements to ensure "Reveal Password" buttons line up correctly in input fields.

--- a/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/credential/BaseGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-core-mfa/src/main/java/org/apereo/cas/gauth/credential/BaseGoogleAuthenticatorTokenCredentialRepository.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.val;
 
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * This is {@link BaseGoogleAuthenticatorTokenCredentialRepository}.
@@ -25,8 +26,9 @@ public abstract class BaseGoogleAuthenticatorTokenCredentialRepository extends B
     protected final IGoogleAuthenticator googleAuthenticator;
 
     protected BaseGoogleAuthenticatorTokenCredentialRepository(final CipherExecutor<String, String> tokenCredentialCipher,
+                                                               final CipherExecutor<Number, Number> scratchCodesCipher,
                                                                final IGoogleAuthenticator googleAuthenticator) {
-        super(tokenCredentialCipher);
+        super(tokenCredentialCipher, scratchCodesCipher);
         this.googleAuthenticator = googleAuthenticator;
     }
 
@@ -37,7 +39,7 @@ public abstract class BaseGoogleAuthenticatorTokenCredentialRepository extends B
             .username(username)
             .secretKey(key.getKey())
             .validationCode(key.getVerificationCode())
-            .scratchCodes(key.getScratchCodes())
+            .scratchCodes(key.getScratchCodes().stream().map(c -> c.intValue()).collect(Collectors.toList()))
             .name(UUID.randomUUID().toString())
             .build();
     }

--- a/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/GoogleAuthenticatorOneTimeTokenCredentialValidator.java
+++ b/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/GoogleAuthenticatorOneTimeTokenCredentialValidator.java
@@ -20,6 +20,7 @@ import javax.security.auth.login.AccountNotFoundException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * This is {@link GoogleAuthenticatorOneTimeTokenCredentialValidator}.
@@ -104,11 +105,12 @@ public class GoogleAuthenticatorOneTimeTokenCredentialValidator implements
         val otp = Integer.parseInt(tokenCredential.getToken());
         return accounts
             .stream()
-            .filter(ac -> isCredentialAssignedToAccount(tokenCredential, ac) && ac.getScratchCodes().contains(otp))
+            .filter(ac -> isCredentialAssignedToAccount(tokenCredential, ac)
+                    && ac.getScratchCodes().stream().map(c -> c.intValue()).collect(Collectors.toList()).contains(otp))
             .map(GoogleAuthenticatorAccount.class::cast)
             .peek(acct -> {
                 LOGGER.info("Using scratch code [{}] to authenticate user [{}]. Scratch code will be removed", otp, uid);
-                acct.getScratchCodes().removeIf(token -> token == otp);
+                acct.getScratchCodes().removeIf(token -> token.intValue() == otp);
                 credentialRepository.update(acct);
             })
             .findFirst();

--- a/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepository.java
@@ -26,8 +26,9 @@ public class InMemoryGoogleAuthenticatorTokenCredentialRepository extends BaseGo
     private final Map<String, List<OneTimeTokenAccount>> accounts;
 
     public InMemoryGoogleAuthenticatorTokenCredentialRepository(final CipherExecutor<String, String> tokenCredentialCipher,
+                                                                final CipherExecutor<Number, Number> scratchCodesCipher,
                                                                 final IGoogleAuthenticator googleAuthenticator) {
-        super(tokenCredentialCipher, googleAuthenticator);
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.accounts = new ConcurrentHashMap<>();
     }
 

--- a/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/JsonGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/JsonGoogleAuthenticatorTokenCredentialRepository.java
@@ -35,8 +35,9 @@ public class JsonGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
     private final StringSerializer<Map<String, List<OneTimeTokenAccount>>> serializer = new OneTimeAccountSerializer();
 
     public JsonGoogleAuthenticatorTokenCredentialRepository(final Resource location, final IGoogleAuthenticator googleAuthenticator,
-                                                            final CipherExecutor<String, String> tokenCredentialCipher) {
-        super(tokenCredentialCipher, googleAuthenticator);
+                                                            final CipherExecutor<String, String> tokenCredentialCipher,
+                                                            final CipherExecutor<Number, Number> scratchCodesCipher) {
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.location = location;
     }
 

--- a/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/RestGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/RestGoogleAuthenticatorTokenCredentialRepository.java
@@ -46,8 +46,9 @@ public class RestGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
 
     public RestGoogleAuthenticatorTokenCredentialRepository(final IGoogleAuthenticator googleAuthenticator,
         final GoogleAuthenticatorMultifactorProperties gauth,
-        final CipherExecutor<String, String> tokenCredentialCipher) {
-        super(tokenCredentialCipher, googleAuthenticator);
+        final CipherExecutor<String, String> tokenCredentialCipher,
+        final CipherExecutor<Number, Number> scratchCodesCipher) {
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.gauth = gauth;
     }
 

--- a/support/cas-server-support-gauth-core/src/test/java/org/apereo/cas/gauth/GoogleAuthenticatorAuthenticationHandlerTests.java
+++ b/support/cas-server-support-gauth-core/src/test/java/org/apereo/cas/gauth/GoogleAuthenticatorAuthenticationHandlerTests.java
@@ -35,6 +35,7 @@ import org.springframework.webflow.test.MockRequestContext;
 
 import javax.security.auth.login.AccountExpiredException;
 import javax.security.auth.login.AccountNotFoundException;
+import java.util.ArrayList;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -65,7 +66,7 @@ public class GoogleAuthenticatorAuthenticationHandlerTests {
         googleAuthenticator = new GoogleAuthenticator(builder.build());
         tokenRepository = new CachingOneTimeTokenRepository(Caffeine.newBuilder().initialCapacity(10).build(s -> null));
         tokenCredentialRepository = new InMemoryGoogleAuthenticatorTokenCredentialRepository(
-            CipherExecutor.noOpOfStringToString(), googleAuthenticator);
+            CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber(), googleAuthenticator);
         googleAuthenticator.setCredentialRepository(new DummyCredentialRepository());
         handler = new GoogleAuthenticatorAuthenticationHandler("GAuth",
             servicesManager,
@@ -105,7 +106,7 @@ public class GoogleAuthenticatorAuthenticationHandlerTests {
             .name(UUID.randomUUID().toString())
             .secretKey(account.getKey())
             .validationCode(account.getVerificationCode())
-            .scratchCodes(account.getScratchCodes())
+            .scratchCodes(new ArrayList<>(account.getScratchCodes()))
             .build();
         tokenCredentialRepository.save(toSave);
         credential.setAccountId(toSave.getId());
@@ -120,7 +121,7 @@ public class GoogleAuthenticatorAuthenticationHandlerTests {
             .name(UUID.randomUUID().toString())
             .secretKey(account.getKey())
             .validationCode(account.getVerificationCode())
-            .scratchCodes(account.getScratchCodes())
+            .scratchCodes(new ArrayList<>(account.getScratchCodes()))
             .build();
         credential.setAccountId(toSave.getId());
         tokenCredentialRepository.save(toSave);
@@ -137,7 +138,7 @@ public class GoogleAuthenticatorAuthenticationHandlerTests {
             .name(UUID.randomUUID().toString())
             .secretKey(account.getKey())
             .validationCode(account.getVerificationCode())
-            .scratchCodes(account.getScratchCodes())
+            .scratchCodes(new ArrayList<>(account.getScratchCodes()))
             .build();
         tokenCredentialRepository.save(toSave);
         credential.setAccountId(toSave.getId());
@@ -158,7 +159,7 @@ public class GoogleAuthenticatorAuthenticationHandlerTests {
                 .name(String.format("deviceName-%s", i))
                 .secretKey(account.getKey())
                 .validationCode(account.getVerificationCode())
-                .scratchCodes(account.getScratchCodes())
+                .scratchCodes(new ArrayList<>(account.getScratchCodes()))
                 .build();
             tokenCredentialRepository.save(toSave);
         }
@@ -179,7 +180,7 @@ public class GoogleAuthenticatorAuthenticationHandlerTests {
             .name(UUID.randomUUID().toString())
             .secretKey(account.getKey())
             .validationCode(account.getVerificationCode())
-            .scratchCodes(account.getScratchCodes())
+            .scratchCodes(new ArrayList<>(account.getScratchCodes()))
             .build();
         tokenCredentialRepository.save(toSave);
         credential.setAccountId(null);

--- a/support/cas-server-support-gauth-couchdb/src/main/java/org/apereo/cas/config/GoogleAuthenticatorCouchDbConfiguration.java
+++ b/support/cas-server-support-gauth-couchdb/src/main/java/org/apereo/cas/config/GoogleAuthenticatorCouchDbConfiguration.java
@@ -54,9 +54,12 @@ public class GoogleAuthenticatorCouchDbConfiguration {
         final IGoogleAuthenticator googleAuthenticatorInstance,
         @Qualifier("googleAuthenticatorAccountCipherExecutor")
         final CipherExecutor googleAuthenticatorAccountCipherExecutor,
+        @Qualifier("googleAuthenticatorScratchCodesCipherExecutor")
+        final CipherExecutor googleAuthenticatorScratchCodesCipherExecutor,
         @Qualifier("couchDbOneTimeTokenAccountRepository")
         final GoogleAuthenticatorAccountCouchDbRepository couchDbRepository) {
-        return new CouchDbGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance, couchDbRepository, googleAuthenticatorAccountCipherExecutor);
+        return new CouchDbGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance, couchDbRepository, googleAuthenticatorAccountCipherExecutor,
+                googleAuthenticatorScratchCodesCipherExecutor);
     }
 
     @ConditionalOnMissingBean(name = "couchDbOneTimeTokenAccountRepository")

--- a/support/cas-server-support-gauth-couchdb/src/main/java/org/apereo/cas/gauth/credential/CouchDbGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-couchdb/src/main/java/org/apereo/cas/gauth/credential/CouchDbGoogleAuthenticatorTokenCredentialRepository.java
@@ -24,8 +24,9 @@ public class CouchDbGoogleAuthenticatorTokenCredentialRepository extends BaseGoo
 
     public CouchDbGoogleAuthenticatorTokenCredentialRepository(final IGoogleAuthenticator googleAuthenticator,
                                                                final GoogleAuthenticatorAccountCouchDbRepository couchDbRepository,
-                                                               final CipherExecutor<String, String> tokenCredentialCipher) {
-        super(tokenCredentialCipher, googleAuthenticator);
+                                                               final CipherExecutor<String, String> tokenCredentialCipher,
+                                                               final CipherExecutor<Number, Number> scratchCodesCipher) {
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.couchDbRepository = couchDbRepository;
     }
 

--- a/support/cas-server-support-gauth-dynamodb/src/main/java/org/apereo/cas/config/GoogleAuthenticatorDynamoDbConfiguration.java
+++ b/support/cas-server-support-gauth-dynamodb/src/main/java/org/apereo/cas/config/GoogleAuthenticatorDynamoDbConfiguration.java
@@ -41,10 +41,12 @@ public class GoogleAuthenticatorDynamoDbConfiguration {
         final IGoogleAuthenticator googleAuthenticatorInstance,
         @Qualifier("googleAuthenticatorAccountCipherExecutor")
         final CipherExecutor googleAuthenticatorAccountCipherExecutor,
+        @Qualifier("googleAuthenticatorScratchCodesCipherExecutor")
+        final CipherExecutor googleAuthenticatorScratchCodesCipherExecutor,
         @Qualifier("googleAuthenticatorTokenCredentialRepositoryFacilitator")
         final DynamoDbGoogleAuthenticatorTokenCredentialRepositoryFacilitator googleAuthenticatorTokenCredentialRepositoryFacilitator) {
         return new DynamoDbGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance, googleAuthenticatorAccountCipherExecutor,
-            googleAuthenticatorTokenCredentialRepositoryFacilitator);
+                googleAuthenticatorScratchCodesCipherExecutor, googleAuthenticatorTokenCredentialRepositoryFacilitator);
     }
 
     @Bean

--- a/support/cas-server-support-gauth-dynamodb/src/main/java/org/apereo/cas/gauth/credential/DynamoDbGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-dynamodb/src/main/java/org/apereo/cas/gauth/credential/DynamoDbGoogleAuthenticatorTokenCredentialRepository.java
@@ -21,8 +21,9 @@ public class DynamoDbGoogleAuthenticatorTokenCredentialRepository extends BaseGo
 
     public DynamoDbGoogleAuthenticatorTokenCredentialRepository(final IGoogleAuthenticator googleAuthenticator,
                                                                 final CipherExecutor<String, String> tokenCredentialCipher,
+                                                                final CipherExecutor<Number, Number> scratchCodesCipher,
                                                                 final DynamoDbGoogleAuthenticatorTokenCredentialRepositoryFacilitator facilitator) {
-        super(tokenCredentialCipher, googleAuthenticator);
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.facilitator = facilitator;
     }
 

--- a/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/config/GoogleAuthenticatorJpaConfiguration.java
+++ b/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/config/GoogleAuthenticatorJpaConfiguration.java
@@ -73,8 +73,11 @@ public class GoogleAuthenticatorJpaConfiguration {
             @Qualifier("googleAuthenticatorInstance")
             final IGoogleAuthenticator googleAuthenticatorInstance,
             @Qualifier("googleAuthenticatorAccountCipherExecutor")
-            final CipherExecutor googleAuthenticatorAccountCipherExecutor) {
-            return new JpaGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorAccountCipherExecutor, googleAuthenticatorInstance);
+            final CipherExecutor googleAuthenticatorAccountCipherExecutor,
+            @Qualifier("googleAuthenticatorScratchCodesCipherExecutor")
+            final CipherExecutor googleAuthenticatorScratchCodesCipherExecutor) {
+            return new JpaGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorAccountCipherExecutor,
+                    googleAuthenticatorScratchCodesCipherExecutor, googleAuthenticatorInstance);
         }
 
         @Bean

--- a/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/gauth/credential/JpaGoogleAuthenticatorAccount.java
+++ b/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/gauth/credential/JpaGoogleAuthenticatorAccount.java
@@ -15,6 +15,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
+import java.util.stream.Collectors;
 
 /**
  * This is {@link JpaGoogleAuthenticatorAccount}.
@@ -50,7 +51,7 @@ public class JpaGoogleAuthenticatorAccount extends GoogleAuthenticatorAccount {
             .username(acct.getUsername().trim().toLowerCase())
             .secretKey(acct.getSecretKey())
             .validationCode(acct.getValidationCode())
-            .scratchCodes(acct.getScratchCodes())
+                .scratchCodes(acct.getScratchCodes().stream().map(c -> c.intValue()).collect(Collectors.toList()))
             .registrationDate(acct.getRegistrationDate())
             .name(acct.getName())
             .build();

--- a/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/gauth/credential/JpaGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-jpa/src/main/java/org/apereo/cas/gauth/credential/JpaGoogleAuthenticatorTokenCredentialRepository.java
@@ -36,8 +36,8 @@ public class JpaGoogleAuthenticatorTokenCredentialRepository extends BaseGoogleA
     private transient EntityManager entityManager;
 
     public JpaGoogleAuthenticatorTokenCredentialRepository(final CipherExecutor<String, String> tokenCredentialCipher,
-        final IGoogleAuthenticator googleAuthenticator) {
-        super(tokenCredentialCipher, googleAuthenticator);
+        final CipherExecutor<Number, Number> scratchCodesCipher, final IGoogleAuthenticator googleAuthenticator) {
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
     }
 
     @Override

--- a/support/cas-server-support-gauth-ldap/src/main/java/org/apereo/cas/config/GoogleAuthenticatorLdapConfiguration.java
+++ b/support/cas-server-support-gauth-ldap/src/main/java/org/apereo/cas/config/GoogleAuthenticatorLdapConfiguration.java
@@ -38,9 +38,13 @@ public class GoogleAuthenticatorLdapConfiguration {
         @Qualifier("googleAuthenticatorInstance")
         final IGoogleAuthenticator googleAuthenticatorInstance,
         @Qualifier("googleAuthenticatorAccountCipherExecutor")
-        final CipherExecutor cipherExecutor, final CasConfigurationProperties casProperties) {
+        final CipherExecutor googleAuthenticatorAccountCipherExecutor,
+        @Qualifier("googleAuthenticatorScratchCodesCipherExecutor")
+        final CipherExecutor googleAuthenticatorScratchCodesCipherExecutor,
+        final CasConfigurationProperties casProperties) {
         val ldap = casProperties.getAuthn().getMfa().getGauth().getLdap();
         val connectionFactory = LdapUtils.newLdaptiveConnectionFactory(ldap);
-        return new LdapGoogleAuthenticatorTokenCredentialRepository(cipherExecutor, googleAuthenticatorInstance, connectionFactory, ldap);
+        return new LdapGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorAccountCipherExecutor,
+                googleAuthenticatorScratchCodesCipherExecutor, googleAuthenticatorInstance, connectionFactory, ldap);
     }
 }

--- a/support/cas-server-support-gauth-ldap/src/main/java/org/apereo/cas/gauth/credential/LdapGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-ldap/src/main/java/org/apereo/cas/gauth/credential/LdapGoogleAuthenticatorTokenCredentialRepository.java
@@ -50,10 +50,11 @@ public class LdapGoogleAuthenticatorTokenCredentialRepository
     private final LdapGoogleAuthenticatorMultifactorProperties ldapProperties;
 
     public LdapGoogleAuthenticatorTokenCredentialRepository(final CipherExecutor<String, String> tokenCredentialCipher,
+                                                            final CipherExecutor<Number, Number> scratchCodesCipher,
                                                             final IGoogleAuthenticator googleAuthenticator,
                                                             final ConnectionFactory connectionFactory,
                                                             final LdapGoogleAuthenticatorMultifactorProperties ldapProperties) {
-        super(tokenCredentialCipher, googleAuthenticator);
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.connectionFactory = connectionFactory;
         this.ldapProperties = ldapProperties;
     }

--- a/support/cas-server-support-gauth-mongo/src/main/java/org/apereo/cas/config/GoogleAuthenticatorMongoDbConfiguration.java
+++ b/support/cas-server-support-gauth-mongo/src/main/java/org/apereo/cas/config/GoogleAuthenticatorMongoDbConfiguration.java
@@ -62,12 +62,15 @@ public class GoogleAuthenticatorMongoDbConfiguration {
         @Qualifier("googleAuthenticatorInstance")
         final IGoogleAuthenticator googleAuthenticatorInstance,
         @Qualifier("googleAuthenticatorAccountCipherExecutor")
-        final CipherExecutor googleAuthenticatorAccountCipherExecutor, final CasConfigurationProperties casProperties,
+        final CipherExecutor googleAuthenticatorAccountCipherExecutor,
+        @Qualifier("googleAuthenticatorScratchCodesCipherExecutor")
+        final CipherExecutor googleAuthenticatorScratchCodesCipherExecutor,
+        final CasConfigurationProperties casProperties,
         @Qualifier("mongoDbGoogleAuthenticatorTemplate")
         final MongoOperations mongoDbGoogleAuthenticatorTemplate) {
         val mongo = casProperties.getAuthn().getMfa().getGauth().getMongo();
         return new MongoDbGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance, mongoDbGoogleAuthenticatorTemplate, mongo.getCollection(),
-            googleAuthenticatorAccountCipherExecutor);
+            googleAuthenticatorAccountCipherExecutor, googleAuthenticatorScratchCodesCipherExecutor);
     }
 
     @Bean

--- a/support/cas-server-support-gauth-mongo/src/main/java/org/apereo/cas/gauth/credential/MongoDbGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-mongo/src/main/java/org/apereo/cas/gauth/credential/MongoDbGoogleAuthenticatorTokenCredentialRepository.java
@@ -33,8 +33,9 @@ public class MongoDbGoogleAuthenticatorTokenCredentialRepository extends BaseGoo
     public MongoDbGoogleAuthenticatorTokenCredentialRepository(final IGoogleAuthenticator googleAuthenticator,
                                                                final MongoOperations mongoTemplate,
                                                                final String collectionName,
-                                                               final CipherExecutor<String, String> tokenCredentialCipher) {
-        super(tokenCredentialCipher, googleAuthenticator);
+                                                               final CipherExecutor<String, String> tokenCredentialCipher,
+                                                               final CipherExecutor<Number, Number> scratchCodesCipher) {
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.mongoTemplate = mongoTemplate;
         this.collectionName = collectionName;
     }

--- a/support/cas-server-support-gauth-redis/src/main/java/org/apereo/cas/config/GoogleAuthenticatorRedisConfiguration.java
+++ b/support/cas-server-support-gauth-redis/src/main/java/org/apereo/cas/config/GoogleAuthenticatorRedisConfiguration.java
@@ -90,6 +90,8 @@ public class GoogleAuthenticatorRedisConfiguration {
         final IGoogleAuthenticator googleAuthenticatorInstance,
         @Qualifier("googleAuthenticatorAccountCipherExecutor")
         final CipherExecutor googleAuthenticatorAccountCipherExecutor,
+        @Qualifier("googleAuthenticatorScratchCodesCipherExecutor")
+        final CipherExecutor googleAuthenticatorScratchCodesCipherExecutor,
         @Qualifier("redisGoogleAuthenticatorTemplate")
         final CasRedisTemplate redisGoogleAuthenticatorTemplate,
         final CasConfigurationProperties casProperties) throws Exception {
@@ -99,6 +101,7 @@ public class GoogleAuthenticatorRedisConfiguration {
                 return new RedisGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
                     redisGoogleAuthenticatorTemplate,
                     googleAuthenticatorAccountCipherExecutor,
+                    googleAuthenticatorScratchCodesCipherExecutor,
                     casProperties.getAuthn().getMfa().getGauth().getRedis().getScanCount());
             })
             .otherwiseProxy()

--- a/support/cas-server-support-gauth-redis/src/main/java/org/apereo/cas/gauth/credential/RedisGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-redis/src/main/java/org/apereo/cas/gauth/credential/RedisGoogleAuthenticatorTokenCredentialRepository.java
@@ -39,8 +39,9 @@ public class RedisGoogleAuthenticatorTokenCredentialRepository extends BaseGoogl
         final IGoogleAuthenticator googleAuthenticator,
         final CasRedisTemplate<String, List<? extends OneTimeTokenAccount>> template,
         final CipherExecutor<String, String> tokenCredentialCipher,
+        final CipherExecutor<Number, Number> scratchCodesCipher,
         final long scanCount) {
-        super(tokenCredentialCipher, googleAuthenticator);
+        super(tokenCredentialCipher, scratchCodesCipher, googleAuthenticator);
         this.template = template;
         this.scanCount = scanCount;
     }

--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -146,8 +146,8 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
                         return new JasyptNumberCipherExecutor(key, "googleAuthenticatorScratchCodesCipherExecutor");
                     })
                     .otherwise(() -> {
-                        LOGGER.warn("Google Authenticator scratch codes encryption/signing is turned off. "
-                                + "Consider turning on encryption, signing to securely and safely store scratch codes.");
+                        LOGGER.warn("Google Authenticator scratch codes encryption key is not defined. "
+                                + "Consider defining the encryption key to securely and safely store scratch codes.");
                         return CipherExecutor.noOp();
                     })
                     .get();

--- a/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-gauth/src/main/java/org/apereo/cas/config/support/authentication/GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration.java
@@ -37,6 +37,7 @@ import org.apereo.cas.otp.web.flow.OneTimeTokenAccountConfirmSelectionRegistrati
 import org.apereo.cas.otp.web.flow.OneTimeTokenAccountCreateRegistrationAction;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.util.cipher.CipherExecutorUtils;
+import org.apereo.cas.util.cipher.JasyptNumberCipherExecutor;
 import org.apereo.cas.util.crypto.CipherExecutor;
 import org.apereo.cas.util.spring.beans.BeanCondition;
 import org.apereo.cas.util.spring.beans.BeanSupplier;
@@ -56,6 +57,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.condition.Conditi
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -102,6 +104,10 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
     @Configuration(value = "GoogleAuthenticatorMultifactorAuthenticationCoreConfiguration", proxyBeanMethods = false)
     @EnableConfigurationProperties(CasConfigurationProperties.class)
     public static class GoogleAuthenticatorMultifactorAuthenticationCoreConfiguration {
+
+        static final BeanCondition SCRATCH_CODES_ENCRYPTION_KEY_EXISTS =
+                BeanCondition.on("cas.authn.mfa.gauth.core.scratch-codes.encryption.key").exists();
+
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         @Bean
         @ConditionalOnMissingBean(name = "googleAuthenticatorInstance")
@@ -126,6 +132,25 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
             LOGGER.warn("Google Authenticator one-time token account encryption/signing is turned off. "
                         + "Consider turning on encryption, signing to securely and safely store one-time token accounts.");
             return CipherExecutor.noOp();
+        }
+
+        @ConditionalOnMissingBean(name = "googleAuthenticatorScratchCodesCipherExecutor")
+        @Bean
+        @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+        public CipherExecutor googleAuthenticatorScratchCodesCipherExecutor(final ApplicationContext applicationContext,
+                                                                            final CasConfigurationProperties casProperties) {
+            return BeanSupplier.of(CipherExecutor.class)
+                    .when(SCRATCH_CODES_ENCRYPTION_KEY_EXISTS.given(applicationContext.getEnvironment()))
+                    .supply(() -> {
+                        val key = casProperties.getAuthn().getMfa().getGauth().getCore().getScratchCodes().getEncryption().getKey();
+                        return new JasyptNumberCipherExecutor(key, "googleAuthenticatorScratchCodesCipherExecutor");
+                    })
+                    .otherwise(() -> {
+                        LOGGER.warn("Google Authenticator scratch codes encryption/signing is turned off. "
+                                + "Consider turning on encryption, signing to securely and safely store scratch codes.");
+                        return CipherExecutor.noOp();
+                    })
+                    .get();
         }
 
         @ConditionalOnMissingBean(name = "googlePrincipalFactory")
@@ -247,18 +272,20 @@ public class GoogleAuthenticatorAuthenticationEventExecutionPlanConfiguration {
             @Qualifier("googleAuthenticatorInstance")
             final IGoogleAuthenticator googleAuthenticatorInstance,
             @Qualifier("googleAuthenticatorAccountCipherExecutor")
-            final CipherExecutor googleAuthenticatorAccountCipherExecutor) {
+            final CipherExecutor googleAuthenticatorAccountCipherExecutor,
+            @Qualifier("googleAuthenticatorScratchCodesCipherExecutor")
+            final CipherExecutor googleAuthenticatorScratchCodesCipherExecutor) {
             val gauth = casProperties.getAuthn().getMfa().getGauth();
             if (gauth.getJson().getLocation() != null) {
                 return new JsonGoogleAuthenticatorTokenCredentialRepository(gauth.getJson().getLocation(),
-                    googleAuthenticatorInstance, googleAuthenticatorAccountCipherExecutor);
+                    googleAuthenticatorInstance, googleAuthenticatorAccountCipherExecutor, googleAuthenticatorScratchCodesCipherExecutor);
             }
             if (StringUtils.isNotBlank(gauth.getRest().getUrl())) {
                 return new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-                    gauth, googleAuthenticatorAccountCipherExecutor);
+                    gauth, googleAuthenticatorAccountCipherExecutor, googleAuthenticatorScratchCodesCipherExecutor);
             }
             return new InMemoryGoogleAuthenticatorTokenCredentialRepository(
-                googleAuthenticatorAccountCipherExecutor, googleAuthenticatorInstance);
+                googleAuthenticatorAccountCipherExecutor, googleAuthenticatorScratchCodesCipherExecutor, googleAuthenticatorInstance);
         }
     }
 

--- a/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/BaseOneTimeTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/BaseOneTimeTokenCredentialRepositoryTests.java
@@ -166,8 +166,8 @@ public abstract class BaseOneTimeTokenCredentialRepositoryTests {
         assertEquals(acct2.getUsername(), acct3.getUsername());
         assertEquals(acct2.getValidationCode(), acct3.getValidationCode());
         assertEquals(acct2.getSecretKey(), acct3.getSecretKey());
-        assertEquals(acct2.getScratchCodes().stream().sorted().collect(Collectors.toList()),
-            acct3.getScratchCodes().stream().sorted().collect(Collectors.toList()));
+        assertEquals(acct2.getScratchCodes().stream().sorted().map(n -> n.intValue()).collect(Collectors.toList()),
+            acct3.getScratchCodes().stream().sorted().map(n -> n.intValue()).collect(Collectors.toList()));
         repo.delete(acct3.getId());
     }
 

--- a/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepositoryEncodingTests.java
+++ b/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepositoryEncodingTests.java
@@ -1,0 +1,47 @@
+package org.apereo.cas.gauth.credential;
+
+import org.apereo.cas.config.CasCoreUtilConfiguration;
+import org.apereo.cas.configuration.model.core.util.EncryptionJwtSigningJwtCryptographyProperties;
+import org.apereo.cas.otp.repository.credentials.OneTimeTokenAccountCipherExecutor;
+import org.apereo.cas.otp.repository.credentials.OneTimeTokenCredentialRepository;
+import org.apereo.cas.util.cipher.CipherExecutorUtils;
+import org.apereo.cas.util.cipher.JasyptNumberCipherExecutor;
+import org.apereo.cas.util.crypto.CipherExecutor;
+import org.apereo.cas.util.gen.Base64RandomStringGenerator;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This is {@link InMemoryGoogleAuthenticatorTokenCredentialRepositoryTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.3.0
+ */
+@SpringBootTest(classes = {
+        RefreshAutoConfiguration.class,
+        CasCoreUtilConfiguration.class
+})
+@Tag("MFAProvider")
+public class InMemoryGoogleAuthenticatorTokenCredentialRepositoryEncodingTests extends BaseOneTimeTokenCredentialRepositoryTests {
+    private final ConcurrentHashMap<String, OneTimeTokenCredentialRepository> repoMap = new ConcurrentHashMap<>();
+
+    @Override
+    public OneTimeTokenCredentialRepository getRegistry() {
+        val crypto = new EncryptionJwtSigningJwtCryptographyProperties();
+        crypto.getEncryption().setKeySize(256);
+        val tokenCredentialCipher = (CipherExecutor) CipherExecutorUtils.newStringCipherExecutor(crypto, OneTimeTokenAccountCipherExecutor.class);
+        val password = new Base64RandomStringGenerator(16).getNewString();
+        val scratchCodesCipher = new JasyptNumberCipherExecutor(password, "scratchCodesCipher");
+        return new InMemoryGoogleAuthenticatorTokenCredentialRepository(tokenCredentialCipher, scratchCodesCipher, getGoogle());
+    }
+
+    @Override
+    public OneTimeTokenCredentialRepository getRegistry(final String testName) {
+        return repoMap.computeIfAbsent(testName, name -> this.getRegistry());
+    }
+}

--- a/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepositoryEncodingTests.java
+++ b/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepositoryEncodingTests.java
@@ -17,10 +17,10 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * This is {@link InMemoryGoogleAuthenticatorTokenCredentialRepositoryTests}.
+ * This is {@link InMemoryGoogleAuthenticatorTokenCredentialRepositoryEncodingTests}.
  *
- * @author Misagh Moayyed
- * @since 5.3.0
+ * @author Jerome LELEU
+ * @since 6.6.0
  */
 @SpringBootTest(classes = {
         RefreshAutoConfiguration.class,

--- a/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/InMemoryGoogleAuthenticatorTokenCredentialRepositoryTests.java
@@ -26,7 +26,8 @@ public class InMemoryGoogleAuthenticatorTokenCredentialRepositoryTests extends B
 
     @Override
     public OneTimeTokenCredentialRepository getRegistry() {
-        return new InMemoryGoogleAuthenticatorTokenCredentialRepository(CipherExecutor.noOpOfStringToString(), getGoogle());
+        return new InMemoryGoogleAuthenticatorTokenCredentialRepository(CipherExecutor.noOpOfStringToString(),
+                CipherExecutor.noOpOfNumberToNumber(), getGoogle());
     }
 
     @Override

--- a/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/JsonGoogleAuthenticatorTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/JsonGoogleAuthenticatorTokenCredentialRepositoryTests.java
@@ -52,7 +52,7 @@ public class JsonGoogleAuthenticatorTokenCredentialRepositoryTests extends BaseO
     public void verifyFails() throws Exception {
         val resource = mock(Resource.class);
         val repo = new JsonGoogleAuthenticatorTokenCredentialRepository(resource,
-            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString());
+            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         assertTrue(repo.load().isEmpty());
         assertNull(repo.update(OneTimeTokenAccount.builder().build()));
         assertEquals(0, repo.count());
@@ -69,7 +69,7 @@ public class JsonGoogleAuthenticatorTokenCredentialRepositoryTests extends BaseO
     @Test
     public void verifyNotExists() {
         val repo = new JsonGoogleAuthenticatorTokenCredentialRepository(new ClassPathResource("acct-bad.json"),
-            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString());
+            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         assertTrue(repo.get("casuser").isEmpty());
     }
 
@@ -78,7 +78,7 @@ public class JsonGoogleAuthenticatorTokenCredentialRepositoryTests extends BaseO
         val file = File.createTempFile("account", ".json");
         FileUtils.writeStringToFile(file, "{}", StandardCharsets.UTF_8);
         val repo = new JsonGoogleAuthenticatorTokenCredentialRepository(new FileSystemResource(file),
-            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString());
+            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         assertTrue(repo.get("casuser").isEmpty());
         repo.deleteAll();
         assertTrue(repo.load().isEmpty());
@@ -96,7 +96,7 @@ public class JsonGoogleAuthenticatorTokenCredentialRepositoryTests extends BaseO
     @Test
     public void verifyBadResource() throws Exception {
         val repo = new JsonGoogleAuthenticatorTokenCredentialRepository(new UrlResource(new URL("https://httpbin.org/get")),
-            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString());
+            googleAuthenticatorInstance, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         assertTrue(repo.get("casuser").isEmpty());
     }
 }

--- a/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/RestGoogleAuthenticatorTokenCredentialRepositoryTests.java
+++ b/support/cas-server-support-gauth/src/test/java/org/apereo/cas/gauth/credential/RestGoogleAuthenticatorTokenCredentialRepositoryTests.java
@@ -52,7 +52,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8551");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         val entity = MAPPER.writeValueAsString(List.of("----"));
         try (val webServer = new MockWebServer(8551,
             new ByteArrayResource(entity.getBytes(UTF_8), "Output"), OK)) {
@@ -71,7 +71,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8551");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         val account = repo.create(UUID.randomUUID().toString());
         val entity = MAPPER.writeValueAsString(CollectionUtils.wrapArrayList(account));
         try (val webServer = new MockWebServer(8551,
@@ -86,7 +86,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8550");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         try (val webServer = new MockWebServer(8550,
             new ByteArrayResource("1".getBytes(UTF_8), "Output"), OK)) {
             webServer.start();
@@ -106,7 +106,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8552");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         val account = repo.create(UUID.randomUUID().toString());
         val entity = MAPPER.writeValueAsString(CollectionUtils.wrapList(account));
         try (val webServer = new MockWebServer(8552,
@@ -121,7 +121,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8552");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         val account = repo.create(UUID.randomUUID().toString());
         val entity = MAPPER.writeValueAsString(account);
         try (val webServer = new MockWebServer(8552,
@@ -136,7 +136,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8552");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         val account = repo.create(UUID.randomUUID().toString());
         val entity = MAPPER.writeValueAsString(account);
         try (val webServer = new MockWebServer(8552,
@@ -151,7 +151,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8552");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         try (val webServer = new MockWebServer(8552,
             new ByteArrayResource("1".getBytes(UTF_8), "Output"), OK)) {
             webServer.start();
@@ -164,7 +164,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8596");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         try (val webServer = new MockWebServer(8596,
             new ByteArrayResource("1".getBytes(UTF_8), "Output"), OK)) {
             webServer.start();
@@ -177,7 +177,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8553");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         val account = repo.create(UUID.randomUUID().toString());
         val entity = MAPPER.writeValueAsString(account);
         try (val webServer = new MockWebServer(8553,
@@ -204,7 +204,7 @@ public class RestGoogleAuthenticatorTokenCredentialRepositoryTests {
         val props = new GoogleAuthenticatorMultifactorProperties();
         props.getRest().setUrl("http://localhost:8554");
         val repo = new RestGoogleAuthenticatorTokenCredentialRepository(googleAuthenticatorInstance,
-            props, CipherExecutor.noOpOfStringToString());
+            props, CipherExecutor.noOpOfStringToString(), CipherExecutor.noOpOfNumberToNumber());
         val account = repo.create(UUID.randomUUID().toString());
         try (val webServer = new MockWebServer(8554,
             new ByteArrayResource(StringUtils.EMPTY.getBytes(UTF_8), "Output"), HttpStatus.BAD_REQUEST)) {

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/repository/credentials/BaseOneTimeTokenCredentialRepository.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/repository/credentials/BaseOneTimeTokenCredentialRepository.java
@@ -24,6 +24,11 @@ public abstract class BaseOneTimeTokenCredentialRepository implements OneTimeTok
     private final CipherExecutor<String, String> tokenCredentialCipher;
 
     /**
+     * The scratch codes cipher.
+     */
+    private final CipherExecutor<Number, Number> scratchCodesCipher;
+
+    /**
      * Encode.
      *
      * @param account the account
@@ -31,6 +36,7 @@ public abstract class BaseOneTimeTokenCredentialRepository implements OneTimeTok
      */
     protected OneTimeTokenAccount encode(final OneTimeTokenAccount account) {
         account.setSecretKey(tokenCredentialCipher.encode(account.getSecretKey()));
+        account.setScratchCodes(account.getScratchCodes().stream().map(code -> scratchCodesCipher.encode(code)).collect(Collectors.toList()));
         account.setUsername(account.getUsername().trim().toLowerCase());
         return account;
     }
@@ -54,8 +60,10 @@ public abstract class BaseOneTimeTokenCredentialRepository implements OneTimeTok
      */
     protected OneTimeTokenAccount decode(final OneTimeTokenAccount account) {
         val decodedSecret = tokenCredentialCipher.decode(account.getSecretKey());
+        val decodedScratchCodes = account.getScratchCodes().stream().map(code -> scratchCodesCipher.decode(code)).collect(Collectors.toList());
         val newAccount = account.clone();
         newAccount.setSecretKey(decodedSecret);
+        newAccount.setScratchCodes(decodedScratchCodes);
         return newAccount;
     }
 }


### PR DESCRIPTION
I have taken into account almost all the things we have talked about here: https://github.com/apereo/cas/pull/5436

There is now a new `scratchCodesCipher` in addition to the `tokenValidatorCipher`.
It is built based on a condition as we said:

```java
        static final BeanCondition SCRATCH_CODES_ENCRYPTION_KEY_EXISTS =
                BeanCondition.on("cas.authn.mfa.gauth.core.scratch-codes.encryption.key").exists();

        @ConditionalOnMissingBean(name = "googleAuthenticatorScratchCodesCipherExecutor")
        @Bean
        @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
        public CipherExecutor googleAuthenticatorScratchCodesCipherExecutor(final ApplicationContext applicationContext,
                                                                            final CasConfigurationProperties casProperties) {
            return BeanSupplier.of(CipherExecutor.class)
                    .when(SCRATCH_CODES_ENCRYPTION_KEY_EXISTS.given(applicationContext.getEnvironment()))
                    .supply(() -> {
                        val key = casProperties.getAuthn().getMfa().getGauth().getCore().getScratchCodes().getEncryption().getKey();
                        return new JasyptNumberCipherExecutor(key, "googleAuthenticatorScratchCodesCipherExecutor");
                    })
                    .otherwise(() -> {
                        LOGGER.warn("Google Authenticator scratch codes encryption key is not defined. "
                                + "Consider defining the encryption key to securely and safely store scratch codes.");
                        return CipherExecutor.noOp();
                    })
                    .get();
        }
```

Tests have been added with true ciphers (and not no-op ones).

Two little things:
- where should I add the short migration doc? In a new section here: https://apereo.github.io/cas/development/mfa/GoogleAuthenticator-Authentication.html?
- for the `JasyptNumberCipherExecutor`, the double decoding is properly handled and returns the input value instead of failing. This "protection" cannot be done for the `encode` operation as you can encode other and other again.
