### PR TITLE
fix strapi puppeteer test

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-login-strapi/init.sh
+++ b/ci/tests/puppeteer/scenarios/oidc-login-strapi/init.sh
@@ -7,7 +7,7 @@ PROJECT=getstarted
 if [[ ! -d $STRAPI_FOLDER/$PROJECT ]] ; then
   mkdir -p $STRAPI_FOLDER
   cd $STRAPI_FOLDER
-  npx -y create-strapi-app $PROJECT --quickstart --no-run
+  npx -y create-strapi-app@experimental $PROJECT --quickstart --no-run
   cd -
 fi
 


### PR DESCRIPTION
This fixed the oidc-login-strapi puppeteer test when I tried it on my fork. Strapi publishes daily builds from their main branch that are tagged "experimental" which should be stable enough for this test, and if not, after the next strapi release we could switch back to latest. 