### PR TITLE
make sure audience in jwt access token contains client id

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
@@ -102,7 +102,7 @@ public class OAuth20JwtAccessTokenEncoder implements CipherExecutor<String, Stri
         val builder = JwtBuilder.JwtRequest.builder();
         val dt = authentication.getAuthenticationDate().plusSeconds(accessToken.getExpirationPolicy().getTimeToLive());
         return builder
-            .serviceAudience(service.getId())
+            .serviceAudience(accessToken.getClientId())
             .issueDate(DateTimeUtils.dateOf(authentication.getAuthenticationDate()))
             .jwtId(accessToken.getId())
             .subject(authentication.getPrincipal().getId())

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/OAuth20TestsSuite.java
@@ -53,7 +53,6 @@ import org.apereo.cas.support.oauth.web.response.OAuth20DefaultCasClientRedirect
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20AccessTokenAtHashGeneratorTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20DefaultAccessTokenResponseGeneratorTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20DefaultTokenGeneratorTests;
-import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20JwtAccessTokenEncoderTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGeneratedResultTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenAuthorizationCodeGrantRequestExtractorTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenGrantRequestExtractorTests;
@@ -61,6 +60,7 @@ import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenPass
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenProofKeyCodeExchangeAuthorizationCodeGrantRequestExtractorTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenRefreshTokenGrantRequestExtractorTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenCipherExecutorTests;
+import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenEncoderTests;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20RegisteredServiceJwtAccessTokenCipherExecutorTests;
 import org.apereo.cas.support.oauth.web.response.callback.DefaultOAuth20AuthorizationModelAndViewBuilderTests;
 import org.apereo.cas.support.oauth.web.response.callback.OAuth20AuthorizationCodeAuthorizationResponseBuilderTests;

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoderTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoderTests.java
@@ -1,4 +1,4 @@
-package org.apereo.cas.support.oauth.web.response.accesstoken;
+package org.apereo.cas.support.oauth.web.response.accesstoken.response;
 
 import org.apereo.cas.AbstractOAuth20Tests;
 import org.apereo.cas.services.DefaultRegisteredServiceProperty;
@@ -6,9 +6,6 @@ import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.services.RegisteredServiceCipherExecutor;
 import org.apereo.cas.services.RegisteredServiceProperty;
 import org.apereo.cas.support.oauth.services.OAuthRegisteredService;
-import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenCipherExecutor;
-import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenEncoder;
-import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20RegisteredServiceJwtAccessTokenCipherExecutor;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 import org.apereo.cas.ticket.accesstoken.OAuth20JwtBuilder;
 import org.apereo.cas.util.crypto.CipherExecutor;
@@ -19,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -140,6 +138,9 @@ public class OAuth20JwtAccessTokenEncoderTests extends AbstractOAuth20Tests {
 
         val encodedAccessToken = encoder.encode(accessToken.getId());
         assertNotNull(encodedAccessToken);
+
+        val jwtRequestBuilder = encoder.getJwtRequestBuilder(Optional.of(registeredService), accessToken);
+        assertEquals(accessToken.getClientId(), jwtRequestBuilder.getServiceAudience());
 
         val decoded = encoder.decode(encodedAccessToken);
         assertNotNull(decoded);


### PR DESCRIPTION
While trying to get OIDC login to Rancher working with CAS, their OIDC library wanted the access token in JWT format and it wanted the audience(s) in the token to contain the client id, but CAS was returning something else. Per the specification CAS could return a list of audiences but if it is only returning one, it needs to be the client id.

https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2
aud:
REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain identifiers for other audiences. In the general case, the aud value is an array of case sensitive strings. In the common special case when there is one audience, the aud value MAY be a single case sensitive string.

This was oidc library code:
https://github.com/coreos/go-oidc/blob/v3/oidc/verify.go#L273
