### PR TITLE
Automatically close MongoDbTemplate streams to mitigate/prevent issues with too many open cursors.

### DIFF
--- a/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
+++ b/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.time.ZonedDateTime;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -41,21 +42,21 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
 
     @Override
     public Stream<? extends CasEvent> load() {
-        return this.mongoTemplate.stream(new Query(), CasEvent.class, this.collectionName);
+        return getCasEventStream(new Query());
     }
 
     @Override
     public Stream<? extends CasEvent> load(final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfTypeForPrincipal(final String type, final String principal) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(PRINCIPAL_ID_PARAM).is(principal));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
+        return getCasEventStream(query);
     }
 
     @Override
@@ -66,36 +67,43 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type)
             .and(PRINCIPAL_ID_PARAM).is(principal)
             .and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String id) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(id));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String principal, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(principal).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
+        return getCasEventStream(query);
     }
+
+    private Stream<CasEvent> getCasEventStream(final Query query) {
+        try (val stream = this.mongoTemplate.stream(query, CasEvent.class, this.collectionName)){
+            return stream.collect(Collectors.toList()).stream();
+        }
+    }
+
 
     @Override
     public CasEvent saveInternal(final CasEvent event) {

--- a/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
+++ b/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.time.ZonedDateTime;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -42,21 +41,21 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
 
     @Override
     public Stream<? extends CasEvent> load() {
-        return getCasEventStream(new Query());
+        return this.mongoTemplate.stream(new Query(), CasEvent.class, this.collectionName);
     }
 
     @Override
     public Stream<? extends CasEvent> load(final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return getCasEventStream(query);
+        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfTypeForPrincipal(final String type, final String principal) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(PRINCIPAL_ID_PARAM).is(principal));
-        return getCasEventStream(query);
+        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
     }
 
     @Override
@@ -67,43 +66,36 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type)
             .and(PRINCIPAL_ID_PARAM).is(principal)
             .and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return getCasEventStream(query);
+        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type));
-        return getCasEventStream(query);
+        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return getCasEventStream(query);
+        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String id) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(id));
-        return getCasEventStream(query);
+        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String principal, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(principal).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return getCasEventStream(query);
+        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName);
     }
-
-    private Stream<CasEvent> getCasEventStream(final Query query) {
-        try (val stream = this.mongoTemplate.stream(query, CasEvent.class, this.collectionName)){
-            return stream.collect(Collectors.toList()).stream();
-        }
-    }
-
 
     @Override
     public CasEvent saveInternal(final CasEvent event) {

--- a/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
+++ b/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
@@ -1,17 +1,33 @@
 package org.apereo.cas.support.events.mongo;
 
+
 import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.MongoDbEventsConfiguration;
+import org.apereo.cas.mock.MockTicketGrantingTicket;
+import org.apereo.cas.support.events.AbstractCasEvent;
 import org.apereo.cas.support.events.AbstractCasEventRepositoryTests;
 import org.apereo.cas.support.events.CasEventRepository;
+import org.apereo.cas.support.events.dao.CasEvent;
+import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
+import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
 
 import lombok.Getter;
+import lombok.val;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test cases for {@link MongoDbCasEventRepository}.
@@ -38,7 +54,59 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 @EnabledIfListeningOnPort(port = 27017)
 public class MongoDbCasEventRepositoryTests extends AbstractCasEventRepositoryTests {
 
+    private static final int NUM_OF_EVENTS_LARGER_THAN_MIN_BATCH_SIZE = 103;
+
     @Autowired
     @Qualifier(CasEventRepository.BEAN_NAME)
     private CasEventRepository eventRepository;
+
+    @Autowired
+    @Qualifier("mongoEventsTemplate")
+    private MongoTemplate mongoTemplate;
+
+    private long currentCount;
+
+
+
+    @BeforeEach
+    public void setup() throws Exception {
+        currentCount = getOpenCursorCount();
+        val tgt = new MockTicketGrantingTicket("casuser");
+        val event = new CasTicketGrantingTicketCreatedEvent(this, tgt, null);
+        for (var x = 0; x < NUM_OF_EVENTS_LARGER_THAN_MIN_BATCH_SIZE; x++) {
+            val dto = prepareCasEvent(event);
+            dto.setCreationTime(event.getTicketGrantingTicket().getCreationTime().toString());
+            dto.putEventId(event.getTicketGrantingTicket().getId());
+            dto.setPrincipalId(event.getTicketGrantingTicket().getAuthentication().getPrincipal().getId());
+            eventRepository.save(dto);
+        }
+    }
+
+    @Test
+    public void makeSureCursorsGetClosed() throws Exception {
+        val stream = eventRepository.load();
+        assertNotNull(stream);
+        assertEquals(currentCount, getOpenCursorCount());
+
+    }
+
+    private CasEvent prepareCasEvent(final AbstractCasEvent event) {
+        val dto = new CasEvent();
+        dto.setType(event.getClass().getCanonicalName());
+        dto.putTimestamp(event.getTimestamp());
+        val dt = DateTimeUtils.zonedDateTimeOf(Instant.ofEpochMilli(event.getTimestamp()));
+        dto.setCreationTime(dt.toString());
+        return dto;
+    }
+
+    public long getOpenCursorCount() {
+        var cmd = new Document("serverStatus", 1);
+        cmd.append("metrics", true);
+        cmd.append("cursor", true);
+        var result = mongoTemplate.executeCommand(cmd);
+        var open = (Document) result.get("metrics", Document.class).get("cursor", Document.class).get("open", Document.class);
+        return open.getLong("total");
+    }
+
+
 }

--- a/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/DefaultCasMongoTemplate.java
+++ b/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/DefaultCasMongoTemplate.java
@@ -1,8 +1,15 @@
 package org.apereo.cas.mongo;
 
+import lombok.val;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This is {@link DefaultCasMongoTemplate}.
@@ -14,5 +21,13 @@ public class DefaultCasMongoTemplate extends MongoTemplate implements CasMongoOp
     public DefaultCasMongoTemplate(final MongoDatabaseFactory mongoDbFactory,
                                    final MappingMongoConverter mappingMongoConverter) {
         super(mongoDbFactory, mappingMongoConverter);
+    }
+
+
+    @Override
+    protected <T> Stream<T> doStream(final Query query, final Class<?> entityType, final String collectionName, final Class<T> returnType) {
+        try (val stream = super.doStream(query, entityType, collectionName, returnType)){
+            return stream.collect(Collectors.toList()).stream();
+        }
     }
 }

--- a/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/DefaultCasMongoTemplate.java
+++ b/support/cas-server-support-mongo-core/src/main/java/org/apereo/cas/mongo/DefaultCasMongoTemplate.java
@@ -5,9 +5,6 @@ import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.query.Query;
-
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 


### PR DESCRIPTION
- [X] Brief description of changes applied
   Modified DefaultCasMongoDbTemplate to override doStream method.  Made the method call the super method with a try-with-resources method, then collected the results as a list, and returned a stream of the list.  

Why?  

  The MongoDbTemplate.doStream method returns a ClosableIterator implementation with an open MongoDb cursor in it.  There is nothing in the usages of the code that close the stream after using it, thus after the stream is used, the class is garbage collected, but the MongoDb cursors can be left open, and is left to the MongoDB server to close upon timeout.  The cursor is left open when the cursor has to iterate through batches of data.  Under high authentication load, making use of all known BaseAuthenticationRequestRiskCalculator implementations when electrofence is enabled, it is possible to cause the MongoDB to run out of available cursors, causing the clients to start throwing errors.  This is somewhat akin to what eventually happens if one fails to close statements/result sets on a JDBC connection.  I considered adding the try-with-resources on implementations making use of the mongodbTemplate.stream() methods,  but I thought it might be better to have it close closer to the source to prevent it from accidentally causing the problem again with a new usage of it.  The current usages of the stream method are in MongoDbCasEventRepository and MongoDbTicketRegistry.
- [X] Test cases for all modified changes, where applicable
 Created test case that fails at the commit below.
 https://github.com/dmalia1/cas/commit/7dfa6374a72211f3fe1e617992383ece5937f5b6
- [X] Any documentation on how to configure, test
 To run the test, make sure you have a mongodb instance running on localhost using credentials specified in the test.
Then run testcas.sh -category mongodb
- [X] Any possible limitations, side effects, etc
  This may slow down processing of data of from mongodb as it will have to fetch the entire resultset before processing.  CasEventRepostiory.load() for example would fetch the entire collection before processing, potentially running into OOM errors.  Other implementations of CasEventRepository do something similar, so I'm not sure this is a showstopper.  The Eclipse link jpa implementation does this as an example.  

As a side note, the hibernate jpa implementation *may* have the same issue that this pull request corrects. However, the underlying stream is also making use of autoclosable, so it *may* work as intended even though the hibernate documentation explicitly says one should close the stream as soon as possible to free up resources. https://docs.jboss.org/hibernate/orm/6.1/javadocs/org/hibernate/query/Query.html#stream().   I have not run any tests to confirm that there is issue with the hibernate jpa implementation, just read the code while reviewing how the other CasEventRepository implementations are implementing 'stream' to make sure I wasn't doing something too horrible.



