### PR TITLE
fix groovy scripts so they are only run when they are the person dao under consideration

### DIFF
--- a/ci/tests/puppeteer/cas.js
+++ b/ci/tests/puppeteer/cas.js
@@ -337,6 +337,11 @@ exports.assertInnerTextContains = async (page, selector, value) => {
     assert(header.includes(value));
 }
 
+exports.assertInnerTextDoesNotContain = async (page, selector, value) => {
+    const header = await this.innerText(page, selector);
+    assert(!header.includes(value));
+}
+
 exports.assertInnerText = async (page, selector, value) => {
     const header = await this.innerText(page, selector);
     assert(header === value)

--- a/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/notusedattributes.groovy
+++ b/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/notusedattributes.groovy
@@ -1,0 +1,12 @@
+import java.util.*
+
+Map<String, List<Object>> run(final Object... args) {
+    def uid = args[0]
+    def attributes = args[1]
+    def logger = args[2]
+    def casProperties = args[3]
+    def casApplicationContext = args[4]
+    def returnAttrs = [username:[uid], shouldntbehere:["somevalue"], alsoshouldntbehere:["anothervalue"]]
+    logger.warn("This attribute repository is defined but not used [{}]", uid)
+    return returnAttrs
+}

--- a/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.js
+++ b/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.js
@@ -66,6 +66,7 @@ const request = require('request');
     await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "casuserx509");
     await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "someattribute");
     await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "user-account-control");
+    await cas.assertInnerTextDoesNotContain(page, "#attribute-tab-0 table#attributesTable tbody", "shouldntbehere");
 
     await browser.close();
 })();

--- a/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.json
+++ b/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.json
@@ -80,7 +80,13 @@
     "--cas.authn.attribute-repository.groovy[0].id=COMMONATTRS",
     "--cas.authn.attribute-repository.groovy[0].location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/attributes.groovy",
     "--cas.authn.attribute-repository.groovy[0].order=2",
-    "--cas.authn.attribute-repository.groovy[0].case-insensitive=false"
+    "--cas.authn.attribute-repository.groovy[0].case-insensitive=false",
+
+    "--cas.authn.attribute-repository.groovy[1].id=NOTUSEDATTRS",
+    "--cas.authn.attribute-repository.groovy[1].location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/notusedattributes.groovy",
+    "--cas.authn.attribute-repository.groovy[1].order=1",
+    "--cas.authn.attribute-repository.groovy[1].case-insensitive=false"
+
   ],
   "trustStoreCertificateFile": "./ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/cert.pem",
   "trustStorePrivateKeyFile": "./ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/key.pem",

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDao.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDao.java
@@ -33,6 +33,8 @@ public class InternalGroovyScriptDao extends BaseGroovyScriptDaoImpl {
 
     private final CasConfigurationProperties casProperties;
 
+    private final String id;
+
     @Override
     public Map<String, List<Object>> getPersonAttributesFromMultivaluedAttributes(final Map<String, List<Object>> attributes) {
         val username = usernameAttributeProvider.getUsernameFromQuery(attributes);
@@ -40,16 +42,18 @@ public class InternalGroovyScriptDao extends BaseGroovyScriptDaoImpl {
         if (StringUtils.isNotBlank(username)) {
             casProperties.getAuthn().getAttributeRepository().getGroovy()
                 .forEach(groovy -> {
-                    val args = new Object[]{username, attributes, LOGGER, casProperties, applicationContext};
-                    val finalAttributes = (Map<String, ?>) ScriptingUtils.executeGroovyScript(
-                        groovy.getLocation(), args, Map.class, true);
-                    LOGGER.debug("Groovy-based attributes found are [{}]", finalAttributes);
+                    if (id == null || id.equals(groovy.getId())) {
+                        val args = new Object[]{username, attributes, LOGGER, casProperties, applicationContext};
+                        val finalAttributes = (Map<String, ?>) ScriptingUtils.executeGroovyScript(
+                                groovy.getLocation(), args, Map.class, true);
+                        LOGGER.debug("Groovy-based attributes found are [{}]", finalAttributes);
 
-                    finalAttributes.forEach((k, v) -> {
-                        val values = new ArrayList<Object>(CollectionUtils.toCollection(v));
-                        LOGGER.trace("Adding Groovy-based attribute [{}] with value(s) [{}]", k, values);
-                        results.put(k, values);
-                    });
+                        finalAttributes.forEach((k, v) -> {
+                            val values = new ArrayList<Object>(CollectionUtils.toCollection(v));
+                            LOGGER.trace("Adding Groovy-based attribute [{}] with value(s) [{}]", k, values);
+                            results.put(k, values);
+                        });
+                    }
                 });
         }
         return results;

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDao.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDao.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication.principal.resolvers;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.core.authentication.GroovyPrincipalAttributesProperties;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.scripting.ScriptingUtils;
 
@@ -33,28 +34,23 @@ public class InternalGroovyScriptDao extends BaseGroovyScriptDaoImpl {
 
     private final CasConfigurationProperties casProperties;
 
-    private final String id;
+    private final GroovyPrincipalAttributesProperties groovyPrincipalAttributesProperties;
 
     @Override
     public Map<String, List<Object>> getPersonAttributesFromMultivaluedAttributes(final Map<String, List<Object>> attributes) {
         val username = usernameAttributeProvider.getUsernameFromQuery(attributes);
         val results = new HashMap<String, List<Object>>();
         if (StringUtils.isNotBlank(username)) {
-            casProperties.getAuthn().getAttributeRepository().getGroovy()
-                .forEach(groovy -> {
-                    if (id == null || id.equals(groovy.getId())) {
-                        val args = new Object[]{username, attributes, LOGGER, casProperties, applicationContext};
-                        val finalAttributes = (Map<String, ?>) ScriptingUtils.executeGroovyScript(
-                                groovy.getLocation(), args, Map.class, true);
-                        LOGGER.debug("Groovy-based attributes found are [{}]", finalAttributes);
+            val args = new Object[]{username, attributes, LOGGER, casProperties, applicationContext};
+            val finalAttributes = (Map<String, ?>) ScriptingUtils.executeGroovyScript(
+                    groovyPrincipalAttributesProperties.getLocation(), args, Map.class, true);
+            LOGGER.debug("Groovy-based attributes found are [{}]", finalAttributes);
 
-                        finalAttributes.forEach((k, v) -> {
-                            val values = new ArrayList<Object>(CollectionUtils.toCollection(v));
-                            LOGGER.trace("Adding Groovy-based attribute [{}] with value(s) [{}]", k, values);
-                            results.put(k, values);
-                        });
-                    }
-                });
+            finalAttributes.forEach((k, v) -> {
+                val values = new ArrayList<Object>(CollectionUtils.toCollection(v));
+                LOGGER.trace("Adding Groovy-based attribute [{}] with value(s) [{}]", k, values);
+                results.put(k, values);
+            });
         }
         return results;
     }

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDaoTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDaoTests.java
@@ -49,7 +49,7 @@ public class InternalGroovyScriptDaoTests {
         queryAttributes.put("username", "casuser");
 
         val results = d.getPeople(queryAttributes);
-        assertTrue(results.isEmpty());
+        assertFalse(results.isEmpty());
     }
 
     @Test

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDaoTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDaoTests.java
@@ -34,7 +34,28 @@ public class InternalGroovyScriptDaoTests {
 
     @Test
     public void verifyAction() {
-        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties));
+        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, null));
+        val queryAttributes = new HashMap<String, Object>();
+        queryAttributes.put("username", "casuser");
+
+        val results = d.getPeople(queryAttributes);
+        assertFalse(results.isEmpty());
+    }
+
+    @Test
+    public void verifyIdMismatch() {
+        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, "test"));
+        val queryAttributes = new HashMap<String, Object>();
+        queryAttributes.put("username", "casuser");
+
+        val results = d.getPeople(queryAttributes);
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void verifyIdMatch() {
+        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, "test"));
+        d.setId("test");
         val queryAttributes = new HashMap<String, Object>();
         queryAttributes.put("username", "casuser");
 

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDaoTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/InternalGroovyScriptDaoTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.authentication.principal.resolvers;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.core.authentication.GroovyPrincipalAttributesProperties;
 
 import lombok.val;
 import org.apereo.services.persondir.support.GroovyPersonAttributeDao;
@@ -11,6 +12,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.io.ClassPathResource;
 
 import java.util.HashMap;
 
@@ -34,28 +36,9 @@ public class InternalGroovyScriptDaoTests {
 
     @Test
     public void verifyAction() {
-        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, null));
-        val queryAttributes = new HashMap<String, Object>();
-        queryAttributes.put("username", "casuser");
-
-        val results = d.getPeople(queryAttributes);
-        assertFalse(results.isEmpty());
-    }
-
-    @Test
-    public void verifyIdMismatch() {
-        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, "test"));
-        val queryAttributes = new HashMap<String, Object>();
-        queryAttributes.put("username", "casuser");
-
-        val results = d.getPeople(queryAttributes);
-        assertFalse(results.isEmpty());
-    }
-
-    @Test
-    public void verifyIdMatch() {
-        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, "test"));
-        d.setId("test");
+        val groovy = new GroovyPrincipalAttributesProperties();
+        groovy.setLocation(new ClassPathResource("/GroovyAttributeDao.groovy"));
+        val d = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, groovy));
         val queryAttributes = new HashMap<String, Object>();
         queryAttributes.put("username", "casuser");
 

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryGroovyConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryGroovyConfiguration.java
@@ -50,7 +50,7 @@ public class CasPersonDirectoryGroovyConfiguration {
                 .stream()
                 .filter(groovy -> groovy.getLocation() != null)
                 .forEach(groovy -> {
-                    val dao = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties));
+                    val dao = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, groovy.getId()));
                     dao.setCaseInsensitiveUsername(groovy.isCaseInsensitive());
                     dao.setOrder(groovy.getOrder());
                     dao.setEnabled(groovy.getState() != AttributeRepositoryStates.DISABLED);

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryGroovyConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryGroovyConfiguration.java
@@ -50,7 +50,7 @@ public class CasPersonDirectoryGroovyConfiguration {
                 .stream()
                 .filter(groovy -> groovy.getLocation() != null)
                 .forEach(groovy -> {
-                    val dao = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, groovy.getId()));
+                    val dao = new GroovyPersonAttributeDao(new InternalGroovyScriptDao(applicationContext, casProperties, groovy));
                     dao.setCaseInsensitiveUsername(groovy.isCaseInsensitive());
                     dao.setOrder(groovy.getOrder());
                     dao.setEnabled(groovy.getState() != AttributeRepositoryStates.DISABLED);


### PR DESCRIPTION
When a groovy script is called and there are multiple groovy attribute repositories defined, they all get invoked by the `InternalGroovyScriptDao` without respect to whether they are in the active repository ids list and without respect to the order they are defined. I have another PR coming for person-directory that may help the case of groovy scripts that are defined but not in the active list, but this PR should take care of that case as long as the groovy DAOs are defined with ids. 