### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,8 +19,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') }}
     timeout-minutes: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,8 +18,13 @@ on:
     - cron: '0 0 * * *'
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,8 +27,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,8 +22,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/puppeteer-macos.yml
+++ b/.github/workflows/puppeteer-macos.yml
@@ -46,8 +46,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: macos-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/puppeteer-windows.yml
+++ b/.github/workflows/puppeteer-windows.yml
@@ -46,8 +46,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: windows-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -39,8 +39,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -28,8 +28,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/test-oidc-conformance.yml
+++ b/.github/workflows/test-oidc-conformance.yml
@@ -23,8 +23,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     timeout-minutes: 1
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -27,8 +27,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     timeout-minutes: 1
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -19,8 +19,13 @@ on:
 
 ##########################################################################
 
+permissions:
+  contents: read
+
 jobs:
   cancel-previous-runs:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI')) && !contains(github.event.head_commit.message, 'trigger dependency update') && !contains(github.event.head_commit.message, 'documentation update') && !contains(github.event.head_commit.message, 'ci:minimal') }}
     runs-on: ubuntu-latest
     timeout-minutes: 1


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
