### PR TITLE
Reinforce security on reset password

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
@@ -126,7 +126,7 @@ public class SendPasswordResetInstructionsAction extends BaseCasWebflowAction {
         val phone = passwordManagementService.findPhone(query);
         if (StringUtils.isBlank(email) && StringUtils.isBlank(phone)) {
             LOGGER.warn("No recipient is provided with a valid email/phone");
-            return getErrorEvent("contact.invalid", "Provided email address or phone number is invalid", requestContext);
+            return success();
         }
 
         val service = WebUtils.getService(requestContext);

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsActionTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsActionTests.java
@@ -88,7 +88,7 @@ public class SendPasswordResetInstructionsActionTests {
             request.addParameter("username", "none");
             WebUtils.putServiceIntoFlowScope(context, RegisteredServiceTestUtils.getService());
             context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, new MockHttpServletResponse()));
-            assertEquals(CasWebflowConstants.TRANSITION_ID_ERROR, sendPasswordResetInstructionsAction.execute(context).getId());
+            assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, sendPasswordResetInstructionsAction.execute(context).getId());
         }
 
         @Test

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages.properties
@@ -62,7 +62,6 @@ screen.pm.password.strength.4=Strong
 
 screen.pm.reset.contact.failed=Unable to send email/SMS as no email/SMS server is defined in the CAS configuration.
 screen.pm.reset.username.required=No email is provided.
-screen.pm.reset.contact.invalid=Provided contact information is missing or invalid.
 screen.pm.reset.email.invalid=Provided email address is invalid.
 screen.pm.reset.username.failed=Failed to send the username to the given email address.
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_de.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_de.properties
@@ -63,7 +63,6 @@ screen.pm.password.strength.4=Stark
 
 screen.pm.reset.contact.failed=Es können keine E-Mails/SMS versendet werden, da kein E-Mail/SMS Server in der CAS-Konfiguration hinterlegt wurde.
 screen.pm.reset.username.required=Keine E-Mail Adresse vorhanden.
-screen.pm.reset.contact.invalid=Angegebene Kontaktinformationen fehlen oder sind ungültig.
 screen.pm.reset.email.invalid=Angegebene E-Mail Adresse ist ungültig.
 screen.pm.reset.username.failed=Es konnte kein Benutzername an die angegebene EMail Adresse gesendet werden.
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_it.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_it.properties
@@ -48,7 +48,6 @@ screen.pm.password.strength.4=Forte
 
 screen.pm.reset.contact.failed=Impossibile inviare email/SMS a causa della mancanza delle configurazioni relative in CAS.
 screen.pm.reset.username.required=Email non fornita.
-screen.pm.reset.contact.invalid=Le informiizoni di contatto sono mancanti o non valide.
 screen.pm.reset.email.invalid=L'indirizzo email fornito non \u00e8 valido..
 screen.pm.reset.username.failed=Non \u00e8 stato possibile inviare la username all'indirizzo email indicato.
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_zh_CN.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_zh_CN.properties
@@ -58,7 +58,6 @@ screen.pm.password.strength.4=强
 
 screen.pm.reset.contact.failed=无法发送电子邮件/短信，因为CAS配置中未定义电子邮件/短信服务器。
 screen.pm.reset.username.required=没有提供电子邮件。
-screen.pm.reset.contact.invalid=提供的联系信息丢失或无效。
 screen.pm.reset.email.invalid=提供的电子邮件地址无效。
 screen.pm.reset.username.failed=无法将用户名发送到给定的电子邮件地址。
 


### PR DESCRIPTION
This is a breaking change I'd like to introduce in v7 to reinforce security on reset password.

If I click on "Reset your password" link and enter an invalid user, I receive the following error: `Provided contact information is missing or invalid.`.

I'd like to return a success in any case, whether the account exists or doesn't. To limit the information provided to an attacker.

What do you think?
