### PR TITLE
Fix Cipher backward compatibility with CAS 6.3

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
@@ -110,7 +110,9 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
 
     private AlgorithmParameterSpec buildParameterSpec(final int encryptionKeySize) {
         val iv = new byte[encryptionSecretKey.length];
-        System.arraycopy(this.encryptionSecretKey, 0, iv, 0, encryptionSecretKey.length);
+        if (encryptionKeySize > MINIMUM_ENCRYPTION_KEY_LENGTH) {
+            System.arraycopy(this.encryptionSecretKey, 0, iv, 0, encryptionSecretKey.length);
+        }
         return encryptionKeySize <= MINIMUM_ENCRYPTION_KEY_LENGTH
             ? new IvParameterSpec(iv)
             : new GCMParameterSpec(GCM_TAG_LENGTH, iv);

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/cipher/DefaultTicketCipherExecutorTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/cipher/DefaultTicketCipherExecutorTests.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.util.cipher;
 
+import org.apereo.cas.util.EncodingUtils;
+
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -68,5 +70,20 @@ public class DefaultTicketCipherExecutorTests {
         val cipher3 = new DefaultTicketCipherExecutor(encryptionKey, signingKey,
             "AES", 512, 16, "webflow");
         assertEquals("ST-1234567890", new String(cipher3.decode(encoded), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void verifyCas63BackwardCompatibility() {
+        val encodedByCas63 = "ZXlKaGJHY2lPaUpJVXpVeE1pSXNJblI1Y0NJNklrcFhWQ0o5LkViVE0wX0ZzMnhfam9tTzNuMGtpcXU4ODhoZ1JZZlR5bUE5bkRHOGh3aWZCazVuND"
+            + "VtTXVmZy40ZUNYYTluRFl3NnJmeEtHU1Y0c2laajh0aG1Sc1BUd0ZDa3NjMXJRYW8tSGlGVGJ6V1lMcXF4Y080TjVxNENqR3IwM0VYZGNOc3V1cV9ISTRidGVsdw==";
+        val encoded = EncodingUtils.decodeBase64(encodedByCas63);
+
+        val signingKey = "RDt6YZHZIH7jUv3nBNIsUMp5Nbs5hblVhK9YYI44KyOXSP5nxpHXD67mH2_7DgklQAPBUcr7WNuOVoeqUFqL6A";
+        val encryptionKey = "UdLCpnNxmFOviC3M-kDvvQ";
+        val cipherCas63 = new DefaultTicketCipherExecutor(encryptionKey, signingKey,
+                "AES", 512, 16, "cas63");
+
+        val decoded = cipherCas63.decode(encoded);
+        assertEquals("CAS_SERVER_VERSION_6.3.X", new String(decoded, StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
I generate an encoded String with the `DefaultTicketCipherExecutor` of CAS 6.3 and ensure it is decodable with CAS 6.6.

All tests pass in the module with the "lucky-smart" fix.