### PR TITLE
SamlAttributeConverter config option for pac4j

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/saml/Pac4jSamlClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/saml/Pac4jSamlClientProperties.java
@@ -290,6 +290,15 @@ public class Pac4jSamlClientProperties extends Pac4jBaseClientProperties impleme
     private String messageStoreFactory = "org.pac4j.saml.store.EmptyStoreFactory";
 
     /**
+     * Controls the way SAML attributes are converted from the SAML authentication response into pac4j attributes.
+     * <ul>
+     *     <li>{@code org.pac4j.saml.profile.converter.SimpleSAML2AttributeConverter}: Values of complex types are serialized into a single attribute. (default)</li>
+     *     <li>{@code org.pac4j.saml.profile.converter.ComplexTypeSAML2AttributeConverter}: Values of complex types are unboxed into several attributes; one per child element.</li>
+     * </ul>
+     */
+    private String samlAttributeConverter = "org.pac4j.saml.profile.converter.SimpleSAML2AttributeConverter";
+
+    /**
      * Indicate the strategy that should be used to sign the generated metadata.
      * <ul>
      *     <li>{@code Default}: Uses a signing strategy using the XMLSecTool tool.</li>

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/BaseDelegatedClientFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/BaseDelegatedClientFactory.java
@@ -31,6 +31,7 @@ import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.http.callback.NoParameterCallbackUrlResolver;
 import org.pac4j.core.http.callback.PathParameterCallbackUrlResolver;
 import org.pac4j.core.http.callback.QueryParameterCallbackUrlResolver;
+import org.pac4j.core.profile.converter.AttributeConverter;
 import org.pac4j.oauth.client.BitbucketClient;
 import org.pac4j.oauth.client.DropBoxClient;
 import org.pac4j.oauth.client.FacebookClient;
@@ -567,6 +568,14 @@ public abstract class BaseDelegatedClientFactory implements DelegatedClientFacto
                 }
                 cfg.setProviderName(saml.getProviderName());
                 cfg.setNameIdPolicyAllowCreate(saml.getNameIdPolicyAllowCreate().toBoolean());
+
+                if (!saml.getSamlAttributeConverter().isEmpty() && saml.getSamlAttributeConverter().contains(".")) {
+                    FunctionUtils.doAndHandle(__ -> {
+                        val clazz = ClassUtils.getClass(getClass().getClassLoader(), saml.getSamlAttributeConverter());
+                        val converter = (AttributeConverter) clazz.getDeclaredConstructor().newInstance();
+                        cfg.setSamlAttributeConverter(converter);
+                    });
+                }
 
                 val mappedAttributes = saml.getMappedAttributes();
                 if (!mappedAttributes.isEmpty()) {


### PR DESCRIPTION
Hey there!

[This pac4j change](https://github.com/pac4j/pac4j/commit/ec734d7759080eb87ccccbfac1a07dde924bf4bc) changed the behaviour of handling XML complex type attributes in pac4j-saml. The commit introduced a new configuration option, which hasn't made it's way into the CAS configuration, yet. However we need the non-default behaviour for our project.

This pull request adds a new configuration option for the Pac4j feature to CAS without changing the default behaviour.

I am not sure whether you require extra unit tests for this, as the configuration is covered by plenty of test cases already?!