### PR TITLE
Fix the double renew call

### DIFF
--- a/ci/tests/puppeteer/scenarios/login-success-double-renew/script.js
+++ b/ci/tests/puppeteer/scenarios/login-success-double-renew/script.js
@@ -1,0 +1,32 @@
+const puppeteer = require('puppeteer');
+const cas = require('../../cas.js');
+const assert = require("assert");
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    await cas.goto(page, "https://localhost:8443/cas/login?locale=en");
+    await page.focus("#username");
+    await page.keyboard.press("Tab");
+    await page.focus("#password");
+    await page.keyboard.press("Tab");
+
+    await cas.assertVisibility(page, "#usernameValidationMessage");
+    await cas.assertVisibility(page, "#passwordValidationMessage");
+
+    await cas.loginWith(page, "casuser", "Mellon");
+
+    await cas.assertCookie(page);
+    await cas.assertPageTitle(page, "CAS - Central Authentication Service Log In Successful");
+    await cas.assertInnerText(page, '#content div h2', "Log In Successful");
+
+    for (i = 0; i < 2; i++) {
+        await cas.goto(page, "https://localhost:8443/cas/login?renew=true");
+        await page.waitForTimeout(1000);
+
+        await cas.assertVisibility(page, "#existingSsoMsg");
+    }
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/login-success-double-renew/script.json
+++ b/ci/tests/puppeteer/scenarios/login-success-double-renew/script.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": "core",
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas"
+  ]
+}

--- a/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/login/InitialFlowSetupAction.java
+++ b/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/login/InitialFlowSetupAction.java
@@ -180,7 +180,7 @@ public class InitialFlowSetupAction extends BaseCasWebflowAction {
             WebUtils.putExistingSingleSignOnSessionAvailable(context, auth != null);
             WebUtils.putExistingSingleSignOnSessionPrincipal(context,
                 Optional.ofNullable(auth).map(Authentication::getPrincipal).orElseGet(NullPrincipal::getInstance));
-            clearTicketGrantingCookieFromContext(context, ticketGrantingTicketId);
+            WebUtils.putTicketGrantingTicketInScopes(context, StringUtils.EMPTY);
         }
     }
 

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/InitialFlowSetupActionTests.java
@@ -229,7 +229,7 @@ public class InitialFlowSetupActionTests {
             val event = this.action.execute(context);
             assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, event.getId());
             assertTrue(WebUtils.isExistingSingleSignOnSessionAvailable(context));
-            assertNull(getTicketRegistry().getTicket(tgt.getId()));
+            assertNotNull(getTicketRegistry().getTicket(tgt.getId()));
         }
 
 


### PR DESCRIPTION
One of my clients reported me an issue in this scenario:
1) `/cas/login` : log in
2) `/cas/login?renew=true`
3) `/cas/login?renew=true`

On the second call to `/cas/login?renew=true`, the message "Welcome back, xxx" is no longer displayed.

The problem comes from this commit: https://github.com/apereo/cas/commit/a0287d7d4b45099e86ef6d59d8c75f7514d2a14b#diff-284e7c342f29ec14acba7e243063917a451cc6ba18f2e1c170f3c7e1d12355d7R184

So I have replaced the full TGT removal (cookie + ticket registry + webflow) by a simple removal in the webflow.

I have added a Puppeteer test to confirm the correct behavior and I have checked that this PR does not break the following scenarios (related to "renew"): `sso-globally-disabled`, `renew-existing-sso` and `ticket-validation-cas-renew`.

The unit test has been updated accordingly.
