### PR TITLE
don't log warnings in FunctionUtils.doAndHandle

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/function/FunctionUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/function/FunctionUtils.java
@@ -288,6 +288,7 @@ public class FunctionUtils {
                 return function.apply(t);
             } catch (final Throwable e) {
                 try {
+                    LoggingUtils.warn(LOGGER, e);
                     return errorHandler.apply(e);
                 } catch (final Throwable ex) {
                     throw new IllegalArgumentException(ex.getMessage());
@@ -311,6 +312,7 @@ public class FunctionUtils {
                 function.accept(value);
             } catch (final Throwable e) {
                 try {
+                    LoggingUtils.warn(LOGGER, e);
                     errorHandler.apply(e);
                 } catch (final Throwable ex) {
                     throw new IllegalArgumentException(ex);
@@ -365,6 +367,7 @@ public class FunctionUtils {
                 return function.get();
             } catch (final Throwable e) {
                 try {
+                    LoggingUtils.warn(LOGGER, e);
                     return errorHandler.apply(e);
                 } catch (final Throwable ex) {
                     if (ex instanceof RuntimeException) {

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/function/FunctionUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/function/FunctionUtils.java
@@ -288,7 +288,6 @@ public class FunctionUtils {
                 return function.apply(t);
             } catch (final Throwable e) {
                 try {
-                    LoggingUtils.warn(LOGGER, e);
                     return errorHandler.apply(e);
                 } catch (final Throwable ex) {
                     throw new IllegalArgumentException(ex.getMessage());
@@ -312,7 +311,6 @@ public class FunctionUtils {
                 function.accept(value);
             } catch (final Throwable e) {
                 try {
-                    LoggingUtils.warn(LOGGER, e);
                     errorHandler.apply(e);
                 } catch (final Throwable ex) {
                     throw new IllegalArgumentException(ex);
@@ -367,7 +365,6 @@ public class FunctionUtils {
                 return function.get();
             } catch (final Throwable e) {
                 try {
-                    LoggingUtils.warn(LOGGER, e);
                     return errorHandler.apply(e);
                 } catch (final Throwable ex) {
                     if (ex instanceof RuntimeException) {

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
@@ -299,18 +299,21 @@ public class CasWebSecurityConfigurerAdapter implements DisposableBean {
 
                 val granted = properties.getRequiredIpAddresses()
                     .stream()
-                    .anyMatch(addr -> {
-                        try {
-                            val ipAddressMatcher = new IpAddressMatcher(addr);
-                            LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addr);
-                            return ipAddressMatcher.matches(remoteAddr);
-                        } catch (final IllegalArgumentException e) {
-                            LOGGER.trace("Falling back to regex match. Couldn't treat [{}] as an IP address or netmask: [{}]", addr, e.getMessage());
-                            val matcher = RegexUtils.createPattern(addr, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
-                            LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addr);
-                            return matcher.find();
-                        }
-                    });
+                        .anyMatch(addr -> FunctionUtils.doAndHandle(() -> {
+                            try {
+                                val ipAddressMatcher = new IpAddressMatcher(addr);
+                                LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addr);
+                                return ipAddressMatcher.matches(remoteAddr);
+                            } catch (final IllegalArgumentException e) {
+                                LOGGER.trace("Falling back to regex match. Couldn't treat [{}] as an IP address or netmask: [{}]", addr, e.getMessage());
+                                val matcher = RegexUtils.createPattern(addr, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
+                                LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addr);
+                                return matcher.find();
+                            }
+                        }, e -> {
+                            LOGGER.warn("Error evaluating address [{}]: [{}]", addr, e.getMessage());
+                            return false;
+                        }).get());
                 if (!granted) {
                     LOGGER.warn("Provided regular expression or IP/netmask [{}] does not match [{}]",
                         properties.getRequiredIpAddresses(), remoteAddr);

--- a/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
+++ b/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
@@ -299,15 +299,18 @@ public class CasWebSecurityConfigurerAdapter implements DisposableBean {
 
                 val granted = properties.getRequiredIpAddresses()
                     .stream()
-                    .anyMatch(addr -> FunctionUtils.doAndHandle(() -> {
-                        val ipAddressMatcher = new IpAddressMatcher(addr);
-                        LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addr);
-                        return ipAddressMatcher.matches(remoteAddr);
-                    }, e -> {
-                        val matcher = RegexUtils.createPattern(addr, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
-                        LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addr);
-                        return matcher.find();
-                    }).get());
+                    .anyMatch(addr -> {
+                        try {
+                            val ipAddressMatcher = new IpAddressMatcher(addr);
+                            LOGGER.trace("Attempting to match [{}] against [{}] as a IP or netmask", remoteAddr, addr);
+                            return ipAddressMatcher.matches(remoteAddr);
+                        } catch (final IllegalArgumentException e) {
+                            LOGGER.trace("Falling back to regex match. Couldn't treat [{}] as an IP address or netmask: [{}]", addr, e.getMessage());
+                            val matcher = RegexUtils.createPattern(addr, Pattern.CASE_INSENSITIVE).matcher(remoteAddr);
+                            LOGGER.trace("Attempting to match [{}] against [{}] as a regular expression", remoteAddr, addr);
+                            return matcher.find();
+                        }
+                    });
                 if (!granted) {
                     LOGGER.warn("Provided regular expression or IP/netmask [{}] does not match [{}]",
                         properties.getRequiredIpAddresses(), remoteAddr);


### PR DESCRIPTION
I don't think these FunctionUtils.doAndHandle() methods should be doing warning logging, it seems like that is better left to the lambda error handler. At least in the case of `CasWebSecurityConfigurerAdapter.configureEndpointAccessByIpAddress()` [Here](https://github.com/apereo/cas/blob/master/webapp/cas-server-webapp-config/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java#L302) - it causes a problem because the method gets called over and over and will log stuff like:
```
2022-12-30 04:56:47,548 WARN [org.apereo.cas.util.function.FunctionUtils] - <Failed to parse address '10\..*'
        IpAddressMatcher.java:parseAddress:96
        IpAddressMatcher.java:<init>:58
        CasWebSecurityConfigurerAdapter.java:lambda$configureEndpointAccessByIpAddress$8:303
```
repeatedly if the configuration is using a regular expression. I don't think adjusting the log level for FunctionUtils would work because there is other logging in that class that should probably stay turned on. 