### PR TITLE
Fix text mistake (Mongodb -> Redis)

### DIFF
--- a/docs/cas-server-documentation/authentication/Configuring-Authentication-Events-Redis.md
+++ b/docs/cas-server-documentation/authentication/Configuring-Authentication-Events-Redis.md
@@ -5,7 +5,7 @@ category: Authentication
 ---
 {% include variables.html %}
 
-# MongoDb Authentication Events
+# Redis Authentication Events
 
 Stores authentication events into a Redis database.
 


### PR DESCRIPTION
Hi,
I fix a little mistake on documentation for Redis Authentication Events.