### PR TITLE
Fix SAML IdP initiated support when authn request is signed

### DIFF
--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/init.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -e "Removing previous SAML metadata directory"
+rm -Rf "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/saml-md"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/ready.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/ready.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "Running SAML server..."
+
+metadataDirectory="${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/saml-md"
+
+cert=$(cat "${metadataDirectory}"/idp-signing.crt | sed 's/-----BEGIN CERTIFICATE-----//g' | sed 's/-----END CERTIFICATE-----//g')
+export IDP_SIGNING_CERTIFICATE=$cert
+echo -e "Using signing certificate:\n$IDP_SIGNING_CERTIFICATE"
+
+cert=$(cat "${metadataDirectory}"/idp-encryption.crt | sed 's/-----BEGIN CERTIFICATE-----//g' | sed 's/-----END CERTIFICATE-----//g')
+export IDP_ENCRYPTION_CERTIFICATE=$cert
+echo -e "Using encryption certificate:\n$IDP_ENCRYPTION_CERTIFICATE"
+
+chmod +x "${PWD}/ci/tests/saml2/run-saml-server.sh"
+"${PWD}/ci/tests/saml2/run-saml-server.sh"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/script.js
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/script.js
@@ -1,0 +1,23 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+const cas = require('../../cas.js');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+    
+    const entityId = "http://localhost:9443/simplesaml/module.php/saml/sp/metadata.php/signed-sp";
+    let url = "https://localhost:8443/cas/idp/profile/SAML2/Unsolicited/SSO";
+    url += `?providerId=${entityId}`;
+    url += "&target=https%3A%2F%2Flocalhost%3A8443%2Fcas%2Flogin%3Flocale%3Den";
+    console.log(`Navigating to ${url}`);
+    await cas.goto(page, url);
+    await cas.screenshot(page);
+    await page.waitForTimeout(4000)
+    await cas.loginWith(page, "casuser", "Mellon");
+    await page.waitForTimeout(4000)
+    await cas.assertPageTitle(page, "CAS - Central Authentication Service Log In Successful");
+    await cas.assertInnerText(page, '#content div h2', "Log In Successful");
+    await cas.removeDirectory(path.join(__dirname, '/saml-md'));
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/script.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": "saml-idp",
+  "conditions": {
+    "docker": "true"
+  },
+  "properties": [
+    "--cas.authn.saml-idp.core.entity-id=https://cas.apereo.org/saml/idp",
+    "--cas.authn.saml-idp.metadata.file-system.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/saml-md",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--logging.level.org.apereo.cas=info",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/init.sh",
+  "readyScript": "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/ready.sh"
+}

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-idp-initiated-authnrequestsigned/services/Sample-1.json
@@ -1,0 +1,11 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "http://localhost:9443/simplesaml.*",
+  "name" : "Sample",
+  "id" : 1,
+  "evaluationOrder" : 1,
+  "metadataLocation" : "http://localhost:9443/simplesaml/module.php/saml/sp/metadata.php/signed-sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}

--- a/ci/tests/saml2/authsources.php
+++ b/ci/tests/saml2/authsources.php
@@ -18,4 +18,11 @@ $config = [
       'certificate' => 'saml.crt',
       'idp' => $_ENV['IDP_ENTITYID']
  ],
+  'signed-sp' => [
+       'saml:SP',
+       'privatekey' => 'saml.pem',
+       'certificate' => 'saml.crt',
+       'idp' => $_ENV['IDP_ENTITYID'],
+       'sign.authnrequest' => true
+  ],
 ];

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/SamlProfileHandlerConfigurationContext.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/SamlProfileHandlerConfigurationContext.java
@@ -77,7 +77,7 @@ public class SamlProfileHandlerConfigurationContext {
     private final CasConfigurationProperties casProperties;
 
     @Nonnull
-    private final SamlObjectSignatureValidator samlObjectSignatureValidator;
+    private SamlObjectSignatureValidator samlObjectSignatureValidator;
 
     @Nonnull
     private final Service callbackService;

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
@@ -179,9 +179,9 @@ public class SamlIdPEndpointsConfiguration {
         @Bean
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public SamlIdPInitiatedProfileHandlerController idpInitiatedSamlProfileHandlerController(
-            @Qualifier("samlProfileHandlerConfigurationContext")
-            final SamlProfileHandlerConfigurationContext samlProfileHandlerConfigurationContext) {
-            return new SamlIdPInitiatedProfileHandlerController(samlProfileHandlerConfigurationContext);
+            @Qualifier("samlIdPInitiatedProfileHandlerConfigurationContext")
+            final SamlProfileHandlerConfigurationContext samlIdPInitiatedProfileHandlerConfigurationContext) {
+            return new SamlIdPInitiatedProfileHandlerController(samlIdPInitiatedProfileHandlerConfigurationContext);
         }
 
         @Bean
@@ -578,6 +578,94 @@ public class SamlIdPEndpointsConfiguration {
                 .callbackService(samlIdPCallbackService)
                 .samlFaultResponseBuilder(samlProfileSamlAttributeQueryFaultResponseBuilder)
                 .build();
+        }
+
+        @Bean
+        @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+        @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+        public SamlProfileHandlerConfigurationContext samlIdPInitiatedProfileHandlerConfigurationContext(
+                @Qualifier("authenticationAttributeReleasePolicy")
+                final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy,
+                @Qualifier("samlIdPCallbackService")
+                final Service samlIdPCallbackService,
+                @Qualifier("samlObjectEncrypter")
+                final SamlIdPObjectEncrypter samlObjectEncrypter,
+                @Qualifier("samlObjectSigner")
+                final SamlIdPObjectSigner samlObjectSigner,
+                @Qualifier(TicketRegistrySupport.BEAN_NAME)
+                final TicketRegistrySupport ticketRegistrySupport,
+                @Qualifier(OpenSamlConfigBean.DEFAULT_BEAN_NAME)
+                final OpenSamlConfigBean openSamlConfigBean,
+                @Qualifier("defaultSamlRegisteredServiceCachingMetadataResolver")
+                final SamlRegisteredServiceCachingMetadataResolver defaultSamlRegisteredServiceCachingMetadataResolver,
+                @Qualifier("samlIdPServiceFactory")
+                final ServiceFactory samlIdPServiceFactory,
+                @Qualifier(TicketRegistry.BEAN_NAME)
+                final TicketRegistry ticketRegistry,
+                final CasConfigurationProperties casProperties,
+                @Qualifier("registeredServiceAccessStrategyEnforcer")
+                final AuditableExecution registeredServiceAccessStrategyEnforcer,
+                @Qualifier(ServicesManager.BEAN_NAME)
+                final ServicesManager servicesManager,
+                @Qualifier("samlIdPTicketValidator")
+                final TicketValidator samlIdPTicketValidator,
+                @Qualifier("ssoSamlHttpRequestExtractor")
+                final SSOSamlHttpRequestExtractor ssoSamlHttpRequestExtractor,
+                @Qualifier(AuthenticationSystemSupport.BEAN_NAME)
+                final AuthenticationSystemSupport authenticationSystemSupport,
+                @Qualifier("samlIdPObjectSignatureValidator")
+                final SamlObjectSignatureValidator samlObjectSignatureValidator,
+                @Qualifier(SingleSignOnParticipationStrategy.BEAN_NAME)
+                final SingleSignOnParticipationStrategy singleSignOnParticipationStrategy,
+                @Qualifier("singleLogoutServiceLogoutUrlBuilder")
+                final SingleLogoutServiceLogoutUrlBuilder singleLogoutServiceLogoutUrlBuilder,
+                @Qualifier("samlIdPLogoutResponseObjectBuilder")
+                final SamlIdPLogoutResponseObjectBuilder samlIdPLogoutResponseObjectBuilder,
+                @Qualifier("samlIdPDistributedSessionCookieGenerator")
+                final CasCookieBuilder samlIdPDistributedSessionCookieGenerator,
+                @Qualifier(CasCookieBuilder.BEAN_NAME_TICKET_GRANTING_COOKIE_BUILDER)
+                final CasCookieBuilder ticketGrantingTicketCookieGenerator,
+                @Qualifier("samlIdPDistributedSessionStore")
+                final SessionStore samlIdPDistributedSessionStore,
+                @Qualifier("samlProfileSamlResponseBuilder")
+                final SamlProfileObjectBuilder<Response> samlProfileSamlResponseBuilder,
+                @Qualifier("samlProfileSamlAttributeQueryFaultResponseBuilder")
+                final SamlProfileObjectBuilder<Envelope> samlProfileSamlAttributeQueryFaultResponseBuilder,
+                @Qualifier(TicketFactory.BEAN_NAME)
+                final TicketFactory defaultTicketFactory,
+                @Qualifier(PrincipalResolver.BEAN_NAME_ATTRIBUTE_REPOSITORY)
+                final IPersonAttributeDao attributeRepository,
+                @Qualifier("ssoPostProfileHandlerDecoders")
+                final HttpServletRequestXMLMessageDecodersMap ssoPostProfileHandlerDecoders) {
+            return SamlProfileHandlerConfigurationContext.builder()
+                    .attributeRepository(attributeRepository)
+                    .samlMessageDecoders(ssoPostProfileHandlerDecoders)
+                    .authenticationAttributeReleasePolicy(authenticationAttributeReleasePolicy)
+                    .samlObjectSigner(samlObjectSigner)
+                    .ticketFactory(defaultTicketFactory)
+                    .samlObjectEncrypter(samlObjectEncrypter)
+                    .authenticationSystemSupport(authenticationSystemSupport)
+                    .servicesManager(servicesManager)
+                    .webApplicationServiceFactory(samlIdPServiceFactory)
+                    .samlRegisteredServiceCachingMetadataResolver(defaultSamlRegisteredServiceCachingMetadataResolver)
+                    .openSamlConfigBean(openSamlConfigBean)
+                    .casProperties(casProperties)
+                    .ticketRegistrySupport(ticketRegistrySupport)
+                    .singleSignOnParticipationStrategy(singleSignOnParticipationStrategy)
+                    .logoutResponseBuilder(samlIdPLogoutResponseObjectBuilder)
+                    .singleLogoutServiceLogoutUrlBuilder(singleLogoutServiceLogoutUrlBuilder)
+                    .samlObjectSignatureValidator(samlObjectSignatureValidator)
+                    .samlHttpRequestExtractor(ssoSamlHttpRequestExtractor)
+                    .responseBuilder(samlProfileSamlResponseBuilder)
+                    .ticketValidator(samlIdPTicketValidator)
+                    .ticketRegistry(ticketRegistry)
+                    .sessionStore(samlIdPDistributedSessionStore)
+                    .ticketGrantingTicketCookieGenerator(ticketGrantingTicketCookieGenerator)
+                    .samlDistributedSessionCookieGenerator(samlIdPDistributedSessionCookieGenerator)
+                    .registeredServiceAccessStrategyEnforcer(registeredServiceAccessStrategyEnforcer)
+                    .callbackService(samlIdPCallbackService)
+                    .samlFaultResponseBuilder(samlProfileSamlAttributeQueryFaultResponseBuilder)
+                    .build();
         }
     }
 }

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
@@ -179,9 +179,12 @@ public class SamlIdPEndpointsConfiguration {
         @Bean
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public SamlIdPInitiatedProfileHandlerController idpInitiatedSamlProfileHandlerController(
-            @Qualifier("samlIdPInitiatedProfileHandlerConfigurationContext")
-            final SamlProfileHandlerConfigurationContext samlIdPInitiatedProfileHandlerConfigurationContext) {
-            return new SamlIdPInitiatedProfileHandlerController(samlIdPInitiatedProfileHandlerConfigurationContext);
+            @Qualifier("samlProfileHandlerConfigurationContext")
+            final SamlProfileHandlerConfigurationContext samlProfileHandlerConfigurationContext,
+            @Qualifier("samlIdPObjectSignatureValidator")
+            final SamlObjectSignatureValidator samlObjectSignatureValidator) {
+            samlProfileHandlerConfigurationContext.setSamlObjectSignatureValidator(samlObjectSignatureValidator);
+            return new SamlIdPInitiatedProfileHandlerController(samlProfileHandlerConfigurationContext);
         }
 
         @Bean
@@ -578,94 +581,6 @@ public class SamlIdPEndpointsConfiguration {
                 .callbackService(samlIdPCallbackService)
                 .samlFaultResponseBuilder(samlProfileSamlAttributeQueryFaultResponseBuilder)
                 .build();
-        }
-
-        @Bean
-        @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-        @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
-        public SamlProfileHandlerConfigurationContext samlIdPInitiatedProfileHandlerConfigurationContext(
-                @Qualifier("authenticationAttributeReleasePolicy")
-                final AuthenticationAttributeReleasePolicy authenticationAttributeReleasePolicy,
-                @Qualifier("samlIdPCallbackService")
-                final Service samlIdPCallbackService,
-                @Qualifier("samlObjectEncrypter")
-                final SamlIdPObjectEncrypter samlObjectEncrypter,
-                @Qualifier("samlObjectSigner")
-                final SamlIdPObjectSigner samlObjectSigner,
-                @Qualifier(TicketRegistrySupport.BEAN_NAME)
-                final TicketRegistrySupport ticketRegistrySupport,
-                @Qualifier(OpenSamlConfigBean.DEFAULT_BEAN_NAME)
-                final OpenSamlConfigBean openSamlConfigBean,
-                @Qualifier("defaultSamlRegisteredServiceCachingMetadataResolver")
-                final SamlRegisteredServiceCachingMetadataResolver defaultSamlRegisteredServiceCachingMetadataResolver,
-                @Qualifier("samlIdPServiceFactory")
-                final ServiceFactory samlIdPServiceFactory,
-                @Qualifier(TicketRegistry.BEAN_NAME)
-                final TicketRegistry ticketRegistry,
-                final CasConfigurationProperties casProperties,
-                @Qualifier("registeredServiceAccessStrategyEnforcer")
-                final AuditableExecution registeredServiceAccessStrategyEnforcer,
-                @Qualifier(ServicesManager.BEAN_NAME)
-                final ServicesManager servicesManager,
-                @Qualifier("samlIdPTicketValidator")
-                final TicketValidator samlIdPTicketValidator,
-                @Qualifier("ssoSamlHttpRequestExtractor")
-                final SSOSamlHttpRequestExtractor ssoSamlHttpRequestExtractor,
-                @Qualifier(AuthenticationSystemSupport.BEAN_NAME)
-                final AuthenticationSystemSupport authenticationSystemSupport,
-                @Qualifier("samlIdPObjectSignatureValidator")
-                final SamlObjectSignatureValidator samlObjectSignatureValidator,
-                @Qualifier(SingleSignOnParticipationStrategy.BEAN_NAME)
-                final SingleSignOnParticipationStrategy singleSignOnParticipationStrategy,
-                @Qualifier("singleLogoutServiceLogoutUrlBuilder")
-                final SingleLogoutServiceLogoutUrlBuilder singleLogoutServiceLogoutUrlBuilder,
-                @Qualifier("samlIdPLogoutResponseObjectBuilder")
-                final SamlIdPLogoutResponseObjectBuilder samlIdPLogoutResponseObjectBuilder,
-                @Qualifier("samlIdPDistributedSessionCookieGenerator")
-                final CasCookieBuilder samlIdPDistributedSessionCookieGenerator,
-                @Qualifier(CasCookieBuilder.BEAN_NAME_TICKET_GRANTING_COOKIE_BUILDER)
-                final CasCookieBuilder ticketGrantingTicketCookieGenerator,
-                @Qualifier("samlIdPDistributedSessionStore")
-                final SessionStore samlIdPDistributedSessionStore,
-                @Qualifier("samlProfileSamlResponseBuilder")
-                final SamlProfileObjectBuilder<Response> samlProfileSamlResponseBuilder,
-                @Qualifier("samlProfileSamlAttributeQueryFaultResponseBuilder")
-                final SamlProfileObjectBuilder<Envelope> samlProfileSamlAttributeQueryFaultResponseBuilder,
-                @Qualifier(TicketFactory.BEAN_NAME)
-                final TicketFactory defaultTicketFactory,
-                @Qualifier(PrincipalResolver.BEAN_NAME_ATTRIBUTE_REPOSITORY)
-                final IPersonAttributeDao attributeRepository,
-                @Qualifier("ssoPostProfileHandlerDecoders")
-                final HttpServletRequestXMLMessageDecodersMap ssoPostProfileHandlerDecoders) {
-            return SamlProfileHandlerConfigurationContext.builder()
-                    .attributeRepository(attributeRepository)
-                    .samlMessageDecoders(ssoPostProfileHandlerDecoders)
-                    .authenticationAttributeReleasePolicy(authenticationAttributeReleasePolicy)
-                    .samlObjectSigner(samlObjectSigner)
-                    .ticketFactory(defaultTicketFactory)
-                    .samlObjectEncrypter(samlObjectEncrypter)
-                    .authenticationSystemSupport(authenticationSystemSupport)
-                    .servicesManager(servicesManager)
-                    .webApplicationServiceFactory(samlIdPServiceFactory)
-                    .samlRegisteredServiceCachingMetadataResolver(defaultSamlRegisteredServiceCachingMetadataResolver)
-                    .openSamlConfigBean(openSamlConfigBean)
-                    .casProperties(casProperties)
-                    .ticketRegistrySupport(ticketRegistrySupport)
-                    .singleSignOnParticipationStrategy(singleSignOnParticipationStrategy)
-                    .logoutResponseBuilder(samlIdPLogoutResponseObjectBuilder)
-                    .singleLogoutServiceLogoutUrlBuilder(singleLogoutServiceLogoutUrlBuilder)
-                    .samlObjectSignatureValidator(samlObjectSignatureValidator)
-                    .samlHttpRequestExtractor(ssoSamlHttpRequestExtractor)
-                    .responseBuilder(samlProfileSamlResponseBuilder)
-                    .ticketValidator(samlIdPTicketValidator)
-                    .ticketRegistry(ticketRegistry)
-                    .sessionStore(samlIdPDistributedSessionStore)
-                    .ticketGrantingTicketCookieGenerator(ticketGrantingTicketCookieGenerator)
-                    .samlDistributedSessionCookieGenerator(samlIdPDistributedSessionCookieGenerator)
-                    .registeredServiceAccessStrategyEnforcer(registeredServiceAccessStrategyEnforcer)
-                    .callbackService(samlIdPCallbackService)
-                    .samlFaultResponseBuilder(samlProfileSamlAttributeQueryFaultResponseBuilder)
-                    .build();
         }
     }
 }


### PR DESCRIPTION
There is an issue with the SAML IdP initiated support. When the auth requests are defined to be signed in the SP metadata, it fails with the following error: `ERROR [org.apereo.cas.support.saml.web.idp.profile.builders.enc.validate.SamlObjectSignatureValidator] - <No valid credentials could be found to verify the signature for [org.opensaml.saml.saml2.core.impl.IssuerImpl@xxx]>`.

Indeed, the `samlObjectSignatureValidator` is not the right one for the `SamlIdPInitiatedProfileHandlerController`: it must be the IdP one: `samlIdPObjectSignatureValidator` (instead of the SP one) like it used to be in version 6.4: https://github.com/apereo/cas/blob/6.4.x/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java#L335

This PR fixes the problem with an integration test.
