### PR TITLE
Fix serialization configuration for Memcached

### DIFF
--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketComponentSerializationConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketComponentSerializationConfiguration.java
@@ -54,6 +54,7 @@ public class CasCoreTicketComponentSerializationConfiguration {
             plan.registerSerializableClass(MultiTimeUseOrTimeoutExpirationPolicy.class);
             plan.registerSerializableClass(MultiTimeUseOrTimeoutExpirationPolicy.ServiceTicketExpirationPolicy.class);
             plan.registerSerializableClass(MultiTimeUseOrTimeoutExpirationPolicy.ProxyTicketExpirationPolicy.class);
+            plan.registerSerializableClass(MultiTimeUseOrTimeoutExpirationPolicy.TransientSessionTicketExpirationPolicy.class);
             plan.registerSerializableClass(NeverExpiresExpirationPolicy.class);
             plan.registerSerializableClass(RememberMeDelegatingExpirationPolicy.class);
             plan.registerSerializableClass(TimeoutExpirationPolicy.class);


### PR DESCRIPTION
When using Memcached as the ticket registry, I encounter this error: `com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: org.apereo.cas.ticket.expiration.MultiTimeUseOrTimeoutExpirationPolicy$TransientSessionTicketExpirationPolicy`.

This PR fixes the problem.

I'm not sure about the v6.5.x backport: it's a bug, but it's also a breaking change. So what do we do?
