### PR TITLE
sanitize oauth refresh tokens in log

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/MessageSanitizationUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/MessageSanitizationUtils.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 public class MessageSanitizationUtils {
     private static final Pattern TICKET_ID_PATTERN = Pattern.compile("(?:(?:" + TicketGrantingTicket.PREFIX + '|'
         + ProxyGrantingTicket.PROXY_GRANTING_TICKET_IOU_PREFIX + '|' + ProxyGrantingTicket.PROXY_GRANTING_TICKET_PREFIX
-        + '|' + "OC" + '|' + "AT"
+        + '|' + "OC" + '|' + "AT" + '|' + "RT"
         + ")-\\d+-)([\\w.-]+)");
 
     private static final Pattern SENSITIVE_TEXT_PATTERN =

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/serialization/MessageSanitizationUtilsTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/serialization/MessageSanitizationUtilsTests.java
@@ -27,6 +27,8 @@ public class MessageSanitizationUtilsTests {
         assertTrue(results.contains("OC-1-*****"));
         results = MessageSanitizationUtils.sanitize("ticket AT-1-abcdefg created");
         assertTrue(results.contains("AT-1-*****"));
+        results = MessageSanitizationUtils.sanitize("ticket RT-1-abcdefg created");
+        assertTrue(results.contains("RT-1-*****"));
 
         results = MessageSanitizationUtils.sanitize("found a [password =se!ns4357$##@@**it!!_ive] here...");
         assertTrue(results.contains("[password =*****"));


### PR DESCRIPTION
Sanitize OAuth2 refresh tokens in logs.
These informations are sensitive and should be sanitized
https://tools.ietf.org/id/draft-ietf-oauth-security-topics-12.html#compromised-resource-server