### PR TITLE
Handle multi use token for reset password

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/ResetPasswordManagementProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pm/ResetPasswordManagementProperties.java
@@ -70,6 +70,12 @@ public class ResetPasswordManagementProperties implements Serializable {
     @DurationCapable
     private String expiration = "PT1M";
 
+    /**
+     * How many times you can use the password reset link.
+     * Stricly lower than 1 means infinite.
+     */
+    private int numberOfUses = -1;
+
     public ResetPasswordManagementProperties() {
         mail.setAttributeName("mail");
         mail.setText("Reset your password via this link: %s");

--- a/ci/tests/puppeteer/scenarios/forgot-password-multi-use/accounts.json
+++ b/ci/tests/puppeteer/scenarios/forgot-password-multi-use/accounts.json
@@ -1,0 +1,11 @@
+{
+  "casuser" : {
+    "email" : "casuser@example.org",
+    "password" : "EaP8R&iX$eK4nb8eAI",
+    "phone" : "3477464665",
+    "securityQuestions" : {
+      "question1" : "answer1",
+      "question2" : "answer2"
+    }
+  }
+}

--- a/ci/tests/puppeteer/scenarios/forgot-password-multi-use/script.js
+++ b/ci/tests/puppeteer/scenarios/forgot-password-multi-use/script.js
@@ -36,29 +36,18 @@ const cas = require('../../cas.js');
     let link = await cas.textContent(page, "div[name=bodyPlainText] .well");
     await cas.goto(page, link);
     await page.waitForTimeout(1000);
+    await cas.assertInnerText(page, "#content #pwdmain h3", "Hello, casuser. You must change your password.");
 
-    await cas.assertInnerText(page, "#content h2", "Answer Security Questions");
-
-    await cas.type(page,'#q0', "answer1");
-    await cas.type(page,'#q1', "answer2");
-    await page.keyboard.press('Enter');
-    await page.waitForNavigation();
+    await page.waitForTimeout(2000);
+    await cas.goto(page, link);
     await page.waitForTimeout(1000);
+    await cas.assertInnerText(page, "#content #pwdmain h3", "Hello, casuser. You must change your password.");
 
-    await typePassword(page, "EaP8R&iX$eK4nb8eAI", "EaP8R&iX$eK4nb8eAI");
+    await page.waitForTimeout(2000);
+    await cas.goto(page, link);
     await page.waitForTimeout(1000);
-    await cas.assertInvisibility(page, '#password-confirm-mismatch-msg');
-    await cas.assertInvisibility(page, '#password-policy-violation-msg');
+    await cas.assertInnerText(page, "#main-content h2", "Password Reset Failed");
 
-    await page.keyboard.press('Enter');
-    await page.waitForNavigation();
-
-    await cas.assertInnerText(page, "#content h2", "Password Change Successful");
-    await cas.assertInnerText(page, "#content p", "Your account password is successfully updated.");
+    await page.waitForTimeout(2000);
     await browser.close();
 })();
-
-async function typePassword(page, pswd, confirm) {
-    await cas.type(page,'#password', pswd);
-    await cas.type(page,'#confirmedPassword', confirm);
-}

--- a/ci/tests/puppeteer/scenarios/forgot-password-multi-use/script.json
+++ b/ci/tests/puppeteer/scenarios/forgot-password-multi-use/script.json
@@ -1,0 +1,26 @@
+{
+  "dependencies": "hazelcast-ticket-registry,pm-webflow",
+  "conditions": {
+    "docker": "true"
+  },
+  "properties": [
+    "--cas.audit.engine.enabled=false",
+    "--cas.authn.pm.core.enabled=true",
+
+    "--spring.mail.host=localhost",
+    "--spring.mail.port=25000",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    
+    "--cas.authn.pm.reset.mail.from=cas@apereo.org",
+    "--cas.authn.pm.reset.mail.text=%s",
+    "--cas.authn.pm.reset.mail.subject=Reset your password",
+    "--cas.authn.pm.reset.mail.attribute-name=mail",
+    "--cas.authn.pm.reset.number-of-uses=2",
+    "--cas.authn.pm.reset.security-questions-enabled=false",
+
+    "--cas.authn.pm.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/accounts.json"
+  ],
+  "initScript": "${PWD}/ci/tests/mail/run-mail-server.sh"
+}

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -51,6 +51,7 @@ public class VerifyPasswordResetRequestAction extends BasePasswordManagementActi
         try {
             passwordResetTicket = ticketRegistry.getTicket(transientTicket, TransientSessionTicket.class);
             passwordResetTicket.update();
+            ticketRegistry.updateTicket(passwordResetTicket);
 
             val token = passwordResetTicket.getProperties().get(PasswordManagementService.PARAMETER_TOKEN).toString();
             val username = passwordManagementService.parseToken(token);


### PR DESCRIPTION
Currently, the reset pwd link can be clicked as many times as you want until the link expires.
This PR provides an option to have a defined number of uses of the reset pwd link.
The default behavior remains the same (hard timeout, infinite use).

So I have added a `numberOfUses` property at the `cas.authn.pm.reset` level (`ResetPasswordManagementProperties.java` model component). By default, it's `-1` meaning infinite (which is backward compatible).
This is taken into account in the  `DefaultPasswordResetUrlBuilder` component and tested in the `SendPasswordResetInstructionsActionTests` class test.

During my manual tests, I have found an issue with external ticket storage systems.
The fix is in the `VerifyPasswordResetRequestAction` component to update the ticket in the ticket registry.
I have added a puppeteer test: `forgot-password-multi-use` to confirm the fix (using Hazelcast as the external system).

Everything should be good. The timeout kind can still be discussed between the `HardTimeoutExpirationPolicy` and the `MultiTimeUseOrTimeoutExpirationPolicy` as the first one has a hard timeout and the second one an idle timeout. I can create a `MultiTimeUseOrHardTimeoutExpirationPolicy` if needed.
