### PR TITLE
add aggregate theme source

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/view/ViewProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/view/ViewProperties.java
@@ -65,6 +65,25 @@ public class ViewProperties implements Serializable {
     private List<String> templatePrefixes = new ArrayList<>(1);
 
     /**
+     * How to search for theme resource bundles and how to deal with multiple property files found for a given theme.
+     * The {@code ThemeSourceTypes.DEFAULT} type uses the first theme resource bundle found across the template prefixes.
+     * The {@code ThemeSourceTypes.AGGREGATE} type combines all the bundles found across template prefixes with the last
+     * prefix overriding the first.
+     */
+    private ThemeSourceTypes themeSourceType = ThemeSourceTypes.DEFAULT;
+
+    public enum ThemeSourceTypes {
+        /**
+         * Theme source that gets the first theme property file found in the prefix locations.
+         */
+        DEFAULT,
+        /**
+         * Theme source that combines all themes property files in all template prefix locations.
+         */
+        AGGREGATE
+    }
+
+    /**
      * CAS1 views and locations.
      */
     @NestedConfigurationProperty

--- a/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/AggregateCasThemeSource.java
+++ b/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/AggregateCasThemeSource.java
@@ -1,0 +1,55 @@
+package org.apereo.cas.services.web;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.util.ResourceUtils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.MessageSource;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.ui.context.support.ResourceBundleThemeSource;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Properties;
+
+/**
+ * This is {@link AggregateCasThemeSource} which merges all the theme resource bundles that it can find.
+ *
+ * @author Hal Deadman
+ * @since 6.6.8
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class AggregateCasThemeSource extends ResourceBundleThemeSource {
+    private final CasConfigurationProperties casProperties;
+
+    @Nonnull
+    @Override
+    protected MessageSource createMessageSource(
+        @Nonnull
+        final String basename) {
+        val source = new StaticMessageSource();
+        source.setParentMessageSource(super.createMessageSource(basename));
+        casProperties.getView().getTemplatePrefixes()
+            .stream()
+            .map(prefix -> StringUtils.appendIfMissing(prefix, "/").concat(basename).concat(".properties"))
+            .filter(ResourceUtils::doesResourceExist)
+            .forEach(path -> {
+                try (val is = ResourceUtils.getRawResourceFrom(path).getInputStream()) {
+                    val properties = new Properties();
+                    properties.load(is);
+                    properties.forEach((key, value) -> {
+                        LOGGER.trace("Loading theme property [{}] from [{}]", key, path);
+                        source.addMessage(key.toString(), Locale.getDefault(), value.toString());
+                    });
+                } catch (final IOException e) {
+                    LOGGER.warn("Error loading resources from bundle: [{}] - [{}]", path, e.getMessage());
+                }
+            });
+        return source;
+    }
+}

--- a/support/cas-server-support-themes/src/main/java/org/apereo/cas/services/web/config/CasThemesConfiguration.java
+++ b/support/cas-server-support-themes/src/main/java/org/apereo/cas/services/web/config/CasThemesConfiguration.java
@@ -3,7 +3,9 @@ package org.apereo.cas.services.web.config;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
+import org.apereo.cas.configuration.model.core.web.view.ViewProperties;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.web.AggregateCasThemeSource;
 import org.apereo.cas.services.web.ChainingThemeResolver;
 import org.apereo.cas.services.web.DefaultCasThemeSource;
 import org.apereo.cas.services.web.RegisteredServiceThemeResolver;
@@ -57,6 +59,9 @@ public class CasThemesConfiguration {
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
     public ThemeSource themeSource(final CasConfigurationProperties casProperties) {
+        if (casProperties.getView().getThemeSourceType().equals(ViewProperties.ThemeSourceTypes.AGGREGATE)) {
+            return new AggregateCasThemeSource(casProperties);
+        }
         return new DefaultCasThemeSource(casProperties);
     }
 

--- a/support/cas-server-support-themes/src/test/java/org/apereo/cas/ThemesTestsSuite.java
+++ b/support/cas-server-support-themes/src/test/java/org/apereo/cas/ThemesTestsSuite.java
@@ -1,5 +1,6 @@
 package org.apereo.cas;
 
+import org.apereo.cas.services.web.AggregateCasThemeSourceTests;
 import org.apereo.cas.services.web.DefaultCasThemeSourceTests;
 import org.apereo.cas.services.web.RegisteredServiceThemeResolverTests;
 import org.apereo.cas.services.web.ServiceThemeResolverTests;
@@ -15,6 +16,7 @@ import org.junit.platform.suite.api.Suite;
  */
 @SelectClasses({
     DefaultCasThemeSourceTests.class,
+    AggregateCasThemeSourceTests.class,
     RegisteredServiceThemeResolverTests.class,
     ServiceThemeResolverTests.class
 })

--- a/support/cas-server-support-themes/src/test/java/org/apereo/cas/services/web/AggregateCasThemeSourceTests.java
+++ b/support/cas-server-support-themes/src/test/java/org/apereo/cas/services/web/AggregateCasThemeSourceTests.java
@@ -1,0 +1,51 @@
+package org.apereo.cas.services.web;
+
+import org.apereo.cas.BaseThemeTests;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+
+import lombok.val;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.ui.context.ThemeSource;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * This is {@link AggregateCasThemeSourceTests}.
+ *
+ * @author Hal Deadman
+ * @since 6.6.8
+ */
+@Tag("Web")
+@SpringBootTest(classes = BaseThemeTests.SharedTestConfiguration.class,
+    properties = {
+                 "cas.view.theme-source-type=AGGREGATE",
+                 "cas.view.template-prefixes[0]=classpath:/ext-templates",
+                 "cas.view.template-prefixes[1]=classpath:/more-ext-templates"
+                 })
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+public class AggregateCasThemeSourceTests {
+    @Autowired
+    @Qualifier("themeSource")
+    private ThemeSource themeSource;
+
+    @Test
+    public void verifyCustomSource() {
+        val theme = themeSource.getTheme("my-theme");
+        assertNotNull(theme);
+        val message = theme.getMessageSource().getMessage("cas.theme.name",
+            ArrayUtils.EMPTY_OBJECT_ARRAY, Locale.getDefault());
+        assertEquals("MyTheme2", message);
+        val message2 = theme.getMessageSource().getMessage("screen.welcome.instructions",
+                ArrayUtils.EMPTY_OBJECT_ARRAY, Locale.getDefault());
+        assertEquals("Test123", message2);
+    }
+}

--- a/support/cas-server-support-themes/src/test/resources/more-ext-templates/my-theme.properties
+++ b/support/cas-server-support-themes/src/test/resources/more-ext-templates/my-theme.properties
@@ -1,0 +1,3 @@
+# MyTheme2 shouldn't be found b/c first resource is used
+cas.theme.name=MyTheme2
+screen.welcome.instructions=Test123


### PR DESCRIPTION
From what I can tell the default theme source for resource bundles only gets the first theme it finds (across the different them prefix locations). I would like to have a default set of values for a theme in the classpath but then override some values in different deployments externally. This PR adds a themeSourceType of "AGGREGATE" that merges all the found bundles for the theme, with the default location used as the parent bundle.

Since the properties are added to the bundle in order that they are found, values from the first template prefixes will be overridden by the same value in later prefixes. That might be different than what happens for other template resources. This could be changed by looping through the template prefixes in reverse order or someone could just store their theme properties in different folders /packages than the templates and just order them the way they want to.

While it might not be backwards compatible for all possible cases, one option would be to change the behavior of the default theme source to aggregate all found resource bundles.