### PR TITLE
Fix Spring Security configuration

### DIFF
--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasWebAppSecurityConfiguration.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/config/CasWebAppSecurityConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
@@ -78,18 +77,6 @@ public class CasWebAppSecurityConfiguration extends GlobalMethodSecurityConfigur
     @Configuration(value = "CasWebappCoreSecurityConfiguration", proxyBeanMethods = false)
     @EnableConfigurationProperties(CasConfigurationProperties.class)
     public static class CasWebappCoreSecurityConfiguration {
-        @Bean
-        @ConditionalOnMissingBean(name = "casWebSecurityCustomizer")
-        public WebSecurityCustomizer casWebSecurityCustomizer(
-            final ObjectProvider<PathMappedEndpoints> pathMappedEndpoints,
-            final List<ProtocolEndpointWebSecurityConfigurer> configurersList,
-            final SecurityProperties securityProperties,
-            final CasConfigurationProperties casProperties) {
-            val adapter = new CasWebSecurityConfigurerAdapter(casProperties, securityProperties,
-                pathMappedEndpoints, configurersList);
-            return adapter::configureWebSecurity;
-        }
-
         @Bean
         @ConditionalOnMissingBean(name = "casWebSecurityConfigurerAdapter")
         public SecurityFilterChain casWebSecurityConfigurerAdapter(


### PR DESCRIPTION
Currently, there are two concerns in the CAS Spring Security configuration:
1) At startup, CAS displays a lot of warnings: `WARN [org.springframework.security.config.annotation.web.builders.WebSecurity] - <You are asking Spring Security to ignore Ant [pattern='/xxx/**']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.>`
2) CAS endpoints are defined twice: to be ignored and then to "permitAll" (the second definition is useless).

There were some performance reasons to chose "ignore" instead of "permit", but this is no longer the case with version >= 5.7.0 (https://github.com/spring-projects/spring-security/issues/10938).

So this PR removes the "ignoring" part and disables CORS for the "permitAll" CAS endpoints.
