### PR TITLE
Allow to dynamically change which file extensions are considered as static resources.

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/security/HttpHeadersRequestProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/security/HttpHeadersRequestProperties.java
@@ -80,4 +80,9 @@ public class HttpHeadersRequestProperties implements Serializable {
      * Multiple directives are separated with a semicolon.
      */
     private String contentSecurityPolicy;
+    
+    /**
+     * Files with these extensions are considered static, so they will be cached by browsers. The value is part of a RegEx.
+     */
+    private String cacheControlStaticResources = "css|js|png|txt|jpg|ico|jpeg|bmp|gif";
 }

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
@@ -80,7 +80,7 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
      */
     public static final String INIT_PARAM_CONTENT_SECURITY_POLICY = "contentSecurityPolicy";
     
-    /*
+    /**
      * Static resources file extension values.
      */
     public static final String INIT_PARAM_CACHE_CONTROL_STATIC_RESOURCES = "cacheControlStaticResources";

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
@@ -89,7 +89,7 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
     private final Object lock = new Object();
 
 
-    private Pattern cacheControlStaticResourcesPattern = Pattern.compile("^.+\\.(css|js|png|txt|jpg|ico|jpeg|bmp|gif)$", Pattern.CASE_INSENSITIVE);
+    private Pattern cacheControlStaticResourcesPattern;
 
     private boolean enableCacheControl;
 

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
@@ -89,7 +89,7 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
     private final Object lock = new Object();
 
 
-    private Pattern cacheControlStaticResourcesPattern;
+    private Pattern cacheControlStaticResourcesPattern = Pattern.compile("^.+\\.(css|js|png|txt|jpg|ico|jpeg|bmp|gif)$", Pattern.CASE_INSENSITIVE);
 
     private boolean enableCacheControl;
 

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilter.java
@@ -79,11 +79,17 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
      * Consent security policy.
      */
     public static final String INIT_PARAM_CONTENT_SECURITY_POLICY = "contentSecurityPolicy";
+    
+    /*
+     * Static resources file extension values.
+     */
+    public static final String INIT_PARAM_CACHE_CONTROL_STATIC_RESOURCES = "cacheControlStaticResources";
 
-    private static final Pattern CACHE_CONTROL_STATIC_RESOURCES_PATTERN = 
-                    Pattern.compile("^.+\\.(css|js|png|txt|jpg|ico|jpeg|bmp|gif)$", Pattern.CASE_INSENSITIVE);
 
     private final Object lock = new Object();
+
+
+    private Pattern cacheControlStaticResourcesPattern;
 
     private boolean enableCacheControl;
 
@@ -131,6 +137,7 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
         recognizedParameterNames.add(INIT_PARAM_CONTENT_SECURITY_POLICY);
         recognizedParameterNames.add(INIT_PARAM_ENABLE_XSS_PROTECTION);
         recognizedParameterNames.add(INIT_PARAM_XSS_PROTECTION);
+        recognizedParameterNames.add(INIT_PARAM_CACHE_CONTROL_STATIC_RESOURCES);
         recognizedParameterNames.add(THROW_ON_ERROR);
 
         while (initParamNames.hasMoreElements()) {
@@ -156,7 +163,9 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
         val stsEnabled = filterConfig.getInitParameter(INIT_PARAM_ENABLE_STRICT_TRANSPORT_SECURITY);
         val xframeOpts = filterConfig.getInitParameter(INIT_PARAM_ENABLE_STRICT_XFRAME_OPTIONS);
         val xssOpts = filterConfig.getInitParameter(INIT_PARAM_ENABLE_XSS_PROTECTION);
-
+        val cacheControlStaticResources = filterConfig.getInitParameter(INIT_PARAM_CACHE_CONTROL_STATIC_RESOURCES);
+        
+        this.cacheControlStaticResourcesPattern = Pattern.compile("^.+\\.(" + cacheControlStaticResources + ")$", Pattern.CASE_INSENSITIVE);
         this.enableCacheControl = Boolean.parseBoolean(cacheControl);
         this.enableXContentTypeOptions = Boolean.parseBoolean(contentTypeOpts);
         this.enableStrictTransportSecurity = Boolean.parseBoolean(stsEnabled);
@@ -418,7 +427,7 @@ public class ResponseHeadersEnforcementFilter extends AbstractSecurityFilter imp
                                             final String value) {
 
         val uri = httpServletRequest.getRequestURI();
-        if (!CACHE_CONTROL_STATIC_RESOURCES_PATTERN.matcher(uri).matches()) {
+        if (!cacheControlStaticResourcesPattern.matcher(uri).matches()) {
             httpServletResponse.addHeader("Cache-Control", value);
             httpServletResponse.addHeader("Pragma", "no-cache");
             httpServletResponse.addIntHeader("Expires", 0);

--- a/core/cas-server-core-web-api/src/test/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilterTests.java
+++ b/core/cas-server-core-web-api/src/test/java/org/apereo/cas/web/support/filters/ResponseHeadersEnforcementFilterTests.java
@@ -35,6 +35,7 @@ public class ResponseHeadersEnforcementFilterTests {
         filterConfig.addInitParameter(ResponseHeadersEnforcementFilter.INIT_PARAM_ENABLE_XCONTENT_OPTIONS, "true");
         filterConfig.addInitParameter(ResponseHeadersEnforcementFilter.INIT_PARAM_ENABLE_XSS_PROTECTION, "true");
         filterConfig.addInitParameter(ResponseHeadersEnforcementFilter.INIT_PARAM_CONTENT_SECURITY_POLICY, "default-src https");
+        filterConfig.addInitParameter(ResponseHeadersEnforcementFilter.INIT_PARAM_CACHE_CONTROL_STATIC_RESOURCES, "css|js|png|txt|jpg|ico|jpeg|bmp|gif");
         this.filter = new ResponseHeadersEnforcementFilter();
     }
 
@@ -62,5 +63,35 @@ public class ResponseHeadersEnforcementFilterTests {
         assertNotNull(servletResponse.getHeaderValue("X-Frame-Options"));
         assertNotNull(servletResponse.getHeaderValue("X-Content-Type-Options"));
         assertNotNull(servletResponse.getHeaderValue("Strict-Transport-Security"));
+    }
+    
+    @Test
+    public void verifyNoCacheParamJpeg() {
+        filter.init(filterConfig);
+
+        val servletRequest = new MockHttpServletRequest();
+        servletRequest.setSecure(true);
+        servletRequest.setRequestURI("test.jpeg");
+        val servletResponse = new MockHttpServletResponse();
+        assertThrows(RuntimeException.class, () -> filter.doFilter(servletRequest, servletResponse, null));
+        assertDoesNotThrow(() -> filter.doFilter(servletRequest, servletResponse, new MockFilterChain()));
+        filter.destroy();
+        assertNull(servletResponse.getHeaderValue("Cache-Control"));
+        assertNull(servletResponse.getHeaderValue("Pragma"));
+    }
+
+    @Test
+    public void verifyNoCacheParamPng() {
+        filter.init(filterConfig);
+
+        val servletRequest = new MockHttpServletRequest();
+        servletRequest.setSecure(true);
+        servletRequest.setRequestURI("test.png");
+        val servletResponse = new MockHttpServletResponse();
+        assertThrows(RuntimeException.class, () -> filter.doFilter(servletRequest, servletResponse, null));
+        assertDoesNotThrow(() -> filter.doFilter(servletRequest, servletResponse, new MockFilterChain()));
+        filter.destroy();
+        assertNull(servletResponse.getHeaderValue("Cache-Control"));
+        assertNull(servletResponse.getHeaderValue("Pragma"));
     }
 }

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceResponseHeadersEnforcementFilterTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/RegisteredServiceResponseHeadersEnforcementFilterTests.java
@@ -21,13 +21,16 @@ import org.apereo.cas.web.support.DefaultArgumentExtractor;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.val;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apereo.cas.web.support.filters.ResponseHeadersEnforcementFilter;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -50,6 +53,10 @@ public class RegisteredServiceResponseHeadersEnforcementFilterTests {
         val response = new MockHttpServletResponse();
         val request = new MockHttpServletRequest();
         request.addParameter(CasProtocolConstants.PARAMETER_SERVICE, "service-0");
+        val servletContext = new MockServletContext();
+        val filterConfig = new MockFilterConfig(servletContext);
+        filterConfig.addInitParameter(ResponseHeadersEnforcementFilter.INIT_PARAM_CACHE_CONTROL_STATIC_RESOURCES, "css|js|png|txt|jpg|ico|jpeg|bmp|gif");
+        filter.init(filterConfig);
         filter.doFilter(request, response, new MockFilterChain());
         assertNotNull(response.getHeader("Cache-Control"));
     }

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasFiltersConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasFiltersConfiguration.java
@@ -115,6 +115,7 @@ public class CasFiltersConfiguration {
             initParams.put(ResponseHeadersEnforcementFilter.INIT_PARAM_STRICT_XFRAME_OPTIONS, header.getXframeOptions());
             initParams.put(ResponseHeadersEnforcementFilter.INIT_PARAM_ENABLE_XSS_PROTECTION, BooleanUtils.toStringTrueFalse(header.isXss()));
             initParams.put(ResponseHeadersEnforcementFilter.INIT_PARAM_XSS_PROTECTION, header.getXssOptions());
+            initParams.put(ResponseHeadersEnforcementFilter.INIT_PARAM_CACHE_CONTROL_STATIC_RESOURCES, header.getCacheControlStaticResources());
             if (StringUtils.isNotBlank(header.getContentSecurityPolicy())) {
                 initParams.put(ResponseHeadersEnforcementFilter.INIT_PARAM_CONTENT_SECURITY_POLICY, header.getContentSecurityPolicy());
             }


### PR DESCRIPTION
File extension of files that are considered as static resources, and therefore are cached, are hardcoded to CAS. With this change they can be dynamically changed with cas.http-web-request.header.cacheControlStaticResources application property. Its default value is css|js|png|txt|jpg|ico|jpeg|bmp|gif, which is the same value as the one that was hardcoded.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
