### PR TITLE
fix refresh_token expiration policy per service

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactory.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactory.java
@@ -45,9 +45,15 @@ public class OAuth20DefaultRefreshTokenFactory implements OAuth20RefreshTokenFac
      */
     protected final ServicesManager servicesManager;
 
+    /**
+     * Indicates whether RefreshToken issued and linked to a ticket-granting ticket
+     * should also be removed as part of logout
+     */
+    protected final  boolean removeDescendantTickets;
+
     public OAuth20DefaultRefreshTokenFactory(final ExpirationPolicyBuilder<OAuth20RefreshToken> expirationPolicy,
                                              final ServicesManager servicesManager) {
-        this(new DefaultUniqueTicketIdGenerator(), expirationPolicy, servicesManager);
+        this(new DefaultUniqueTicketIdGenerator(), expirationPolicy, servicesManager, false);
     }
 
     @Override
@@ -78,7 +84,9 @@ public class OAuth20DefaultRefreshTokenFactory implements OAuth20RefreshTokenFac
             val policy = registeredService.getRefreshTokenExpirationPolicy();
             val timeToKill = policy.getTimeToKill();
             if (StringUtils.isNotBlank(timeToKill)) {
-                return new OAuth20RefreshTokenExpirationPolicy(Beans.newDuration(timeToKill).getSeconds());
+                long timeToKillInSeconds = Beans.newDuration(timeToKill).getSeconds();
+                return removeDescendantTickets ? new OAuth20RefreshTokenExpirationPolicy(timeToKillInSeconds) :
+                    new OAuth20RefreshTokenExpirationPolicy.OAuthRefreshTokenStandaloneExpirationPolicy(timeToKillInSeconds);
             }
         }
         return this.expirationPolicy.buildTicketExpirationPolicy();

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactory.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactory.java
@@ -46,8 +46,7 @@ public class OAuth20DefaultRefreshTokenFactory implements OAuth20RefreshTokenFac
     protected final ServicesManager servicesManager;
 
     /**
-     * Indicates whether RefreshToken issued and linked to a ticket-granting ticket
-     * should also be removed as part of logout
+     * Indicates whether token expiration policy should be standalone or not
      */
     protected final  boolean removeDescendantTickets;
 

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -1246,9 +1246,11 @@ public class CasOAuth20Configuration {
             @Qualifier("refreshTokenExpirationPolicy")
             final ExpirationPolicyBuilder refreshTokenExpirationPolicy,
             @Qualifier(ServicesManager.BEAN_NAME)
-            final ServicesManager servicesManager) {
+            final ServicesManager servicesManager,
+            final CasConfigurationProperties casProperties) {
             return new OAuth20DefaultRefreshTokenFactory(refreshTokenIdGenerator,
-                refreshTokenExpirationPolicy, servicesManager);
+                refreshTokenExpirationPolicy, servicesManager,
+                casProperties.getLogout().isRemoveDescendantTickets());
         }
 
         @Bean

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactorySovereignExpirationPolicyTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactorySovereignExpirationPolicyTests.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * This is {@link OAuth20DefaultRefreshTokenFactorySovereignExpirationPolicyTests}.
  *
- * @since 6.2.0
+ * @since 7.0.0
  */
 @Tag("OAuthToken")
 @TestPropertySource(properties = "cas.logout.remove-descendant-tickets=false")

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactorySovereignExpirationPolicyTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactorySovereignExpirationPolicyTests.java
@@ -19,14 +19,13 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This is {@link OAuth20DefaultRefreshTokenFactoryTests}.
+ * This is {@link OAuth20DefaultRefreshTokenFactorySovereignExpirationPolicyTests}.
  *
- * @author Misagh Moayyed
  * @since 6.2.0
  */
 @Tag("OAuthToken")
-@TestPropertySource(properties = "cas.logout.remove-descendant-tickets=true")
-public class OAuth20DefaultRefreshTokenFactoryTests extends AbstractOAuth20Tests {
+@TestPropertySource(properties = "cas.logout.remove-descendant-tickets=false")
+public class OAuth20DefaultRefreshTokenFactorySovereignExpirationPolicyTests extends AbstractOAuth20Tests {
     @Test
     public void verifyOperationWithExpPolicy() {
         val registeredService = getRegisteredService("https://rt.oauth.org", "clientid-rt", "secret-at");
@@ -44,7 +43,7 @@ public class OAuth20DefaultRefreshTokenFactoryTests extends AbstractOAuth20Tests
 
         assertFalse(token.isExpired(), "Refresh token should not be expired");
         tgt.markTicketExpired();
-        assertTrue(token.isExpired(),
-            "Refresh token must expire when TGT is expired and removeDescendantTickets is true");
+        assertFalse(token.isExpired(),
+            "Refresh token must not expire when TGT is expired and removeDescendantTickets is false");
     }
 }

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactoryTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/ticket/refreshtoken/OAuth20DefaultRefreshTokenFactoryTests.java
@@ -36,6 +36,7 @@ public class OAuth20DefaultRefreshTokenFactoryTests extends AbstractOAuth20Tests
             Set.of("Scope1", "Scope2"), "clientid-rt",
             "at-1234567890", Map.of(), OAuth20ResponseTypes.CODE, OAuth20GrantTypes.AUTHORIZATION_CODE);
         assertNotNull(token);
+        assertEquals(OAuth20RefreshTokenExpirationPolicy.OAuthRefreshTokenStandaloneExpirationPolicy.class, token.getExpirationPolicy().getClass());
         assertNotNull(defaultAccessTokenFactory.get(OAuth20RefreshToken.class));
     }
 }


### PR DESCRIPTION
Currently, when we set a `refreshTokenExpirationPolicy` in an OAuth2 service, an `OAuth20RefreshTokenExpirationPolicy` is created regardless of the `removeDescendantTickets` setting (which is `false` by default).

The consequence is that `refresh_token` cannot be used when the associated TGT no longer exists (CAS considers `refresh_token` to be expired).

The fix creates the correct ExpirationPolicy based on the `removeDescendantTickets` setting.

Related to [PR 5619](https://github.com/apereo/cas/pull/5619) but with more complete tests