### PR TITLE
Use the HttpClient to fetch SAML metadata

### DIFF
--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/MetadataQueryProtocolMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/MetadataQueryProtocolMetadataResolver.java
@@ -10,6 +10,7 @@ import org.apereo.cas.support.saml.services.SamlRegisteredService;
 import org.apereo.cas.util.EncodingUtils;
 import org.apereo.cas.util.HttpUtils;
 import org.apereo.cas.util.function.FunctionUtils;
+import org.apereo.cas.util.http.HttpClient;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -42,9 +43,10 @@ import java.util.stream.StreamSupport;
 @Slf4j
 public class MetadataQueryProtocolMetadataResolver extends UrlResourceMetadataResolver {
 
-    public MetadataQueryProtocolMetadataResolver(final SamlIdPProperties samlIdPProperties,
+    public MetadataQueryProtocolMetadataResolver(final HttpClient httpClient,
+                                                 final SamlIdPProperties samlIdPProperties,
                                                  final OpenSamlConfigBean configBean) {
-        super(samlIdPProperties, configBean);
+        super(httpClient, samlIdPProperties, configBean);
     }
 
     @Override

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
@@ -18,6 +18,7 @@ import org.apereo.cas.util.HttpUtils;
 import org.apereo.cas.util.LoggingUtils;
 import org.apereo.cas.util.ResourceUtils;
 import org.apereo.cas.util.function.FunctionUtils;
+import org.apereo.cas.util.http.HttpClient;
 import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolver;
 
 import lombok.extern.slf4j.Slf4j;
@@ -63,11 +64,15 @@ public class UrlResourceMetadataResolver extends BaseSamlRegisteredServiceMetada
 
     private static final String DIRNAME_METADATA_BACKUPS = "metadata-backups";
 
+    private final HttpClient httpClient;
+
     private final File metadataBackupDirectory;
 
-    public UrlResourceMetadataResolver(final SamlIdPProperties samlIdPProperties,
+    public UrlResourceMetadataResolver(final HttpClient httpClient,
+                                       final SamlIdPProperties samlIdPProperties,
                                        final OpenSamlConfigBean configBean) {
         super(samlIdPProperties, configBean);
+        this.httpClient = httpClient;
 
         val md = samlIdPProperties.getMetadata();
         val backupLocation = StringUtils.defaultIfBlank(md.getHttp().getMetadataBackupLocation(), md.getFileSystem().getLocation());
@@ -223,6 +228,7 @@ public class UrlResourceMetadataResolver extends BaseSamlRegisteredServiceMetada
             .method(HttpMethod.GET)
             .url(metadataLocation)
             .proxyUrl(service.getMetadataProxyLocation())
+            .httpClient(httpClient)
             .build();
         return HttpUtils.execute(exec);
     }

--- a/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceDefaultCachingMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/SamlRegisteredServiceDefaultCachingMetadataResolverTests.java
@@ -215,9 +215,9 @@ public class SamlRegisteredServiceDefaultCachingMetadataResolverTests extends Ba
         val resolutionPlan = new DefaultSamlRegisteredServiceMetadataResolutionPlan();
         val props = casProperties.getAuthn().getSamlIdp();
         resolutionPlan.registerMetadataResolver(
-            new UrlResourceMetadataResolver(props, openSamlConfigBean));
+            new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean));
         resolutionPlan.registerMetadataResolver(
-            new MetadataQueryProtocolMetadataResolver(props, openSamlConfigBean));
+            new MetadataQueryProtocolMetadataResolver(httpClient, props, openSamlConfigBean));
         resolutionPlan.registerMetadataResolver(
             new ClasspathResourceMetadataResolver(props, openSamlConfigBean));
         val cacheLoader = new SamlRegisteredServiceMetadataResolverCacheLoader(openSamlConfigBean, httpClient, resolutionPlan);

--- a/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/MetadataQueryProtocolMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/MetadataQueryProtocolMetadataResolverTests.java
@@ -26,7 +26,7 @@ public class MetadataQueryProtocolMetadataResolverTests extends BaseSamlIdPServi
     public void verifyResolverSupports() throws Exception {
         val props = new SamlIdPProperties();
         props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
-        val resolver = new MetadataQueryProtocolMetadataResolver(props, openSamlConfigBean);
+        val resolver = new MetadataQueryProtocolMetadataResolver(httpClient, props, openSamlConfigBean);
         val service = new SamlRegisteredService();
         service.setMetadataLocation("http://www.testshib.org/metadata/testshib-providers.xml");
         assertFalse(resolver.supports(service));
@@ -38,7 +38,7 @@ public class MetadataQueryProtocolMetadataResolverTests extends BaseSamlIdPServi
     public void verifyResolverResolves() throws Exception {
         val props = new SamlIdPProperties();
         props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
-        val resolver = new MetadataQueryProtocolMetadataResolver(props, openSamlConfigBean);
+        val resolver = new MetadataQueryProtocolMetadataResolver(httpClient, props, openSamlConfigBean);
         val service = new SamlRegisteredService();
         service.setId(100);
         service.setName("Dynamic");
@@ -52,7 +52,7 @@ public class MetadataQueryProtocolMetadataResolverTests extends BaseSamlIdPServi
     public void verifyResolverFails() throws Exception {
         val props = new SamlIdPProperties();
         props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
-        val resolver = new MetadataQueryProtocolMetadataResolver(props, openSamlConfigBean);
+        val resolver = new MetadataQueryProtocolMetadataResolver(httpClient, props, openSamlConfigBean);
         val service = new SamlRegisteredService();
         service.setId(100);
         service.setName("Dynamic");

--- a/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata/src/test/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolverTests.java
@@ -40,7 +40,7 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
             webServer.start();
             val props = new SamlIdPProperties();
             props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
-            val resolver = new UrlResourceMetadataResolver(props, openSamlConfigBean);
+            val resolver = new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean);
             val service = new SamlRegisteredService();
             service.setMetadataLocation("http://localhost:9155");
             assertTrue(resolver.supports(service));
@@ -63,7 +63,7 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
             val props = new SamlIdPProperties();
             props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
             props.getMetadata().getHttp().setForceMetadataRefresh(true);
-            val resolver = new UrlResourceMetadataResolver(props, openSamlConfigBean);
+            val resolver = new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean);
             val results = resolver.resolve(service);
             assertFalse(results.isEmpty());
         }
@@ -71,7 +71,7 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
         val props = new SamlIdPProperties();
         props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
         props.getMetadata().getHttp().setForceMetadataRefresh(false);
-        val resolver = new UrlResourceMetadataResolver(props, openSamlConfigBean);
+        val resolver = new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean);
         val results = resolver.resolve(service);
         assertFalse(results.isEmpty());
 
@@ -98,7 +98,7 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
             val props = new SamlIdPProperties();
             props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
             val service = new SamlRegisteredService();
-            val resolver = new UrlResourceMetadataResolver(props, openSamlConfigBean);
+            val resolver = new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean);
             service.setName("TestShib");
             service.setId(1000);
             service.setMetadataLocation("http://localhost:9155");
@@ -117,7 +117,7 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
             props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
             val service = new SamlRegisteredService();
             service.setAccessStrategy(new DefaultRegisteredServiceAccessStrategy(false, false));
-            val resolver = new UrlResourceMetadataResolver(props, openSamlConfigBean);
+            val resolver = new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean);
             service.setName("TestShib");
             service.setId(1000);
             service.setMetadataLocation("http://localhost:9155");
@@ -130,7 +130,7 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
         val props = new SamlIdPProperties();
         props.getMetadata().getFileSystem().setLocation(new FileSystemResource(FileUtils.getTempDirectory()).getFile().getCanonicalPath());
         val service = new SamlRegisteredService();
-        val resolver = new UrlResourceMetadataResolver(props, openSamlConfigBean);
+        val resolver = new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean);
         service.setName("TestShib");
         service.setId(1000);
         service.setMetadataLocation("https://localhost:9999");
@@ -144,7 +144,7 @@ public class UrlResourceMetadataResolverTests extends BaseSamlIdPServicesTests {
             val props = new SamlIdPProperties();
             props.getMetadata().getFileSystem().setLocation("file:/" + FileUtils.getTempDirectory());
             val service = new SamlRegisteredService();
-            val resolver = new UrlResourceMetadataResolver(props, openSamlConfigBean);
+            val resolver = new UrlResourceMetadataResolver(httpClient, props, openSamlConfigBean);
             service.setName("TestShib");
             service.setId(1000);
             service.setMetadataLocation("http://localhost:9155");

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPMetadataConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPMetadataConfiguration.java
@@ -185,8 +185,10 @@ public class SamlIdPMetadataConfiguration {
         public SamlRegisteredServiceMetadataResolver metadataQueryProtocolMetadataResolver(
             final CasConfigurationProperties casProperties,
             @Qualifier(OpenSamlConfigBean.DEFAULT_BEAN_NAME)
-            final OpenSamlConfigBean openSamlConfigBean) {
-            return new MetadataQueryProtocolMetadataResolver(casProperties.getAuthn().getSamlIdp(), openSamlConfigBean);
+            final OpenSamlConfigBean openSamlConfigBean,
+            @Qualifier("httpClient")
+            final HttpClient httpClient) {
+            return new MetadataQueryProtocolMetadataResolver(httpClient, casProperties.getAuthn().getSamlIdp(), openSamlConfigBean);
         }
 
         @ConditionalOnMissingBean(name = "jsonResourceMetadataResolver")
@@ -218,8 +220,10 @@ public class SamlIdPMetadataConfiguration {
         public SamlRegisteredServiceMetadataResolver urlResourceMetadataResolver(
             final CasConfigurationProperties casProperties,
             @Qualifier(OpenSamlConfigBean.DEFAULT_BEAN_NAME)
-            final OpenSamlConfigBean openSamlConfigBean) {
-            return new UrlResourceMetadataResolver(casProperties.getAuthn().getSamlIdp(), openSamlConfigBean);
+            final OpenSamlConfigBean openSamlConfigBean,
+            @Qualifier("httpClient")
+            final HttpClient httpClient) {
+            return new UrlResourceMetadataResolver(httpClient, casProperties.getAuthn().getSamlIdp(), openSamlConfigBean);
         }
 
         @ConditionalOnMissingBean(name = "classpathResourceMetadataResolver")


### PR DESCRIPTION
This allows to reuse the `httpClient` configuration in the SAML URL metadata fetching.
