### PR TITLE
Fix tests

### DIFF
--- a/testcas.sh
+++ b/testcas.sh
@@ -229,7 +229,7 @@ while (( "$#" )); do
                 task+="testCasConfiguration "
                 ;;
             geolocation|geo)
-                task+="testGeoLocation"
+                task+="testGeoLocation "
                 ;;
             git)
                 task+="testGit "
@@ -325,10 +325,10 @@ while (( "$#" )); do
                 task+="testIgnite "
                 ;;
             infinispan)
-                task+="testInfinispan"
+                task+="testInfinispan "
                 ;;
             spnego)
-                task+="testSpnego"
+                task+="testSpnego "
                 ;;
             cosmosdb|cosmos)
                 isDockerOnLinux && ./ci/tests/cosmosdb/run-cosmosdb-server.sh


### PR DESCRIPTION
Fix gradle test command issue in testcas.sh

A space is missing after geo, infinispan, and spnego category. For example, if the spnego and simple test tasks are executed at the same time, an error occurs:

./testcas.sh --category spnego,simple
...
FAILURE: Build failed with an exception.

What went wrong:
Task 'testSpnegotestSimple' not found in root project 'cas-server'.