### PR TITLE
open jpa ticketregistry configuration for overrides

### DIFF
--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
@@ -164,6 +164,7 @@ public class JpaTicketRegistryConfiguration {
         }
 
         @Bean
+        @ConditionalOnMissingBean(name = TicketRegistry.BEAN_NAME)
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public TicketRegistry ticketRegistry(
             final ConfigurableApplicationContext applicationContext,


### PR DESCRIPTION
Since my last PR (#5570) could not be accepted due to missing/bad tests. I try to split up my PR in 2 parts, so I can try to work out good tests for the fix I want to apply, but also get the ability to override the JpaTicketRegistry in 7.0.0+.

This PR only gives adopters the possibility to override the JpaTicketRegistry