### PR TITLE
fix refresh_token expiration policy per service

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactory.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactory.java
@@ -45,9 +45,15 @@ public class OAuth20DefaultRefreshTokenFactory implements OAuth20RefreshTokenFac
      */
     protected final ServicesManager servicesManager;
 
+    /**
+     * Indicates whether RefreshToken issued and linked to a ticket-granting ticket
+     * should also be removed as part of logout
+     */
+    protected final  boolean removeDescendantTickets;
+
     public OAuth20DefaultRefreshTokenFactory(final ExpirationPolicyBuilder<OAuth20RefreshToken> expirationPolicy,
                                              final ServicesManager servicesManager) {
-        this(new DefaultUniqueTicketIdGenerator(), expirationPolicy, servicesManager);
+        this(new DefaultUniqueTicketIdGenerator(), expirationPolicy, servicesManager, false);
     }
 
     @Override
@@ -78,7 +84,9 @@ public class OAuth20DefaultRefreshTokenFactory implements OAuth20RefreshTokenFac
             val policy = registeredService.getRefreshTokenExpirationPolicy();
             val timeToKill = policy.getTimeToKill();
             if (StringUtils.isNotBlank(timeToKill)) {
-                return new OAuth20RefreshTokenExpirationPolicy(Beans.newDuration(timeToKill).getSeconds());
+                long timeToKillInSeconds = Beans.newDuration(timeToKill).getSeconds();
+                return removeDescendantTickets ? new OAuth20RefreshTokenExpirationPolicy(timeToKillInSeconds) :
+                    new OAuth20RefreshTokenExpirationPolicy.OAuthRefreshTokenStandaloneExpirationPolicy(timeToKillInSeconds);
             }
         }
         return this.expirationPolicy.buildTicketExpirationPolicy();

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -1246,9 +1246,11 @@ public class CasOAuth20Configuration {
             @Qualifier("refreshTokenExpirationPolicy")
             final ExpirationPolicyBuilder refreshTokenExpirationPolicy,
             @Qualifier(ServicesManager.BEAN_NAME)
-            final ServicesManager servicesManager) {
+            final ServicesManager servicesManager,
+            final CasConfigurationProperties casProperties) {
             return new OAuth20DefaultRefreshTokenFactory(refreshTokenIdGenerator,
-                refreshTokenExpirationPolicy, servicesManager);
+                refreshTokenExpirationPolicy, servicesManager,
+                casProperties.getLogout().isRemoveDescendantTickets());
         }
 
         @Bean

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactoryTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactoryTests.java
@@ -36,6 +36,7 @@ public class OAuth20DefaultRefreshTokenFactoryTests extends AbstractOAuth20Tests
             Set.of("Scope1", "Scope2"), "clientid-rt",
             "at-1234567890", Map.of(), OAuth20ResponseTypes.CODE, OAuth20GrantTypes.AUTHORIZATION_CODE);
         assertNotNull(token);
+        assertEquals(OAuth20RefreshTokenExpirationPolicy.OAuthRefreshTokenStandaloneExpirationPolicy.class, token.getExpirationPolicy().getClass());
         assertNotNull(defaultAccessTokenFactory.get(OAuth20RefreshToken.class));
     }
 }


### PR DESCRIPTION
Currently, when we set a `refreshTokenExpirationPolicy` in an OAuth2 service, an `OAuth20RefreshTokenExpirationPolicy` is created regardless of the `removeDescendantTickets` setting (which is `false` by default).

The consequence is that `refresh_token` cannot be used when the associated TGT no longer exists (CAS considers `refresh_token` to be expired).

The fix creates the correct ExpirationPolicy based on the `removeDescendantTickets` setting.