### PR TITLE
fix casInterruptView.html autoRedirect (broken by new Thymeleaf?)

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
@@ -16,7 +16,7 @@
 
         if (autoRedirect && !emptyLinks) {
 
-            var link = /*[[${interrupt.links.values().iterator().next()}]]*/;
+            var link = /*[[${interrupt.links.values().toArray()[0]}]]*/;
             var redirectTimeout = /*[[${interrupt.autoRedirectAfterSeconds}]]*/;
 
             setTimeout(function () {


### PR DESCRIPTION
Quick'n'dirty fix for exception below. There may be better solutions?

org.springframework.expression.EvaluationException: Calling
       method 'next' is forbidden for type 'class java.util.LinkedHashMap$LinkedValueIterator'
       in Thymeleaf expressions. Blocked classes are: [com.sun.*, jakarta.*, java.*, javax.*, jdk.*, org.ietf.jgss.*, org.omg.*, org.w3c.dom.*, org.xml.sax.*, sun.*].
       Allowed classes are: [java.lang.Boolean, ..., java.util.LinkedHashMap, java.util.LinkedHashSet, java.util.LinkedList, java.util.List, java.util.Locale, java.util.Map, java.util.Map$Entry, ...].
       at org.thymeleaf.spring6.expression.ThymeleafEvaluationContext$ThymeleafEvaluationContextACLMethodResolver.resolve(ThymeleafEvaluationContext.java:282)


NB: the list of allowed classes seems to come from https://github.com/thymeleaf/thymeleaf/blob/3.1-master/lib/thymeleaf/src/main/java/org/thymeleaf/util/ExpressionUtils.java#L72

Tested on 7.0.0-RC3.
