### PR TITLE
backport - restore support for IP subnet authz on actuators (#5523)

### DIFF
--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
@@ -30,6 +30,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -286,18 +287,25 @@ public class CasWebSecurityConfigurerAdapter implements DisposableBean {
         requests
             .requestMatchers(endpoint)
             .access((authentication, context) -> {
-                val addresses = properties.getRequiredIpAddresses()
-                    .stream()
-                    .map(address -> '(' + address + ')')
-                    .collect(Collectors.joining("|"));
                 val remoteAddr = StringUtils.defaultIfBlank(
                     context.getRequest().getHeader(casProperties.getAudit().getEngine().getAlternateClientAddrHeaderName()),
                     context.getRequest().getRemoteAddr());
-                LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addresses);
-                val matcher = RegexUtils.createPattern(addresses, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
-                val granted = matcher.matches();
+
+                val addresses = properties.getRequiredIpAddresses()
+                        .stream()
+                        .filter(addr -> FunctionUtils.doAndHandle(() -> {
+                            val ipAddressMatcher = new IpAddressMatcher(addr);
+                            LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addr);
+                            return ipAddressMatcher.matches(remoteAddr);
+                        }, e -> {
+                            val matcher = RegexUtils.createPattern(addr, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
+                            LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addr);
+                            return matcher.matches();
+                        }).get())
+                        .findFirst();
+                val granted = addresses.isPresent();
                 if (!granted) {
-                    LOGGER.warn("Provided regular expression pattern [{}] does not match [{}]", addresses, remoteAddr);
+                    LOGGER.warn("Provided regular expression or IP/netmask [{}] does not match [{}]", properties.getRequiredIpAddresses(), remoteAddr);
                 }
                 return new AuthorizationDecision(granted);
             });

--- a/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
+++ b/webapp/cas-server-webapp-config/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
@@ -48,7 +48,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "cas.monitor.endpoints.endpoint.env.access=AUTHENTICATED",
 
         "cas.monitor.endpoints.endpoint.health.access=IP_ADDRESS",
-        "cas.monitor.endpoints.endpoint.health.required-ip-addresses=196.+",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[0]=196.+",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[1]=10.0.0.0/24",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[2]=172.16.0.0/16",
+        "cas.monitor.endpoints.endpoint.health.required-ip-addresses[3]=200\\\\.0\\\\.0\\\\....",
 
         "cas.monitor.endpoints.form-login-enabled=true"
     }, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -87,6 +90,15 @@ public class CasWebSecurityConfigurerAdapterWebTests {
             .andExpect(status().isOk());
         mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "196.1.1.0"))
             .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "10.0.0.9"))
+                .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "172.16.55.9"))
+                .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "200.0.0.123"))
+                .andExpect(status().isOk());
+        mvc.perform(get("/cas/actuator/health").header("X-Forwarded-For", "192.168.0.1"))
+                .andExpect(status().isUnauthorized());
+
         mvc.perform(get("/cas/actuator/health")).andExpect(status().isUnauthorized());
     }
 


### PR DESCRIPTION
Backport to 6.6.x for more compatibility with previous releases. 