### PR TITLE
update template view resolver

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/config/CasThymeleafConfiguration.java
+++ b/support/cas-server-support-thymeleaf/src/main/java/org/apereo/cas/config/CasThymeleafConfiguration.java
@@ -128,20 +128,23 @@ public class CasThymeleafConfiguration {
         val templatePrefixes = casProperties.getView().getTemplatePrefixes();
         templatePrefixes.forEach(prefix -> {
             try {
-                val prefixPath = ResourceUtils.getFile(prefix).getCanonicalPath();
+                val prefixPath = prefix.startsWith(ResourceUtils.CLASSPATH_URL_PREFIX)
+                        ? prefix
+                        : ResourceUtils.getFile(prefix).getCanonicalPath();
                 val viewPath = StringUtils.appendIfMissing(prefixPath, "/");
                 val theme = prefix.startsWith(ResourceUtils.CLASSPATH_URL_PREFIX)
                     ? new ThemeClassLoaderTemplateResolver(themeResolver)
                     : new ThemeFileTemplateResolver(casProperties, themeResolver);
                 configureTemplateViewResolver(theme, thymeleafProperties);
-                theme.setPrefix(viewPath + "themes/%s/");
+                theme.setPrefix(StringUtils.removeStart(viewPath, ResourceUtils.CLASSPATH_URL_PREFIX) + "themes/%s/");
                 chain.addResolver(theme);
                 val template = prefix.startsWith(ResourceUtils.CLASSPATH_URL_PREFIX) ? new ClassLoaderTemplateResolver() : new FileTemplateResolver();
                 configureTemplateViewResolver(template, thymeleafProperties);
-                template.setPrefix(viewPath);
+                template.setPrefix(StringUtils.removeStart(viewPath, ResourceUtils.CLASSPATH_URL_PREFIX));
                 chain.addResolver(template);
             } catch (final Exception e) {
-                LoggingUtils.warn(LOGGER, String.format("Could not add template prefix '%s' to resolver", prefix), e);
+                LoggingUtils.warn(LOGGER,
+                        String.format("Could not add template prefix '%s' to resolver: [%s]", prefix, e.getMessage()), e);
             }
         });
         val themeCp = new ThemeClassLoaderTemplateResolver(themeResolver);

--- a/support/cas-server-support-thymeleaf/src/test/java/org/apereo/cas/web/view/CasThymeleafConfigurationTests.java
+++ b/support/cas-server-support-thymeleaf/src/test/java/org/apereo/cas/web/view/CasThymeleafConfigurationTests.java
@@ -7,9 +7,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.thymeleaf.IEngineConfiguration;
 import org.thymeleaf.templateresolver.AbstractTemplateResolver;
 
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * This is {@link CasThymeleafConfigurationTests}.
@@ -28,8 +32,15 @@ public class CasThymeleafConfigurationTests {
     @Qualifier("chainingTemplateViewResolver")
     private AbstractTemplateResolver chainingTemplateViewResolver;
 
+    /**
+     * Make sure there are 7 template view resolvers.
+     * Two for each template prefix, one for rest url,and one for a theme folder under templates in the
+     * classpath and one for templates in thymeleaf/templates.
+     */
     @Test
     public void verifyOperation() {
         assertNotNull(chainingTemplateViewResolver);
+        assertEquals(7, ((ChainingTemplateViewResolver) chainingTemplateViewResolver).getResolvers().size());
+        assertNotNull(chainingTemplateViewResolver.resolveTemplate(mock(IEngineConfiguration.class), null, "testTemplate", new HashMap<>()));
     }
 }


### PR DESCRIPTION
```
val prefixPath = ResourceUtils.getFile(prefix).getCanonicalPath();
```
That fails if the classpath template prefix is inside war or jar so this change avoids calling it for classpath entries.

The `ThemeClassLoaderTemplateResolver` doesn't want the `classpath:` prefix so that needs to be stripped off. 