### PR TITLE
Upgrade the SmsMode support

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/SmsModeProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/SmsModeProperties.java
@@ -10,8 +10,6 @@ import lombok.experimental.Accessors;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This is {@link SmsModeProperties}.
@@ -36,26 +34,8 @@ public class SmsModeProperties implements Serializable {
     private String accessToken;
 
     /**
-     * Query attribute name for the message.
-     */
-    private String messageAttribute = "message";
-
-    /**
-     * Query attribute name for the to field.
-     */
-    private String toAttribute = "numero";
-
-    /**
-     * URL to contact and send messages (GET only).
+     * URL to contact and send messages (POST only).
      */
     @RequiredProperty
-    private String url = "https://api.smsmode.com/http/1.6/sendSMS.do";
-
-    /**
-     * Headers, defined as a Map, to include in the request when making the HTTP call.
-     * Will overwrite any header that CAS is pre-defined to
-     * send and include in the request. Key in the map should be the header name
-     * and the value in the map should be the header value.
-     */
-    private Map<String, String> headers = new HashMap<>();
+    private String url = "https://rest.smsmode.com/sms/v1/messages";
 }

--- a/support/cas-server-support-sms-smsmode/src/main/java/org/apereo/cas/support/sms/SmsModeSmsSender.java
+++ b/support/cas-server-support-sms-smsmode/src/main/java/org/apereo/cas/support/sms/SmsModeSmsSender.java
@@ -5,19 +5,18 @@ import org.apereo.cas.notifications.sms.SmsSender;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.HttpUtils;
 import org.apereo.cas.util.LoggingUtils;
+import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpEntityContainer;
 import org.apache.hc.core5.http.HttpResponse;
-import org.apereo.inspektr.common.web.ClientInfoHolder;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
@@ -29,42 +28,39 @@ import java.util.HashMap;
  */
 @Slf4j
 public record SmsModeSmsSender(SmsModeProperties properties) implements SmsSender {
-    private static final String SMSMODE_SENT_SMS_RESPONSE_CODE = "0";
+
+    private static final ObjectMapper MAPPER = JacksonObjectMapperFactory.builder()
+            .defaultTypingEnabled(false).build().toObjectMapper();
 
     @Override
     public boolean send(final String from, final String to, final String message) {
         HttpResponse response = null;
         try {
-            val parameters = new HashMap<String, String>();
-            val holder = ClientInfoHolder.getClientInfo();
-            if (holder != null) {
-                parameters.put("clientIpAddress", holder.getClientIpAddress());
-                parameters.put("serverIpAddress", holder.getServerIpAddress());
-            }
-            parameters.put("from", from);
-            parameters.put(properties.getToAttribute(), to);
-            parameters.put(properties.getMessageAttribute(), message);
-            parameters.put("accessToken", properties.getAccessToken());
+            val data = new HashMap<String, Object>();
+            val recipient = new HashMap<String, Object>();
+            recipient.put("to", to);
+            data.put("recipient", recipient);
+            val body = new HashMap<String, Object>();
+            body.put("text", message);
+            data.put("body", body);
+            data.put("from", from);
 
-            val headers = CollectionUtils.<String, String>wrap("Content-Type", MediaType.TEXT_PLAIN_VALUE);
-            headers.putAll(properties.getHeaders());
+            val headers = CollectionUtils.<String, String>wrap(
+                    "Content-Type", MediaType.APPLICATION_JSON_VALUE,
+                    "Accept", MediaType.APPLICATION_JSON_VALUE,
+                    "X-Api-Key", properties.getAccessToken());
             val exec = HttpUtils.HttpExecutionRequest.builder()
-                .method(HttpMethod.GET)
-                .url(properties.getUrl())
-                .parameters(parameters)
-                .headers(headers)
-                .build();
+                    .method(HttpMethod.POST)
+                    .url(properties.getUrl())
+                    .headers(headers)
+                    .entity(MAPPER.writeValueAsString(data))
+                    .build();
             response = HttpUtils.execute(exec);
+
             val status = HttpStatus.valueOf(response.getCode());
-            if (status.is2xxSuccessful()) {
-                val entity = ((HttpEntityContainer) response).getEntity();
-                val charset = entity.getContentEncoding() != null
-                    ? Charset.forName(entity.getContentEncoding())
-                    : StandardCharsets.ISO_8859_1;
-                val resp = IOUtils.toString(entity.getContent(), charset);
-                LOGGER.debug("Response from SmsMode: [{}]", resp);
-                return StringUtils.startsWith(resp, SMSMODE_SENT_SMS_RESPONSE_CODE);
-            }
+            val entity = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
+            LOGGER.debug("Response from SmsMode: [{}]", entity);
+            return status.is2xxSuccessful();
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         } finally {
@@ -72,5 +68,4 @@ public record SmsModeSmsSender(SmsModeProperties properties) implements SmsSende
         }
         return false;
     }
-
 }


### PR DESCRIPTION
The current API of SmsMode is deprecated: https://dev.smsmode.com/http-api/reference/

This PR uses the appropriate SmsMode API: https://dev.smsmode.com/sms/v1/message/

The test has been updated as well.

I have of course made manual tests with a working API key I can't share publicly.
