### PR TITLE
Fix oauth 2.0 introspection response according to rfc7662

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/introspection/OAuth20IntrospectionAccessTokenResponse.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/introspection/OAuth20IntrospectionAccessTokenResponse.java
@@ -1,6 +1,9 @@
 package org.apereo.cas.support.oauth.web.response.introspection;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +17,11 @@ import lombok.Setter;
 @Setter
 public class OAuth20IntrospectionAccessTokenResponse {
 
+	/**
+	 * According to rfc7662 Introspection Response - active REQUIRED.
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7662#section-2.2"> Introspection Response</a>
+	 */
+    @JsonInclude(Include.ALWAYS)
     private boolean active;
 
     private String sub;


### PR DESCRIPTION
When introspecting an invalid or expired access token at /cas/oauth2.0/introspect the response body contains only the not null not 0 not false properties:
```
{
    "scope": "CAS"
}
```
Previous version 6.1.x rendered this response:
```
{
    "active": false,
    "sub": null,
    "scope": "CAS",
    "iat": 0,
    "exp": 0,
    "realmName": null,
    "uniqueSecurityName": null,
    "tokenType": null,
    "aud": "somehost/introspect",
    "iss": "https://someotherhost/cas/oidc",
    "client_id": "a_client_id",
    "grant_type": null
}
```

It seems the JSON marshalling configuration was changed.

[https://datatracker.ietf.org/doc/html/rfc7662#section-2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2)
According to RFC7662 "OAuth 2.0 Token Introspection" section "2.2 Introspection Response" states
```
active
      REQUIRED.
```

This can be achieved by adding field annotation
```
    @JsonInclude(Include.ALWAYS)
    private boolean active;

```

Was not able to find a reasonable unit test to really test this. OAuth20IntrospectionEndpointControllerTests was a candidate, but this only generates ResponseEntities, but does not include marshalling.
