### PR TITLE
fix so method name makes sense

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DefaultLogMessageSummarizer.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DefaultLogMessageSummarizer.java
@@ -14,7 +14,7 @@ public class DefaultLogMessageSummarizer implements LogMessageSummarizer {
 
     @Override
     public boolean shouldSummarize(final Logger logger) {
-        return logger.isDebugEnabled();
+        return !logger.isDebugEnabled();
     }
 
     @Override

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
@@ -95,8 +95,8 @@ public class LoggingUtils {
      */
     public static void error(final Logger logger, final String msg, final Throwable throwable) {
         FunctionUtils.doIf(LOG_MESSAGE_SUMMARIZER.shouldSummarize(logger),
-                unused -> logger.error(msg, throwable),
-                unused -> logger.error(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(msg, throwable)))
+                unused -> logger.error(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(msg, throwable)),
+                unused -> logger.error(msg, throwable))
             .accept(throwable);
     }
 
@@ -129,8 +129,8 @@ public class LoggingUtils {
      */
     public static void warn(final Logger logger, final String message, final Throwable throwable) {
         FunctionUtils.doIf(LOG_MESSAGE_SUMMARIZER.shouldSummarize(logger),
-                unused -> logger.warn(message, throwable),
-                unused -> logger.warn(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(message, throwable)))
+                unused -> logger.warn(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(message, throwable)),
+                unused -> logger.warn(message, throwable))
             .accept(throwable);
     }
 

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
@@ -30,7 +30,7 @@ public class LoggingUtils {
     static {
         LOG_MESSAGE_SUMMARIZER = ServiceLoader.load(LogMessageSummarizer.class)
                 .findFirst()
-                .orElse(new DefaultLogMessageSummarizer());
+                .orElseGet(DefaultLogMessageSummarizer::new);
     }
 
     private static final int CHAR_REPEAT_ACCOUNT = 60;


### PR DESCRIPTION
I had the logic wrong in the shouldSummarize method but the order of the FunctionUtils.doIf was also wrong to compensate, so it was working, but the method name didn't make sense (e.g. you would have to return true from shouldSummarize to turn off summarization). 