### PR TITLE
Fixes an issue that prevented using Groovy scripts from classpath in authentication

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/GroovyScriptAuthenticationPolicy.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/policy/GroovyScriptAuthenticationPolicy.java
@@ -82,7 +82,7 @@ public class GroovyScriptAuthenticationPolicy extends BaseAuthenticationPolicy {
             if (!matcherFile.find()) {
                 throw new IllegalArgumentException("Unable to locate groovy script file at " + script);
             }
-            val resource = ResourceUtils.getRawResourceFrom(matcherFile.group(2));
+            val resource = ResourceUtils.getRawResourceFrom(script);
             this.executableScript = new WatchableGroovyScriptResource(resource);
         }
     }

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/policy/GroovyScriptAuthenticationPolicyTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/policy/GroovyScriptAuthenticationPolicyTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.authentication.policy;
 
+import javax.security.auth.login.AccountNotFoundException;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 
 import lombok.val;
@@ -54,6 +55,13 @@ public class GroovyScriptAuthenticationPolicyTests {
         FileUtils.write(scriptFile, script, StandardCharsets.UTF_8);
         val p = new GroovyScriptAuthenticationPolicy("file:" + scriptFile.getCanonicalPath());
         assertTrue(p.shouldResumeOnFailure(new RuntimeException()));
+    }
+
+    @Test
+    public void verifyResumeOnFailureClasspath() {
+        val p = new GroovyScriptAuthenticationPolicy("classpath:/GroovyAuthenticationPolicy.groovy");
+        assertFalse(p.shouldResumeOnFailure(new RuntimeException()));
+        assertTrue(p.shouldResumeOnFailure(new AccountNotFoundException()));
     }
 
     @Test

--- a/core/cas-server-core-authentication-api/src/test/resources/GroovyAuthenticationPolicy.groovy
+++ b/core/cas-server-core-authentication-api/src/test/resources/GroovyAuthenticationPolicy.groovy
@@ -1,0 +1,23 @@
+import java.util.*
+import org.apereo.cas.authentication.exceptions.*
+import javax.security.auth.login.*
+
+def run(final Object... args) {
+    def principal = args[0]
+    def logger = args[1]
+
+    if (conditionYouMayDesign() == true) {
+        return new AccountDisabledException()
+    }
+    return null
+}
+
+def shouldResumeOnFailure(final Object... args) {
+    def failure = args[0]
+    def logger = args[1]
+
+    if (failure instanceof AccountNotFoundException) {
+        return true
+    }
+    return false
+}


### PR DESCRIPTION
Same PR as #5453 but on 6.5.x branch.

----------------------

When defining a Groovy script from classpath from this configuration key `key cas.authn.policy.groovy[0].script=` (see [here](https://apereo.github.io/cas/6.5.x/authentication/Configuring-Authentication-Policy-Groovy.html) for details), the script cannot be loaded.

This was due to `org.apereo.cas.authentication.policy.GroovyScriptAuthenticationPolicy#initializeWatchableScriptIfNeeded()` that tried to create the resource from only a part of the provided URI (`classpath:/script.groovy` was loaded as `/script.groovy`), thus the code was trying to load the script from filesystem instead of classpath.

I used the full URI to load the resource, and added a test case to cover this case.