### PR TITLE
Avoid conflict when trying to use oidc and jdbc authentication.

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcJwksJpaConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/oidc/config/OidcJwksJpaConfiguration.java
@@ -5,6 +5,7 @@ import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
 import org.apereo.cas.configuration.model.support.jpa.JpaConfigurationContext;
 import org.apereo.cas.configuration.support.JpaBeans;
+import org.apereo.cas.hibernate.CasHibernateJpaBeanFactory;
 import org.apereo.cas.jpa.JpaBeanFactory;
 import org.apereo.cas.oidc.jwks.generator.OidcJsonWebKeystoreEntity;
 import org.apereo.cas.oidc.jwks.generator.OidcJsonWebKeystoreGeneratorService;
@@ -47,7 +48,7 @@ import java.util.function.Supplier;
  */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @Slf4j
-@ConditionalOnClass(JpaBeanFactory.class)
+@ConditionalOnClass(CasHibernateJpaBeanFactory.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.OpenIDConnect, module = "jpa")
 @AutoConfiguration
 public class OidcJwksJpaConfiguration {


### PR DESCRIPTION
- [] Brief description of changes applied
Switch the ConditionalOnClass to a class only in the module specified in https://apereo.github.io/cas/6.6.x/authentication/OIDC-Authentication-JWKS-Storage.html

- [] Test cases for all modified changes, where applicable
Sorry, I've no idea how to do this. I couldn't find other cases of checking modules start appropriately.

- [] The same pull request targeted at the master branch, if applicable
Thought I'd suggest this one to see if anywhere near acceptable first.

- [] Any documentation on how to configure, test
Just trying to use OIDC and JDBC authentication causes it for me.

- [] Any possible limitations, side effects, etc
I don't really understand why the pattern isn't to use ConditionalOnProperty then use a mandatory property for the feature. I'd also be tempted to remove the dependency of JDBC authentication on a JPA util module but waaaay
 beyond my understanding of the code base.

- [] Reference any other pull requests that might be related
Not a pull request but posts to the google group https://groups.google.com/a/apereo.org/g/cas-user/c/KrVJdliRD04/m/j1ADALU0BgAJ
