### PR TITLE
FIX: javax.crypto.spec.IvParameterSpec

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseBinaryCipherExecutor.java
@@ -113,9 +113,9 @@ public abstract class BaseBinaryCipherExecutor extends AbstractCipherExecutor<by
         if (encryptionKeySize > MINIMUM_ENCRYPTION_KEY_LENGTH) {
             System.arraycopy(this.encryptionSecretKey, 0, iv, 0, encryptionSecretKey.length);
         }
-        return encryptionKeySize <= MINIMUM_ENCRYPTION_KEY_LENGTH
-            ? new IvParameterSpec(iv)
-            : new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+        // FIX: <Unsupported parameter: javax.crypto.spec.IvParameterSpec@36f8204d>
+        return GCMParameterSpec(GCM_TAG_LENGTH, iv);
+    
     }
 
     private void ensureEncryptionKeyExists(final String encryptionSecretKey, final int encryptionKeySize) {


### PR DESCRIPTION
FIX <Unsupported parameter: javax.crypto.spec.IvParameterSpec@36f8204d>
When customizing Webflow, The CAS trows exception.
force to return GCMParameterSpec();

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
