### PR TITLE
fix redis sentinel tests

### DIFF
--- a/ci/tests/redis/docker-compose.yml
+++ b/ci/tests/redis/docker-compose.yml
@@ -1,20 +1,30 @@
 version: "3"
 
 services:
-  master:
+  redis-master:
     image: bitnami/redis:${REDIS_VERSION}
     container_name: redis_server_master
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_REPLICATION_MODE=master
+      - REDIS_REPLICA_IP=127.0.0.1
+      - REDIS_REPLICA_PORT=6379
+      - REDIS_MASTER_HOST=localhost
+      - REDIS_MASTER_PORT_NUMBER=6379
     ports:
       - 6379:6379
 
   replica_1:
     image: bitnami/redis:${REDIS_VERSION}
     container_name: redis_server_replica_1
-    command: redis-server --slaveof master 6379
+    command: redis-server --slaveof redis-master 6379
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_REPLICA_IP=127.0.0.1
+      - REDIS_REPLICA_PORT=6380
+      - REDIS_MASTER_HOST=localhost
+      - REDIS_MASTER_PORT_NUMBER=6379
     ports:
       - 6380:6379
     depends_on:
@@ -23,9 +33,14 @@ services:
   replica_2:
     image: bitnami/redis:${REDIS_VERSION}
     container_name: redis_server_replica_2
-    command: redis-server --slaveof master 6379
+    command: redis-server --slaveof redis-master 6379
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_REPLICA_IP=127.0.0.1
+      - REDIS_REPLICA_PORT=6381
+      - REDIS_MASTER_HOST=localhost
+      - REDIS_MASTER_PORT_NUMBER=6379
     ports:
       - 6381:6379
     depends_on:
@@ -37,9 +52,9 @@ services:
     ports:
       - 26379:26379
     environment:
-      - MASTER_NAME=mymaster
-      - QUORUM=2
-      - MASTER=master
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+      - REDIS_MASTER_HOST=localhost
     depends_on:
       - master
 
@@ -49,9 +64,9 @@ services:
     ports:
       - 26380:26379
     environment:
-      - MASTER_NAME=mymaster
-      - QUORUM=2
-      - MASTER=master
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+      - REDIS_MASTER_HOST=localhost
     depends_on:
       - master
 
@@ -61,8 +76,8 @@ services:
     ports:
       - 26381:26379
     environment:
-      - MASTER_NAME=mymaster
-      - QUORUM=2
-      - MASTER=master
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+      - REDIS_MASTER_HOST=localhost
     depends_on:
       - master

--- a/support/cas-server-support-redis-service-registry/src/test/java/org/apereo/cas/adaptors/redis/services/RedisSentinelServerServiceRegistryTests.java
+++ b/support/cas-server-support-redis-service-registry/src/test/java/org/apereo/cas/adaptors/redis/services/RedisSentinelServerServiceRegistryTests.java
@@ -23,7 +23,8 @@ import org.springframework.test.context.TestPropertySource;
     "cas.service-registry.redis.sentinel.master=mymaster",
     "cas.service-registry.redis.sentinel.node[0]=localhost:26379",
     "cas.service-registry.redis.sentinel.node[1]=localhost:26380",
-    "cas.service-registry.redis.sentinel.node[2]=localhost:26381"
+    "cas.service-registry.redis.sentinel.node[2]=localhost:26381",
+    "cas.service-registry.redis.timeout=5000"
 })
 @EnabledIfListeningOnPort(port = 6379)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisSentinelServerTicketRegistryTests.java
+++ b/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisSentinelServerTicketRegistryTests.java
@@ -22,7 +22,8 @@ import org.springframework.test.context.TestPropertySource;
     "cas.ticket.registry.redis.sentinel.master=mymaster",
     "cas.ticket.registry.redis.sentinel.node[0]=localhost:26379",
     "cas.ticket.registry.redis.sentinel.node[1]=localhost:26380",
-    "cas.ticket.registry.redis.sentinel.node[2]=localhost:26381"
+    "cas.ticket.registry.redis.sentinel.node[2]=localhost:26381",
+    "cas.ticket.registry.redis.timeout=5000"
 })
 @EnabledIfListeningOnPort(port = 6379)
 @Tag("Redis")


### PR DESCRIPTION
This should fix the redis sentinel unit tests so they work with updated redis/sentinel. The tests work locally with docker for windows and I think they worked on linux once, although I might have made minor changes after that test. 