### PR TITLE
fix redis ticket registry bean type

### DIFF
--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/RedisTicketRegistryConfiguration.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/RedisTicketRegistryConfiguration.java
@@ -72,7 +72,7 @@ public class RedisTicketRegistryConfiguration {
         @ConditionalOnMissingBean(name = "redisTicketRegistryMessageListenerContainer")
         public RedisMessageListenerContainer redisTicketRegistryMessageListenerContainer(
             @Qualifier("redisTicketRegistryMessageTopic")
-            final ChannelTopic redisTicketRegistryMessageTopic,
+            final Topic redisTicketRegistryMessageTopic,
             @Qualifier("redisTicketRegistryMessageListener")
             final MessageListener redisTicketRegistryMessageListener,
             @Qualifier("redisTicketConnectionFactory")


### PR DESCRIPTION
I am working on trying to re-create (locally with puppeteer test) cas in k8s talking to redis sentinel cluster in k8s, b/c I don't think CAS recovers from redis master changing. and this bean was failing unless I changed argument type to `Topic` (changing bean type to `ChannelTopic` also worked). Not sure why it works in existing tests, but my test just has `reports` and `redis-ticket-registry`.