### PR TITLE
change module attributes on features that are named differently elsewhere

### DIFF
--- a/support/cas-server-support-aup-couchdb/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyCouchDbConfiguration.java
+++ b/support/cas-server-support-aup-couchdb/src/main/java/org/apereo/cas/config/CasAcceptableUsagePolicyCouchDbConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
  * @since 6.0.0
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.AcceptableUsagePolicy, module = "couchDb")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.AcceptableUsagePolicy, module = "couchdb")
 @AutoConfiguration
 public class CasAcceptableUsagePolicyCouchDbConfiguration {
 

--- a/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/config/DynamoDbServiceRegistryConfiguration.java
+++ b/support/cas-server-support-dynamodb-service-registry/src/main/java/org/apereo/cas/config/DynamoDbServiceRegistryConfiguration.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  * @since 5.1.0
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.ServiceRegistry, module = "hazelcast")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.ServiceRegistry, module = "dynamodb")
 @AutoConfiguration
 public class DynamoDbServiceRegistryConfiguration {
 

--- a/support/cas-server-support-events-couchdb/src/main/java/org/apereo/cas/config/CouchDbEventsConfiguration.java
+++ b/support/cas-server-support-events-couchdb/src/main/java/org/apereo/cas/config/CouchDbEventsConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
  * @since 6.0.0
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "couchDb")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "couchdb")
 @AutoConfiguration
 public class CouchDbEventsConfiguration {
 

--- a/support/cas-server-support-events-dynamodb/src/main/java/org/apereo/cas/config/CasEventsDynamoDbRepositoryConfiguration.java
+++ b/support/cas-server-support-events-dynamodb/src/main/java/org/apereo/cas/config/CasEventsDynamoDbRepositoryConfiguration.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
  * @since 6.3.0
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "dynamoDb")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "dynamodb")
 @AutoConfiguration
 public class CasEventsDynamoDbRepositoryConfiguration {
 

--- a/support/cas-server-support-events-influxdb/src/main/java/org/apereo/cas/support/events/config/CasEventsInfluxDbRepositoryConfiguration.java
+++ b/support/cas-server-support-events-influxdb/src/main/java/org/apereo/cas/support/events/config/CasEventsInfluxDbRepositoryConfiguration.java
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
  * @since 5.2.0
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "influxDb")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "influxdb")
 @AutoConfiguration
 public class CasEventsInfluxDbRepositoryConfiguration {
 

--- a/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/config/MongoDbEventsConfiguration.java
+++ b/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/config/MongoDbEventsConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
  * @since 5.0.0
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "mongoDb")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Events, module = "mongo")
 @AutoConfiguration
 public class MongoDbEventsConfiguration {
 

--- a/support/cas-server-support-saml-idp-metadata-couchdb/src/main/java/org/apereo/cas/config/CouchDbSamlIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-couchdb/src/main/java/org/apereo/cas/config/CouchDbSamlIdPMetadataConfiguration.java
@@ -43,7 +43,7 @@ import java.util.Optional;
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @Slf4j
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.SAMLIdentityProviderMetadata, module = "couch-db")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.SAMLIdentityProviderMetadata, module = "couchdb")
 @AutoConfiguration
 public class CouchDbSamlIdPMetadataConfiguration {
     private static final BeanCondition CONDITION = BeanCondition.on("cas.authn.saml-idp.metadata.couch-db.idp-metadata-enabled").isTrue();

--- a/support/cas-server-support-saml-idp-metadata-mongo/src/main/java/org/apereo/cas/config/SamlIdPMongoDbIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp-metadata-mongo/src/main/java/org/apereo/cas/config/SamlIdPMongoDbIdPMetadataConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @Slf4j
-@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.SAMLIdentityProviderMetadata, module = "mongoDb")
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.SAMLIdentityProviderMetadata, module = "mongo")
 @AutoConfiguration
 public class SamlIdPMongoDbIdPMetadataConfiguration {
     private static final BeanCondition CONDITION = BeanCondition.on("cas.authn.saml-idp.metadata.mongo.idp-metadata-collection");


### PR DESCRIPTION
couch-db and couchDb is couchdb in most places
dynamodb class is specified with module as hazelcast
some modules had camelcase for Db while most did not
mongo is usually specified as mongo but was mongoDb in a couple places