### PR TITLE
fix: SecurityContextHolderStrategy.MODE_GLOBAL thread-safe issue

### DIFF
--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasWebAppSecurityConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasWebAppSecurityConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.webflow.execution.Action;
@@ -68,11 +67,6 @@ public class CasWebAppSecurityConfiguration implements WebMvcConfigurer {
     @ConditionalOnMissingBean(name = "casWebSecurityConfigurerJdbcAdapter")
     public CasWebSecurityJdbcConfigurerAdapter casWebSecurityConfigurerJdbcAdapter() {
         return new CasWebSecurityJdbcConfigurerAdapter(casProperties, applicationContext);
-    }
-
-    @Bean
-    public InitializingBean securityContextHolderInitialization() {
-        return () -> SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_GLOBAL);
     }
 
     @Bean


### PR DESCRIPTION
SecurityContextHolderStrategy.MODE_GLOBAL(GlobalSecurityContextHolderStrategy) has thread-safe issue
And should not used on web app.

This was fixed on 6.5.x branch and master branch, also should fixed on 6.4.x branch!
ref:https://github.com/apereo/cas/commit/5ffdc985e69b4e10547a24dc6e0d8f691cf3817f

Should change SecurityContextHolderStrategy.MODE_GLOBAL  to SecurityContextHolder.MODE_THREADLOCAL
And Spring it's spring security default (SecurityContextHolder.MODE_THREADLOCAL)
so we just remove the useless code

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
