### PR TITLE
CSS expects .login-section to be a direct child of .d-flex

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginView.html
@@ -22,7 +22,7 @@
                 <a href="fragments/loginform.html">Login Form goes here</a>
             </div>
         </section>
-        <span th:if="${#bools.isFalse(delegatedAuthenticationDynamicProviderSelection) && #bools.isFalse(delegatedAuthenticationDisabled)}">
+        <span th:remove="tag" th:if="${#bools.isFalse(delegatedAuthenticationDynamicProviderSelection) && #bools.isFalse(delegatedAuthenticationDisabled)}">
             <section id="loginProviders" class="login-section login-providers card-body"
                     th:if="${delegatedAuthenticationProviderConfigurations} OR ${wsfedUrls}">
                 <div th:replace="fragments/loginProviders :: loginProviders">


### PR DESCRIPTION
without this fix, "flex: 1 1 auto;" on .login-section in cas.css does not work

fixes regression introduced in commit 2c3e30e215b441bc81cd3dcbe25c0011a4885d5c "support discovery for idp selection"
