### PR TITLE
WIP - SAML NPE when sp metadata doesn't contain nameid

### DIFF
--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/SamlRegisteredServiceServiceProviderMetadataFacade.java
@@ -35,6 +35,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -219,7 +220,9 @@ public class SamlRegisteredServiceServiceProviderMetadataFacade {
         val children = this.ssoDescriptor.getOrderedChildren();
         if (children != null) {
             nameIdFormats.addAll(children.stream().filter(NameIDFormat.class::isInstance)
-                .map(child -> ((NameIDFormat) child).getURI()).collect(Collectors.toList()));
+                .map(child -> ((NameIDFormat) child).getURI())
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()));
         }
         return nameIdFormats;
     }

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/nameid/SamlProfileSamlNameIdBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/nameid/SamlProfileSamlNameIdBuilder.java
@@ -218,7 +218,7 @@ public class SamlProfileSamlNameIdBuilder extends AbstractSaml20ObjectBuilder im
 
     private String getNameIdValueFromNameFormat(final String nameFormat,
                                                 final SamlProfileBuilderContext context) {
-        if (nameFormat.trim().equalsIgnoreCase(NameIDType.TRANSIENT)) {
+        if (NameIDType.TRANSIENT.equalsIgnoreCase(StringUtils.trim(nameFormat))) {
             val entityId = context.getAdaptor().getEntityId();
             if (context.getRegisteredService().isSkipGeneratingTransientNameId()) {
                 LOGGER.debug("Generation of transient NameID value is skipped for [{}] and [{}] will be used instead",

--- a/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/RegisteredServiceThemeResolver.java
+++ b/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/RegisteredServiceThemeResolver.java
@@ -149,7 +149,7 @@ public class RegisteredServiceThemeResolver extends AbstractThemeResolver {
             .stream()
             .map(prefix -> StringUtils.appendIfMissing(prefix, "/").concat(theme).concat(".properties"))
             .anyMatch(ResourceUtils::doesResourceExist)) {
-            LOGGER.trace("Found custom extrnal theme [{}] for service [{}]", theme, registeredService.getName());
+            LOGGER.trace("Found custom external theme [{}] for service [{}]", theme, registeredService.getName());
             return theme;
         }
 


### PR DESCRIPTION
An application I am using produces SP metadata with no NameID in the metadata and a short expiration that requires me to use a url to download it from the server (via service metadataLocation). Based on debug output, the `supportedNameFormats` collection contains a null entry and my theory is that a NameIDFormat must be getting created somewhere with a null URI. I haven't figured out where that is yet and haven't been able to re-create in a unit test yet. 

```
2023-04-27 13:22:49,380 WARN [org.apereo.cas.support.saml.web.idp.profile.builders.nameid.SamlProfileSamlNameIdBuilder] - <Required NameID format [urn:oasis:names:tc:SAML:2.0:nameid-format:transient] in the AuthN request issued by [https://rke2.mgmt.example.com/v1-saml/shibboleth/saml/metadata] is not supported based on the metadata for [https://rke2.mgmt.example.com/v1-saml/shibboleth/saml/metadata]. The requested NameID format may not be honored. You should consult the metadata for this service and ensure the requested NameID format is present in the collection of supported metadata formats in the metadata, which are the following: [[null]]>
2023-04-27 13:22:49,380 DEBUG [org.apereo.cas.support.saml.web.idp.profile.builders.nameid.SamlProfileSamlNameIdBuilder] - <Evaluating NameID format [null]>
2023-04-27 13:22:49,380 DEBUG [org.apereo.cas.support.saml.web.idp.profile.builders.nameid.SamlProfileSamlNameIdBuilder] - <Preparing NameID attribute for principal [deadmanh]>
2023-04-27 13:22:49,380 ERROR [org.apereo.cas.support.saml.web.idp.profile.builders.nameid.SamlProfileSamlNameIdBuilder] - <Cannot invoke "String.trim()" because "nameFormat" is null>
2023-04-27 13:22:49,380 WARN [org.apereo.cas.support.saml.web.idp.profile.builders.nameid.SamlProfileSamlNameIdBuilder] - <No NameID could be determined based on the supported formats [[null]]>
```