### PR TITLE
update saml to avoid unnecessary stack trace

### DIFF
--- a/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
+++ b/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
@@ -384,6 +384,10 @@ public abstract class AbstractSaml20ObjectBuilder extends AbstractSamlObjectBuil
 
         if (StringUtils.isNotBlank(recipient)) {
             data.setRecipient(recipient);
+            val ip = InetAddressUtils.getByName(recipient);
+            if (ip != null) {
+                data.setAddress(ip.getHostName());
+            }
         }
 
         if (notOnOrAfter != null) {
@@ -392,10 +396,6 @@ public abstract class AbstractSaml20ObjectBuilder extends AbstractSamlObjectBuil
 
         if (StringUtils.isNotBlank(inResponseTo)) {
             data.setInResponseTo(inResponseTo);
-            val ip = InetAddressUtils.getByName(inResponseTo);
-            if (ip != null) {
-                data.setAddress(ip.getHostName());
-            }
         }
 
         if (notBefore != null) {

--- a/support/cas-server-support-saml-core/src/test/java/org/apereo/cas/support/saml/util/NonInflatingSaml20ObjectBuilderTests.java
+++ b/support/cas-server-support-saml-core/src/test/java/org/apereo/cas/support/saml/util/NonInflatingSaml20ObjectBuilderTests.java
@@ -142,7 +142,7 @@ public class NonInflatingSaml20ObjectBuilderTests {
         val id = builder.getNameID(NameIDType.UNSPECIFIED, "casuser");
         val subjectId = builder.getNameID(NameIDType.UNSPECIFIED, "casuser");
         val sub = builder.newSubject(id, subjectId, "cas", ZonedDateTime.now(ZoneOffset.UTC),
-            "https://github.com", ZonedDateTime.now(ZoneOffset.UTC));
+            "2ab8d364-7d6a-4e3e-ab17-c48b87c487e2", ZonedDateTime.now(ZoneOffset.UTC));
         assertNotNull(sub);
     }
 

--- a/support/cas-server-support-saml-core/src/test/java/org/apereo/cas/support/saml/util/NonInflatingSaml20ObjectBuilderTests.java
+++ b/support/cas-server-support-saml-core/src/test/java/org/apereo/cas/support/saml/util/NonInflatingSaml20ObjectBuilderTests.java
@@ -141,8 +141,18 @@ public class NonInflatingSaml20ObjectBuilderTests {
         val builder = new NonInflatingSaml20ObjectBuilder(openSamlConfigBean);
         val id = builder.getNameID(NameIDType.UNSPECIFIED, "casuser");
         val subjectId = builder.getNameID(NameIDType.UNSPECIFIED, "casuser");
-        val sub = builder.newSubject(id, subjectId, "cas", ZonedDateTime.now(ZoneOffset.UTC),
+        val sub = builder.newSubject(id, subjectId, "https://www.apereo.org/app/sp", ZonedDateTime.now(ZoneOffset.UTC),
             "2ab8d364-7d6a-4e3e-ab17-c48b87c487e2", ZonedDateTime.now(ZoneOffset.UTC));
+        assertNotNull(sub);
+    }
+
+    @Test
+    public void verifySubjectNoRecipient() {
+        val builder = new NonInflatingSaml20ObjectBuilder(openSamlConfigBean);
+        val id = builder.getNameID(NameIDType.UNSPECIFIED, "casuser");
+        val subjectId = builder.getNameID(NameIDType.UNSPECIFIED, "casuser");
+        val sub = builder.newSubject(id, subjectId, null, ZonedDateTime.now(ZoneOffset.UTC),
+                "2ab8d364-7d6a-4e3e-ab17-c48b87c487e2", ZonedDateTime.now(ZoneOffset.UTC));
         assertNotNull(sub);
     }
 


### PR DESCRIPTION
I was seeing stack trace warnings logged during a saml login when the code was trying to parse a guid in the `inResponseTo` as a URL. This change tries to get an IP address by parsing the `recipient` which can be URL if it isn't blank. If there is a scenario where the `inResponseTo` starts with a URL, maybe we could parse it if it contains a colon? 