### PR TITLE
Fix services reloading

### DIFF
--- a/core/cas-server-core-services/src/main/java/org/apereo/cas/config/CasCoreServicesConfiguration.java
+++ b/core/cas-server-core-services/src/main/java/org/apereo/cas/config/CasCoreServicesConfiguration.java
@@ -335,6 +335,7 @@ public class CasCoreServicesConfiguration {
     public static class CasCoreServicesSchedulingConfiguration {
         @Bean
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+        @Lazy(false)
         public Runnable servicesManagerScheduledLoader(
             final ConfigurableApplicationContext applicationContext,
             @Qualifier("serviceRegistryExecutionPlan") final ServiceRegistryExecutionPlan serviceRegistryExecutionPlan,


### PR DESCRIPTION
Due to lazzy initialization, the service reloading scheduler must be marked `@Lazy(false)`.