### PR TITLE
Use a hard timeout for the multi use policy

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/TransientSessionTicket.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/TransientSessionTicket.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * @since 5.3.0
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-public interface TransientSessionTicket extends Ticket {
+public interface TransientSessionTicket extends Ticket, TicketGrantingTicketAwareTicket {
     /**
      * Ticket prefix for the delegated authentication request.
      */

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/MultiTimeUseOrTimeoutExpirationPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/expiration/MultiTimeUseOrTimeoutExpirationPolicy.java
@@ -62,11 +62,11 @@ public class MultiTimeUseOrTimeoutExpirationPolicy extends AbstractCasExpiration
             return true;
         }
         val systemTime = ZonedDateTime.now(getClock());
-        val lastTimeUsed = ticketState.getLastTimeUsed();
-        val expirationTime = lastTimeUsed.plus(this.timeToKillInSeconds, ChronoUnit.SECONDS);
-        if (systemTime.isAfter(expirationTime)) {
-            LOGGER.debug("Ticket [{}] has expired; difference between current time [{}] and ticket time [{}] is greater than or equal to [{}].",
-                ticketState.getId(), systemTime, lastTimeUsed, this.timeToKillInSeconds);
+        val creationTime = ticketState.getCreationTime();
+        val expiringTime = creationTime.plus(this.timeToKillInSeconds, ChronoUnit.SECONDS);
+        if (expiringTime.isBefore(systemTime)) {
+            LOGGER.debug("Ticket [{}] has expired; difference between current time [{}] and ticket creation time [{}] is greater than or equal to [{}].",
+                ticketState.getId(), systemTime, creationTime, this.timeToKillInSeconds);
             return true;
         }
         return super.isExpired(ticketState);

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/expiration/MultiTimeUseOrTimeoutExpirationPolicyTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/expiration/MultiTimeUseOrTimeoutExpirationPolicyTests.java
@@ -58,14 +58,14 @@ public class MultiTimeUseOrTimeoutExpirationPolicyTests {
 
     @Test
     public void verifyTicketIsNotExpired() {
-        this.expirationPolicy.setClock(Clock.fixed(this.ticket.getLastTimeUsed().toInstant().plusSeconds(TIMEOUT_SECONDS).minusNanos(1), ZoneOffset.UTC));
+        this.expirationPolicy.setClock(Clock.fixed(this.ticket.getCreationTime().toInstant().plusSeconds(TIMEOUT_SECONDS).minusNanos(1), ZoneOffset.UTC));
         assertFalse(this.ticket.isExpired());
         assertEquals(0, this.expirationPolicy.getTimeToIdle());
     }
 
     @Test
     public void verifyTicketIsExpiredByTime() {
-        this.expirationPolicy.setClock(Clock.fixed(this.ticket.getLastTimeUsed().toInstant().plusSeconds(TIMEOUT_SECONDS).plusNanos(1), ZoneOffset.UTC));
+        this.expirationPolicy.setClock(Clock.fixed(this.ticket.getCreationTime().toInstant().plusSeconds(TIMEOUT_SECONDS).plusNanos(1), ZoneOffset.UTC));
         assertTrue(this.ticket.isExpired());
     }
 

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -83,7 +83,7 @@ public class VerifyPasswordResetRequestAction extends BasePasswordManagementActi
             LoggingUtils.error(LOGGER, "Password reset token could not be located or verified", e);
             return error();
         } finally {
-            if (passwordResetTicket != null && passwordResetTicket.isExpired()) {
+            if (passwordResetTicket != null && passwordResetTicket.getExpirationPolicy().isExpired(passwordResetTicket)) {
                 ticketRegistry.deleteTicket(passwordResetTicket);
             }
         }


### PR DESCRIPTION
Following up https://github.com/apereo/cas/pull/5505

The `MultiTimeUseOrTimeoutExpirationPolicy` now uses a hard timeout.

BTW, the expiration test is revisited in `VerifyPasswordResetRequestAction`.

Waiting for the build to pass...