### PR TITLE
Add rebase option to git

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/git/services/BaseGitProperties.java
@@ -66,9 +66,14 @@ public abstract class BaseGitProperties implements Serializable {
     private boolean pushChanges;
 
     /**
-     * Whether or not commits should be signed.
+     * Whether commits should be signed.
      */
     private boolean signCommits;
+
+    /**
+     * Whether to rebase on pulls.
+     */
+    private boolean rebase;
 
     /**
      * Password for the SSH private key.

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/DefaultGitRepository.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/DefaultGitRepository.java
@@ -42,6 +42,8 @@ public class DefaultGitRepository implements GitRepository {
 
     private final boolean signCommits;
 
+    private final boolean rebase;
+
     @Override
     public File getRepositoryDirectory() {
         return this.gitInstance.getRepository().getDirectory().getParentFile();
@@ -132,7 +134,7 @@ public class DefaultGitRepository implements GitRepository {
         return this.gitInstance.pull()
             .setTimeout((int) timeoutInSeconds)
             .setFastForward(MergeCommand.FastForwardMode.FF)
-            .setRebase(false)
+            .setRebase(this.rebase)
             .setTransportConfigCallback(this.transportConfigCallback)
             .setProgressMonitor(new LoggingGitProgressMonitor())
             .setCredentialsProvider(new ChainingCredentialsProvider(providers))

--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -65,6 +65,8 @@ public class GitRepositoryBuilder {
 
     private final boolean signCommits;
 
+    private final boolean rebase;
+
     private final boolean strictHostKeyChecking;
 
     private final boolean clearExistingIdentities;
@@ -92,6 +94,7 @@ public class GitRepositoryBuilder {
             .sshSessionPassword(props.getSshSessionPassword())
             .timeoutInSeconds(Beans.newDuration(props.getTimeout()).toSeconds())
             .signCommits(props.isSignCommits())
+            .rebase(props.isRebase())
             .clearExistingIdentities(props.isClearExistingIdentities())
             .strictHostKeyChecking(props.isStrictHostKeyChecking())
             .httpClientType(props.getHttpClientType());
@@ -197,7 +200,7 @@ public class GitRepositoryBuilder {
         }
         LOGGER.debug("Cloning repository to [{}] with branch [{}]", this.repositoryDirectory, this.activeBranch);
         return new DefaultGitRepository(cloneCommand.call(), credentialsProviders,
-            transportCallback, this.timeoutInSeconds, this.signCommits);
+            transportCallback, this.timeoutInSeconds, this.signCommits, this.rebase);
     }
 
 
@@ -208,6 +211,6 @@ public class GitRepositoryBuilder {
             .setName(this.activeBranch)
             .call();
         return new DefaultGitRepository(git, this.credentialsProviders, transportCallback,
-            this.timeoutInSeconds, this.signCommits);
+            this.timeoutInSeconds, this.signCommits, this.rebase);
     }
 }

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryTests.java
@@ -6,6 +6,8 @@ import org.apereo.cas.util.ResourceUtils;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.CredentialsProvider;
@@ -18,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,12 +47,15 @@ public class GitRepositoryTests {
         props.setBranchesToClone("master");
         props.setStrictHostKeyChecking(false);
         props.setClearExistingIdentities(true);
-        props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
-            FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID()));
+        val cloneDir = FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID();
+        props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(cloneDir));
         val repo = GitRepositoryBuilder.newInstance(props).build();
         assertTrue(repo.pull());
         assertFalse(repo.getObjectsInRepository().isEmpty());
-
+        FileUtils.writeStringToFile(new File(cloneDir, "test.txt"), "test", Charset.defaultCharset());
+        try (val git = Git.open(ResourceUtils.getRawResourceFrom(cloneDir).getFile())) {
+            git.reset().setMode(ResetCommand.ResetType.HARD).setRef("HEAD~1").call();
+        }
         repo.getCredentialsProvider().add(new CredentialsProvider() {
             @Override
             public boolean isInteractive() {
@@ -68,6 +74,14 @@ public class GitRepositoryTests {
         });
         try {
             repo.commitAll("Test");
+            props.setRebase(true);
+            val repo2 = GitRepositoryBuilder.newInstance(props).build();
+            repo2.pull();
+            try (val git = Git.open(ResourceUtils.getRawResourceFrom(cloneDir).getFile())) {
+                var log = git.log().setMaxCount(1).call();
+                var revCommit = log.iterator().next();
+                assertEquals("Test", revCommit.getFullMessage());
+            }
             repo.push();
             fail("Pushing changes should fail");
         } catch (final Exception e) {


### PR DESCRIPTION
If CAS is configured with a git service registry but is not configured to push to the remote repo, and if it auto-generates a service (e.g. due to configured saml service provider metadata), then it can't pull any new services without someone manually resetting the local repository on each server to remove the local commits. By allowing CAS to rebase on pulls, the local commit stays local but doesn't prevent new services from being added. 