### PR TITLE
Fix Maven support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,8 +126,8 @@ allprojects {
     apply plugin: "java-library"
     apply plugin: "jacoco"
 
-    if (gradle.startParameter.taskNames.any { task -> task.equalsIgnoreCase("install") }) {
-        apply plugin: "maven"
+    if (gradle.startParameter.taskNames.any { task -> task.equalsIgnoreCase("publishToMavenLocal") }) {
+        apply plugin: "maven-publish"
     }
 
     def skipRetry = providers.systemProperty('skipTestRetry').present


### PR DESCRIPTION
Since Gradle 7, the `maven` plugin does no longer exist: https://docs.gradle.org/7.0/userguide/upgrading_version_6.html?_ga=2.160666173.1473045748.1668408332-1466678468.1668408332#removal_of_the_legacy_maven_plugin

This PR fixes the Maven support by upgrading to the `maven-publish` plugin.
