### PR TITLE
Fix the consistency of the JWT attributes for the OIDC user info

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
@@ -22,8 +22,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -91,9 +91,9 @@ public class OidcUserProfileViewRenderer extends OAuth20DefaultUserProfileViewRe
         return new ResponseEntity<>("Unable to produce user profile", HttpStatus.BAD_REQUEST);
     }
 
-    private Object useSingleValueForSingletonList(final Object value) {
-        if (value instanceof List && ((List) value).size() == 1) {
-            return ((List) value).get(0);
+    private static Object useSingleValueForSingletonList(final Object value) {
+        if (value instanceof Collection && ((Collection) value).size() == 1) {
+            return ((Collection) value).iterator().next();
         }
         return value;
     }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
@@ -6,6 +6,7 @@ import org.apereo.cas.services.OidcRegisteredService;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.oauth.util.OAuth20Utils;
 import org.apereo.cas.support.oauth.web.views.OAuth20DefaultUserProfileViewRenderer;
+import org.apereo.cas.support.oauth.web.views.OAuth20UserProfileViewRenderer;
 import org.apereo.cas.ticket.OAuth20TokenSigningAndEncryptionService;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 import org.apereo.cas.util.CollectionUtils;
@@ -21,6 +22,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -55,7 +58,16 @@ public class OidcUserProfileViewRenderer extends OAuth20DefaultUserProfileViewRe
             if (signingAndEncryptionService.shouldSignToken(registeredService)
                 || signingAndEncryptionService.shouldEncryptToken(registeredService)) {
                 val claims = new JwtClaims();
-                userProfile.forEach(claims::setClaim);
+                userProfile.forEach((key, value) -> {
+                    if (OAuth20UserProfileViewRenderer.MODEL_ATTRIBUTE_ATTRIBUTES.equals(key)) {
+                        val attributes = (Map<String, Object>) value;
+                        val newAttributes = new HashMap<String, Object>();
+                        attributes.forEach((k, v) -> newAttributes.put(k, useSingleValueForSingletonList(v)));
+                        claims.setClaim(key, newAttributes);
+                    } else {
+                        claims.setClaim(key, useSingleValueForSingletonList(value));
+                    }
+                });
                 claims.setAudience(registeredService.getClientId());
                 claims.setIssuedAt(NumericDate.now());
                 claims.setIssuer(this.signingAndEncryptionService.getIssuer());
@@ -77,5 +89,12 @@ public class OidcUserProfileViewRenderer extends OAuth20DefaultUserProfileViewRe
             LoggingUtils.error(LOGGER, e);
         }
         return new ResponseEntity<>("Unable to produce user profile", HttpStatus.BAD_REQUEST);
+    }
+
+    private Object useSingleValueForSingletonList(final Object value) {
+        if (value instanceof List && ((List) value).size() == 1) {
+            return ((List) value).get(0);
+        }
+        return value;
     }
 }


### PR DESCRIPTION
On the OIDC user info endpoint, we return the user attributes in JSON format in a flat or not way.

For a single value attribute, I get: `"email": "jj@mail.com"` (FLAT) or `"attributes": { "email": "jj@mail.com" }` (none-FLAT).

When the response format is JWT (it means I get a JWS or JWE and not a JSON response), the attributes are arrays even if there is a single value in the array.

This PR fixes this consistency issue.

Two tests have been added (for the FLAT and none-FLAT modes).
