### PR TITLE
support non-existence of deviceProperties in webauthn flow

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/webauthn/webauthn.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/webauthn/webauthn.js
@@ -538,13 +538,15 @@ function authenticate(username = null, getRequest = getAuthenticateRequest) {
                 addDeviceAttributeAsRow("Credential Nickname", reg.credentialNickname);
                 addDeviceAttributeAsRow("Registration Date", reg.registrationTime);
                 addDeviceAttributeAsRow("Session Token", data.sessionToken);
-                addDeviceAttributeAsRow("Device Id", reg.attestationMetadata.deviceProperties.deviceId);
-                addDeviceAttributeAsRow("Device Name", reg.attestationMetadata.deviceProperties.displayName);
-
-                showDeviceInfo({
-                    "displayName": reg.attestationMetadata.deviceProperties.displayName,
-                    "imageUrl": reg.attestationMetadata.deviceProperties.imageUrl
-                })
+                if (reg.attestationMetadata.deviceProperties) {
+                    addDeviceAttributeAsRow("Device Id", reg.attestationMetadata.deviceProperties.deviceId);
+                    addDeviceAttributeAsRow("Device Name", reg.attestationMetadata.deviceProperties.displayName);
+    
+                    showDeviceInfo({
+                        "displayName": reg.attestationMetadata.deviceProperties.displayName,
+                        "imageUrl": reg.attestationMetadata.deviceProperties.imageUrl
+                    })   
+                }
             });
 
             $('#authnButton').hide();


### PR DESCRIPTION
<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test
- [x] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->

**Reason:** 

Currently, the WebAuthN flow allows to use devices which's attestations cannot be veryified/trusted, through the property `cas.authn.mfa.web-authn.core.allow-untrusted-attestation=true` . But when I enabled this flow, I realized that the UI wasn't receiving the attestationMetadata, which, from what I read at https://webauthn-doc.spomky-labs.com/webauthn-in-a-nutshell/attestation-and-metadata-statement, seems to make sense, as the attestation wasn't being checked. But the code between lines 541-546 at webauthn.js was assuming this metadatada was available, trying to access it, and breaking the authentication flow in the process.

**Changes:**

In order to avoid this problem, I added a check before the code that accessed the metadata, to execute it only when that metadata is availabe.

**How to test:**

Using a simple CAS installation with WebAuthN enabled:

1. Configure it to not to check attestation of devices, with `cas.authn.mfa.web-authn.core.allow-untrusted-attestation=true`
2. Through a web browser, try to access Apereo CAS or an app that is relying on it to do the authentication
3. The authentication flow, including the webauthn related part, should work smoothly and allow a succesful authentication

**Possible limitations/Side effects:**

* This code might allow for authentication flows where `cas.authn.mfa.web-authn.core.allow-untrusted-attestation=false` to succesfully pass even if no device data is given. But I don't know how it could be possible to access the state of `cas.authn.mfa.web-authn.core.allow-untrusted-attestation`  from webauthn.js, in order to check its state and act accordingly