### PR TITLE
Upgrade to spring-webmvc-pac4j v6.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -248,7 +248,7 @@ commonsCollectionsVersion=4.4
 ###############################
 # Pac4j versions
 ###############################
-pac4jSpringWebmvcVersion=6.0.3
+pac4jSpringWebmvcVersion=6.1.0
 pac4jVersion=5.5.0
 ###############################
 # ACME versions

--- a/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
+++ b/support/cas-server-support-oauth-uma/src/main/java/org/apereo/cas/config/CasOAuthUmaConfiguration.java
@@ -53,7 +53,6 @@ import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.matching.matcher.DefaultMatchers;
 import org.pac4j.http.client.direct.HeaderClient;
-import org.pac4j.jee.http.adapter.JEEHttpActionAdapter;
 import org.pac4j.springframework.web.SecurityInterceptor;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.ObjectProvider;
@@ -190,9 +189,8 @@ public class CasOAuthUmaConfiguration {
             val clients = Stream.of(headerClient.getName()).collect(Collectors.joining(","));
             val config = new Config(OAuth20Utils.casOAuthCallbackUrl(casProperties.getServer().getPrefix()), headerClient);
             config.setSessionStore(oauthDistributedSessionStore);
-            val interceptor = new SecurityInterceptor(config, clients, JEEHttpActionAdapter.INSTANCE);
-            interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
-            interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
+            val interceptor = new SecurityInterceptor(config, clients, DefaultAuthorizers.IS_FULLY_AUTHENTICATED,
+                    DefaultMatchers.SECURITYHEADERS);
             return interceptor;
         }
         @Bean

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
@@ -23,7 +23,6 @@ import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.engine.DefaultSecurityLogic;
 import org.pac4j.core.matching.matcher.DefaultMatchers;
-import org.pac4j.jee.http.adapter.JEEHttpActionAdapter;
 import org.pac4j.springframework.web.SecurityInterceptor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -139,10 +138,8 @@ public class CasOAuth20ThrottleConfiguration {
             final CasCookieBuilder ticketGrantingTicketCookieGenerator,
             @Qualifier(TicketRegistry.BEAN_NAME)
             final TicketRegistry ticketRegistry) {
-            val interceptor = new SecurityInterceptor(oauthSecConfig,
-                Authenticators.CAS_OAUTH_CLIENT, JEEHttpActionAdapter.INSTANCE);
-            interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
-            interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
+            val interceptor = new SecurityInterceptor(oauthSecConfig, Authenticators.CAS_OAUTH_CLIENT,
+                    DefaultAuthorizers.IS_FULLY_AUTHENTICATED, DefaultMatchers.SECURITYHEADERS);
 
             val logic = new OAuth20TicketGrantingTicketAwareSecurityLogic(ticketGrantingTicketCookieGenerator, ticketRegistry);
             interceptor.setSecurityLogic(logic);
@@ -160,9 +157,8 @@ public class CasOAuth20ThrottleConfiguration {
                 .filter(client -> client instanceof DirectClient)
                 .map(Client::getName)
                 .collect(Collectors.joining(","));
-            val interceptor = new SecurityInterceptor(oauthSecConfig, clients, JEEHttpActionAdapter.INSTANCE);
-            interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
-            interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
+            val interceptor = new SecurityInterceptor(oauthSecConfig, clients,
+                    DefaultAuthorizers.IS_FULLY_AUTHENTICATED, DefaultMatchers.SECURITYHEADERS);
 
             val logic = new DefaultSecurityLogic();
             logic.setLoadProfilesFromSession(false);

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcConfiguration.java
@@ -111,7 +111,6 @@ import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.matching.matcher.DefaultMatchers;
 import org.pac4j.http.client.direct.DirectFormClient;
 import org.pac4j.http.client.direct.HeaderClient;
-import org.pac4j.jee.http.adapter.JEEHttpActionAdapter;
 import org.pac4j.springframework.web.SecurityInterceptor;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.ObjectProvider;
@@ -190,11 +189,9 @@ public class OidcConfiguration {
             final SecurityLogic oidcAuthorizationSecurityLogic,
             @Qualifier("oauthSecConfig")
             final Config oauthSecConfig) {
-            val interceptor = new SecurityInterceptor(oauthSecConfig,
-                Authenticators.CAS_OAUTH_CLIENT, JEEHttpActionAdapter.INSTANCE);
-            interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
-            interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
-            interceptor.setSecurityLogic(oidcAuthorizationSecurityLogic);
+            val interceptor = SecurityInterceptor.build(oauthSecConfig, Authenticators.CAS_OAUTH_CLIENT,
+                    DefaultAuthorizers.IS_FULLY_AUTHENTICATED, DefaultMatchers.SECURITYHEADERS,
+                    oidcAuthorizationSecurityLogic);
             return interceptor;
         }
     }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcEndpointsConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcEndpointsConfiguration.java
@@ -60,7 +60,6 @@ import org.pac4j.core.authorization.authorizer.DefaultAuthorizers;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.matching.matcher.DefaultMatchers;
-import org.pac4j.jee.http.adapter.JEEHttpActionAdapter;
 import org.pac4j.springframework.web.SecurityInterceptor;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.ObjectProvider;
@@ -143,9 +142,7 @@ public class OidcEndpointsConfiguration {
             final Config oauthSecConfig) {
             val interceptor = new SecurityInterceptor(oauthSecConfig,
                 Authenticators.CAS_OAUTH_CLIENT_DYNAMIC_REGISTRATION_AUTHN,
-                JEEHttpActionAdapter.INSTANCE);
-            interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
-            interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
+                DefaultAuthorizers.IS_FULLY_AUTHENTICATED, DefaultMatchers.SECURITYHEADERS);
             return interceptor;
         }
 
@@ -155,9 +152,8 @@ public class OidcEndpointsConfiguration {
             @Qualifier("oauthSecConfig")
             final Config oauthSecConfig) {
             val clients = String.join(",", OidcConstants.CAS_OAUTH_CLIENT_CONFIG_ACCESS_TOKEN_AUTHN);
-            val interceptor = new SecurityInterceptor(oauthSecConfig, clients, JEEHttpActionAdapter.INSTANCE);
-            interceptor.setMatchers(DefaultMatchers.SECURITYHEADERS);
-            interceptor.setAuthorizers(DefaultAuthorizers.IS_FULLY_AUTHENTICATED);
+            val interceptor = new SecurityInterceptor(oauthSecConfig, clients, DefaultAuthorizers.IS_FULLY_AUTHENTICATED,
+                    DefaultMatchers.SECURITYHEADERS);
             return interceptor;
         }
 


### PR DESCRIPTION
Two things are done when upgrading:
- passing the `JEEHttpActionAdapter.INSTANCE` to the `SecurityInterceptor` is useless, it is the default `HttpActionAdapter`: https://github.com/pac4j/spring-webmvc-pac4j/blob/spring-webmvc-pac4j-6.1.0/src/main/java/org/pac4j/springframework/web/SecurityInterceptor.java#L89
- the "smart" builder `SecurityInterceptor.build` can be used for multiple input types: https://github.com/apereo/cas/compare/master...leleuj:cas:springwebmvcpac4j61?expand=1#diff-68d41d51d66f4e3c4fa771feef620c44c6482e98cc7f1549fed760706816ca0aR192

This is only a proposal. Keep what you think is clearer to you.
