### PR TITLE
allow jwt signing algorithm per service

### DIFF
--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
@@ -186,11 +186,11 @@ public interface RegisteredServiceProperty extends Serializable {
             RegisteredServicePropertyGroups.DELEGATED_AUTHN_WSFED, RegisteredServicePropertyTypes.STRING,
             "Used when delegating authentication to ADFS to indicate the relying party identifier."),
         /**
-         * Produce a JWT as a response when generating service tickets.
+         * The algorithm header value used to sign the JWT.
          **/
         TOKEN_SIGNING_ALG("jwtSigningAlg", StringUtils.EMPTY,
             RegisteredServicePropertyGroups.JWT_TOKENS, RegisteredServicePropertyTypes.STRING,
-            "The algorithm header value used to sign the access token."),
+            "The algorithm header value used to sign the JWT."),
         /**
          * Produce a JWT as a response when generating service tickets.
          **/

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceProperty.java
@@ -188,6 +188,12 @@ public interface RegisteredServiceProperty extends Serializable {
         /**
          * Produce a JWT as a response when generating service tickets.
          **/
+        TOKEN_SIGNING_ALG("jwtSigningAlg", StringUtils.EMPTY,
+            RegisteredServicePropertyGroups.JWT_TOKENS, RegisteredServicePropertyTypes.STRING,
+            "The algorithm header value used to sign the access token."),
+        /**
+         * Produce a JWT as a response when generating service tickets.
+         **/
         TOKEN_AS_SERVICE_TICKET("jwtAsServiceTicket", "false",
             RegisteredServicePropertyGroups.JWT_SERVICE_TICKETS, RegisteredServicePropertyTypes.BOOLEAN,
             "Produce a JWT as a response when generating service tickets."),

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/util/InternalJwtAccessTokenCipherExecutor.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/util/InternalJwtAccessTokenCipherExecutor.java
@@ -92,6 +92,8 @@ public class InternalJwtAccessTokenCipherExecutor extends JwtTicketCipherExecuto
         }
         cipher.setCommonHeaders(CollectionUtils.wrap(
             RegisteredServiceCipherExecutor.CUSTOM_HEADER_REGISTERED_SERVICE_ID, registeredService.getId()));
+        val jwtSigningAlg = cipher.getJwtSigningAlg(registeredService);
+        jwtSigningAlg.ifPresent(s -> cipher.getSigningOpHeaders().put(JsonWebKey.ALGORITHM_PARAMETER, s));
         return cipher;
     }
 
@@ -140,7 +142,7 @@ public class InternalJwtAccessTokenCipherExecutor extends JwtTicketCipherExecuto
                 }
                 val alg = StringUtils.defaultIfBlank(key.getAlgorithm(),
                     getSigningAlgorithmFor(key.getKey()));
-                getSigningOpHeaders().put(JsonWebKey.ALGORITHM_PARAMETER, alg);
+                getSigningOpHeaders().putIfAbsent(JsonWebKey.ALGORITHM_PARAMETER, alg);
                 return super.signWith(value, alg, signingKey);
             })
             .orElseGet(() -> super.sign(value, signingKey));

--- a/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/cipher/JwtTicketCipherExecutor.java
+++ b/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/cipher/JwtTicketCipherExecutor.java
@@ -102,5 +102,30 @@ public class JwtTicketCipherExecutor extends BaseStringCipherExecutor {
         return RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET_CIPHER_STRATEGY_TYPE;
     }
 
+    /**
+     * Gets jwt signing algorithm.
+     *
+     * @param registeredService the registered service
+     * @return the jwt signing algorithm
+     */
+    protected Optional<String> getJwtSigningAlg(final RegisteredService registeredService) {
+        val property = getJwtSigningAlgRegisteredServiceProperty(registeredService);
+        if (property.isAssignedTo(registeredService)) {
+            val alg = property.getPropertyValue(registeredService).value();
+            return Optional.of(alg);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Gets jwt signing algorithm registered service property.
+     *
+     * @param registeredService the registered service
+     * @return the jwt signing algorithm registered service property.
+     */
+    protected RegisteredServiceProperty.RegisteredServiceProperties getJwtSigningAlgRegisteredServiceProperty(final RegisteredService registeredService) {
+        return RegisteredServiceProperty.RegisteredServiceProperties.TOKEN_SIGNING_ALG;
+    }
+
 
 }

--- a/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/cipher/RegisteredServiceJwtTicketCipherExecutor.java
+++ b/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/cipher/RegisteredServiceJwtTicketCipherExecutor.java
@@ -6,6 +6,7 @@ import org.apereo.cas.services.RegisteredServiceProperty;
 import org.apereo.cas.services.RegisteredServiceProperty.RegisteredServiceProperties;
 import org.apereo.cas.util.CollectionUtils;
 
+import com.nimbusds.jose.HeaderParameterNames;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -91,6 +92,8 @@ public class RegisteredServiceJwtTicketCipherExecutor extends JwtTicketCipherExe
         val cipher = new JwtTicketCipherExecutor(encryptionKey, signingKey,
             StringUtils.isNotBlank(encryptionKey), StringUtils.isNotBlank(signingKey), 0, 0);
         cipher.getCommonHeaders().putAll(CollectionUtils.wrap(CUSTOM_HEADER_REGISTERED_SERVICE_ID, registeredService.getId()));
+        val jwtSigningAlg = cipher.getJwtSigningAlg(registeredService);
+        jwtSigningAlg.ifPresent(s -> cipher.getSigningOpHeaders().put(HeaderParameterNames.ALGORITHM, s));
         return cipher;
     }
 

--- a/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/cipher/RegisteredServiceJwtTicketCipherExecutorTests.java
+++ b/support/cas-server-support-token-core/src/test/java/org/apereo/cas/token/cipher/RegisteredServiceJwtTicketCipherExecutorTests.java
@@ -5,10 +5,12 @@ import org.apereo.cas.services.RegisteredServiceProperty.RegisteredServiceProper
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.util.cipher.BaseStringCipherExecutor;
 
+import com.nimbusds.jwt.JWTParser;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.text.ParseException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,4 +40,28 @@ public class RegisteredServiceJwtTicketCipherExecutorTests {
             new DefaultRegisteredServiceProperty(BaseStringCipherExecutor.CipherOperationsStrategyType.SIGN_AND_ENCRYPT.name()));
         assertTrue(c.getCipherOperationsStrategyType(service).isPresent());
     }
+
+    @Test
+    public void verifyCipherSigningAlgPerService() throws ParseException {
+        val service = RegisteredServiceTestUtils.getRegisteredService();
+        val c = new RegisteredServiceJwtTicketCipherExecutor();
+
+        val properties = service.getProperties();
+        val hs256 = "HS256";
+        properties.put(RegisteredServiceProperties.TOKEN_SIGNING_ALG.getPropertyName(),
+            new DefaultRegisteredServiceProperty(hs256));
+        properties.put(RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET_SIGNING_ENABLED.getPropertyName(),
+            new DefaultRegisteredServiceProperty("true"));
+        properties.put(RegisteredServiceProperties.TOKEN_AS_SERVICE_TICKET_SIGNING_KEY.getPropertyName(),
+            new DefaultRegisteredServiceProperty("qeALfMKRSME3mkHy0Qis6mhbGQFzps0ZiU-qyjsPOq_tYyR4fk2uAQR3wZfYTAlGGO3yhpJAMsq2JufeEC4fQg"));
+
+        val payload = "{\"jwtId\": \"ST-123456\"}";
+        val token = c.encode(payload, Optional.of(service));
+
+        val jwt = JWTParser.parse(token);
+        assertEquals(hs256, jwt.getHeader().getAlgorithm().getName());
+
+        assertEquals(payload, c.decode(token, Optional.of(service)));
+    }
+
 }


### PR DESCRIPTION
Allow to specify JWT signing algorithm per service (like `idTokenSigningAlg` in OIDC client)

Actually, `RS512` and `HS512` are CAS defaults, but [IETF spec](https://datatracker.ietf.org/doc/html/rfc7518#section-3.1) recommends or requires others, like `RS256` and `HS256`.
These algorithms are often required by third-party RPs.

The PR is another attempt after [PR 5193](https://github.com/apereo/cas/pull/5193) but without breaking changes for existing setup.