### PR TITLE
Improve Google Analytics support

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/googleanalytics.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/googleanalytics.html
@@ -1,20 +1,16 @@
 
-<script th:fragment="ga" th:inline="javascript">
+<script th:fragment="ga" th:inline="javascript" th:if="${not #strings.isEmpty(googleAnalyticsTrackingId)}">
     /*<![CDATA[*/
-    let trackGeoLocation = /*[[${trackGeoLocation}]]*/ === "true";
-
     let googleAnalyticsTrackingId = /*[[${googleAnalyticsTrackingId}]]*/;
              
-    if (googleAnalyticsTrackingId != null && googleAnalyticsTrackingId !== '') {
-        let script = document.createElement('script');
-        script.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleAnalyticsTrackingId;
-        document.head.appendChild(script);
+    let script = document.createElement('script');
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + googleAnalyticsTrackingId;
+    document.head.appendChild(script);
 
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-        gtag('config', googleAnalyticsTrackingId);
-    }
+    gtag('config', googleAnalyticsTrackingId);
     /*]]>*/
 </script>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/scripts.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/scripts.html
@@ -18,6 +18,7 @@
     $(() => {
         typeof cssVars === "function" && cssVars({onlyLegacy: true});
     })
+    let trackGeoLocation = /*[[${trackGeoLocation}]]*/ === "true";
 </script>
 
 <script th:replace="fragments/googleanalytics :: ga"></script>


### PR DESCRIPTION
Currently, the activation of Google Analytics relies on a Javascript test. This should be a Thymeleaf test to spare a few HTML bytes.