### PR TITLE
changed the default value of ipsToCheckPattern

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/spnego/SpnegoProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/spnego/SpnegoProperties.java
@@ -89,7 +89,7 @@ public class SpnegoProperties implements Serializable {
     /**
      * A regex pattern that indicates whether the client IP is allowed for spnego.
      */
-    private String ipsToCheckPattern = "127.+";
+    private String ipsToCheckPattern = "^127.+";
 
     /**
      * Alternative header name to use in order to find the host address.


### PR DESCRIPTION
After I searched the documentation and code in this repo, I can't figured it out why the default value of ipsToCheckPatten is `127.+` . 
It will match not only `127.0.0.1`, but also IPs like `192.168.127.5` that contain `127`, thus causing an unexpected 401 error in our production. 
So, I've changed the default value of ipsToCheckPattern to `^127.+`.
Is this the right thing to do? Thanks.