### PR TITLE
Add authentication attributes on resource password grant type

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20UsernamePasswordAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20UsernamePasswordAuthenticator.java
@@ -23,6 +23,7 @@ import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.profile.CommonProfile;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -94,6 +95,7 @@ public class OAuth20UsernamePasswordAuthenticator implements Authenticator {
 
             profile.setId(id);
             profile.addAttributes((Map) attributes);
+            profile.addAuthenticationAttributes(new HashMap<>(authentication.getAttributes()));
             LOGGER.debug("Authenticated user profile [{}]", profile);
             credentials.setUserProfile(profile);
         } catch (final Exception e) {

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20UsernamePasswordAuthenticatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20UsernamePasswordAuthenticatorTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.jee.context.JEEContext;
 import org.pac4j.jee.context.session.JEESessionStore;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -46,6 +47,7 @@ public class OAuth20UsernamePasswordAuthenticatorTests extends BaseOAuth20Authen
         authenticator.validate(credentials, ctx, JEESessionStore.INSTANCE);
         assertNotNull(credentials.getUserProfile());
         assertEquals("casuser", credentials.getUserProfile().getId());
+        assertTrue(((CommonProfile) credentials.getUserProfile()).getAuthenticationAttributes().size() >= 1);
     }
 
     @Test
@@ -58,6 +60,7 @@ public class OAuth20UsernamePasswordAuthenticatorTests extends BaseOAuth20Authen
         authenticator.validate(credentials, ctx, JEESessionStore.INSTANCE);
         assertNotNull(credentials.getUserProfile());
         assertEquals("casuser", credentials.getUserProfile().getId());
+        assertTrue(((CommonProfile) credentials.getUserProfile()).getAuthenticationAttributes().size() >= 1);
     }
 
     @Test
@@ -118,5 +121,6 @@ public class OAuth20UsernamePasswordAuthenticatorTests extends BaseOAuth20Authen
         authenticator.validate(credentials, ctx, JEESessionStore.INSTANCE);
         assertNotNull(credentials.getUserProfile());
         assertEquals("casuser", credentials.getUserProfile().getId());
+        assertTrue(((CommonProfile) credentials.getUserProfile()).getAuthenticationAttributes().size() >= 1);
     }
 }


### PR DESCRIPTION
If I perform an OAuth authorization code grant type and then look at the data (`/cas/actuator/ssoSessions`), I see the `clientIpAddress` in the authentication attributes.
This is not the case if I perfom an OAuth resource password grant type.

In both cases, the authentication attributes have been properly computed by the CAS `authenticationManager`. The problem comes from the `OAuth20UsernamePasswordAuthenticator` which does not save into the `pac4j` profile the authentication attributes (which would then be retrieved by the `OAuth20DefaultCasAuthenticationBuilder` and put in the CAS `Authentication`).

This PR fixes the problem.
