### PR TITLE
Fix RequestParameterPolicyEnforcementFilter configuration logic

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/RequestParameterPolicyEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/RequestParameterPolicyEnforcementFilter.java
@@ -207,7 +207,7 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
         if (initParamValue.trim().isEmpty()) {
             logException(new IllegalArgumentException('[' + initParamValue + "] had no tokens but should have had at least one token."));
         }
-        val tokens = Splitter.onPattern("\\s+").splitToList(initParamValue.trim());
+        val tokens = Splitter.onPattern("\\,").splitToList(initParamValue.trim());
         if (allowWildcard && 1 == tokens.size() && "*".equals(tokens.get(0))) {
             return new HashSet<>(0);
         }
@@ -222,10 +222,12 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
     }
 
     /**
-     * Parse a whitespace delimited set of Characters from a String.
+     * Parse a space delimited set of Characters from a String.
      * <p>
      * If the String is "none" parse to empty set meaning block no characters.
      * If the String is empty throw, to avoid configurer accidentally configuring not to block any characters.
+     * <p>
+     * Note that only the space charater should be used as a delimiter, not tabs or newlines.
      *
      * @param value value of the init param to parse
      * @return non-null Set of zero or more Characters to block
@@ -237,7 +239,7 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
         var paramValue = value;
         if (paramValue == null) {
             paramValue = DEFAULT_CHARACTERS_BLOCKED;
-        } else if (paramValue.trim().isEmpty()) {
+        } else if (paramValue.strip().isEmpty()) {
             logException(new IllegalArgumentException("Expected tokens when parsing [" + paramValue + "] but found no tokens."));
         }
 
@@ -245,7 +247,7 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
             return charactersToForbid;
         }
 
-        val tokens = Splitter.onPattern("\\s+").splitToList(paramValue);
+        val tokens = Splitter.onPattern("\\ +").splitToList(paramValue);
         for (val token : tokens) {
             if (token.length() > 1) {
                 logException(new IllegalArgumentException("Expected tokens of length 1 but found [" + token + "] when parsing [" + paramValue + ']'));


### PR DESCRIPTION
* Fix "parameters-to-check" property parsing to be comma-delimited so the default property value will work as expected
* Allow characters below 0x20 to be blocked by the filter by parsing the "characters-to-forbid" property as delimited only by the space character, rather than by any whitespace character

Will do another PR against master when I can get it to compile.