### PR TITLE
Updates mfa-webauthn-register test

### DIFF
--- a/ci/tests/puppeteer/scenarios/mfa-webauthn-register/script.js
+++ b/ci/tests/puppeteer/scenarios/mfa-webauthn-register/script.js
@@ -17,7 +17,7 @@ const cas = require('../../cas.js');
     await cas.assertVisibility(page, '#residentKeysPanel');
     await cas.assertVisibility(page, '#registerDiscoverableCredentialButton');
     let xhrData = page.waitForResponse((r) => r.request().url().includes("/webauthn/register") && r.request().method() !== "OPTIONS");
-    page.click('#registerButton');
+    page.click("#registerButton");
     let xhrResp = await xhrData;
     let xhrResult = JSON.parse(await xhrResp.json());
     

--- a/ci/tests/puppeteer/scenarios/mfa-webauthn-register/script.js
+++ b/ci/tests/puppeteer/scenarios/mfa-webauthn-register/script.js
@@ -16,6 +16,11 @@ const cas = require('../../cas.js');
     await cas.assertVisibility(page, '#registerButton');
     await cas.assertVisibility(page, '#residentKeysPanel');
     await cas.assertVisibility(page, '#registerDiscoverableCredentialButton');
-
+    let xhr_data = page.waitForResponse(r => r.request().url().includes("/webauthn/register") && r.request().method() != 'OPTIONS');
+    page.click('#registerButton');
+    let xhr_resp = await xhr_data;
+    let xhr_result = JSON.parse(await xhr_resp.json());
+    console.log('CAS WebAuthn Register: ', xhr_result);
+    
     await browser.close();
 })();

--- a/ci/tests/puppeteer/scenarios/mfa-webauthn-register/script.js
+++ b/ci/tests/puppeteer/scenarios/mfa-webauthn-register/script.js
@@ -16,11 +16,10 @@ const cas = require('../../cas.js');
     await cas.assertVisibility(page, '#registerButton');
     await cas.assertVisibility(page, '#residentKeysPanel');
     await cas.assertVisibility(page, '#registerDiscoverableCredentialButton');
-    let xhr_data = page.waitForResponse(r => r.request().url().includes("/webauthn/register") && r.request().method() != 'OPTIONS');
+    let xhrData = page.waitForResponse((r) => r.request().url().includes("/webauthn/register") && r.request().method() !== "OPTIONS");
     page.click('#registerButton');
-    let xhr_resp = await xhr_data;
-    let xhr_result = JSON.parse(await xhr_resp.json());
-    console.log('CAS WebAuthn Register: ', xhr_result);
+    let xhrResp = await xhrData;
+    let xhrResult = JSON.parse(await xhrResp.json());
     
     await browser.close();
 })();


### PR DESCRIPTION
This updates the test to ensure it actually attempts to register instead of just testing that the register device page is shown. You can see some of my diagnostics in the below google groups discussion and I just keep getting lost at trying to fix it myself.

You will see the error,

`Console error: Failed to load resource: the server responded with a status of 403 ()`
`Console error: Registration failed JSHandle@error`
`Console: SyntaxError: No number after minus sign in JSON at position 1`
`SyntaxError: Unexpected number in JSON at position 1`

[https://groups.google.com/a/apereo.org/g/cas-user/c/wTEKfdz4Tc8](https://groups.google.com/a/apereo.org/g/cas-user/c/wTEKfdz4Tc8)

