### PR TITLE
make JpaTicketRegistry overrideable

### DIFF
--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/JpaTicketRegistryConfiguration.java
@@ -166,6 +166,7 @@ public class JpaTicketRegistryConfiguration {
         }
 
         @Bean
+        @ConditionalOnMissingBean(name = "jpaTicketRegistry")
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public TicketRegistry ticketRegistry(
             final ConfigurableApplicationContext applicationContext,


### PR DESCRIPTION
Allow custom implementations of the JpaTicketRegistry by using `ConditionalOnMissingBean`