### PR TITLE
fix sonarqube puppeteer test

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -33,7 +33,7 @@ env:
   NODE_CURRENT: '18'
   MAX_ATTEMPTS: 3
   RETRY_MINUTES: 15
-  SCENARIO_REGEX: ".*"
+  SCENARIO_REGEX: "oidc-login-sonar.*"
 
 on:
   push:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -32,7 +32,7 @@ env:
   JDK_CURRENT: 17
   NODE_CURRENT: '18'
   MAX_ATTEMPTS: 3
-  RETRY_MINUTES: 15
+  RETRY_MINUTES: 20
   SCENARIO_REGEX: "oidc-login-sonar.*"
 
 on:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -32,8 +32,8 @@ env:
   JDK_CURRENT: 17
   NODE_CURRENT: '18'
   MAX_ATTEMPTS: 3
-  RETRY_MINUTES: 20
-  SCENARIO_REGEX: "oidc-login-sonar.*"
+  RETRY_MINUTES: 15
+  SCENARIO_REGEX: ".*"
 
 on:
   push:

--- a/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/script.js
@@ -5,8 +5,8 @@ const cas = require('../../cas.js');
     const browser = await puppeteer.launch(cas.browserOptions());
     const page = await cas.newPage(browser);
 
-    await cas.goto(page, "https://host.k3d.internal");
-    await page.waitForTimeout(5000);
+    await cas.goto(page, "https://host.k3d.internal/sessions/new?return_to=%2F");
+    await page.waitForTimeout(10000);
     await cas.assertPageTitle(page, "SonarQube");
     await cas.assertInnerText(page, 'h1.login-title',"Log in to SonarQube");
     //await cas.sleep(5000);

--- a/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/sonarqube-test-values.yaml
+++ b/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/sonarqube-test-values.yaml
@@ -50,3 +50,4 @@ sonarProperties:
   sonar.log.level.app: "info"
   sonar.auth.oidc.allowUsersToSignUp: "true"
   sonar.auth.oidc.loginButtonText: "CAS OpenID Connect"
+  sonar.plugins.risk.consent: "ACCEPTED"


### PR DESCRIPTION
This works locally and it worked on my fork when I increased the retry timeout to 20 minutes, at that time it worked in less than 15 minutes. It seemed like it was allowed to run for 20 minutes when it was failing on the main project. I thought the problem was that they were disabling all plugins until an admin logged in once and accepted the risk, although I not 100% sure that was the issue, but I set a property to accept risk. Going directly to the link that sonarqube redirects to seemed to help and so did increasing the timeout. 