### PR TITLE
fix so method name makes sense

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DefaultLogMessageSummarizer.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DefaultLogMessageSummarizer.java
@@ -14,7 +14,7 @@ public class DefaultLogMessageSummarizer implements LogMessageSummarizer {
 
     @Override
     public boolean shouldSummarize(final Logger logger) {
-        return logger.isDebugEnabled();
+        return !logger.isDebugEnabled();
     }
 
     @Override

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/LoggingUtils.java
@@ -106,8 +106,8 @@ public class LoggingUtils {
      */
     public static void error(final Logger logger, final String msg, final Throwable throwable) {
         FunctionUtils.doIf(LOG_MESSAGE_SUMMARIZER.shouldSummarize(logger),
-                __ -> logger.error(msg, throwable),
-                __ -> logger.error(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(msg, throwable)))
+                __ -> logger.error(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(msg, throwable)),
+                __ -> logger.error(msg, throwable))
             .accept(throwable);
     }
 
@@ -142,8 +142,8 @@ public class LoggingUtils {
      */
     public static void warn(final Logger logger, final String message, final Throwable throwable) {
         FunctionUtils.doIf(LOG_MESSAGE_SUMMARIZER.shouldSummarize(logger),
-                __ -> logger.warn(message, throwable),
-                __ -> logger.warn(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(message, throwable)))
+                __ -> logger.warn(LOG_MESSAGE_SUMMARIZER.summarizeStackTrace(message, throwable)),
+                __ -> logger.warn(message, throwable))
             .accept(throwable);
     }
 


### PR DESCRIPTION
I had the logic wrong in the shouldSummarize method but the order of the FunctionUtils.doIf was also wrong to compensate, so it was working, but the method name didn't make sense (e.g. you would have to return true from shouldSummarize to turn off summarization).