### PR TITLE
Fix the OIDC back channel logout

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/slo/OidcSingleLogoutServiceMessageHandler.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/slo/OidcSingleLogoutServiceMessageHandler.java
@@ -102,7 +102,7 @@ public class OidcSingleLogoutServiceMessageHandler extends BaseSingleLogoutServi
             val exec = HttpUtils.HttpExecutionRequest.builder()
                 .method(HttpMethod.POST)
                 .url(msg.getUrl().toExternalForm())
-                .parameters(CollectionUtils.wrap("logout_token", payload))
+                .entity("logout_token=" + payload)
                 .headers(CollectionUtils.wrap("Content-Type", msg.getContentType()))
                 .build();
             response = HttpUtils.execute(exec);


### PR DESCRIPTION
This is a small fix, but the spec clearly states that the "The POST body uses the application/x-www-form-urlencoded encoding and must include a logout_token parameter" (not a request parameter).
See: https://openid.net/specs/openid-connect-backchannel-1_0.html#BCRequest
