### PR TITLE
Update Change Password Action to correctly set current password

### DIFF
--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
@@ -60,7 +60,7 @@ public class PasswordChangeAction extends BaseCasWebflowAction {
         try {
             val bean = getPasswordChangeRequest(requestContext);
             Optional.ofNullable(WebUtils.getCredential(requestContext, UsernamePasswordCredential.class))
-                    .ifPresent(credential -> bean.setCurrentPassword(bean.getCurrentPassword()));
+                    .ifPresent(credential -> bean.setCurrentPassword(credential.getPassword()));
             
             LOGGER.debug("Attempting to validate the password change bean for username [{}]", bean.getUsername());
             if (StringUtils.isBlank(bean.getUsername()) || !passwordValidationService.isValid(bean)) {


### PR DESCRIPTION
Currently the bean current password is being set to itself.

This change will correctly set bean current password the credential password.
