### PR TITLE
Fix typo in TicketRegistry

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
@@ -182,10 +182,10 @@ public interface TicketRegistry {
     }
 
     /**
-     * Gets tickets with authenication attributes.
+     * Gets tickets with authentication attributes.
      *
      * @param queryAttributes the query attributes
-     * @return the tickets with authenication attributes
+     * @return the tickets with authentication attributes
      */
     default Stream<? extends Ticket> getSessionsWithAttributes(final Map<String, List<Object>> queryAttributes) {
         return getTickets(ticket -> {


### PR DESCRIPTION
This PR fixes a small typo I found while reviewing the ticket registry API update (`getSessionsWithAttributes`).