### PR TITLE
WIP - OIDC and JDBC auth conflict - try2

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/script.js
@@ -1,0 +1,52 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    let url1 = "https://httpbin.org/anything/sample1";
+    await cas.logg(`Trying with URL ${url1}`);
+    let payload = await getPayload(page, url1, "client1", "secret1");
+    let decoded = await cas.decodeJwt(payload.id_token);
+    assert(decoded.sub === "CAS@EXAMPLE.ORG");
+    assert(decoded["preferred_username"] === "CAS@EXAMPLE.ORG");
+
+    let url2 = "https://httpbin.org/anything/sample2";
+    await cas.logg(`Trying with URL ${url2}`);
+    payload = await getPayload(page, url2, "client2", "secret2");
+    decoded = await cas.decodeJwt(payload.id_token);
+    assert(decoded.sub === "CASUSER");
+    assert(decoded["preferred_username"] === "CASUSER");
+
+    await browser.close();
+})();
+
+async function getPayload(page, redirectUri, clientId, clientSecret) {
+    const url = `https://localhost:8443/cas/oidc/authorize?response_type=code&client_id=${clientId}&scope=openid%20profile%20email&redirect_uri=${redirectUri}`;
+    await cas.goto(page, url);
+    console.log(`Page URL: ${page.url()}`);
+    await page.waitForTimeout(1000);
+    
+    if (await cas.isVisible(page, "#username")) {
+        await cas.loginWith(page, "casuser", "Mellon");
+        await page.waitForTimeout(1000)
+    }
+    if (await cas.isVisible(page, "#allow")) {
+        await cas.click(page, "#allow");
+        await page.waitForNavigation();
+    }
+
+    let code = await cas.assertParameter(page, "code");
+    console.log(`Current code is ${code}`);
+    const accessTokenUrl = `https://localhost:8443/cas/oidc/token?grant_type=authorization_code`
+        + `&client_id=${clientId}&client_secret=${clientSecret}&redirect_uri=${redirectUri}&code=${code}`;
+    await cas.goto(page, accessTokenUrl);
+    console.log(`Page URL: ${page.url()}`);
+    await page.waitForTimeout(1000);
+    let content = await cas.textContent(page, "body");
+    const payload = JSON.parse(content);
+    console.log(payload);
+    return payload;
+}

--- a/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/script.json
+++ b/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/script.json
@@ -1,0 +1,33 @@
+{
+  "dependencies": "oidc", "jdbc"
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--logging.level.org.apereo.cas=info",
+
+    "--cas.audit.engine.enabled=false",
+
+    "--cas.authn.attribute-repository.stub.attributes.cn=casuser",
+    "--cas.authn.attribute-repository.stub.attributes.mail=cas@example.org",
+    "--cas.authn.attribute-repository.stub.attributes.sn=Apereo",
+    "--cas.authn.attribute-repository.stub.attributes.givenName=CAS",
+
+    "--cas.authn.oidc.core.issuer=https://localhost:8443/cas/oidc",
+    "--cas.authn.oidc.jwks.file-system.jwks-file=file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
+    
+    "--cas.authn.oidc.discovery.scopes=openid,profile,email",
+    "--cas.authn.oidc.discovery.claims=sub,name,family_name,given_name,email",
+
+    "--cas.authn.oidc.core.claims-map.email=mail",
+    "--cas.authn.oidc.core.claims-map.name=cn",
+    "--cas.authn.oidc.core.claims-map.family_name=sn",
+    "--cas.authn.oidc.core.claims-map.given_name=givenName",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services"
+  ]
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/services/Sample-1.json
@@ -1,0 +1,17 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client1",
+  "clientSecret": "secret1",
+  "serviceId": "^https://httpbin.org/anything/sample1",
+  "name": "Sample",
+  "id": 1,
+  "scopes" : [ "java.util.HashSet", [ "email", "profile" ] ],
+  "supportedGrantTypes": [ "java.util.HashSet", [ "authorization_code" ] ],
+  "supportedResponseTypes": [ "java.util.HashSet", [ "code" ] ],
+  "bypassApprovalPrompt": true,
+  "usernameAttributeProvider" : {
+    "@class" : "org.apereo.cas.services.PrincipalAttributeRegisteredServiceUsernameProvider",
+    "usernameAttribute" : "mail",
+    "canonicalizationMode" : "UPPER"
+  }
+}

--- a/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/services/Sample-2.json
+++ b/ci/tests/puppeteer/scenarios/oidc-jdbc-auth-combined/services/Sample-2.json
@@ -1,0 +1,17 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client2",
+  "clientSecret": "secret2",
+  "serviceId": "^https://httpbin.org/anything/sample2",
+  "name": "Sample",
+  "id": 2,
+  "scopes" : [ "java.util.HashSet", [ "email", "profile" ] ],
+  "supportedGrantTypes": [ "java.util.HashSet", [ "authorization_code" ] ],
+  "supportedResponseTypes": [ "java.util.HashSet", [ "code" ] ],
+  "bypassApprovalPrompt": true,
+  "usernameAttributeProvider" : {
+    "@class" : "org.apereo.cas.services.PrincipalAttributeRegisteredServiceUsernameProvider",
+    "usernameAttribute" : "cn",
+    "canonicalizationMode" : "UPPER"
+  }
+}


### PR DESCRIPTION
I hope it is OK, this is truly a work in progress. First commit just to see that all the CI tests run OK (I got unexpected failures in my rejected pull request). If that goes as expected I'll try and reduce down the test I've added and show the problem. Finally apply my proposed fix).

[] Brief description of changes applied
Switch the ConditionalOnClass to a class only in the module specified in https://apereo.github.io/cas/6.6.x/authentication/OIDC-Authentication-JWKS-Storage.html

[] Test cases for all modified changes, where applicable
I'm trying to add a puppeteer test as this seems the most straightforward way to show this failure.

[] The same pull request targeted at the master branch, if applicable
Thought I'd suggest this one to see if anywhere near acceptable first.

[] Any documentation on how to configure, test
Just trying to use OIDC and JDBC authentication causes it for me.

[] Any possible limitations, side effects, etc
I don't really understand why the pattern isn't to use ConditionalOnProperty then use a mandatory property for the feature. I'd also be tempted to remove the dependency of JDBC authentication on a JPA util module but waaaay
beyond my understanding of the code base.

[] Reference any other pull requests that might be related
Not a pull request but posts to the google group https://groups.google.com/a/apereo.org/g/cas-user/c/KrVJdliRD04/m/j1ADALU0BgAJ