### PR TITLE
Handle open cursor electro fence

### DIFF
--- a/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculator.java
+++ b/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculator.java
@@ -53,14 +53,17 @@ public abstract class BaseAuthenticationRequestRiskCalculator implements Authent
                 return getCasTicketGrantingTicketCreatedEventsFor(principal.getId());
             }
         };
-        try (val eventStream = events.get()) {
-            if (eventStream.findAny().isEmpty()) {
-                return new AuthenticationRiskScore(HIGHEST_RISK_SCORE);
-            }
+
+        if (doesNotHaveEvents(events)) {
+            return new AuthenticationRiskScore(HIGHEST_RISK_SCORE);
         }
         val score = new AuthenticationRiskScore(calculateScore(request, authentication, service, events));
         LOGGER.debug("Calculated authentication risk score by [{}] is [{}]", getClass().getSimpleName(), score);
         return score;
+    }
+
+    protected boolean doesNotHaveEvents(final Supplier<Stream<? extends CasEvent>> events) {
+        return events.get().findAny().isEmpty();
     }
 
     /**

--- a/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculator.java
+++ b/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculator.java
@@ -53,9 +53,10 @@ public abstract class BaseAuthenticationRequestRiskCalculator implements Authent
                 return getCasTicketGrantingTicketCreatedEventsFor(principal.getId());
             }
         };
-
-        if (events.get().findAny().isEmpty()) {
-            return new AuthenticationRiskScore(HIGHEST_RISK_SCORE);
+        try (val eventStream = events.get()) {
+            if (eventStream.findAny().isEmpty()) {
+                return new AuthenticationRiskScore(HIGHEST_RISK_SCORE);
+            }
         }
         val score = new AuthenticationRiskScore(calculateScore(request, authentication, service, events));
         LOGGER.debug("Calculated authentication risk score by [{}] is [{}]", getClass().getSimpleName(), score);

--- a/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculator.java
+++ b/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/calcs/BaseAuthenticationRequestRiskCalculator.java
@@ -63,7 +63,9 @@ public abstract class BaseAuthenticationRequestRiskCalculator implements Authent
     }
 
     protected boolean doesNotHaveEvents(final Supplier<Stream<? extends CasEvent>> events) {
-        return events.get().findAny().isEmpty();
+        try (val stream = events.get()){
+            return stream.findAny().isEmpty();
+        }
     }
 
     /**

--- a/support/cas-server-support-electrofence/src/test/java/org/apereo/cas/impl/calcs/DateTimeAuthenticationRequestRiskCalculatorTests.java
+++ b/support/cas-server-support-electrofence/src/test/java/org/apereo/cas/impl/calcs/DateTimeAuthenticationRequestRiskCalculatorTests.java
@@ -61,8 +61,7 @@ public class DateTimeAuthenticationRequestRiskCalculatorTests extends BaseAuthen
         val events = new Supplier<Stream<? extends CasEvent>>() {
             @Override
             public Stream<? extends CasEvent> get() {
-                val iterator = getCloseableIterator(list, closeCalls);
-                return StreamSupport.stream(iterator.spliterator(), false);
+                return getCloseableIterator(list, closeCalls).stream();
             }
         };
         val newList = events.get().collect(Collectors.toList());
@@ -70,12 +69,12 @@ public class DateTimeAuthenticationRequestRiskCalculatorTests extends BaseAuthen
         assertTrue(!closeCalls.isEmpty());
         closeCalls.clear();
         val calculator = new DateTimeAuthenticationRequestRiskCalculator(casEventRepository, casProperties);
-        assertTrue(calculator.hasEvents(events));
+        assertTrue(!calculator.doesNotHaveEvents(events));
         assertTrue(!closeCalls.isEmpty());
 
     }
 
-    private static CloseableIterator<CasEvent> getCloseableIterator(final List<CasEvent> list, final List<Boolean> closeCalls) {
+    private CloseableIterator<CasEvent> getCloseableIterator(final List<CasEvent> list, final List<Boolean> closeCalls) {
         return new CloseableIterator<CasEvent>(){
             private Iterator<CasEvent> iterator = list.iterator();
             @Override
@@ -102,6 +101,5 @@ public class DateTimeAuthenticationRequestRiskCalculatorTests extends BaseAuthen
             }
         };
     }
-
 
 }

--- a/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
+++ b/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
@@ -1,17 +1,36 @@
 package org.apereo.cas.support.events.mongo;
 
+
+
 import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.MongoDbEventsConfiguration;
+import org.apereo.cas.mock.MockTicketGrantingTicket;
+import org.apereo.cas.support.events.AbstractCasEvent;
 import org.apereo.cas.support.events.AbstractCasEventRepositoryTests;
 import org.apereo.cas.support.events.CasEventRepository;
+import org.apereo.cas.support.events.dao.CasEvent;
+import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
+import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
 
 import lombok.Getter;
+import lombok.val;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import java.time.Instant;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases for {@link MongoDbCasEventRepository}.
@@ -21,24 +40,87 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
  */
 @Tag("MongoDb")
 @SpringBootTest(classes = {
-    MongoDbEventsConfiguration.class,
-    CasCoreHttpConfiguration.class,
-    RefreshAutoConfiguration.class
+        MongoDbEventsConfiguration.class,
+        CasCoreHttpConfiguration.class,
+        RefreshAutoConfiguration.class
 },
-    properties = {
-        "cas.events.mongo.user-id=root",
-        "cas.events.mongo.password=secret",
-        "cas.events.mongo.host=localhost",
-        "cas.events.mongo.port=27017",
-        "cas.events.mongo.authentication-database-name=admin",
-        "cas.events.mongo.database-name=events",
-        "cas.events.mongo.drop-collection=true"
-    })
+        properties = {
+                "cas.events.mongo.user-id=root",
+                "cas.events.mongo.password=secret",
+                "cas.events.mongo.host=localhost",
+                "cas.events.mongo.port=27017",
+                "cas.events.mongo.authentication-database-name=admin",
+                "cas.events.mongo.database-name=events",
+                "cas.events.mongo.drop-collection=true"
+        })
 @Getter
 @EnabledIfListeningOnPort(port = 27017)
 public class MongoDbCasEventRepositoryTests extends AbstractCasEventRepositoryTests {
 
+    private static final int NUM_OF_EVENTS_LARGER_THAN_MIN_BATCH_SIZE = 103;
+
     @Autowired
     @Qualifier(CasEventRepository.BEAN_NAME)
     private CasEventRepository eventRepository;
+
+    @Autowired
+    @Qualifier("mongoEventsTemplate")
+    private MongoTemplate mongoTemplate;
+
+    private long currentCount;
+
+
+    @BeforeEach
+    public void setup() throws Exception {
+        currentCount = getOpenCursorCount();
+        val tgt = new MockTicketGrantingTicket("casuser");
+        val event = new CasTicketGrantingTicketCreatedEvent(this, tgt, null);
+        for (var x = 0; x < NUM_OF_EVENTS_LARGER_THAN_MIN_BATCH_SIZE; x++) {
+            val dto = prepareCasEvent(event);
+            dto.setCreationTime(event.getTicketGrantingTicket().getCreationTime().toString());
+            dto.putEventId(event.getTicketGrantingTicket().getId());
+            dto.setPrincipalId(event.getTicketGrantingTicket().getAuthentication().getPrincipal().getId());
+            eventRepository.save(dto);
+        }
+    }
+
+    @Test
+    public void makeSureCursorsGetClosed() throws Exception {
+        val stream = eventRepository.load();
+        assertNotNull(stream);
+        val noValues = stream.findAny().isEmpty();
+        assertFalse(noValues);
+        assertEquals(currentCount, getOpenCursorCount());
+
+    }
+
+    @Test
+    public void makeSureCursorsGetClosedIterateThroughStream() throws Exception {
+        val stream = eventRepository.load();
+        assertNotNull(stream);
+        val aList = stream.collect(Collectors.toList());
+        assertTrue(!aList.isEmpty());
+        assertEquals(currentCount, getOpenCursorCount());
+
+    }
+
+    private CasEvent prepareCasEvent(final AbstractCasEvent event) {
+        val dto = new CasEvent();
+        dto.setType(event.getClass().getCanonicalName());
+        dto.putTimestamp(event.getTimestamp());
+        val dt = DateTimeUtils.zonedDateTimeOf(Instant.ofEpochMilli(event.getTimestamp()));
+        dto.setCreationTime(dt.toString());
+        return dto;
+    }
+
+    public long getOpenCursorCount() {
+        var cmd = new Document("serverStatus", 1);
+        cmd.append("metrics", true);
+        cmd.append("cursor", true);
+        var result = mongoTemplate.executeCommand(cmd);
+        var open = (Document) result.get("metrics", Document.class).get("cursor", Document.class).get("open", Document.class);
+        return open.getLong("total");
+    }
+
+
 }

--- a/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
+++ b/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
@@ -86,10 +86,11 @@ public class MongoDbCasEventRepositoryTests extends AbstractCasEventRepositoryTe
 
     @Test
     public void makeSureCursorsGetClosed() throws Exception {
-        val stream = eventRepository.load();
-        assertNotNull(stream);
-        val noValues = stream.findAny().isEmpty();
-        assertFalse(noValues);
+        try (val stream = eventRepository.load()) {
+            assertNotNull(stream);
+            val noValues = stream.findAny().isEmpty();
+            assertFalse(noValues);
+        }
         assertEquals(currentCount, getOpenCursorCount());
 
     }

--- a/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
+++ b/support/cas-server-support-events-mongo/src/test/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepositoryTests.java
@@ -1,36 +1,17 @@
 package org.apereo.cas.support.events.mongo;
 
-
-
 import org.apereo.cas.config.CasCoreHttpConfiguration;
 import org.apereo.cas.config.MongoDbEventsConfiguration;
-import org.apereo.cas.mock.MockTicketGrantingTicket;
-import org.apereo.cas.support.events.AbstractCasEvent;
 import org.apereo.cas.support.events.AbstractCasEventRepositoryTests;
 import org.apereo.cas.support.events.CasEventRepository;
-import org.apereo.cas.support.events.dao.CasEvent;
-import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
-import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
 
 import lombok.Getter;
-import lombok.val;
-import org.bson.Document;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import java.time.Instant;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases for {@link MongoDbCasEventRepository}.
@@ -40,88 +21,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Tag("MongoDb")
 @SpringBootTest(classes = {
-        MongoDbEventsConfiguration.class,
-        CasCoreHttpConfiguration.class,
-        RefreshAutoConfiguration.class
+    MongoDbEventsConfiguration.class,
+    CasCoreHttpConfiguration.class,
+    RefreshAutoConfiguration.class
 },
-        properties = {
-                "cas.events.mongo.user-id=root",
-                "cas.events.mongo.password=secret",
-                "cas.events.mongo.host=localhost",
-                "cas.events.mongo.port=27017",
-                "cas.events.mongo.authentication-database-name=admin",
-                "cas.events.mongo.database-name=events",
-                "cas.events.mongo.drop-collection=true"
-        })
+    properties = {
+        "cas.events.mongo.user-id=root",
+        "cas.events.mongo.password=secret",
+        "cas.events.mongo.host=localhost",
+        "cas.events.mongo.port=27017",
+        "cas.events.mongo.authentication-database-name=admin",
+        "cas.events.mongo.database-name=events",
+        "cas.events.mongo.drop-collection=true"
+    })
 @Getter
 @EnabledIfListeningOnPort(port = 27017)
 public class MongoDbCasEventRepositoryTests extends AbstractCasEventRepositoryTests {
 
-    private static final int NUM_OF_EVENTS_LARGER_THAN_MIN_BATCH_SIZE = 103;
-
     @Autowired
     @Qualifier(CasEventRepository.BEAN_NAME)
     private CasEventRepository eventRepository;
-
-    @Autowired
-    @Qualifier("mongoEventsTemplate")
-    private MongoTemplate mongoTemplate;
-
-    private long currentCount;
-
-
-    @BeforeEach
-    public void setup() throws Exception {
-        currentCount = getOpenCursorCount();
-        val tgt = new MockTicketGrantingTicket("casuser");
-        val event = new CasTicketGrantingTicketCreatedEvent(this, tgt, null);
-        for (var x = 0; x < NUM_OF_EVENTS_LARGER_THAN_MIN_BATCH_SIZE; x++) {
-            val dto = prepareCasEvent(event);
-            dto.setCreationTime(event.getTicketGrantingTicket().getCreationTime().toString());
-            dto.putEventId(event.getTicketGrantingTicket().getId());
-            dto.setPrincipalId(event.getTicketGrantingTicket().getAuthentication().getPrincipal().getId());
-            eventRepository.save(dto);
-        }
-    }
-
-    @Test
-    public void makeSureCursorsGetClosed() throws Exception {
-        try (val stream = eventRepository.load()) {
-            assertNotNull(stream);
-            val noValues = stream.findAny().isEmpty();
-            assertFalse(noValues);
-        }
-        assertEquals(currentCount, getOpenCursorCount());
-
-    }
-
-    @Test
-    public void makeSureCursorsGetClosedIterateThroughStream() throws Exception {
-        val stream = eventRepository.load();
-        assertNotNull(stream);
-        val aList = stream.collect(Collectors.toList());
-        assertTrue(!aList.isEmpty());
-        assertEquals(currentCount, getOpenCursorCount());
-
-    }
-
-    private CasEvent prepareCasEvent(final AbstractCasEvent event) {
-        val dto = new CasEvent();
-        dto.setType(event.getClass().getCanonicalName());
-        dto.putTimestamp(event.getTimestamp());
-        val dt = DateTimeUtils.zonedDateTimeOf(Instant.ofEpochMilli(event.getTimestamp()));
-        dto.setCreationTime(dt.toString());
-        return dto;
-    }
-
-    public long getOpenCursorCount() {
-        var cmd = new Document("serverStatus", 1);
-        cmd.append("metrics", true);
-        cmd.append("cursor", true);
-        var result = mongoTemplate.executeCommand(cmd);
-        var open = (Document) result.get("metrics", Document.class).get("cursor", Document.class).get("open", Document.class);
-        return open.getLong("total");
-    }
-
-
 }


### PR DESCRIPTION
- [X] Brief description of changes applied
 I modified the check to see if there are events to use try-with-resources.
Why?
The stream method in MongoDbTemplate can contain an open cursors to the database. The stream, if not properly closed, can lead to leaks of resources (leaving the cursor open).  Under sustained high authentication load, and with all 4 RiskCalculator implementations enabled, this can cause the db to run out of open cursors blocking until the db eventually cleans them up.
- [X] Test cases for all modified changes, where applicable
I didn't keep the test case I wrote showing this is possible, but if you checkout https://github.com/dmalia1/cas/commit/42bb6e5ed2399f5428c264bbc3cffcf04d721ad8, and run the mongodb tests, you will see the test failing.  There is also a successful test doing something that causes the closable interface to trigger the close method. (iterate through all results).  The failing test just calls stream().findAny(), which doesn't iterate through all the results, and just returns the first thing encountered.  The stream fails to get closed.   This commit https://github.com/dmalia1/cas/commit/133be4b2d42174d8f62a5cbfdc0455fcacf407cb shows the test successfully executing.   I chose to not keep the unit tests because the actual code change is in the electrofence package.  That said it does demonstrate the cursors leaking.

I created a different failing test in the cas-sserver-support-electrofence package that was kept. https://github.com/dmalia1/cas/commit/77b02b4dcc9927bcc36e463815a5878b78d2506a This test creates a 'ClosableIterator' instance to simulate getting a stream from a CasEventRepository instance.  It makes a call to 'collect' everything in the iterator to show that the iterator gets closed, then it calls the 'BaseAuthenticationRequestCalculator.doesNotHaveEvents()' method to check if there are events.  The test fails because the 'close' method on the ClosableIterator doesn't get called.  I then updated the doesNotHaveEvents method to make use of try-with-resources to ensure the iterator is closed, and thus causing the test to pass.
- [X] Any documentation on how to configure, test
To view the mongodb cursors getting left open in general, you can check out this commit https://github.com/dmalia1/cas/commit/42bb6e5ed2399f5428c264bbc3cffcf04d721ad8 and run "testcas.sh --category mongodb"

To view BaseAuthenticationRequestRiskCalculator having the same issue, checkout out https://github.com/dmalia1/cas/commit/77b02b4dcc9927bcc36e463815a5878b78d2506a and run "testcas.sh --category authentication"  To verify the test is working checkout https://github.com/dmalia1/cas/tree/handleOpenCursorElectroFence and run "testcas.sh --category authentication"
- [X] Any possible limitations, side effects, etc
There shouldn't really be any side effects with this implementation.  

A limitation is nothing is preventing a data resource leakage like this from occurring again.  Its best practice to 'close' streams that make use of I/O resources to prevent resource leakage, and a lot of places in the code assume the stream is getting closed, but may not be if the entire stream is not processed e.g. stream.findFirst() may also cause this issue.  The MongoDB implementation could mitigate risk by overriding the DefaultCasMongoDbTemplate.doStream method to collect the stream into a Collection, then return a stream of the collection.  The HibernateJPA implementation may have a similar issue as the MongoDB implementation, just based off of the documentation at https://docs.jboss.org/hibernate/orm/6.1/javadocs/org/hibernate/query/Query.html#stream().  I do understand there may be performance reasons for not collecting it all at once.  


