### PR TITLE
JpaTicketEntity for MariaDB

### DIFF
--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketEntityFactory.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketEntityFactory.java
@@ -9,6 +9,7 @@ import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicketAwareTicket;
 import org.apereo.cas.ticket.registry.generic.BaseTicketEntity;
 import org.apereo.cas.ticket.registry.generic.JpaTicketEntity;
+import org.apereo.cas.ticket.registry.maria.MariaJpaTicketEntity;
 import org.apereo.cas.ticket.registry.mssql.MsSqlServerJpaTicketEntity;
 import org.apereo.cas.ticket.registry.mysql.MySQLJpaTicketEntity;
 import org.apereo.cas.ticket.registry.oracle.OracleJpaTicketEntity;
@@ -125,6 +126,9 @@ public class JpaTicketEntityFactory extends AbstractJpaEntityFactory<BaseTicketE
         }
         if (isMsSqlServer()) {
             return MsSqlServerJpaTicketEntity.class;
+        }
+        if (isMariaDb()) {
+            return MariaJpaTicketEntity.class;
         }
         return JpaTicketEntity.class;
     }

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/maria/MariaJpaTicketEntity.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/maria/MariaJpaTicketEntity.java
@@ -1,0 +1,41 @@
+package org.apereo.cas.ticket.registry.maria;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.io.*;
+import java.util.List;
+import java.util.Map;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+import org.apereo.cas.ticket.registry.generic.BaseTicketEntity;
+import org.hibernate.annotations.Type;
+
+/**
+ * {@link BaseTicketEntity} for MariaDB which covers the fact that there is no native JSON datatype.
+ *
+ * @author Thomas Seliger
+ * @since 7.0.0
+ */
+@SuperBuilder
+@NoArgsConstructor
+@AttributeOverrides(@AttributeOverride(name = "body", column = @Column(columnDefinition = "text")))
+@Entity(name = "MySQLJpaTicketEntity")
+@Table(name = "CasTickets")
+@Setter
+@Getter
+@Accessors(chain = true)
+public class MariaJpaTicketEntity extends BaseTicketEntity {
+    @Serial
+    private static final long serialVersionUID = 1325901961547418201L;
+
+    @Type(JsonType.class)
+    @Column(columnDefinition = "longtext CHECK (JSON_VALID(attributes))")
+    private Map<String, List<Object>> attributes;
+}


### PR DESCRIPTION
Adds an addition JpaTicketEntity for MariaDB since there is no native support for the JSON datatype (see https://mariadb.com/kb/en/json-data-type/). The column will be mapped as a longtext with additional json validation.