### PR TITLE
Fix layout of casLoginView with delegated login providers

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginView.html
@@ -22,7 +22,7 @@
                 <a href="fragments/loginform.html">Login Form goes here</a>
             </div>
         </section>
-        <span th:if="${#bools.isFalse(delegatedAuthenticationDynamicProviderSelection) && #bools.isFalse(delegatedAuthenticationDisabled)}">
+        <span th:if="${#bools.isFalse(delegatedAuthenticationDynamicProviderSelection) && #bools.isFalse(delegatedAuthenticationDisabled)}" th:remove="tag">
             <section id="loginProviders" class="login-section login-providers card-body"
                     th:if="${delegatedAuthenticationProviderConfigurations} OR ${wsfedUrls}">
                 <div th:replace="fragments/loginProviders :: loginProviders">


### PR DESCRIPTION
In `casLoginView`, a `<span>` element wraps the section for delegated authentication providers with a `th:if` condition. However, this breaks the layout since the resulting `<section>` elements are no longer siblings; visually, the login form on the left has a very large column, and the login providers on the right a very thin column.

This PR removes the wrapper `<span>` element using `th:remove="tag"`, and restores the usual 2-columns layout with equal sizes.