### PR TITLE
Fixing potential NullpointerException

### DIFF
--- a/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/WebAuthnMultifactorDeviceProviderAction.java
+++ b/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/WebAuthnMultifactorDeviceProviderAction.java
@@ -47,8 +47,8 @@ public class WebAuthnMultifactorDeviceProviderAction extends BaseCasWebflowActio
 
     protected MultifactorAuthenticationRegisteredDevice mapWebAuthnAccount(
         final CredentialRegistration acct) {
-        val vendor = acct.getAttestationMetadata().getVendorProperties().orElseGet(Map::of);
-        val device = acct.getAttestationMetadata().getDeviceProperties().orElseGet(Map::of);
+        val vendor = Optional.ofNullable(acct.getAttestationMetadata()).orElseGet(Attestation::empty).getVendorProperties().orElseGet(Map::of);
+        val device = Optional.ofNullable(acct.getAttestationMetadata()).orElseGet(Attestation::empty).getDeviceProperties().orElseGet(Map::of);
         return FunctionUtils.doUnchecked(() -> MultifactorAuthenticationRegisteredDevice.builder()
             .id(acct.getCredential().getCredentialId().getBase64Url())
             .name(acct.getCredentialNickname())


### PR DESCRIPTION
If a MFA device has no attestation metadata (like WebAuthn via Android FIDO2 API), this leads to a NullpointerException when calling Account Management --> Multifactor Devices.

Registration of such devices is only possible via `cas.authn.mfa.web-authn.core.allow-untrusted-attestation=true`.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

If your pull request targets a maintenance branch and is not directed at `master`, make sure your reference the pull request that
has already ported your changes forward to the `master` branch. You may do so by including the following in your pull request description:

```
master: https://github.com/apereo/cas/pull/$PR_NUMBER
```

Do not keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

If you have questions, please [reach out](https://apereo.github.io/cas/Mailing-Lists.html).

Thanks again!
-->
