### PR TITLE
restore support for IP subnet authz on actuators

### DIFF
--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
@@ -272,31 +272,25 @@ public class CasWebSecurityConfigurerAdapter implements DisposableBean {
         requests
             .requestMatchers(endpoint)
             .access((authentication, context) -> {
-                val addresses = properties.getRequiredIpAddresses()
-                    .stream()
-                    .map(address -> '(' + address + ')')
-                    .collect(Collectors.joining("|"));
                 val remoteAddr = StringUtils.defaultIfBlank(
                     context.getRequest().getHeader(casProperties.getAudit().getEngine().getAlternateClientAddrHeaderName()),
                     context.getRequest().getRemoteAddr());
 
-                LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addresses);
-                val addressNets = properties.getRequiredIpAddresses()
+                val addresses = properties.getRequiredIpAddresses()
                         .stream()
-                        .filter(addr -> !addr.contains(".+"))
-                        .filter(addr -> !addr.contains(".*"))
-                        .filter(addr -> FunctionUtils.doWithoutThrows(ip -> new IpAddressMatcher(addr)))
-                        .map(IpAddressMatcher::new)
-                        .filter(ip -> ip.matches(remoteAddr))
+                        .filter(addr -> FunctionUtils.doAndHandle(() -> {
+                            val ipAddressMatcher = new IpAddressMatcher(addr);
+                            LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addr);
+                            return ipAddressMatcher.matches(remoteAddr);
+                        }, e -> {
+                            val matcher = RegexUtils.createPattern(addr, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
+                            LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addr);
+                            return matcher.matches();
+                        }).get())
                         .findFirst();
-                if (addressNets.isPresent()) {
-                    return new AuthorizationDecision(true);
-                }
-                LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addresses);
-                val matcher = RegexUtils.createPattern(addresses, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
-                val granted = matcher.matches();
+                val granted = addresses.isPresent();
                 if (!granted) {
-                    LOGGER.warn("Provided regular expression or IP/netmask [{}] does not match [{}]", addresses, remoteAddr);
+                    LOGGER.warn("Provided regular expression or IP/netmask [{}] does not match [{}]", properties.getRequiredIpAddresses(), remoteAddr);
                 }
                 return new AuthorizationDecision(granted);
             });

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
@@ -283,7 +283,8 @@ public class CasWebSecurityConfigurerAdapter implements DisposableBean {
                 LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addresses);
                 val addressNets = properties.getRequiredIpAddresses()
                         .stream()
-                        .filter(addr -> !addr.matches("\\.\\+|\\.\\*"))
+                        .filter(addr -> !addr.contains(".+"))
+                        .filter(addr -> !addr.contains(".*"))
                         .filter(addr -> FunctionUtils.doWithoutThrows(ip -> new IpAddressMatcher(addr)))
                         .map(IpAddressMatcher::new)
                         .filter(ip -> ip.matches(remoteAddr))

--- a/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
+++ b/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
@@ -48,7 +48,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "cas.monitor.endpoints.endpoint.env.access=AUTHENTICATED",
 
         "cas.monitor.endpoints.endpoint.health.access=IP_ADDRESS",
-        "cas.monitor.endpoints.endpoint.health.required-ip-addresses=196.+",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[0]=196.+",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[1]=10.0.0.0/24",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[2]=172.16.0.0/16",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[3]=200\\\\.0\\\\.0\\\\....",
 
         "cas.monitor.endpoints.form-login-enabled=true"
     }, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -87,6 +90,15 @@ public class CasWebSecurityConfigurerAdapterWebTests {
             .andExpect(status().isOk());
         mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "196.1.1.0"))
             .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "10.0.0.9"))
+                .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "172.16.55.9"))
+                .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "200.0.0.123"))
+                .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "192.168.0.1"))
+                .andExpect(status().isUnauthorized());
+
         mvc.perform(get("/cas/actuator/health")).andExpect(status().isUnauthorized());
     }
 


### PR DESCRIPTION
This is restoring the ability to use IP subnet patterns for the `requiredIpAddresses`  property on actuators, something that was supported in versions before 6.6. It also supports regular expressions. The stream through the various patterns filters out likely regular expressions, then creates an `IpAddressMatcher` to see if the value is an IP or subnet and if it is valid it creates `IpAddressMatcher` again and checks if it matches against the remote IP. If there is a way to get the `IpAddressMatcher` the first time it is created while ignoring the exception, that would be better. Alternatively, there could be two different properties for `requiredIpAddresses` and `requiredIpNetworks`. 