### PR TITLE
Add backward compatibility for the locale parameter

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/CasLocaleChangeInterceptor.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/CasLocaleChangeInterceptor.java
@@ -82,8 +82,9 @@ public class CasLocaleChangeInterceptor extends LocaleChangeInterceptor {
             }
         }
 
-        val newLocale = request.getParameter(getParamName());
+        var newLocale = request.getParameter(getParamName());
         if (newLocale != null) {
+            newLocale = newLocale.replace('_', '-');
             val locale = Locale.forLanguageTag(newLocale);
             configureLocale(request, response, locale);
         }

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/CasLocaleChangeInterceptorTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/CasLocaleChangeInterceptorTests.java
@@ -94,6 +94,28 @@ public class CasLocaleChangeInterceptorTests {
     }
 
     @Test
+    public void verifyRequestParamWithRegion() throws Exception {
+        val request = new MockHttpServletRequest();
+        request.addParameter("locale", "pt-BR");
+        val response = new MockHttpServletResponse();
+        val resolver = new SessionLocaleResolver();
+        request.setAttribute(DispatcherServlet.LOCALE_RESOLVER_ATTRIBUTE, resolver);
+        getInterceptor(false).preHandle(request, response, new Object());
+        assertEquals(new Locale("pt", "BR"), resolver.resolveLocale(request));
+    }
+
+    @Test
+    public void verifyRequestParamWithRegionUnderscore() throws Exception {
+        val request = new MockHttpServletRequest();
+        request.addParameter("locale", "pt_BR");
+        val response = new MockHttpServletResponse();
+        val resolver = new SessionLocaleResolver();
+        request.setAttribute(DispatcherServlet.LOCALE_RESOLVER_ATTRIBUTE, resolver);
+        getInterceptor(false).preHandle(request, response, new Object());
+        assertEquals(new Locale("pt", "BR"), resolver.resolveLocale(request));
+    }
+
+    @Test
     public void verifyForcedCasDefaultBeatsAll() throws Exception {
         val request = new MockHttpServletRequest();
         request.addParameter("locale", "it");

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/PasswordChangeAction.java
@@ -60,7 +60,7 @@ public class PasswordChangeAction extends BaseCasWebflowAction {
         try {
             val bean = getPasswordChangeRequest(requestContext);
             Optional.ofNullable(WebUtils.getCredential(requestContext, UsernamePasswordCredential.class))
-                    .ifPresent(credential -> bean.setCurrentPassword(bean.getCurrentPassword()));
+                    .ifPresent(credential -> bean.setCurrentPassword(credential.getPassword()));
             
             LOGGER.debug("Attempting to validate the password change bean for username [{}]", bean.getUsername());
             if (StringUtils.isBlank(bean.getUsername()) || !passwordValidationService.isValid(bean)) {


### PR DESCRIPTION
I have encountered an issue with the `locale` parameter when upgrading from CAS v5 to CAS v6.

In CAS v5, the `LocaleChangeInterceptor` was based (by default) on `StringUtils.parseLocaleString(locale)`, meaning that the region is separated from the language by `_` (underscore).

In CAS v6, the `CasLocaleChangeSeparator` is based on `Locale.forLanguageTag`, meaning that the region is separated from the language by `-` (dash).

As I cannot control old CAS clients still using the `_` (underscore) in URLs, I propose this PR to bring backward compatibility.
