### PR TITLE
Allow to configure the SAML logout request bindings

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPLogoutProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPLogoutProperties.java
@@ -9,6 +9,7 @@ import lombok.experimental.Accessors;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -62,5 +63,9 @@ public class SamlIdPLogoutProperties implements Serializable {
     /**
      * The order in which the logout request binginds should be tried (if available at the SP level).
      */
-    private List<String> logoutRequestBindings;
+    private List<String> logoutRequestBindings = Arrays.asList(
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+        "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+        "urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+    );
 }

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPLogoutProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/saml/idp/SamlIdPLogoutProperties.java
@@ -9,6 +9,7 @@ import lombok.experimental.Accessors;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * This is {@link SamlIdPLogoutProperties}.
@@ -57,4 +58,9 @@ public class SamlIdPLogoutProperties implements Serializable {
      * Whether SAML SLO is enabled and processed.
      */
     private boolean singleLogoutCallbacksDisabled;
+
+    /**
+     * The order in which the logout request binginds should be tried (if available at the SP level).
+     */
+    private List<String> logoutRequestBindings;
 }

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceLogoutUrlBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceLogoutUrlBuilder.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.support.saml.web.idp.profile.slo;
 
 import org.apereo.cas.authentication.principal.WebApplicationService;
+import org.apereo.cas.configuration.model.support.saml.idp.SamlIdPProperties;
 import org.apereo.cas.logout.slo.BaseSingleLogoutServiceLogoutUrlBuilder;
 import org.apereo.cas.logout.slo.SingleLogoutUrl;
 import org.apereo.cas.services.RegisteredService;
@@ -20,8 +21,11 @@ import org.opensaml.saml.saml2.metadata.SingleLogoutService;
 import org.springframework.core.Ordered;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -42,11 +46,27 @@ public class SamlIdPSingleLogoutServiceLogoutUrlBuilder extends BaseSingleLogout
      */
     protected final SamlRegisteredServiceCachingMetadataResolver samlRegisteredServiceCachingMetadataResolver;
 
+    /**
+     * The logout request bindings.
+     */
+    protected final List<String> logoutRequestBindings;
+
     public SamlIdPSingleLogoutServiceLogoutUrlBuilder(final ServicesManager servicesManager,
                                                       final SamlRegisteredServiceCachingMetadataResolver resolver,
-                                                      final UrlValidator urlValidator) {
+                                                      final UrlValidator urlValidator,
+                                                      final SamlIdPProperties samlIdPProperties) {
         super(servicesManager, urlValidator);
         this.samlRegisteredServiceCachingMetadataResolver = resolver;
+        val bindings = samlIdPProperties.getLogout().getLogoutRequestBindings();
+        if (bindings != null) {
+            this.logoutRequestBindings = bindings;
+        } else {
+            this.logoutRequestBindings = Arrays.asList(
+                SAMLConstants.SAML2_POST_BINDING_URI,
+                SAMLConstants.SAML2_REDIRECT_BINDING_URI,
+                SAMLConstants.SAML2_SOAP11_BINDING_URI
+            );
+        }
     }
 
     @Override
@@ -96,17 +116,11 @@ public class SamlIdPSingleLogoutServiceLogoutUrlBuilder extends BaseSingleLogout
         }
         val adaptor = adaptorRes.get();
 
-        var sloService = adaptor.getSingleLogoutService(SAMLConstants.SAML2_POST_BINDING_URI);
-        if (sloService != null) {
-            return finalizeSingleLogoutUrl(sloService, samlRegisteredService);
-        }
-        sloService = adaptor.getSingleLogoutService(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
-        if (sloService != null) {
-            return finalizeSingleLogoutUrl(sloService, samlRegisteredService);
-        }
-        sloService = adaptor.getSingleLogoutService(SAMLConstants.SAML2_SOAP11_BINDING_URI);
-        if (sloService != null) {
-            return finalizeSingleLogoutUrl(sloService, samlRegisteredService);
+        for (val binding : this.logoutRequestBindings) {
+            var sloService = adaptor.getSingleLogoutService(binding);
+            if (sloService != null) {
+                return finalizeSingleLogoutUrl(sloService, samlRegisteredService);
+            }
         }
         LOGGER.warn("Cannot find SLO service in metadata for entity id [{}]", entityID);
         return null;

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceLogoutUrlBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceLogoutUrlBuilder.java
@@ -16,14 +16,12 @@ import org.apereo.cas.web.UrlValidator;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
 import org.springframework.core.Ordered;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -57,16 +55,7 @@ public class SamlIdPSingleLogoutServiceLogoutUrlBuilder extends BaseSingleLogout
                                                       final SamlIdPProperties samlIdPProperties) {
         super(servicesManager, urlValidator);
         this.samlRegisteredServiceCachingMetadataResolver = resolver;
-        val bindings = samlIdPProperties.getLogout().getLogoutRequestBindings();
-        if (bindings != null) {
-            this.logoutRequestBindings = bindings;
-        } else {
-            this.logoutRequestBindings = Arrays.asList(
-                SAMLConstants.SAML2_POST_BINDING_URI,
-                SAMLConstants.SAML2_REDIRECT_BINDING_URI,
-                SAMLConstants.SAML2_SOAP11_BINDING_URI
-            );
-        }
+        this.logoutRequestBindings = samlIdPProperties.getLogout().getLogoutRequestBindings();
     }
 
     @Override

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPConfiguration.java
@@ -659,8 +659,10 @@ public class SamlIdPConfiguration {
             @Qualifier(ServicesManager.BEAN_NAME)
             final ServicesManager servicesManager,
             @Qualifier(UrlValidator.BEAN_NAME)
-            final UrlValidator urlValidator) {
-            return new SamlIdPSingleLogoutServiceLogoutUrlBuilder(servicesManager, defaultSamlRegisteredServiceCachingMetadataResolver, urlValidator);
+            final UrlValidator urlValidator,
+            final CasConfigurationProperties casProperties) {
+            return new SamlIdPSingleLogoutServiceLogoutUrlBuilder(servicesManager, defaultSamlRegisteredServiceCachingMetadataResolver,
+                                                                  urlValidator, casProperties.getAuthn().getSamlIdp());
         }
 
         @ConditionalOnMissingBean(name = "samlSingleLogoutServiceLogoutUrlBuilderConfigurer")


### PR DESCRIPTION
The CAS server always tries to send a SAML logout request using the POST binding, then the REDIRECT binding and finally the SOAP binding.
This PR allows to configure that bindings order.

Notice that the `logoutRequestBindings` property of the `SamlIdPLogoutProperties` class does not contain any default values to avoid pulling the `opensaml-saml-api` dependency.
The default values are computed in the `SamlIdPSingleLogoutServiceLogoutUrlBuilder` component.
