### PR TITLE
Update WS Federation Protocol Docs

### DIFF
--- a/docs/cas-server-documentation/protocol/WS-Federation-Protocol.md
+++ b/docs/cas-server-documentation/protocol/WS-Federation-Protocol.md
@@ -77,7 +77,7 @@ Support is enabled by including the following dependency in the WAR overlay:
 
 | Endpoint             | Description                                                                                                   |
 |----------------------|---------------------------------------------------------------------------------------------------------------|
-| `/ws/idp/metadata`   | Displays the current federation metadata based on the configuration realm for the identity provider.          |
+| `/ws/idpmetadata`    | Displays the current federation metadata based on the configuration realm for the identity provider.          |
 | `/ws/idp/federation` | Endpoint to receive initial `GET` authentication requests from clients, typically identified as the `issuer`. |
 
 ## Realms


### PR DESCRIPTION
The URL defined in [WSFederationConstants.java](https://github.com/apereo/cas/blob/master/support/cas-server-support-ws-idp-api/src/main/java/org/apereo/cas/ws/idp/WSFederationConstants.java#L160) does not have a slash prepended on the metadata endpoint like it does on the federation endpoints.

Changing the actual endpoint seems like a significant change seeing as how that has been active for 2 years now.