### PR TITLE
Fix LDAP direct bind

### DIFF
--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -818,22 +818,23 @@ public class LdapUtils {
         if (StringUtils.isBlank(l.getDnFormat())) {
             throw new IllegalArgumentException("Dn format cannot be empty/blank for direct bind authentication");
         }
-        return getAuthenticatorViaDnFormat(l);
+        return getAuthenticatorViaDnFormat(l, null);
     }
 
     private static Authenticator getActiveDirectoryAuthenticator(final AbstractLdapAuthenticationProperties l) {
         if (StringUtils.isBlank(l.getDnFormat())) {
             throw new IllegalArgumentException("Dn format cannot be empty/blank for active directory authentication");
         }
-        return getAuthenticatorViaDnFormat(l);
+        return getAuthenticatorViaDnFormat(l, newLdaptiveConnectionFactory(l));
     }
 
-    private static Authenticator getAuthenticatorViaDnFormat(final AbstractLdapAuthenticationProperties l) {
+    private static Authenticator getAuthenticatorViaDnFormat(final AbstractLdapAuthenticationProperties l,
+                                                             final ConnectionFactory factory) {
         val resolver = new FormatDnResolver(l.getDnFormat());
         val authenticator = new Authenticator(resolver, getBindAuthenticationHandler(newLdaptiveConnectionFactory(l)));
 
         if (l.isEnhanceWithEntryResolver()) {
-            authenticator.setEntryResolver(newLdaptiveSearchEntryResolver(l, newLdaptiveConnectionFactory(l)));
+            authenticator.setEntryResolver(newLdaptiveSearchEntryResolver(l, factory));
         }
         return authenticator;
     }


### PR DESCRIPTION
One of my clients has reported me a tricky bug with LDAP direct binding.

I have been able to reproduce it with OpenLDAP. Here is my Docker configuration:

```
version: '2'

services:
  openldap:
    image: docker.io/bitnami/openldap:2.6
    ports:
      - '1389:1389'
      - '1636:1636'
    environment:
      - LDAP_ROOT=dc=example,dc=com
      - LDAP_USER_DC=people
      - LDAP_USERS=jleleu
      - LDAP_PASSWORDS=password
      - LDAP_ALLOW_ANON_BINDING=no
    volumes:
      - './data:/bitnami/openldap'

```

And my CAS configuration:

```
cas.authn.ldap[0].type: DIRECT
cas.authn.ldap[0].principal-attribute-list: cn,sn,displayName
cas.authn.ldap[0].ldap-url: ldap://localhost:1389
cas.authn.ldap[0].base-dn: ou=people,dc=example,dc=com
cas.authn.ldap[0].dn-format: cn=%s,ou=people,dc=example,dc=com
```

With both settings, the authentication works great and I can log in with: `jleleu`/`password` and the `displayName` attribute is retrieved.

Though, if I only allow the user to access the `displayName` attribute with this LDIF:

```
dn: olcDatabase={2}mdb,cn=config
changetype: modify
replace: olcAccess
olcAccess: {0}to attrs=displayName by self write by * none
olcAccess: {1}to * by * read
```


The `displayName` attribute is no longer retrieved:

```
Requested LDAP attribute [displayName] could not be found on LDAP entry for [...]
```

The problem heppens in the `SearchEntryResolver`: https://github.com/vt-middleware/ldaptive/blob/main/core/src/main/java/org/ldaptive/auth/SearchEntryResolver.java#L43

As a connection is already defined, the connection of the response (on which the bind has happened) is not used. This PR fixes the problem.
