### PR TITLE
Support for enabling or disabling passwordless authentication

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/PasswordlessAuthenticationCoreProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/PasswordlessAuthenticationCoreProperties.java
@@ -28,6 +28,11 @@ public class PasswordlessAuthenticationCoreProperties implements Serializable {
     private static final long serialVersionUID = 6726382874579042117L;
 
     /**
+     * Flag to indicate if paswordless authentication is enabled.
+     */
+    private boolean enabled = true;
+
+    /**
      * Allow passwordless authentication to skip its own flow
      * in favor of multifactor authentication providers that may be available
      * and defined in CAS.

--- a/support/cas-server-support-passwordless-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-passwordless-authentication/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -2,6 +2,7 @@ package org.apereo.cas;
 
 import org.apereo.cas.api.PasswordlessAuthenticationPreProcessorTests;
 import org.apereo.cas.authentication.PasswordlessTokenAuthenticationHandlerTests;
+import org.apereo.cas.authentication.DisablePasswordlessTokenAuthenticationTests;
 import org.apereo.cas.impl.account.GroovyPasswordlessUserAccountStoreTests;
 import org.apereo.cas.impl.account.JsonPasswordlessUserAccountStoreTests;
 import org.apereo.cas.impl.account.RestfulPasswordlessUserAccountStoreTests;
@@ -26,7 +27,8 @@ import org.junit.platform.suite.api.Suite;
     GroovyPasswordlessUserAccountStoreTests.class,
     SimplePasswordlessUserAccountStoreTests.class,
     InMemoryPasswordlessTokenRepositoryTests.class,
-    PasswordlessTokenAuthenticationHandlerTests.class
+    PasswordlessTokenAuthenticationHandlerTests.class,
+    DisablePasswordlessTokenAuthenticationTests.class,
 })
 @Suite
 public class AllTestsSuite {

--- a/support/cas-server-support-passwordless-authentication/src/test/java/org/apereo/cas/authentication/DisablePasswordlessTokenAuthenticationTests.java
+++ b/support/cas-server-support-passwordless-authentication/src/test/java/org/apereo/cas/authentication/DisablePasswordlessTokenAuthenticationTests.java
@@ -1,0 +1,32 @@
+package org.apereo.cas.authentication;
+
+import org.apereo.cas.impl.BasePasswordlessUserAccountStoreTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This is {@link DisablePasswordlessTokenAuthenticationTests}.
+ */
+@TestPropertySource(properties = "cas.authn.passwordless.core.enabled=false")
+@Tag("AuthenticationHandler")
+public class DisablePasswordlessTokenAuthenticationTests extends BasePasswordlessUserAccountStoreTests {
+
+    @Autowired
+    @Qualifier(AuthenticationEventExecutionPlan.DEFAULT_BEAN_NAME)
+    private AuthenticationEventExecutionPlan authenticationEventExecutionPlan;
+
+    @Test
+    public void verifyDisable() {
+        Set<AuthenticationHandler> authenticationHandlers =
+                authenticationEventExecutionPlan.getAuthenticationHandlersBy(
+                        h -> h instanceof PasswordlessTokenAuthenticationHandler);
+        assertTrue(authenticationHandlers.isEmpty());
+    }
+}


### PR DESCRIPTION
Use `cas.authn.passwordless.core.enabled` to turn passwordless authentication on or off.