### PR TITLE
Support + as the scope separator in OIDC authorize URL

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/script.js
@@ -42,7 +42,7 @@ const assert = require('assert');
 })();
 
 async function getPayload(page, redirectUri, clientId, clientSecret, scopes) {
-    const url = `https://localhost:8443/cas/oidc/oidcAuthorize?response_type=code&client_id=${clientId}&scope=${scopes}&redirect_uri=${redirectUri}`;
+    const url = `https://localhost:8443/cas/oidc/authorize?response_type=code&client_id=${clientId}&scope=${scopes}&redirect_uri=${redirectUri}`;
     await cas.goto(page, url);
     console.log(`Authorize URL: ${page.url()}`);
     await page.waitForTimeout(1000);

--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/script.js
@@ -1,0 +1,70 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    let url1 = "https://httpbin.org/anything/sample1";
+    await cas.logg(`Trying with URL ${url1}`);
+
+    let payload = await getPayload(page, url1, "client1", "secret1",
+        'openid+email');
+    let decoded = await cas.decodeJwt(payload.id_token);
+    assert(decoded.sub === "CAS@EXAMPLE.ORG");
+    assert(decoded.aud === "client1");
+    assert(decoded["preferred_username"] === "CAS@EXAMPLE.ORG");
+    assert(decoded["family_name"] === undefined);
+    assert(decoded["given_name"] === undefined);
+    assert(decoded["email"] === "cas@example.org");
+    assert(decoded["ClientIpAddress"] === undefined);
+    assert(decoded["authenticationDate"] === undefined);
+    assert(decoded["authenticationMethod"] === undefined);
+
+    let profileUrl = `https://localhost:8443/cas/oidc/profile?access_token=${payload.access_token}`;
+    console.log(`Calling user profile ${profileUrl}`);
+    await cas.doPost(profileUrl, "", {
+        'Content-Type': "application/json"
+    }, res => {
+        assert(res.data.id === "CAS@EXAMPLE.ORG");
+        assert(res.data.sub === "CAS@EXAMPLE.ORG");
+        assert(res.data.attributes["email"] === "cas@example.org");
+        assert(res.data.attributes["authenticationMethod"] === undefined);
+        assert(res.data.attributes["ClientIpAddress"] === undefined);
+        assert(res.data.attributes["given_name"] === undefined);
+        assert(res.data.attributes["family_name"] === undefined);
+    }, error => {
+        throw `Operation failed: ${error}`;
+    });
+
+    await browser.close();
+})();
+
+async function getPayload(page, redirectUri, clientId, clientSecret, scopes) {
+    const url = `https://localhost:8443/cas/oidc/oidcAuthorize?response_type=code&client_id=${clientId}&scope=${scopes}&redirect_uri=${redirectUri}`;
+    await cas.goto(page, url);
+    console.log(`Authorize URL: ${page.url()}`);
+    await page.waitForTimeout(1000);
+    
+    if (await cas.isVisible(page, "#username")) {
+        await cas.loginWith(page, "casuser", "Mellon");
+        await page.waitForTimeout(1000)
+    }
+    if (await cas.isVisible(page, "#allow")) {
+        await cas.click(page, "#allow");
+        await page.waitForNavigation();
+    }
+
+    let code = await cas.assertParameter(page, "code");
+    console.log(`Current code is ${code}`);
+    const accessTokenUrl = `https://localhost:8443/cas/oidc/token?grant_type=authorization_code`
+        + `&client_id=${clientId}&client_secret=${clientSecret}&redirect_uri=${redirectUri}&code=${code}`;
+    await cas.goto(page, accessTokenUrl);
+    console.log(`Token URL: ${page.url()}`);
+    await page.waitForTimeout(1000);
+    let content = await cas.textContent(page, "body");
+    const payload = JSON.parse(content);
+    console.log(payload);
+    return payload;
+}

--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/script.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/script.json
@@ -1,0 +1,35 @@
+{
+  "dependencies": "oidc",
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--logging.level.org.apereo.cas=info",
+
+    "--cas.audit.engine.enabled=false",
+
+    "--cas.authn.attribute-repository.stub.attributes.cn=casuser",
+    "--cas.authn.attribute-repository.stub.attributes.mail=cas@example.org",
+    "--cas.authn.attribute-repository.stub.attributes.sn=Apereo",
+    "--cas.authn.attribute-repository.stub.attributes.givenName=CAS",
+
+    "--cas.authn.oidc.core.issuer=https://localhost:8443/cas/oidc",
+    "--cas.authn.oidc.jwks.file-system.jwks-file=file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
+    
+    "--cas.authn.oidc.discovery.scopes=openid,profile,email,authentication",
+    "--cas.authn.oidc.discovery.claims=sub,name,family_name,given_name,email,ClientIpAddress,authenticationDate,authenticationMethod",
+
+    "--cas.authn.oidc.core.user-defined-scopes.authentication=ClientIpAddress,authenticationDate,authenticationMethod",
+
+    "--cas.authn.oidc.core.claims-map.email=mail",
+    "--cas.authn.oidc.core.claims-map.name=cn",
+    "--cas.authn.oidc.core.claims-map.family_name=sn",
+    "--cas.authn.oidc.core.claims-map.given_name=givenName",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services"
+  ]
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset-plusseparator/services/Sample-1.json
@@ -1,0 +1,15 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client1",
+  "clientSecret": "secret1",
+  "serviceId": "^https://httpbin.org/anything/sample1",
+  "name": "Sample",
+  "id": 1,
+  "scopes" : [ "java.util.HashSet", [ "email", "profile", "authentication" ] ],
+  "bypassApprovalPrompt": false,
+  "usernameAttributeProvider" : {
+    "@class" : "org.apereo.cas.services.PrincipalAttributeRegisteredServiceUsernameProvider",
+    "usernameAttribute" : "mail",
+    "canonicalizationMode" : "UPPER"
+  }
+}

--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/script.js
@@ -42,7 +42,7 @@ const assert = require('assert');
 })();
 
 async function getPayload(page, redirectUri, clientId, clientSecret, scopes) {
-    const url = `https://localhost:8443/cas/oidc/oidcAuthorize?response_type=code&client_id=${clientId}&scope=${scopes}&redirect_uri=${redirectUri}`;
+    const url = `https://localhost:8443/cas/oidc/authorize?response_type=code&client_id=${clientId}&scope=${scopes}&redirect_uri=${redirectUri}`;
     await cas.goto(page, url);
     console.log(`Authorize URL: ${page.url()}`);
     await page.waitForTimeout(1000);

--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/script.js
@@ -1,0 +1,70 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    let url1 = "https://httpbin.org/anything/sample1";
+    await cas.logg(`Trying with URL ${url1}`);
+
+    let payload = await getPayload(page, url1, "client1", "secret1",
+        encodeURIComponent('openid email'));
+    let decoded = await cas.decodeJwt(payload.id_token);
+    assert(decoded.sub === "CAS@EXAMPLE.ORG");
+    assert(decoded.aud === "client1");
+    assert(decoded["preferred_username"] === "CAS@EXAMPLE.ORG");
+    assert(decoded["family_name"] === undefined);
+    assert(decoded["given_name"] === undefined);
+    assert(decoded["email"] === "cas@example.org");
+    assert(decoded["ClientIpAddress"] === undefined);
+    assert(decoded["authenticationDate"] === undefined);
+    assert(decoded["authenticationMethod"] === undefined);
+
+    let profileUrl = `https://localhost:8443/cas/oidc/profile?access_token=${payload.access_token}`;
+    console.log(`Calling user profile ${profileUrl}`);
+    await cas.doPost(profileUrl, "", {
+        'Content-Type': "application/json"
+    }, res => {
+        assert(res.data.id === "CAS@EXAMPLE.ORG");
+        assert(res.data.sub === "CAS@EXAMPLE.ORG");
+        assert(res.data.attributes["email"] === "cas@example.org");
+        assert(res.data.attributes["authenticationMethod"] === undefined);
+        assert(res.data.attributes["ClientIpAddress"] === undefined);
+        assert(res.data.attributes["given_name"] === undefined);
+        assert(res.data.attributes["family_name"] === undefined);
+    }, error => {
+        throw `Operation failed: ${error}`;
+    });
+
+    await browser.close();
+})();
+
+async function getPayload(page, redirectUri, clientId, clientSecret, scopes) {
+    const url = `https://localhost:8443/cas/oidc/oidcAuthorize?response_type=code&client_id=${clientId}&scope=${scopes}&redirect_uri=${redirectUri}`;
+    await cas.goto(page, url);
+    console.log(`Authorize URL: ${page.url()}`);
+    await page.waitForTimeout(1000);
+    
+    if (await cas.isVisible(page, "#username")) {
+        await cas.loginWith(page, "casuser", "Mellon");
+        await page.waitForTimeout(1000)
+    }
+    if (await cas.isVisible(page, "#allow")) {
+        await cas.click(page, "#allow");
+        await page.waitForNavigation();
+    }
+
+    let code = await cas.assertParameter(page, "code");
+    console.log(`Current code is ${code}`);
+    const accessTokenUrl = `https://localhost:8443/cas/oidc/token?grant_type=authorization_code`
+        + `&client_id=${clientId}&client_secret=${clientSecret}&redirect_uri=${redirectUri}&code=${code}`;
+    await cas.goto(page, accessTokenUrl);
+    console.log(`Token URL: ${page.url()}`);
+    await page.waitForTimeout(1000);
+    let content = await cas.textContent(page, "body");
+    const payload = JSON.parse(content);
+    console.log(payload);
+    return payload;
+}

--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/script.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/script.json
@@ -1,0 +1,35 @@
+{
+  "dependencies": "oidc",
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--logging.level.org.apereo.cas=info",
+
+    "--cas.audit.engine.enabled=false",
+
+    "--cas.authn.attribute-repository.stub.attributes.cn=casuser",
+    "--cas.authn.attribute-repository.stub.attributes.mail=cas@example.org",
+    "--cas.authn.attribute-repository.stub.attributes.sn=Apereo",
+    "--cas.authn.attribute-repository.stub.attributes.givenName=CAS",
+
+    "--cas.authn.oidc.core.issuer=https://localhost:8443/cas/oidc",
+    "--cas.authn.oidc.jwks.file-system.jwks-file=file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
+    
+    "--cas.authn.oidc.discovery.scopes=openid,profile,email,authentication",
+    "--cas.authn.oidc.discovery.claims=sub,name,family_name,given_name,email,ClientIpAddress,authenticationDate,authenticationMethod",
+
+    "--cas.authn.oidc.core.user-defined-scopes.authentication=ClientIpAddress,authenticationDate,authenticationMethod",
+
+    "--cas.authn.oidc.core.claims-map.email=mail",
+    "--cas.authn.oidc.core.claims-map.name=cn",
+    "--cas.authn.oidc.core.claims-map.family_name=sn",
+    "--cas.authn.oidc.core.claims-map.given_name=givenName",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services"
+  ]
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authn-claims-scoped-subset/services/Sample-1.json
@@ -1,0 +1,15 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client1",
+  "clientSecret": "secret1",
+  "serviceId": "^https://httpbin.org/anything/sample1",
+  "name": "Sample",
+  "id": 1,
+  "scopes" : [ "java.util.HashSet", [ "email", "profile", "authentication" ] ],
+  "bypassApprovalPrompt": false,
+  "usernameAttributeProvider" : {
+    "@class" : "org.apereo.cas.services.PrincipalAttributeRegisteredServiceUsernameProvider",
+    "usernameAttribute" : "mail",
+    "canonicalizationMode" : "UPPER"
+  }
+}


### PR DESCRIPTION
When doing integration tests between the pac4j OIDC client (6.0.0-RC5-SNAPSHOT) and the CAS server v7.0.0-SNAPSHOT for an OIDC service with approval, I noticed that the scopes were not properly taken into account.

This is due to the + between the scopes in the /authorize URL instead of %20.

My feeling is that it's better to use %20, but it may be interesting to support + as well for backward compatibility.

I can of course patch pac4j v6.0.0-RC5-SNAPSHOT (I already did that locally) if you prefer not to fix it on the CAS server side.

To demonstrate the problem, this PR adds 2 Puppeteer tests: one with %20 which passes and one with + which fails.
