### PR TITLE
Allow to define a proxy for the SmsMode support

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/SmsModeProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/SmsModeProperties.java
@@ -38,4 +38,9 @@ public class SmsModeProperties implements Serializable {
      */
     @RequiredProperty
     private String url = "https://rest.smsmode.com/sms/v1/messages";
+
+    /**
+     * URL of the proxy (if defined).
+     */
+    private String proxyUrl;
 }

--- a/support/cas-server-support-sms-smsmode/src/main/java/org/apereo/cas/support/sms/SmsModeSmsSender.java
+++ b/support/cas-server-support-sms-smsmode/src/main/java/org/apereo/cas/support/sms/SmsModeSmsSender.java
@@ -52,6 +52,7 @@ public record SmsModeSmsSender(SmsModeProperties properties) implements SmsSende
             val exec = HttpUtils.HttpExecutionRequest.builder()
                     .method(HttpMethod.POST)
                     .url(properties.getUrl())
+                    .proxyUrl(properties.getProxyUrl())
                     .headers(headers)
                     .entity(MAPPER.writeValueAsString(data))
                     .build();


### PR DESCRIPTION
Small change to allow the use of a proxy for the `SmsModeSmsSender`.