### PR TITLE
docs: fix grammatical and name typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Additional resources are available as follows:
 ## Getting Started
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.apereo.cas/cas-server-webapp?style=for-the-badge&logo=apachemaven)][casmavencentral]
-[![Github Releases](https://img.shields.io/github/release/apereo/cas.svg?style=for-the-badge&logo=github)][githubreleases]
+[![GitHub Releases](https://img.shields.io/github/release/apereo/cas.svg?style=for-the-badge&logo=github)][githubreleases]
 
 It is recommended to deploy CAS locally using the [WAR Overlay method][overlay]. Cloning or downloading the CAS codebase
 is **ONLY** required if you wish to contribute to the development of the project.
@@ -64,11 +64,11 @@ The following features are supported by the CAS project:
 * OAuth v2 Protocol
 * OpenID Connect Protocol
 * WS-Federation Passive Requestor Protocol
-* Authentication via JAAS, LDAP, RDBMS, X.509, Radius, SPNEGO, JWT, Remote, Apache Cassandra, Trusted, BASIC, Apache Shiro, MongoDb, Pac4J and more.
+* Authentication via JAAS, LDAP, RDBMS, X.509, Radius, SPNEGO, JWT, Remote, Apache Cassandra, Trusted, BASIC, Apache Shiro, MongoDB, Pac4J and more.
 * Delegated authentication to WS-FED, Facebook, Twitter, SAML IdP, OpenID Connect, CAS and more.
 * Authorization via ABAC, Time/Date, REST, Internet2's Grouper and more.
-* HA clustered deployments via Hazelcast, JPA, Apache Cassandra, Memcached, Apache Ignite, MongoDb, Redis, DynamoDb, and more.
-* Application registration backed by JSON, LDAP, YAML, Apache Cassandra, JPA, MongoDb, DynamoDb, Redis and more.
+* HA clustered deployments via Hazelcast, JPA, Apache Cassandra, Memcached, Apache Ignite, MongoDB, Redis, DynamoDb, and more.
+* Application registration backed by JSON, LDAP, YAML, Apache Cassandra, JPA, MongoDB, DynamoDb, Redis and more.
 * Multifactor authentication via Duo Security, YubiKey, RSA, Google Authenticator, U2F, WebAuthn and more.
 * Administrative UIs to manage logging, monitoring, statistics, configuration, client registration and more.
 * Global and per-application user interface theme and branding.

--- a/docs/cas-server-documentation/authentication/OIDC-Authentication-DPoP.md
+++ b/docs/cas-server-documentation/authentication/OIDC-Authentication-DPoP.md
@@ -23,7 +23,7 @@ The SPA authentication flow with a DPoP token can be summarized as such:
 
 - The SPA generates a new RSA or EC key pair in such a way so the private key parameters cannot be exported from the browser.
 - To request a DPoP access token the SPA generates a one-time-use JWT signed with the private key. The function of this JWT is to demonstrate possession of the key. Its header includes the public parameters of the signing key in JWK format. 
-- The SPA makes the usual token request to CAS but to trigger issue of a DPoP access token the proof JWT must be included in a HTTP request header called *DPoP*.
+- The SPA makes the usual token request to CAS but to trigger issue of a DPoP access token the proof JWT must be included in an HTTP request header called *DPoP*.
 - If the DPoP proof is valid and signed with a supported JWS algorithms the token response will appear in the usual format, but with the token type set to *DPoP*.
 
 To access a protected resource with a DPoP token (such as the `profile` endpoint in CAS) the client needs 

--- a/docs/cas-server-documentation/authentication/X509-Authentication.md
+++ b/docs/cas-server-documentation/authentication/X509-Authentication.md
@@ -97,7 +97,7 @@ acceptable client certificates.
 
 These settings can be used to turn on and configure CAS to
 extract an X509 certificate from a base64 encoded certificate
-on a HTTP request header (placed there by a proxy in front of CAS).
+on an HTTP request header (placed there by a proxy in front of CAS).
 If this is set to true, it is important that the proxy cannot
 be bypassed by users and that the proxy ensures the header
 never originates from the browser.

--- a/docs/cas-server-documentation/configuration/Configuration-Management-Clustered.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Management-Clustered.md
@@ -20,7 +20,7 @@ If CAS nodes are not sharing a central location for configuration properties suc
 node contains a copy of the settings, any changes you make to one node must be replicated and
 synced across all nodes so they are persisted on disk. The broadcast mechanism noted above only
 applies changes to the runtime and the running CAS instance. Ideally, you should be keeping track
-of CAS settings in a shared (git) repository (or better yet, inside a private Github repository perhaps)
+of CAS settings in a shared (git) repository (or better yet, inside a private GitHub repository perhaps)
 where you make a change in one place and it's broadcasted to all nodes. This model removes the need for
 synchronizing changes across disks and CAS nodes.CAS uses the Spring Cloud Bus to manage configuration 
 in a distributed deployment. Spring Cloud Bus links nodes of a distributed system with a lightweight message broker.

--- a/docs/cas-server-documentation/configuration/Configuration-Server-Management-SpringCloud-Default.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Server-Management-SpringCloud-Default.md
@@ -9,7 +9,7 @@ category: Configuration
 # Spring Cloud Configuration Server - Spring Cloud Default
 
 The Spring Cloud Configuration Server is able to handle `git` or `svn` based repositories that host CAS configuration.
-Such repositories can either be local to the deployment, or they could be on the cloud in form of GitHub/BitBucket. Access to
+Such repositories can either be local to the deployment, or they could be on the cloud in form of GitHub/Bitbucket. Access to
 cloud-based repositories can either be in form of a username/password, or via SSH so as long the appropriate keys are configured in the
 CAS deployment environment which is really no different than how one would normally access a git repository via SSH.
 
@@ -44,5 +44,5 @@ thirdPartyStartsWith="spring.cloud.config.server.git"
 thirdPartyExactMatch="spring.profiles.active"
 %}
 
-The above configuration also applies to online git-based repositories such as Github, BitBucket, etc.
+The above configuration also applies to online git-based repositories such as GitHub, Bitbucket, etc.
 

--- a/docs/cas-server-documentation/configuration/Configuration-Server-Management-SpringCloud-HashiCorpConsul.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Server-Management-SpringCloud-HashiCorpConsul.md
@@ -23,7 +23,7 @@ config/application/
 
 The most specific property source is at the top, with the least specific at the bottom. Properties in the `config/application` folder are applicable to all applications using consul for configuration. Properties in the `config/cas` folder are only available to the instances of the service named `cas`.
 
-Configuration is currently read on startup of the application. Sending a HTTP POST to `/refresh` will cause the configuration to be reloaded. Watching the key value store (which Consul supports) is not currently possible, but will be a future addition to this project.
+Configuration is currently read on startup of the application. Sending an HTTP POST to `/refresh` will cause the configuration to be reloaded. Watching the key value store (which Consul supports) is not currently possible, but will be a future addition to this project.
 
 The Consul Config Watch takes advantage of the ability of consul to [watch a key prefix](https://www.consul.io/docs/agent). The Config Watch makes a blocking Consul HTTP API call to determine if any relevant configuration data has changed for the current application. If there is new configuration data a `Refresh Event` is published. This is equivalent to calling the `/refresh` Spring Boot actuator endpoint.
 

--- a/docs/cas-server-documentation/developer/Build-Process.md
+++ b/docs/cas-server-documentation/developer/Build-Process.md
@@ -31,7 +31,7 @@ git clone --recursive --depth=1 --single-branch --branch=master git@github.com:a
 # git fetch --unshallow
 ```
 
-For a successful clone, you will need to have set up SSH keys for your account on Github.
+For a successful clone, you will need to have set up SSH keys for your account on GitHub.
 If that is not an option, you may clone the CAS repository under `https` via `https://github.com/apereo/cas.git`.
 
 You may also need to update submodules linked to the CAS repository. Newer versions of Git will do this automatically, 
@@ -186,7 +186,7 @@ cd cas-server
 ./gradlew eclipse
 ```
 
-Then, import the project into eclipse using "General\Existing Projects into Workspace" 
+Then, import the project into Eclipse using "General\Existing Projects into Workspace" 
 and choose "Add Gradle Nature" from the "Configure" context menu of the project.
 
 <div class="alert alert-warning">:warning: <strong>YMMV</strong><p>We have had a less than ideal experience with Eclipse and its support for Gradle-based 

--- a/docs/cas-server-documentation/developer/Contributor-Guidelines.md
+++ b/docs/cas-server-documentation/developer/Contributor-Guidelines.md
@@ -135,7 +135,7 @@ you for longer prosperity. Be not afraid; the worst that could happen is someone
 
 ## How do I know who's working on what?
 
-- Follow the *WIP Pattern* and submit an early pull requests in Draft status. This is the recommended strategy from Github:
+- Follow the *WIP Pattern* and submit an early pull requests in Draft status. This is the recommended strategy from GitHub:
 
 > Pull Requests are a great way to start a conversation of a feature, so start one as soon as possible- 
 > even before you are finished with the code. Your team can comment on the feature as it evolves, 
@@ -199,7 +199,7 @@ share your use case and ideas with others and brainstorm about variations and po
 often help clear the path to better and more objective solutions. That said, if you are specifically looking for an idea repository where you would
 log an idea or feature request for someone else to come along and spend time, money and energy to review and 
 provide a solution or enhancement for you, that place does not exist with the CAS project. As was noted earlier, 
-if you would like to see a enhancement in CAS, you are to either study, learn and do the work yourself and contribute that back 
+if you would like to see an enhancement in CAS, you are to either study, learn and do the work yourself and contribute that back 
 to the CAS project after having had the proper discussions with the wider developer community, or you can provide funding for 
 the work or contract with someone so they can do the work on your behalf. There are no other viable, sustainable options.
 
@@ -290,13 +290,13 @@ Before you do anything else, make sure you have a [functional build](Build-Proce
 To successfully finish this exercise you need:
 
 1. [Git](https://git-scm.com/downloads)
-2. [IntelliJ IDEA](https://www.jetbrains.com/idea/download/), eclipse or NetBeans (Depending on the change, `vim` may be perfectly fine too)
+2. [IntelliJ IDEA](https://www.jetbrains.com/idea/download/), Eclipse or NetBeans (Depending on the change, `vim` may be perfectly fine too)
 3. [Java (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 
 ### Fork the repository
 
 First thing you need to do is to fork the CAS repository under your own account. The 
-CAS repository is hosted on Github and is available [here](https://github.com/apereo/cas).
+CAS repository is hosted on GitHub and is available [here](https://github.com/apereo/cas).
 
 ### Clone Repositories
 

--- a/docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md
+++ b/docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md
@@ -50,7 +50,7 @@ application.
 **1.1. Conventions & Definitions**
 ----------------------------------
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in RFC 2119[[1](<#1>)].
 
@@ -128,7 +128,7 @@ MUST be handled by `/login`.
 
 -   `service` [OPTIONAL] - the identifier of the application the client is
     trying to access. In almost all cases, this will be the URL of the
-    application. As a HTTP request parameter, this URL value MUST be
+    application. As an HTTP request parameter, this URL value MUST be
     URL-encoded as described in section 2.2 of RFC 3986 [[4](<#4>)].
     If a `service` is not specified and a single sign-on session does not yet
     exist, CAS SHOULD request credentials from the user to initiate a single
@@ -261,7 +261,7 @@ as a credential acceptor. They are all case-sensitive and they all MUST be
 handled by `/login`.
 
 -   `service` [OPTIONAL] - the URL of the application the client is trying to
-    access. As a HTTP request parameter, this URL value MUST be URL-encoded as
+    access. As an HTTP request parameter, this URL value MUST be URL-encoded as
     described in Section 2.2 of RFC 1738 [[4](<#4>)]. CAS MUST redirect the
     client to this URL upon successful authentication. This is discussed in
     detail in Section [2.2.4](#head2.2.4). If the CAS Server operates in
@@ -363,7 +363,7 @@ sensitive and SHOULD be handled by `/logout`.
     browser might be automatically redirected to the URL specified by `service`
     after the logout was performed by the CAS server. If redirection by the
     CAS Server is actually performed depends on the server configuration.
-    As a HTTP request parameter, the `service` value MUST be URL-encoded as
+    As an HTTP request parameter, the `service` value MUST be URL-encoded as
     described in Section 2.2 of RFC 1738 [[4](<#4>)].
 
     > Note: It is STRONGLY RECOMMENDED that all `service` urls be filtered via
@@ -408,7 +408,7 @@ after successful logout.
 
 The CAS Server MAY support Single Logout (SLO). SLO means that the user gets
 logged out not only from the CAS Server, but also from all visited CAS client
-applications. If SLO is supported by the CAS Server, the CAS Server MUST send a
+applications. If SLO is supported by the CAS Server, the CAS Server MUST send an
 HTTP POST request containing a logout XML document (see [Appendix
 C](<#head_appdx_c>)) to all service URLs provided to CAS during this CAS session
 whenever a Ticket Granting Ticket is explicitly expired by the user (e.g. during logout).
@@ -435,7 +435,7 @@ availability ("fire and forget").
 Handling the logout POST request data is up to the CAS client. It is RECOMMENDED
 to logout the user from the application identified by the service ticket id sent
 in the SLO POST request.
-If the client supports SLO POST request handling, the client SHALL return a HTTP success
+If the client supports SLO POST request handling, the client SHALL return an HTTP success
 status code.
 
 
@@ -460,7 +460,7 @@ case sensitive and MUST all be handled by `/validate`.
 
 -   `service` [REQUIRED] - the identifier of the service for which the ticket was
     issued, as discussed in Section 2.2.1.
-    As a HTTP request parameter, the `service` value MUST be URL-encoded as
+    As an HTTP request parameter, the `service` value MUST be URL-encoded as
     described in Section 2.2 of RFC 1738 [[4](<#4>)].
 
     > Note: It is STRONGLY RECOMMENDED that all `service` urls be filtered via
@@ -535,7 +535,7 @@ are case sensitive and MUST all be handled by `/serviceValidate`.
 
 -   `service` [REQUIRED] - the identifier of the service for which the ticket was
     issued, as discussed in Section [2.2.1](#head2.2.1).
-    As a HTTP request parameter, the `service` value MUST be URL-encoded as
+    As an HTTP request parameter, the `service` value MUST be URL-encoded as
     described in Section 2.2 of RFC 1738 [[4](<#4>)].
 
     > Note: It is STRONGLY RECOMMENDED that all `service` urls be filtered via
@@ -552,7 +552,7 @@ are case sensitive and MUST all be handled by `/serviceValidate`.
 
 -   `pgtUrl` [OPTIONAL] - the URL of the proxy callback. Discussed in Section
     [2.5.4](#head2.5.4).
-    As a HTTP request parameter, the "pgtUrl" value MUST be URL-encoded as
+    As an HTTP request parameter, the "pgtUrl" value MUST be URL-encoded as
     described in Section 2.2 of RFC 1738 [[4](<#4>)].
 
 -   `renew` [OPTIONAL] - if this parameter is set, ticket validation will only
@@ -898,7 +898,7 @@ case-sensitive.
     service ticket or proxy ticket validation.
 -   `targetService` [REQUIRED] - the service identifier of the back-end service.
     Note that not all back-end services are web services so this service identifier
-    will not always be an URL. However, the service identifier specified here
+    will not always be a URL. However, the service identifier specified here
     MUST match the `service` parameter specified to `/proxyValidate` upon validation
     of the proxy ticket.
 
@@ -1362,7 +1362,7 @@ The Long-Term Ticket Granting Ticket lifetime MAY not exceed 3 months.
 -------------------------------
 
 `/samlValidate` checks the validity of a Service Ticket by a SAML 1.1 request
-document provided by a HTTP POST. A SAML (Secure Access Markup Language)[[7](#7)] 1.1
+document provided by an HTTP POST. A SAML (Secure Access Markup Language)[[7](#7)] 1.1
 response document MUST be returned. This allows the release of additional
 information (attributes) of the authenticated NetID. The Security Assertion
 Markup Language (SAML) describes a document and protocol framework by which
@@ -1391,7 +1391,7 @@ are both case-sensitive.
 
 ### **4.2.2 HTTP Request Method and Body**
 
-Request to /samlValidate MUST be a HTTP POST request. The request body MUST be a valid
+Request to /samlValidate MUST be an HTTP POST request. The request body MUST be a valid
 SAML 1.0 or 1.1 request XML document of document type "text/xml".
 
 

--- a/docs/cas-server-documentation/protocol/CAS-Protocol-V2-Specification.md
+++ b/docs/cas-server-documentation/protocol/CAS-Protocol-V2-Specification.md
@@ -24,7 +24,7 @@ Copyright © 2005, Yale University
 This is the official specification of the CAS 1.0 and 2.0 protocols. It is subject to change.
 
 ## 1.1. Conventions & Definitions
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
 and "OPTIONAL" in this document are to be interpreted as described in RFC 2119[1].
 
 * "Client" refers to the end user and/or the web browser.
@@ -61,7 +61,7 @@ to present credentials regardless of the existence of a single sign-on session w
 with the "gateway" parameter. Services redirecting to the */login* URI and login form views posting to the */login* URI
 SHOULD NOT set both the "renew" and "gateway" request parameters. Behavior is undefined if both are set. It is RECOMMENDED
 that CAS implementations ignore the "gateway" parameter if "renew" is set. It is RECOMMENDED that when the renew parameter
-is set itsvalue be "true".
+is set, its value be "true".
 3. `gateway [OPTIONAL]` - if this parameter is set, CAS will not ask the client for credentials. If the client has a pre-existing
 single sign-on session with CAS, or if a single sign-on session can be established through non-interactive means
 (i.e. trust authentication), CAS MAY redirect the client to the URL specified by the "service" parameter, appending a valid

--- a/docs/cas-server-documentation/release_notes/RC4.md
+++ b/docs/cas-server-documentation/release_notes/RC4.md
@@ -35,7 +35,7 @@ maintenance and release planning, especially when it comes to addressing critica
 ## System Requirements
 
 The JDK baseline requirement for this CAS release is and **MUST** be JDK `17`. All compatible distributions
-such as Amazon Corretto, Zulu, eclipse Temurin, etc should work and are implicitly supported.
+such as Amazon Corretto, Zulu, Eclipse Temurin, etc should work and are implicitly supported.
 
 ## New & Noteworthy
 


### PR DESCRIPTION
Firstly, I was about to fix just `This page MUST include a form with the parameters, "username", "password", and "lt"` which doesn't seem to be true (as LT is no longer used by CAS itself), in the "docs/cas-server-documentation/protocol/CAS-Protocol-Specification.md". But then IDEA gave me hints on some other typos, so I decided to fix some of them beforehand.

I have focused basically on some basic MD files + fixed some of the typos also in other MD files by using "Replace in files"...