### PR TITLE
Fix null issuer for JWS/JWE on the OIDC user info endpoint

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
@@ -2,6 +2,7 @@ package org.apereo.cas.oidc.profile;
 
 import org.apereo.cas.configuration.model.support.oauth.OAuthProperties;
 import org.apereo.cas.oidc.OidcConstants;
+import org.apereo.cas.oidc.issuer.OidcIssuerService;
 import org.apereo.cas.services.OidcRegisteredService;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.support.oauth.util.OAuth20Utils;
@@ -24,6 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -36,13 +38,16 @@ import java.util.UUID;
 public class OidcUserProfileViewRenderer extends OAuth20DefaultUserProfileViewRenderer {
     private final ServicesManager servicesManager;
     private final OAuth20TokenSigningAndEncryptionService signingAndEncryptionService;
+    private final OidcIssuerService oidcIssuerService;
 
     public OidcUserProfileViewRenderer(final OAuthProperties oauthProperties,
                                        final ServicesManager servicesManager,
-                                       final OAuth20TokenSigningAndEncryptionService signingAndEncryptionService) {
+                                       final OAuth20TokenSigningAndEncryptionService signingAndEncryptionService,
+                                       final OidcIssuerService oidcIssuerService) {
         super(oauthProperties);
         this.servicesManager = servicesManager;
         this.signingAndEncryptionService = signingAndEncryptionService;
+        this.oidcIssuerService = oidcIssuerService;
     }
 
     @Override
@@ -70,7 +75,7 @@ public class OidcUserProfileViewRenderer extends OAuth20DefaultUserProfileViewRe
                 });
                 claims.setAudience(registeredService.getClientId());
                 claims.setIssuedAt(NumericDate.now());
-                claims.setIssuer(this.signingAndEncryptionService.getIssuer());
+                claims.setIssuer(this.oidcIssuerService.determineIssuer(Optional.of(registeredService)));
                 claims.setJwtId(UUID.randomUUID().toString());
 
                 LOGGER.debug("Collected user profile claims, before cipher operations, are [{}]", claims);

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -212,9 +212,11 @@ public class OidcConfiguration {
             final OAuth20TokenSigningAndEncryptionService oidcUserProfileSigningAndEncryptionService,
             @Qualifier(ServicesManager.BEAN_NAME)
             final ServicesManager servicesManager,
-            final CasConfigurationProperties casProperties) throws Exception {
+            final CasConfigurationProperties casProperties,
+            @Qualifier(OidcIssuerService.BEAN_NAME)
+            final OidcIssuerService oidcIssuerService) throws Exception {
             return new OidcUserProfileViewRenderer(casProperties.getAuthn().getOauth(),
-                servicesManager, oidcUserProfileSigningAndEncryptionService);
+                servicesManager, oidcUserProfileSigningAndEncryptionService, oidcIssuerService);
         }
 
         @Bean

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRendererDefaultTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRendererDefaultTests.java
@@ -109,5 +109,6 @@ public class OidcUserProfileViewRendererDefaultTests extends AbstractOidcTests {
         val claims = JwtBuilder.parse(body);
         assertNotNull(claims);
         assertEquals("casuser@example.org", ((JSONObject) claims.getClaim("attributes")).get("email"));
+        assertEquals("https://sso.example.org/cas/oidc", claims.getIssuer());
     }
 }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRendererFlatTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRendererFlatTests.java
@@ -78,6 +78,7 @@ public class OidcUserProfileViewRendererFlatTests extends AbstractOidcTests {
         val claims = JwtBuilder.parse(body);
         assertNotNull(claims);
         assertEquals("casuser@example.org", claims.getClaim("email"));
+        assertEquals("https://sso.example.org/cas/oidc", claims.getIssuer());
     }
 
     @Test


### PR DESCRIPTION
When the response is a JWS or JWE on the OIDC user info endpoint, the issuer is always `null`.

This PR fixes the problem. Tests have been updated accordingly.
