### PR TITLE
Add missing argument in passwordMeter.js

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/passwordMeter.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/passwordMeter.js
@@ -69,7 +69,7 @@ function jqueryReady() {
                     $(indicator).html(strength[4]);
                 }
             } else {
-                setProgress(0);
+                setProgress(0, settings.bar);
                 $(progressBar).removeClass(settings.allProgressBarClasses).addClass(settings.progressBarClass0);
                 $(indicator).html('');
             }


### PR DESCRIPTION
A call of setPassword in passwordMeter.js is missing second argument. This causes an error when user clears password field when setting a new password ex. due to the password policy).