### PR TITLE
Expected PAR behavior

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-par-authzcode-login/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-par-authzcode-login/script.js
@@ -1,0 +1,93 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require('assert');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    await page.setRequestInterception(true);
+
+    page.once("request", interceptedRequest => {
+        interceptedRequest.continue({
+            'method': 'POST',
+            'postData': 'response_type=code&'
+                + 'client_id=client&scope=openid%20profile%20MyCustomScope&'
+                + 'redirect_uri=https://apereo.github.io&nonce=3d3a7457f9ad3&'
+                + 'state=1735fd6c43c14&claims=%7B%22userinfo%22%3A%20%7B%20%22name%22%3A%20%7B%22essential'
+                + '%22%3A%20true%7D%2C%22phone_number%22%3A%20%7B%22essential%22%3A%20true%7D%7D%7D&'
+                + 'client_secret=secret',
+            headers: {
+                ...interceptedRequest.headers(),
+                "Content-Type": "application/x-www-form-urlencoded"
+            }
+        });
+    });
+
+    const response = await page.goto('https://localhost:8443/cas/oidc/oidcPushAuthorize');
+    const responseBody = await response.text();
+    const data = JSON.parse(responseBody);
+    const requestUri = data.request_uri;
+    await page.waitForTimeout(3000);
+
+    page.setRequestInterception(false);
+
+    const url = "https://localhost:8443/cas/oidc/oidcAuthorize?response_type=code"
+        + "&client_id=client&request_uri=" + requestUri;
+
+    await cas.goto(page, url);
+    await page.waitForTimeout(3000);
+    await cas.loginWith(page, "casuser", "Mellon");
+
+    await page.waitForTimeout(3000);
+
+    if (await cas.isVisible(page, "#allow")) {
+        await cas.click(page, "#allow");
+        await page.waitForNavigation();
+    }
+
+    let code = await cas.assertParameter(page, "code");
+    console.log(`Current code is ${code}`);
+    const accessTokenUrl = `https://localhost:8443/cas/oidc/token?grant_type=authorization_code`
+        + `&client_id=client&client_secret=secret&redirect_uri=https://apereo.github.io&code=${code}`;
+    await cas.goto(page, accessTokenUrl);
+    await page.waitForTimeout(3000);
+    let content = await cas.textContent(page, "body");
+    const payload = JSON.parse(content);
+    assert(payload.access_token != null);
+    assert(payload.token_type != null);
+    assert(payload.expires_in != null);
+    assert(payload.scope != null);
+
+    let decoded = await cas.decodeJwt(payload.id_token);
+    assert(decoded["sub"] === 'casuser');
+    assert(decoded["client_id"] === 'client');
+    assert(decoded["preferred_username"] === 'casuser');
+
+    assert(decoded["identity-name"] === undefined);
+    assert(decoded["common-name"] === undefined);
+    assert(decoded["lastname"] === undefined);
+    
+    assert(decoded["cn"] !== null);
+    assert(decoded["family_name"] !== null);
+    assert(decoded["name"] !== null);
+
+    let profileUrl = `https://localhost:8443/cas/oidc/profile?access_token=${payload.access_token }`;
+    console.log(`Calling user profile ${profileUrl}`);
+
+    await cas.doPost(profileUrl, "", {
+        'Content-Type': "application/json"
+    }, res => {
+        assert(decoded["common-name"] === undefined);
+        assert(decoded["lastname"] === undefined);
+
+        assert(res.data["cn"] != null);
+        assert(res.data["name"] != null);
+        assert(res.data["family_name"] != null);
+        assert(res.data.sub != null)
+    }, error => {
+        throw `Operation failed: ${error}`;
+    });
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/oidc-par-authzcode-login/script.json
+++ b/ci/tests/puppeteer/scenarios/oidc-par-authzcode-login/script.json
@@ -1,0 +1,35 @@
+{
+  "dependencies": "oidc",
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--logging.level.org.apereo.cas=info",
+
+    "--cas.audit.engine.enabled=false",
+
+    "--cas.authn.attribute-repository.stub.attributes.common-name=casuser",
+    "--cas.authn.attribute-repository.stub.attributes.name=CAS",
+    "--cas.authn.attribute-repository.stub.attributes.lastname=Apereo",
+    "--cas.authn.attribute-repository.stub.attributes.identity-name=apereo-cas",
+
+    "--cas.authn.oidc.core.issuer=https://localhost:8443/cas/oidc",
+    "--cas.authn.oidc.discovery.scopes=openid,profile,email,address,phone,MyCustomScope",
+    "--cas.authn.oidc.discovery.claims=sub,name,cn,given-name,given:name,family_name",
+
+    "--cas.authn.oidc.core.user-defined-scopes.MyCustomScope=cn,given:name,name,family_name",
+    "--cas.authn.oidc.jwks.file-system.jwks-file=file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
+
+    "--cas.authn.oidc.core.claims-map.cn=common-name",
+    "--cas.authn.oidc.core.claims-map.name=identity-name",
+    "--cas.authn.oidc.core.claims-map.family_name=lastname",
+
+    "--cas.authn.oauth.core.user-profile-view-type=FLAT",
+    
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services"
+  ]
+}
+
+
+

--- a/ci/tests/puppeteer/scenarios/oidc-par-authzcode-login/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/oidc-par-authzcode-login/services/Sample-1.json
@@ -1,0 +1,15 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client",
+  "clientSecret": "secret",
+  "serviceId": ".*",
+  "name": "Sample",
+  "id": 1,
+  "description": "Sample Service",
+  "evaluationOrder": 10000,
+  "informationUrl": "https://github.com/apereo/cas",
+  "privacyUrl": "https://github.com/apereo/cas",
+  "scopes" : [ "java.util.HashSet", [ "MyCustomScope", "openid", "profile" ] ],
+  "supportedGrantTypes": [ "java.util.HashSet", [ "authorization_code" ] ],
+  "supportedResponseTypes": [ "java.util.HashSet", [ "code" ] ]
+}


### PR DESCRIPTION
This PR is a Puppeteer test demonstrating the expected behavior for the PAR support:

1) A request is made to `/oidcPushAuthorize` to get the `request_uri`
2) A request is made to `/authorize` with the `client_id` and `request_uri`: a login is performed for `casuser`/`Mellon`
3) The `code` is retrieved to get the `access token`
4) The profile is retrieved thanks to the `access token`.

The profile should be the one of `casuser`, not of the OIDC `client`. This is where it currently fails: https://github.com/apereo/cas/compare/master...leleuj:cas:par?expand=1#diff-79f0ef8304f34731da561bfb8a1d0302cccac54ca82ed524033ae11c14f24ab4R63
