### PR TITLE
Correct event id for CasAuthenticationTransactionFailureEvent

### DIFF
--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
@@ -71,7 +71,7 @@ public record CasAuthenticationAuthenticationEventListener(CasEventRepository ca
     public void handleCasAuthenticationTransactionFailureEvent(final CasAuthenticationTransactionFailureEvent event) throws Exception {
         val dto = prepareCasEvent(event);
         dto.setPrincipalId(event.getCredential().getId());
-        dto.putEventId(CasAuthenticationPolicyFailureEvent.class.getSimpleName());
+        dto.putEventId(CasAuthenticationTransactionFailureEvent.class.getSimpleName());
         this.casEventRepository.save(dto);
     }
 

--- a/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/CasAuthenticationEventListenerTests.java
+++ b/core/cas-server-core-events/src/test/java/org/apereo/cas/support/events/CasAuthenticationEventListenerTests.java
@@ -83,7 +83,10 @@ public class CasAuthenticationEventListenerTests {
             CollectionUtils.wrap("error", new FailedLoginException()),
             CollectionUtils.wrap(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword()));
         applicationContext.publishEvent(event);
-        assertFalse(casEventRepository.load().findAny().isEmpty());
+        val savedEventOptional = casEventRepository.load().findFirst();
+        assertFalse(savedEventOptional.isEmpty());
+        val savedEvent = savedEventOptional.get();
+        assertEquals(CasAuthenticationTransactionFailureEvent.class.getSimpleName(), savedEvent.getEventId());
     }
 
     @Test


### PR DESCRIPTION
Set the correct event id in event DTO for `CasAuthenticationTransactionFailureEvent`