### PR TITLE
Fix inconsistency in spec

### DIFF
--- a/docs/cas-server-documentation/installation/Logout-Single-Signout.md
+++ b/docs/cas-server-documentation/installation/Logout-Single-Signout.md
@@ -70,7 +70,7 @@ A sample back channel SLO message:
     ID="[RANDOM ID]"
     Version="2.0"
     IssueInstant="[CURRENT DATE/TIME]">
-    <saml:NameID>@NOT_USED@</saml:NameID>
+    <saml:NameID>[PRINCIPAL IDENTIFIER]</saml:NameID>
     <samlp:SessionIndex>[SESSION IDENTIFIER]</samlp:SessionIndex>
 </samlp:LogoutRequest>
 ```

--- a/docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md
+++ b/docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md
@@ -1734,9 +1734,7 @@ following SAML Logout Request XML document:
 ```xml
   <samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
      ID="[RANDOM ID]" Version="2.0" IssueInstant="[CURRENT DATE/TIME]">
-    <saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
-      @NOT_USED@
-    </saml:NameID>
+    <saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">[PRINCIPAL IDENTIFIER]</saml:NameID>
     <samlp:SessionIndex>[SESSION IDENTIFIER]</samlp:SessionIndex>
   </samlp:LogoutRequest>
 ```


### PR DESCRIPTION
In the latest CAS server versions, the `NameID` in the CAS logout request is the principal identifier and no longer the constant `@NOT_USED@`.

This PR fixes this inconsistency in the spec.
