### PR TITLE
Fix JsonResourceAuthenticationHandler to work with encoded passwords

### DIFF
--- a/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/JsonResourceAuthenticationHandler.java
+++ b/support/cas-server-support-generic/src/main/java/org/apereo/cas/adaptors/generic/JsonResourceAuthenticationHandler.java
@@ -71,13 +71,12 @@ public class JsonResourceAuthenticationHandler extends AbstractUsernamePasswordA
 
         val map = readAccountsFromResource();
         val username = credential.getUsername();
-        val password = credential.getPassword();
         if (!map.containsKey(username)) {
             throw new AccountNotFoundException();
         }
 
         val account = map.get(username);
-        if (matches(password, account.getPassword())) {
+        if (matches(originalPassword, account.getPassword())) {
             switch (account.getStatus()) {
                 case DISABLED:
                     throw new AccountDisabledException();

--- a/support/cas-server-support-generic/src/test/resources/sample-users.json
+++ b/support/cas-server-support-generic/src/test/resources/sample-users.json
@@ -10,5 +10,15 @@
     "status" : "OK",
     "expirationDate" : "2050-01-19",
     "warnings" : [ "java.util.ArrayList", [ "warning.code1" ] ]
+  },
+  "casmd5" : {
+    "@class" : "org.apereo.cas.adaptors.generic.CasUserAccount",
+    "password" : "9414f9301cdb492b4dcd83f8c711d8bb",
+    "attributes" : {
+      "@class" : "java.util.LinkedHashMap",
+      "firstName" : [ "java.util.List", ["Apereo"] ],
+      "lastName" : [ "java.util.List", ["CAS"] ]
+    },
+    "status" : "OK"
   }
 }


### PR DESCRIPTION
`JsonResourceAuthenticationHandler` did not work when using a `PasswordEncoder` (like MD5, SHA1, BCrypt ...) for storing encoded passwords in the JSON file.

This is because it didn't use the `originalPassword` when matching passwords, so it actually encoded it twice when doing the comparison. Existing test cases didn't cover the use of a `PasswordEncoder`, so I also added one.