### PR TITLE
Allow usage of requestPassword attribute in LdapPasswordlessUserAcco…

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/account/PasswordlessAuthenticationLdapAccountsProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/account/PasswordlessAuthenticationLdapAccountsProperties.java
@@ -42,4 +42,10 @@ public class PasswordlessAuthenticationLdapAccountsProperties extends AbstractLd
      * indicates the user's name.
      */
     private String nameAttribute = "cn";
+
+    /**
+     * Name of the LDAP attribute that
+     * is used to disable passwordless.
+     */
+    private String requestPasswordAttribute = "requestPassword";
 }

--- a/support/cas-server-support-passwordless-ldap/src/main/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStore.java
+++ b/support/cas-server-support-passwordless-ldap/src/main/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStore.java
@@ -54,6 +54,9 @@ public class LdapPasswordlessUserAccountStore implements PasswordlessUserAccount
                 if (entry.getAttribute(ldapProperties.getPhoneAttribute()) != null) {
                     acctBuilder.phone(entry.getAttribute(ldapProperties.getPhoneAttribute()).getStringValue());
                 }
+                if (entry.getAttribute(ldapProperties.getRequestPasswordAttribute()) != null) {
+                    acctBuilder.requestPassword(Boolean.parseBoolean(entry.getAttribute(ldapProperties.getRequestPasswordAttribute()).getStringValue()));
+                }
                 val attributes = new LinkedHashMap<String, List<String>>(entry.getAttributes().size());
                 entry.getAttributes().forEach(attr -> attributes.put(attr.getName(), new ArrayList<>(attr.getStringValues())));
                 val acct = acctBuilder.attributes(attributes).build();

--- a/support/cas-server-support-passwordless-ldap/src/test/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStoreTests.java
+++ b/support/cas-server-support-passwordless-ldap/src/test/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStoreTests.java
@@ -35,7 +35,8 @@ import static org.junit.jupiter.api.Assertions.*;
     "cas.authn.passwordless.accounts.ldap.bind-dn=cn=Directory Manager",
     "cas.authn.passwordless.accounts.ldap.bind-credential=password",
     "cas.authn.passwordless.accounts.ldap.email-attribute=mail",
-    "cas.authn.passwordless.accounts.ldap.phone-attribute=telephoneNumber"
+    "cas.authn.passwordless.accounts.ldap.phone-attribute=telephoneNumber",
+    "cas.authn.passwordless.accounts.ldap.request-password=false"
 })
 @Slf4j
 @Import(LdapPasswordlessAuthenticationConfiguration.class)
@@ -55,5 +56,6 @@ public class LdapPasswordlessUserAccountStoreTests extends BasePasswordlessUserA
         assertTrue(user.isPresent());
         assertEquals("passwordlessuser@example.org", user.get().getEmail());
         assertEquals("123456789", user.get().getPhone());
+        assertEquals(false, user.get().getRequestPassword());
     }
 }

--- a/support/cas-server-support-passwordless-ldap/src/test/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStoreTests.java
+++ b/support/cas-server-support-passwordless-ldap/src/test/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStoreTests.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
     "cas.authn.passwordless.accounts.ldap.bind-credential=password",
     "cas.authn.passwordless.accounts.ldap.email-attribute=mail",
     "cas.authn.passwordless.accounts.ldap.phone-attribute=telephoneNumber",
-    "cas.authn.passwordless.accounts.ldap.request-password=false"
+    "cas.authn.passwordless.accounts.ldap.request-password=true"
 })
 @Slf4j
 @Import(LdapPasswordlessAuthenticationConfiguration.class)
@@ -56,6 +56,6 @@ public class LdapPasswordlessUserAccountStoreTests extends BasePasswordlessUserA
         assertTrue(user.isPresent());
         assertEquals("passwordlessuser@example.org", user.get().getEmail());
         assertEquals("123456789", user.get().getPhone());
-        assertEquals(false, user.get().getRequestPassword());
+        assertEquals(true, user.get().getRequestPassword());
     }
 }


### PR DESCRIPTION
Add support for requestPassword attribute in Ldap passwordless user account store.
Actually only simple account store support disabling passswordless webflow.
