### PR TITLE
Use UTF-8 for german message bundle, like it was before PR #5550

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_de.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_de.properties
@@ -1,9 +1,9 @@
 # German Translations
 
-screen.welcome.security=Aus Sicherheitsgründen sollten Sie bei Verlassen der passwortgeschützten Bereiche sich explizit <a href="logout">ausloggen</a> und Ihren Webbrowser schließen!
+screen.welcome.security=Aus SicherheitsgrÃ¼nden sollten Sie bei Verlassen der passwortgeschÃ¼tzten Bereiche sich explizit <a href="logout">ausloggen</a> und Ihren Webbrowser schlieÃŸen!
 screen.welcome.instructions=Bitte geben Sie Ihre Benutzernamen und Ihr Passwort ein.
-screen.welcome.forcedsso=Willkommen zurück, <code><strong>{0}</strong></code>. Wir haben für Sie eine exsitierende Single-SignOn Session erkannt. Jedoch, \
-  werden Sie aufgefordert sich erneut zu authentifizieren, da CAS ihre vorherige Single-SignOn Session nicht akzeptieren kann, da sie möglicherweise \
+screen.welcome.forcedsso=Willkommen zurÃ¼ck, <code><strong>{0}</strong></code>. Wir haben fÃ¼r Sie eine exsitierende Single-SignOn Session erkannt. Jedoch, \
+  werden Sie aufgefordert sich erneut zu authentifizieren, da CAS ihre vorherige Single-SignOn Session nicht akzeptieren kann, da sie mÃ¶glicherweise \
   an die Richtlichte <code><strong>{1}</strong></code> gebunden ist. Bitte geben Sie ihren Benutzernamen und Ihr Passwort ein und fahren Sie fort.
 screen.welcome.label.source=Quelle:
 screen.welcome.label.token=Token:
@@ -11,8 +11,8 @@ screen.welcome.label.netid=<span class="accesskey">B</span>enutzername:
 screen.welcome.label.netid.accesskey=b
 screen.welcome.label.password=<span class="accesskey">P</span>asswort:
 screen.welcome.label.password.accesskey=p
-screen.welcome.label.publicstation=Ich bin an einem öffentlichen Computer.
-screen.welcome.label.warn=Ich möchte ge<span class="accesskey">w</span>arnt werden, bevor ich mich in einen anderen Bereich einlogge.
+screen.welcome.label.publicstation=Ich bin an einem Ã¶ffentlichen Computer.
+screen.welcome.label.warn=Ich mÃ¶chte ge<span class="accesskey">w</span>arnt werden, bevor ich mich in einen anderen Bereich einlogge.
 screen.welcome.label.warn.accesskey=w
 screen.welcome.label.warnremove=Nicht noch einmal warnen
 screen.welcome.button.login=Anmelden
@@ -21,78 +21,78 @@ screen.welcome.button.loginwip=Einen Moment bitte...
 screen.welcome.button.register=Registrieren
 screen.welcome.button.deregister=Abmelden
 screen.welcome.button.print=Drucken
-screen.welcome.button.clear=Löschen
+screen.welcome.button.clear=LÃ¶schen
 screen.welcome.button.confirm=Ok
 
-screen.welcome.label.loginwith=Oder einloggen über:
-screen.welcome.label.navto=Weiterleitung zu externem Identitätsprovider <strong>{0}</strong>. Bitte warten...
+screen.welcome.label.loginwith=Oder einloggen Ã¼ber:
+screen.welcome.label.navto=Weiterleitung zu externem IdentitÃ¤tsprovider <strong>{0}</strong>. Bitte warten...
 screen.welcome.button.loginx509=Anmelden mit Zertifikat
 
 screen.cookies.disabled.title=Cookies im Browser deaktiviert
-screen.cookies.disabled.message=Ihr Browser akzeptiert keine Cookies. Die Funktionalität Cookies zu lesen und zu schreiben \
-  ist notwendig für Single-SignOn. Bitte prüfen Sie ihre Browser-Einstellungen und stellen Sie sicher das Cookies aktiviert sind.
+screen.cookies.disabled.message=Ihr Browser akzeptiert keine Cookies. Die FunktionalitÃ¤t Cookies zu lesen und zu schreiben \
+  ist notwendig fÃ¼r Single-SignOn. Bitte prÃ¼fen Sie ihre Browser-Einstellungen und stellen Sie sicher das Cookies aktiviert sind.
   
 screen.acct.button.signUp=Registrieren
 
 screen.pm.button.submit=Absenden
 screen.pm.button.cancel=Abbrechen
 screen.pm.button.forgotpwd=<a href="{0}">Passwort vergessen?</a>
-screen.pm.button.resetPassword=Passwort zurücksetzen
+screen.pm.button.resetPassword=Passwort zurÃ¼cksetzen
 screen.pm.button.forgotUsername=Benutzername vergessen?
 screen.pm.reset.username=Benutzername:
 screen.pm.reset.email=E-Mail:
-screen.pm.reset.heading=Zurücksetzen des Passworts fehlgeschlagen
-screen.pm.reset.message=Ihre Anfrage zum Zurücksetzen des Passwortes kann aktuell nicht verarbeitet werden.
+screen.pm.reset.heading=ZurÃ¼cksetzen des Passworts fehlgeschlagen
+screen.pm.reset.message=Ihre Anfrage zum ZurÃ¼cksetzen des Passwortes kann aktuell nicht verarbeitet werden.
 screen.pm.reset.qstitle=Beantworten Sie die Sicherheitsfragen
-screen.pm.reset.qsmsg=Willkommen <strong>{0}</strong>. Bevor Sie Ihr Passwort zurücksetzen können, müssen Sie die folgenden Sicherheitsfragen beantworten.
-screen.pm.reset.sentInstructions=Sie werden in Kürze eine E-Mail mit Anweisungen zum weiteren Vorgehen erhalten, um Ihr Passwort zurückzusetzen. Bitte führen Sie diese Anweisungen \
-  möglichst schnell aus, das sie nach einer gewissen Zeit ungültig werden können.
-screen.pm.reset.sent=Anweisungen zum Zurücksetzen des Passworts erfolgreich versandt.
-screen.pm.reset.title=Passwort zurücksetzen
+screen.pm.reset.qsmsg=Willkommen <strong>{0}</strong>. Bevor Sie Ihr Passwort zurÃ¼cksetzen kÃ¶nnen, mÃ¼ssen Sie die folgenden Sicherheitsfragen beantworten.
+screen.pm.reset.sentInstructions=Sie werden in KÃ¼rze eine E-Mail mit Anweisungen zum weiteren Vorgehen erhalten, um Ihr Passwort zurÃ¼ckzusetzen. Bitte fÃ¼hren Sie diese Anweisungen \
+  mÃ¶glichst schnell aus, das sie nach einer gewissen Zeit ungÃ¼ltig werden kÃ¶nnen.
+screen.pm.reset.sent=Anweisungen zum ZurÃ¼cksetzen des Passworts erfolgreich versandt.
+screen.pm.reset.title=Passwort zurÃ¼cksetzen
 screen.pm.reset.instructions=Bitte geben Sie Ihren Benutzernamen ein. Sie werden eine E-Mail mit Anweisungen zum weiteren Vorgehen erhalten.
 screen.pm.reset.answer=Antwort {0}
 screen.pm.reset.question=Frage {0}
 screen.pm.password.policyViolation=Das Passwort entspricht nicht der Passwortrichtlinie.
-screen.pm.password.confirmMismatch=Die Passwörter stimmen nicht überein.
-screen.pm.password.strength=Passwort-Stärke:
+screen.pm.password.confirmMismatch=Die PasswÃ¶rter stimmen nicht Ã¼berein.
+screen.pm.password.strength=Passwort-StÃ¤rke:
 screen.pm.password.strength.0=Grauenhaft
 screen.pm.password.strength.1=Schlecht
 screen.pm.password.strength.2=Schwach
 screen.pm.password.strength.3=Gut
 screen.pm.password.strength.4=Stark
 
-screen.pm.reset.contact.failed=Es können keine E-Mails/SMS versendet werden, da kein E-Mail/SMS Server in der CAS-Konfiguration hinterlegt wurde.
+screen.pm.reset.contact.failed=Es kÃ¶nnen keine E-Mails/SMS versendet werden, da kein E-Mail/SMS Server in der CAS-Konfiguration hinterlegt wurde.
 screen.pm.reset.username.required=Keine E-Mail Adresse vorhanden.
-screen.pm.reset.contact.invalid=Angegebene Kontaktinformationen fehlen oder sind ungültig.
-screen.pm.reset.email.invalid=Angegebene E-Mail Adresse ist ungültig.
+screen.pm.reset.contact.invalid=Angegebene Kontaktinformationen fehlen oder sind ungÃ¼ltig.
+screen.pm.reset.email.invalid=Angegebene E-Mail Adresse ist ungÃ¼ltig.
 screen.pm.reset.username.failed=Es konnte kein Benutzername an die angegebene EMail Adresse gesendet werden.
 
 screen.pm.forgotusername.title=Benutzername vergessen?
 screen.pm.forgotusername.instructions=Bitte geben Sie ihre E-Mail Adresse an. Sie werden eine E-Mail mit ihrem Benutzernamen erhalten.
-screen.pm.forgotusername.email.failed=Es können keine E-Mails versendet werden, da kein E-Mail Server in der CAS-Konfiguration hinterlegt wurde.
-screen.pm.forgotusername.email.invalid=Keine E-Mail Adresse angegeben oder die angebene E-Mail Adresse ist ungültig.
-screen.pm.forgotusername.contact.invalid=Angebene E-Mail Adresse oder Telefonnummer sind ungültig.
-screen.pm.forgotusername.username.missing=Es konnte kein Benutzername für die angegebene E-Mail Adresse gefunden werden.
+screen.pm.forgotusername.email.failed=Es kÃ¶nnen keine E-Mails versendet werden, da kein E-Mail Server in der CAS-Konfiguration hinterlegt wurde.
+screen.pm.forgotusername.email.invalid=Keine E-Mail Adresse angegeben oder die angebene E-Mail Adresse ist ungÃ¼ltig.
+screen.pm.forgotusername.contact.invalid=Angebene E-Mail Adresse oder Telefonnummer sind ungÃ¼ltig.
+screen.pm.forgotusername.username.missing=Es konnte kein Benutzername fÃ¼r die angegebene E-Mail Adresse gefunden werden.
 screen.pm.forgotusername.username.failed=Der Benutzernamen konnte nicht an die angegebene E-Mail Adresse gesendet werden.
 screen.pm.forgotusername.sent=Anweisungen erfolgreich versandt.
-screen.pm.forgotusername.sentInstructions=Sie werden in Kürze eine Nachricht mit Anweisungen erhalten, wie Sie Ihren Benutzernamen abrufen können.
+screen.pm.forgotusername.sentInstructions=Sie werden in KÃ¼rze eine Nachricht mit Anweisungen erhalten, wie Sie Ihren Benutzernamen abrufen kÃ¶nnen.
 
 screen.aup.heading=Nutzungsbedingungen
-screen.aup.policyterms=<p>Der Zweck dieser Richtlinie besteht darin, die akzeptable und inakzeptable Nutzung elektronischer Geräte festzulegen \
-und Netzwerkressourcen in Verbindung mit der etablierten Kultur des ethischen und rechtmäßigen Verhaltens, der Offenheit, des Vertrauens und der Integrität.</p> \
-<p>Durch die Nutzung dieser Ressourcen erklären Sie sich mit der Richtlinie zur akzeptablen Nutzung einverstanden.</p>
+screen.aup.policyterms=<p>Der Zweck dieser Richtlinie besteht darin, die akzeptable und inakzeptable Nutzung elektronischer GerÃ¤te festzulegen \
+und Netzwerkressourcen in Verbindung mit der etablierten Kultur des ethischen und rechtmÃ¤ÃŸigen Verhaltens, der Offenheit, des Vertrauens und der IntegritÃ¤t.</p> \
+<p>Durch die Nutzung dieser Ressourcen erklÃ¤ren Sie sich mit der Richtlinie zur akzeptablen Nutzung einverstanden.</p>
 
 screen.aup.button.accept=AKZEPTIEREN
 screen.aup.button.cancel=ABBRECHEN
 
-screen.saml.idp.discovery=SAML2-Identitätsprovider-Erkennung
+screen.saml.idp.discovery=SAML2-IdentitÃ¤tsprovider-Erkennung
 
 screen.consent.confirm=Ok
 screen.consent.cancel=Abbrechen
 screen.consent.title=Zustimmung
 screen.consent.attributes=Attribute
 screen.consent.options=Optionen
-screen.consent.attributes.header=Folgende Attribute werden an <strong>[{0}]</strong> übermittelt:
+screen.consent.attributes.header=Folgende Attribute werden an <strong>[{0}]</strong> Ã¼bermittelt:
 screen.consent.attributes.attribute=Attribut
 screen.consent.attributes.values=Wert(e)
 \
@@ -100,14 +100,14 @@ screen.consent.options.header=Wie soll ich wieder nach Zustimmung gefragt werden
 screen.consent.options.always=<strong>Immer</strong>
 screen.consent.options.desc.always=Bei jedem Login bei {0} nach Zustimmung fragen.
 screen.consent.options.attributename=<strong>Attributnamen</strong>
-screen.consent.options.desc.attributename=Nach Zustimmung fragen, wenn ein Attribut zur Freigabe an {0} hinzugefügt oder entfernt wird.
+screen.consent.options.desc.attributename=Nach Zustimmung fragen, wenn ein Attribut zur Freigabe an {0} hinzugefÃ¼gt oder entfernt wird.
 screen.consent.options.attributevalue=<strong>Attributwerte</strong>
 screen.consent.options.desc.attributevalue.intro=Nach Zustimmung fragen, wenn:
-screen.consent.options.desc.attributevalue.first=Ein neues Attribut zur Freigabe an {0} hinzugefügt oder entfernt wird.
+screen.consent.options.desc.attributevalue.first=Ein neues Attribut zur Freigabe an {0} hinzugefÃ¼gt oder entfernt wird.
 screen.consent.options.desc.attributevalue.second=Ein zuvor freigegebenes Attribut von der Freigabe an {0} entfernt wird.
-screen.consent.options.desc.attributevalue.third=Der Wert eines für {0} freigegebenen Attributs sich ändert.
+screen.consent.options.desc.attributevalue.third=Der Wert eines fÃ¼r {0} freigegebenen Attributs sich Ã¤ndert.
 screen.consent.options.reminder.header=Wie oft soll ich wieder nach Zustimmung gefragt werden?
-screen.consent.options.reminder.expl=Als Erinnerung nach Zustimmung fragen, wenn sich an den für {0} freigegebenen Attributen nichts ändert.
+screen.consent.options.reminder.expl=Als Erinnerung nach Zustimmung fragen, wenn sich an den fÃ¼r {0} freigegebenen Attributen nichts Ã¤ndert.
 screen.consent.options.timeunit.seconds=Sekunden
 screen.consent.options.timeunit.minutes=Minuten
 screen.consent.options.timeunit.hours=Stunden
@@ -119,14 +119,14 @@ screen.consent.options.timeunit.years=Jahre
 screen.consent.review.header=Zustimmungen bearbeiten
 screen.consent.review.loading=Lade Zustimmungen...
 screen.consent.review.noconsentdecisions=Es sind keine Zustimmungen vorhanden.
-screen.consent.review.success=Zustimmung wurde erfolgreich gelöscht.
+screen.consent.review.success=Zustimmung wurde erfolgreich gelÃ¶scht.
 screen.consent.review.error=Es gab einen Fehler.
-screen.consent.review.confirm=Lösche Zustimmung für [{}]?
+screen.consent.review.confirm=LÃ¶sche Zustimmung fÃ¼r [{}]?
 screen.consent.review.yes=Ja
 screen.consent.review.no=Nein
 screen.consent.review.date=Datum
 screen.consent.review.service=Dienst
-screen.consent.review.delete=LÖSCHEN
+screen.consent.review.delete=LÃ–SCHEN
 screen.consent.review.createddate=Erteilt am:
 screen.consent.review.reminder=Erinnerung:
 screen.consent.review.option=Option:
@@ -134,30 +134,30 @@ screen.consent.review.options.attributename=Attributnamen
 screen.consent.review.options.attributevalue=Attributwerte
 screen.consent.review.options.always=Immer
 screen.consent.review.options.desc.always=Bei jedem Login nach Zustimmung fragen.
-screen.consent.review.options.desc.attributename=Nach Zustimmung fragen, wenn ein Attribut zur Freigabe hinzugefügt oder entfernt wird.
-screen.consent.review.options.desc.attributevalue=Nach Zustimmung fragen, wenn 1) ein neues Attribut zur Freigabe hinzugefügt wird, 2) ein zuvor freigegebenes Attribut von der Freigabe entfernt wird, 3) der Wert eines freigegebenen Attributs sich ändert.
+screen.consent.review.options.desc.attributename=Nach Zustimmung fragen, wenn ein Attribut zur Freigabe hinzugefÃ¼gt oder entfernt wird.
+screen.consent.review.options.desc.attributevalue=Nach Zustimmung fragen, wenn 1) ein neues Attribut zur Freigabe hinzugefÃ¼gt wird, 2) ein zuvor freigegebenes Attribut von der Freigabe entfernt wird, 3) der Wert eines freigegebenen Attributs sich Ã¤ndert.
 screen.consent.review.attributes=Attribute:
 screen.consent.review.data.search=Suchen
 screen.consent.review.data.zerorecords=Keine passenden Zustimmungen gefunden
-screen.consent.review.data.info=Zeigt _START_ bis _END_ von _TOTAL_ Einträgen
-screen.consent.review.data.infofiltered=(von insgesamt _MAX_ Einträgen)
-screen.consent.review.data.infoempty=Keine Einträge anzuzeigen
-screen.consent.review.logout.success=Sie haben sich erfolgreich abgemeldet. Sie können sich zusätzlich vollständig vom Zentralen Authentifizierungsdienst <a href="../logout">abmelden</a> und Ihre Single Sign-On Sitzung beenden.
+screen.consent.review.data.info=Zeigt _START_ bis _END_ von _TOTAL_ EintrÃ¤gen
+screen.consent.review.data.infofiltered=(von insgesamt _MAX_ EintrÃ¤gen)
+screen.consent.review.data.infoempty=Keine EintrÃ¤ge anzuzeigen
+screen.consent.review.logout.success=Sie haben sich erfolgreich abgemeldet. Sie kÃ¶nnen sich zusÃ¤tzlich vollstÃ¤ndig vom Zentralen Authentifizierungsdienst <a href="../logout">abmelden</a> und Ihre Single Sign-On Sitzung beenden.
 
 screen.nonsecure.title=Unsichere Verbindung
-screen.nonsecure.message=Sie greifen auf CAS über eine unsichere Verbindung zu. Das Single Sign-On wird NICHT FUNKTIONIEREN. Damit es funktioniert, muss der Login über HTTPS erfolgen.
+screen.nonsecure.message=Sie greifen auf CAS Ã¼ber eine unsichere Verbindung zu. Das Single Sign-On wird NICHT FUNKTIONIEREN. Damit es funktioniert, muss der Login Ã¼ber HTTPS erfolgen.
 
 screen.accountunlocked.heading=Ihr Konto ist nun entsperrt.
 screen.account.unlock.description=Ihr Konto wurde gesperrt und kann nicht zum einloggen verwendet werden. Bitte folgen Sie den Anweisungen \
   auf dem Bildschirm um ihr Konto zu entsprren und versuchen Sie sich dann erneut einzuloggen.
 screen.account.unlock.label=Image Text
 screen.account.unlock.hint=Um fortzufahren, geben Sie bitte die Zeichen ein, die Sie im Bild sehen.
-screen.account.unlock.fail=CAS kann ihr Konto nicht zurücksetzen und entsperren. Kontaktieren Sie ihren CAS Administrator für weitere Informationen.
-screen.account.unlock.success=Ihr Konto ist nun entsperrt. Beachten Sie, dass es einige Zeit dauern kann, bis diese Änderung vollständig wirksam wird. \
-   Sie sollten sich jetzt anmelden und fortfahren können.
+screen.account.unlock.fail=CAS kann ihr Konto nicht zurÃ¼cksetzen und entsperren. Kontaktieren Sie ihren CAS Administrator fÃ¼r weitere Informationen.
+screen.account.unlock.success=Ihr Konto ist nun entsperrt. Beachten Sie, dass es einige Zeit dauern kann, bis diese Ã„nderung vollstÃ¤ndig wirksam wird. \
+   Sie sollten sich jetzt anmelden und fortfahren kÃ¶nnen.
 
 screen.defaultauthn.title=Statische Anmeldung
-screen.defaultauthn.heading=CAS ist so konfiguriert, dass eine statische Liste von Benutzern zur primären Anmeldung akzeptiert wird. Bitte beachten Sie, dass dies NUR zu Demonstrationszwecken nützlich ist. \
+screen.defaultauthn.heading=CAS ist so konfiguriert, dass eine statische Liste von Benutzern zur primÃ¤ren Anmeldung akzeptiert wird. Bitte beachten Sie, dass dies NUR zu Demonstrationszwecken nÃ¼tzlich ist. \
   Es wird empfohlen, statt dessen CAS an LDAP, JDBC, usw. anzubinden.
 logo.title=zur Apereo Seite wechseln
 copyright=Copyright &copy; 2005&ndash;2021 Apereo, Inc.
@@ -168,8 +168,8 @@ screen.post.response.message=Sie werden weitergleitet zu {0}.
 screen.interrupt.title=Authentikationsunterbrechnung
 screen.interrupt.message=Die Anmeldung wurde unterbrochen. CAS hat noch keine Single Sign-On Sitzung eingerichtet <strong>{0}</strong>.
 
-screen.mdui.infolink.text=<a href="{0}" target="_blank">Mehr Informationen über diese Anwendung</a>.
-screen.mdui.privacylink.text=<a href="{0}" target="_blank">Datenschutzerklärung dieser Anwendung</a>.
+screen.mdui.infolink.text=<a href="{0}" target="_blank">Mehr Informationen Ã¼ber diese Anwendung</a>.
+screen.mdui.privacylink.text=<a href="{0}" target="_blank">DatenschutzerklÃ¤rung dieser Anwendung</a>.
 
 screen.interrupt.btn.proceed=Fortfahren
 screen.interrupt.btn.cancel=Abbrechen
@@ -178,19 +178,19 @@ screen.interrupt.btn.cancel=Abbrechen
 ########################################
 screen.error.page.heading=Fehler
 screen.error.page.invalidrequest.title=Unbekannte Anfrage
-screen.error.page.invalidrequest.desc=Die an CAS gesendete Authentifizierungsanforderung ist ungültig, falsch aufgebaut, \
-   oder enthält Parameter, die als ungültig oder abgelaufen angesehen werden. Bitte überprüfen Sie die ursprüngliche Anfrage, konsultieren Sie die CAS-Logdateien und versuchen Sie es erneut.
+screen.error.page.invalidrequest.desc=Die an CAS gesendete Authentifizierungsanforderung ist ungÃ¼ltig, falsch aufgebaut, \
+   oder enthÃ¤lt Parameter, die als ungÃ¼ltig oder abgelaufen angesehen werden. Bitte Ã¼berprÃ¼fen Sie die ursprÃ¼ngliche Anfrage, konsultieren Sie die CAS-Logdateien und versuchen Sie es erneut.
 screen.error.page.invalidrequest=Fehlerhafte/Unbekannte Anfrage
 screen.error.page.title.accessdenied=Fehler - 401
 screen.error.page.title.permissiondenied=Fehler - Berechtigung verweigert
 screen.error.page.title.pagenotfound=Fehler - Seite nicht gefunden
-screen.error.page.title.requestunsupported=Fehler - Nicht unterstützte Anfrage
+screen.error.page.title.requestunsupported=Fehler - Nicht unterstÃ¼tzte Anfrage
 screen.error.page.accessdenied=Zugriff verweigert
 screen.error.page.permissiondenied=Sie haben nicht die Berechtigung diese Seite zu sehen.
-screen.error.page.requestunsupported=Der Anforderungstyp oder die Syntax wird nicht unterstützt.
+screen.error.page.requestunsupported=Der Anforderungstyp oder die Syntax wird nicht unterstÃ¼tzt.
 screen.error.page.loginagain=Erneut anmelden
 screen.error.page.notfound=Seite nicht gefunden
-screen.error.page.doesnotexist=Die Seite, auf die Sie zugreifen möchten, existiert aktuell nicht.
+screen.error.page.doesnotexist=Die Seite, auf die Sie zugreifen mÃ¶chten, existiert aktuell nicht.
 screen.error.page.authdenied=Anmeldung fehlgeschlagen
 
 # Remember-Me Authentication
@@ -202,228 +202,228 @@ screen.gua.confirm.message=Wenn Sie dieses Bild nicht als das Ihre erkennen, fah
 # Blocked Errors Page
 screen.error.page.title.blocked=Fehler - Berechtigung verweigert
 screen.blocked.header=Zugriff verweigert
-screen.blocked.message=Das Kennwort für den Benutzer wurde zu oft falsch eingegeben. Ihr Zugriff wird gedrosselt.
-AbstractAccessDecisionManager.accessDenied=Sie sind nicht berechtigt auf diese Ressource zuzugrifen. Kontaktieen Sie Ihren CAS-Administrator für weitere Informationen.
+screen.blocked.message=Das Kennwort fÃ¼r den Benutzer wurde zu oft falsch eingegeben. Ihr Zugriff wird gedrosselt.
+AbstractAccessDecisionManager.accessDenied=Sie sind nicht berechtigt auf diese Ressource zuzugrifen. Kontaktieen Sie Ihren CAS-Administrator fÃ¼r weitere Informationen.
 
 #Confirmation Screen Messages
-screen.confirmation.message=Klicken Sie <a href="{0}">hier</a> um zu der zuvor angeforderten Seite zurückzukehren.
+screen.confirmation.message=Klicken Sie <a href="{0}">hier</a> um zu der zuvor angeforderten Seite zurÃ¼ckzukehren.
 screen.authentication.warning=Anmeldung mit Warnungen erfolgreich
 
 # Account Profile Messages
 screen.account.success=Sie, <strong>{0}</strong>, haben sich erfolgreich beim Central Authentication Service angemeldet. Diese Seite erlaubt Ihnen, \
-  ihr Benutzerprofil zu überprüfen und zu verwalten, und die von CAS gesammelten Personenattribute zu überprüfen.
-screen.account.security=Wenn Sie fertig sind, <a href="logout">melden Sie sich aus Sicherheitsgründen ab</a> und schließen Sie ihren Browser.
-screen.account.tooltip.logout=Dieser Vorgang erzwingt eine Abmeldung, bevor das Kennwort geändert wird.
+  ihr Benutzerprofil zu Ã¼berprÃ¼fen und zu verwalten, und die von CAS gesammelten Personenattribute zu Ã¼berprÃ¼fen.
+screen.account.security=Wenn Sie fertig sind, <a href="logout">melden Sie sich aus SicherheitsgrÃ¼nden ab</a> und schlieÃŸen Sie ihren Browser.
+screen.account.tooltip.logout=Dieser Vorgang erzwingt eine Abmeldung, bevor das Kennwort geÃ¤ndert wird.
 screen.account.failure=Fehler
-screen.account.securityquestions.subtitle=Sie können hier Ihre Sicherheitsfragen überprüfen und aktualisieren. \
-  Bedenken Sie dass alle Sicherheitsfragen und Antworten einzigartig sein <strong>müssen</strong>. \
+screen.account.securityquestions.subtitle=Sie kÃ¶nnen hier Ihre Sicherheitsfragen Ã¼berprÃ¼fen und aktualisieren. \
+  Bedenken Sie dass alle Sicherheitsfragen und Antworten einzigartig sein <strong>mÃ¼ssen</strong>. \
   Doppelte Fragen oder Antworten werden von CAS abgelehnt.
-screen.account.mfadevices.title=Mehrstufige Authentifizierungsgeräte
-screen.account.mfadevices.subtitle=Die folgenden Geräte sind registriert und können für die mehrstufige Authentifizierung genutzt werden.
+screen.account.mfadevices.title=Mehrstufige AuthentifizierungsgerÃ¤te
+screen.account.mfadevices.subtitle=Die folgenden GerÃ¤te sind registriert und kÃ¶nnen fÃ¼r die mehrstufige Authentifizierung genutzt werden.
 screen.account.auditlog.title=Audit Log
-screen.account.auditlog.subtitle=Untersuchen Sie Ihre Authentifizierungsaktivität, wie sie von CAS aufgezeichnet und erfasst wurde.
+screen.account.auditlog.subtitle=Untersuchen Sie Ihre AuthentifizierungsaktivitÃ¤t, wie sie von CAS aufgezeichnet und erfasst wurde.
 screen.account.securityquestions.title=Sicherheitsfragen verwalten
-screen.account.securityquestions.failure=Ihre Sicherheitsfragen können nicht akzeptiert und aktualisiert werden. 
+screen.account.securityquestions.failure=Ihre Sicherheitsfragen kÃ¶nnen nicht akzeptiert und aktualisiert werden. 
 screen.account.securityquestions.success=Ihre Sicherheitsfragen wurden akzeptiert und erfolgreich aktualisiert. 
-screen.account.sessions=Überprüfen Sie Ihre bei CAS registrierten aktiven Single-Sign-On-Sitzungen auf allen Ihren Geräten und Browsern.
-screen.account.applications=Bei CAS sind Anwendungen registriert, für die CAS berechtigt ist, Ihnen den Zugriff zu gewähren.
-screen.account.attributes=Dies sind die Attribute, die CAS gefunden und an Ihr authentifiziertes Profil angehängt hat. \
-   Diese Attribute sind in dem Pool verfügbarer Attribute enthalten, die geteilt und für Anwendungen freigegeben werden können.
+screen.account.sessions=ÃœberprÃ¼fen Sie Ihre bei CAS registrierten aktiven Single-Sign-On-Sitzungen auf allen Ihren GerÃ¤ten und Browsern.
+screen.account.applications=Bei CAS sind Anwendungen registriert, fÃ¼r die CAS berechtigt ist, Ihnen den Zugriff zu gewÃ¤hren.
+screen.account.attributes=Dies sind die Attribute, die CAS gefunden und an Ihr authentifiziertes Profil angehÃ¤ngt hat. \
+   Diese Attribute sind in dem Pool verfÃ¼gbarer Attribute enthalten, die geteilt und fÃ¼r Anwendungen freigegeben werden kÃ¶nnen.
 screen.account.consent.title=Attribut-Zustimmungsentscheidungen
-screen.account.consent.subtitle=Dies sind die Zustimmungsentscheidungen für Attribute, die CAS gefunden und Ihrem authentifizierten Profil angehängt hat.
+screen.account.consent.subtitle=Dies sind die Zustimmungsentscheidungen fÃ¼r Attribute, die CAS gefunden und Ihrem authentifizierten Profil angehÃ¤ngt hat.
 screen.account.consent.always=Immer
-screen.account.consent.attribute_name=Änderungen des Attributnamens
-screen.account.consent.attribute_value=Änderungen des Attributwerts
+screen.account.consent.attribute_name=Ã„nderungen des Attributnamens
+screen.account.consent.attribute_value=Ã„nderungen des Attributwerts
 
 #Generic Success Screen Messages
 screen.success.header=Anmeldung erfolgreich
 screen.success.success=Sie haben sich erfolgreich am Central Authentication Service angemeldet. Sie sehen jedoch \
-   diese Seite, da CAS Ihr Ziel nicht kennt und nicht weiß, wie es Sie dorthin gelangen. Überprüfen Sie die Authentifizierungsanforderung erneut und \
+   diese Seite, da CAS Ihr Ziel nicht kennt und nicht weiÃŸ, wie es Sie dorthin gelangen. ÃœberprÃ¼fen Sie die Authentifizierungsanforderung erneut und \
    stellen Sie sicher, dass ein Zieldienst/eine Zielanwendung angegeben ist, die bei CAS autorisiert und registriert ist.
-screen.success.security=Aus Sicherheitsgründen sollten Sie bei Verlassen der passwortgeschützten Bereiche sich explizit <a href="logout">ausloggen</a> und Ihren Webbrowser schliessen!
+screen.success.security=Aus SicherheitsgrÃ¼nden sollten Sie bei Verlassen der passwortgeschÃ¼tzten Bereiche sich explizit <a href="logout">ausloggen</a> und Ihren Webbrowser schliessen!
 
 #Logout Screen Messages
-screen.logout.confirm.header=Möchten sie sich wirklich ganz abmelden?
-screen.logout.confirm.text=Eine Anwendung könnte Sie zum Zentralen Authentifizierungsdienst weitergeleitet haben, \
+screen.logout.confirm.header=MÃ¶chten sie sich wirklich ganz abmelden?
+screen.logout.confirm.text=Eine Anwendung kÃ¶nnte Sie zum Zentralen Authentifizierungsdienst weitergeleitet haben, \
   um sich ganz abzumelden und Ihre Single Sign-On Sitzung zu beenden. Wenn Sie sich abmelden, werden Sie erneut aufgefordert Ihre \
-  Zugangsdaten einzugeben und sich erneut anzumelden, sobald Sie auf eine Anwendung zugreifen.<p><p><br>Möchten Sie fortfahren?
+  Zugangsdaten einzugeben und sich erneut anzumelden, sobald Sie auf eine Anwendung zugreifen.<p><p><br>MÃ¶chten Sie fortfahren?
 screen.logout.confirm.proceed=Wollen Sie fortfahren?
 
 screen.logout.header=Abmeldung erfolgreich
 screen.logout.success=Sie haben sich erfolgreich vom Zentralen Authentifizierungsdienst abgemeldet.
-screen.logout.fc.success=Sie haben sich erfolgreich vom Zentralen Authentifizierungsdienst abgemeldet. Für den Fall, dass Single Logout in CAS aktiviert ist, \
+screen.logout.fc.success=Sie haben sich erfolgreich vom Zentralen Authentifizierungsdienst abgemeldet. FÃ¼r den Fall, dass Single Logout in CAS aktiviert ist, \
   werden die folgenden Anwendungen <strong>nur benachrichtigt</strong> Sie auszuloggen und Ihre Sitzung zu beenden. Denken Sie daran, dass es sich nur um eine \
   Benachrichtigung handelt, nicht um eine Garantie. Es obliegt der Anwendung selbst auf diese Benachrichtigungen zu reagieren und angemessene Schritte zu unternehmen, um Sie abzumelden.
-screen.logout.security=Aus Sicherheitsgründen sollten Sie den Browser schliessen.
+screen.logout.security=Aus SicherheitsgrÃ¼nden sollten Sie den Browser schliessen.
 
 screen.service.sso.error.header=Eine Neuanmeldung ist erforderlich, um auf den Service zuzugreifen.
 screen.service.sso.error.message=Sie haben versucht, auf einen Dienst zuzugreifen, der eine Authentifizierung erfordert, ohne sich erneut zu authentifizieren. Bitte versuchen Sie erneut, sich zu authentifizieren.
 screen.service.required.message=Sie versuchen sich anzumelden ohne die Ziel-Anwendung anzugeben. Bitte untersuchen Sie Ihre Anfrage und versuchen Sie es erneut.
 screen.service.initial.message=Der Versuch, auf CAS oder die angegebene Zielanwendung zuzugreifen, ist derzeit nicht erlaubt. \
-  Die Authentifizierungsrichtlinie erfordert, dass Sie Ihre Startanwendung ändern \
+  Die Authentifizierungsrichtlinie erfordert, dass Sie Ihre Startanwendung Ã¤ndern \
   und wechseln Sie dann zu anderen Anwendungen und Diensten.
 
-captchaError=reCAPTCHA Bestätigung fehlgeschlagen.
+captchaError=reCAPTCHA BestÃ¤tigung fehlgeschlagen.
 username.required=Benutzername ist ein Pflichtfeld.
 password.required=Passwort ist ein Pflichtfeld.
 source.required=Authentifizierungsquelle ist ein Pflichtfeld.
 
 # Password Management
-confirmedPassword.required=Das Passwort muss bestätigt werden.
-pm.passwordsMustMatch=Die eingegebenen Passwörter stimmen nicht überein.
+confirmedPassword.required=Das Passwort muss bestÃ¤tigt werden.
+pm.passwordsMustMatch=Die eingegebenen PasswÃ¶rter stimmen nicht Ã¼berein.
 pm.passwordFailedCriteria=Das eingegebene Passwort entspricht nicht der Passwortrichtlinie. Bitte versuchen Sie es erneut.
-pm.updateFailure=Das Passwort konnte nicht geändert werden. Bitte versuchen Sie es erneut.
+pm.updateFailure=Das Passwort konnte nicht geÃ¤ndert werden. Bitte versuchen Sie es erneut.
 
 # Authentication failure messages
 authenticationFailure.AccountDisabledException=Dieses Konto wurde deaktiviert.
 authenticationFailure.AccountLockedException=Dieses Konto wurde gesperrt.
 authenticationFailure.AccountExpiredException=Dieses Konto ist abgelaufen und zu keiner Zeit mehr zur Anmeldung berechtigt.
 authenticationFailure.CredentialExpiredException=Ihr Kennwort ist abgelaufen.
-authenticationFailure.InvalidLoginLocationException=Sie können sich von dieser Workstation nicht anmelden.
-authenticationFailure.UniquePrincipalRequiredException=Sie können sich zu diesem Zeitpunkt nicht anmelden, da Sie noch eine andere aktive Single-SignOn Session haben \
+authenticationFailure.InvalidLoginLocationException=Sie kÃ¶nnen sich von dieser Workstation nicht anmelden.
+authenticationFailure.UniquePrincipalRequiredException=Sie kÃ¶nnen sich zu diesem Zeitpunkt nicht anmelden, da Sie noch eine andere aktive Single-SignOn Session haben \
   und CAS mit einer Anmelderichtlienie konfiguriert ist, die mehrere Single-SignOn Sessions unterbindet.
 authenticationFailure.InvalidLoginTimeException=Ihrem Konto ist es nicht gestattet sich zu diesem Zeitpunkt anzumelden.
 authenticationFailure.AccountNotFoundException=Das Konto wurde nicht gefunden.
-authenticationFailure.FailedLoginException=Der Authentifizierungsversuch ist fehlgeschlagen, wahrscheinlich aufgrund ungültiger Anmeldeinformationen. Bitte überprüfen und erneut versuchen.
-authenticationFailure.MultifactorAuthenticationProviderAbsentException=Die Anforderungen für die mehrstufige Authentifizierung können nicht erfüllt werden. \
-   Ihr Konto ist für eine mehrstufige Authentifizierung konfiguriert, CAS kann diese jedoch nicht finden und ausführen \
-   höchstwahrscheinlich aufgrund einer Fehlkonfiguration des Servers. Wenden Sie sich an die Administratoren, um Unterstützung zu erhalten.
-authenticationFailure.SurrogateAuthenticationException=Sie sind aktuell nicht berechtigt, die Identität des angegebene Benutzers anzunehmen.
-authenticationFailure.AccountPasswordMustChangeException=Ihr Passwort ist abgelaufen und muss geändert werden.
+authenticationFailure.FailedLoginException=Der Authentifizierungsversuch ist fehlgeschlagen, wahrscheinlich aufgrund ungÃ¼ltiger Anmeldeinformationen. Bitte Ã¼berprÃ¼fen und erneut versuchen.
+authenticationFailure.MultifactorAuthenticationProviderAbsentException=Die Anforderungen fÃ¼r die mehrstufige Authentifizierung kÃ¶nnen nicht erfÃ¼llt werden. \
+   Ihr Konto ist fÃ¼r eine mehrstufige Authentifizierung konfiguriert, CAS kann diese jedoch nicht finden und ausfÃ¼hren \
+   hÃ¶chstwahrscheinlich aufgrund einer Fehlkonfiguration des Servers. Wenden Sie sich an die Administratoren, um UnterstÃ¼tzung zu erhalten.
+authenticationFailure.SurrogateAuthenticationException=Sie sind aktuell nicht berechtigt, die IdentitÃ¤t des angegebene Benutzers anzunehmen.
+authenticationFailure.AccountPasswordMustChangeException=Ihr Passwort ist abgelaufen und muss geÃ¤ndert werden.
 authenticationFailure.UnauthorizedServiceForPrincipalException=Zugriff auf die Anwendung aufgrund fehlender Berechtigungen verweigert.
-authenticationFailure.MultifactorAuthenticationRequiredException=Der Authentifizierungsversuch für Ihr Konto wurde verweigert, \
-   da Ihr Konto noch nicht für die mehrstufige Authentifizierung konfiguriert ist. Wenden Sie sich an die Administratoren \
-   um Hilfe zu erhalten, vergewissern Sie sich, dass Ihr Konto registriert und für die mehrstufige Authentifizierung berechtigt ist, und versuchen Sie es erneut.
+authenticationFailure.MultifactorAuthenticationRequiredException=Der Authentifizierungsversuch fÃ¼r Ihr Konto wurde verweigert, \
+   da Ihr Konto noch nicht fÃ¼r die mehrstufige Authentifizierung konfiguriert ist. Wenden Sie sich an die Administratoren \
+   um Hilfe zu erhalten, vergewissern Sie sich, dass Ihr Konto registriert und fÃ¼r die mehrstufige Authentifizierung berechtigt ist, und versuchen Sie es erneut.
 authenticationFailure.UNKNOWN=Authentifizierungsversuch ist fehlgeschlagen.
-authenticationFailure.AuthenticationException=Die Zugangsdaten sind ungültig und der Anmeldeversuch ist fehlgeschlagen.
+authenticationFailure.AuthenticationException=Die Zugangsdaten sind ungÃ¼ltig und der Anmeldeversuch ist fehlgeschlagen.
 
 INVALID_REQUEST_PROXY=Die Anfrage ist falsch formatiert. Stellen Sie sicher, dass alle erforderlichen Parameter richtig codiert und enthalten sind.
-INVALID_TICKET_SPEC=Das Ticket entspricht nicht den Überprüfungsregeln. Ein möglicher Fehler könnte sein, dass versucht wurde, ein Proxy Ticket mit einem Service Ticket Validierer zu überprüfen, oder man sich nicht an den renew true Request gehalten hat.
+INVALID_TICKET_SPEC=Das Ticket entspricht nicht den ÃœberprÃ¼fungsregeln. Ein mÃ¶glicher Fehler kÃ¶nnte sein, dass versucht wurde, ein Proxy Ticket mit einem Service Ticket Validierer zu Ã¼berprÃ¼fen, oder man sich nicht an den renew true Request gehalten hat.
 INVALID_REQUEST=Diese Anfrage kann nicht identifiziert, autorisiert oder abgeschlossen werden, wahrscheinlich aufgrund falsch formatierter oder fehlender erforderlicher Parameter.
-INVALID_AUTHENTICATION_CONTEXT=Die Validierungsanfrage für [''{0}''] kann nicht bedient werden. Die Anfrage ist entweder unerkannt oder unerfüllt.
+INVALID_AUTHENTICATION_CONTEXT=Die Validierungsanfrage fÃ¼r [''{0}''] kann nicht bedient werden. Die Anfrage ist entweder unerkannt oder unerfÃ¼llt.
 INVALID_TICKET=Ticket ''{0}'' wurde nicht anerkannt
-INVALID_PROXY_GRANTING_TICKET=PGT bereits generiert für dieses ST. Es kann nicht mehr als ein PGT für ein ST generiert werden
-INVALID_SERVICE=Ticket ''{0}'' passt nicht zum angegebenen Service. Der ursprüngliche Service war ''{1}'' und der übermittelte Service war ''{2}''.
+INVALID_PROXY_GRANTING_TICKET=PGT bereits generiert fÃ¼r dieses ST. Es kann nicht mehr als ein PGT fÃ¼r ein ST generiert werden
+INVALID_SERVICE=Ticket ''{0}'' passt nicht zum angegebenen Service. Der ursprÃ¼ngliche Service war ''{1}'' und der Ã¼bermittelte Service war ''{2}''.
 INVALID_PROXY_CALLBACK=Die angegebene Proxy-Callback-Url ''{0}'' kann nicht authentifiziert werden. Entweder ist ''{0}'' nicht erreichbar \
-   oder nicht berechtigt, eine Proxy-Authentifikation durchzuführen.
+   oder nicht berechtigt, eine Proxy-Authentifikation durchzufÃ¼hren.
 UNAUTHORIZED_SERVICE_PROXY=Dem angegebenen Service ''{0}'' ist es nicht gestattet eine CAS Proxy Authentifizierung zu verwenden.
-UNSATISFIED_AUTHN_POLICY=Der Zugriff auf die Anwendung wurde aufgrund einer nicht erfüllten Authentifkationsrichtlinie (authentication policy) verweigert.
-INVALID_AUTHN_REQUEST=Authentifizierungsversuch fehlgeschlagen, wahrscheinlich aufgrund ungültiger Anmeldeinformationen.
+UNSATISFIED_AUTHN_POLICY=Der Zugriff auf die Anwendung wurde aufgrund einer nicht erfÃ¼llten Authentifkationsrichtlinie (authentication policy) verweigert.
+INVALID_AUTHN_REQUEST=Authentifizierungsversuch fehlgeschlagen, wahrscheinlich aufgrund ungÃ¼ltiger Anmeldeinformationen.
 BLOCKED_AUTHN_REQUEST=Der Authentifizierungsversuch ist blockiert und kann nicht fortgesetzt werden, wahrscheinlich aufgrund falsch formatierter oder fehlender erforderlicher Parameter. \
   Untersuchen Sie die CAS-Serverprotokolle, um die Ursache des Fehlers zu finden.
 UNSATISFIED_SAML_REQUEST=Die SAML-Authentifizierungsanfrage kann von CAS nicht verstanden, akzeptiert oder validiert werden, \
-  wahrscheinlich aufgrund fehlerhafter oder fehlender erforderlicher Parameter. Bitte überprüfen Sie die CAS-Serverprotokolle, um die Ursache des Fehlers zu finden
+  wahrscheinlich aufgrund fehlerhafter oder fehlender erforderlicher Parameter. Bitte Ã¼berprÃ¼fen Sie die CAS-Serverprotokolle, um die Ursache des Fehlers zu finden
 
 screen.service.error.header=Anwendung nicht berechtigt CAS zu verwenden
-service.principal.resolution.error=CAS ist es nicht möglich den korrekten Prinzipal zu bestimmen. \
-  Enweder konnte der Prinzipal nicht korrekt als einzelne, eindeutige Entität aufgelöst werden oder CAS hat \
-  mehrere Entitäten gefunden und ist nicht in der Lage präzise zu entscheiden, welche davon genutzt werden soll. \
+service.principal.resolution.error=CAS ist es nicht mÃ¶glich den korrekten Prinzipal zu bestimmen. \
+  Enweder konnte der Prinzipal nicht korrekt als einzelne, eindeutige EntitÃ¤t aufgelÃ¶st werden oder CAS hat \
+  mehrere EntitÃ¤ten gefunden und ist nicht in der Lage prÃ¤zise zu entscheiden, welche davon genutzt werden soll. \
   Dieser Fehler kann auch auftreten, wenn der authentifizierte Prinzipal keine Berechtigung zum Zugriff auf die Ziel-Anwendung \
   hat, weil die von der Authentifikationsrichtlinie (policy) geforderten Berechtigungen fehlen.
 service.not.authorized.missing.attr=Sie sind nicht berichtigt auf diese Anwednung zuzugreifen, da Ihrem Konto \
   die Berechtigung fehlt, um Sie bei der Anwendung anzumelden. Bitte wenden Sie sich an Ihren IT-Support.
-screen.service.error.message=Die Anwendung, an die Sie sich anmelden möchten, ist nicht berechtigt CAS zu verwenden. \
+screen.service.error.message=Die Anwendung, an die Sie sich anmelden mÃ¶chten, ist nicht berechtigt CAS zu verwenden. \
   Dies ist typischer Weise in Hinweis darauf, dass die Anwendung nicht bei CAS registiert ist, die Authentifikationsrichtlinie (policy) ihres Registierungseintrags \
-  die Nutzung von CAS-Funktionalität verhindert oder der Eintrag nicht wohlgeformt ist. \
-  Kontaktieren Sie Ihren CAS-Administrator, um in Erfahrung zu bringen, wie Sie Ihre Anwendung ggf. bei CAS registieren und mit CAS integrieren können.
+  die Nutzung von CAS-FunktionalitÃ¤t verhindert oder der Eintrag nicht wohlgeformt ist. \
+  Kontaktieren Sie Ihren CAS-Administrator, um in Erfahrung zu bringen, wie Sie Ihre Anwendung ggf. bei CAS registieren und mit CAS integrieren kÃ¶nnen.
 screen.service.empty.error.message=Die Service-Registrierung des CAS Server ist leer und hat keine Service-Definitionen.\
-  Anwendungen, welche über CAS authentifizieren möchten, müssen in der Services-Registrierung definiert werden.
+  Anwendungen, welche Ã¼ber CAS authentifizieren mÃ¶chten, mÃ¼ssen in der Services-Registrierung definiert werden.
 screen.service.expired.message=Die Anwendung, bei der Sie versucht haben, sich zu authentifizieren, ist in der CAS-Dienstregistrierung abgelaufen. \
   Wenn dieser Dienst weiterhin verwendet werden soll, wenden Sie sich bitte an die Administratoren, um die Anwendung erneuern zu lassen.
 # Surrogate Account Selection
 screen.surrogates.account.selection.header=Auswahl des Surrogate-Kontos
-screen.surrogates.choose.account=Wählen Sie das Konto
-screen.surrogates.message=<p>Ihnen wir eine liste der Konten angezeigt, für die es Ihnen erlaubt ist, sich in dessen Namen anzumelden.</p> \
-  <p>Wählen Sie ein Konto aus und fahren Sie fort.</p>
+screen.surrogates.choose.account=WÃ¤hlen Sie das Konto
+screen.surrogates.message=<p>Ihnen wir eine liste der Konten angezeigt, fÃ¼r die es Ihnen erlaubt ist, sich in dessen Namen anzumelden.</p> \
+  <p>WÃ¤hlen Sie ein Konto aus und fahren Sie fort.</p>
 screen.surrogates.button.cancel=Abbrechen
 screen.surrogates.account.selection.error=Sie sind derzeit nicht berechtigt, sich als der angegebene Benutzer auszugeben.
-screen.surrogates.wildcard.title=Identitätswechsel-Kontoauswahl
+screen.surrogates.wildcard.title=IdentitÃ¤tswechsel-Kontoauswahl
 screen.surrogates.wildcard.description=Ihr Konto wird von CAS intern als eines mit besonderen Berechtigungen erkannt, \
-  berechtigt, sich für alle Benutzer und Konten auszugeben. Daher ist die Auswahl eines Identitätswechselkontos für Ihr \
-  Konto nicht erlaubt. Stattdessen können Sie sich direkt anmelden und sich mit seinem Benutzernamen für ein anderes Konto ausgeben.
+  berechtigt, sich fÃ¼r alle Benutzer und Konten auszugeben. Daher ist die Auswahl eines IdentitÃ¤tswechselkontos fÃ¼r Ihr \
+  Konto nicht erlaubt. Stattdessen kÃ¶nnen Sie sich direkt anmelden und sich mit seinem Benutzernamen fÃ¼r ein anderes Konto ausgeben.
 
 # Password policy
-password.expiration.warning=Ihr Kennwort läuft in {0} Tagen ab. Bitte <a href\="{1}">ändern Sie Ihr Kennwort</a>.
-password.expiration.loginsRemaining=Sie haben {0} Anmeldungen übrig, bevor Sie Ihr Kennwort ändern <strong>müssen</strong>.
+password.expiration.warning=Ihr Kennwort lÃ¤uft in {0} Tagen ab. Bitte <a href\="{1}">Ã¤ndern Sie Ihr Kennwort</a>.
+password.expiration.loginsRemaining=Sie haben {0} Anmeldungen Ã¼brig, bevor Sie Ihr Kennwort Ã¤ndern <strong>mÃ¼ssen</strong>.
 screen.accountdisabled.heading=Dieses Konto wurde deaktiviert.
 screen.accountdisabled.message=Bitte kontaktieren Sie Ihren System Administrator um wieder Zugriff zu erhalten.
 screen.accountlocked.heading=Dieses Konto wurde gesperrt.
 screen.accountlocked.message=Bitte kontaktieren Sie den Systemadministrator um wieder Zugang zu erlangen.
 screen.expiredpass.heading=Ihr Kennwort ist abgelaufen.
-screen.expiredpass.message=Bitte <a href="{0}">ändern Sie Ihr Kennwort</a>.
-screen.mustchangepass.heading=Sie müssen Ihr Kennwort ändern.
-screen.mustchangepass.message=Bitte <a href="{0}">ändern Sie Ihr Kennwort</a>.
+screen.expiredpass.message=Bitte <a href="{0}">Ã¤ndern Sie Ihr Kennwort</a>.
+screen.mustchangepass.heading=Sie mÃ¼ssen Ihr Kennwort Ã¤ndern.
+screen.mustchangepass.message=Bitte <a href="{0}">Ã¤ndern Sie Ihr Kennwort</a>.
 screen.badhours.heading=Ihrem Konto ist es nicht gestattet sich zu diesem Zeitpunkt anzumelden.
-screen.badhours.message=Bitte versuchen Sie es später noch einmal.
+screen.badhours.message=Bitte versuchen Sie es spÃ¤ter noch einmal.
 screen.authnblocked.heading=Anmeldeversuch blockiert.
-screen.authnblocked.message=Der Anmeldeversuch von Ihrer aktuellen Workstation ist nicht vertrauenswürdig und unbefugt.
+screen.authnblocked.message=Der Anmeldeversuch von Ihrer aktuellen Workstation ist nicht vertrauenswÃ¼rdig und unbefugt.
 screen.risk.authnblocked.heading=Anmeldeversuch blockiert.
-screen.risk.authnblocked.message=Der Anmeldeversuch von Ihrer aktuellen Workstation ist nicht vertrauenswürdig und unbefugt.
-screen.badworkstation.heading=Sie können sich von dieser Workstation aus nicht anmelden.
+screen.risk.authnblocked.message=Der Anmeldeversuch von Ihrer aktuellen Workstation ist nicht vertrauenswÃ¼rdig und unbefugt.
+screen.badworkstation.heading=Sie kÃ¶nnen sich von dieser Workstation aus nicht anmelden.
 screen.badworkstation.message=Bitte kontaktieren Sie Ihren System Administrator um Zugriff zu erhalten.
-screen.button.changePassword=Passwort ändern
+screen.button.changePassword=Passwort Ã¤ndern
 
-screen.pm.success.header=Passwortänderung erfolgreich
-screen.pm.success.message=Das Passwort Ihres Kontos wurde erfolgreich geändert.
+screen.pm.success.header=PasswortÃ¤nderung erfolgreich
+screen.pm.success.message=Das Passwort Ihres Kontos wurde erfolgreich geÃ¤ndert.
 
-screen.pm.confirmpsw=Passwort bestätigen:
+screen.pm.confirmpsw=Passwort bestÃ¤tigen:
 screen.pm.enterpsw=Passwort eingeben:
 
-screen.pac4j.authn.TechnicalException=Die Konfiguration des Identitätsanbieters kann nicht gefunden oder analysiert werden, höchstwahrscheinlich aufgrund einer Fehlkonfiguration. \
-  Überprüfen Sie die Protokolle, um die Ursache des Problems zu finden.
-screen.pac4j.authn.unknown=Die vom externen Identitätsanbieter an den CAS übermittelte Authentifizierungsantwort kann nicht akzeptiert werden.
+screen.pac4j.authn.TechnicalException=Die Konfiguration des IdentitÃ¤tsanbieters kann nicht gefunden oder analysiert werden, hÃ¶chstwahrscheinlich aufgrund einer Fehlkonfiguration. \
+  ÃœberprÃ¼fen Sie die Protokolle, um die Ursache des Problems zu finden.
+screen.pac4j.authn.unknown=Die vom externen IdentitÃ¤tsanbieter an den CAS Ã¼bermittelte Authentifizierungsantwort kann nicht akzeptiert werden.
 screen.pac4j.unauthz.pagetitle=Unbefugter Zugriff
 screen.pac4j.unauthz.gotoapp=Zur Anwendung
-screen.pac4j.unauthz.login=Zurück zu CAS
+screen.pac4j.unauthz.login=ZurÃ¼ck zu CAS
 screen.pac4j.unauthz.heading=Unbefugter Zugriff
 screen.pac4j.unauthz.message=Entweder wurde Ihre Anmeldeversuch abgewiesen/abgebrochen oder die Authentifikationsstelle (authentication provider) hat den Zugriff verweigert, da \
-  Berechtigungen fehlen, usw. Untersuchen Sie die Logs, um den ursprünglichen Auslöser dieses Fehlers zu finden.
+  Berechtigungen fehlen, usw. Untersuchen Sie die Logs, um den ursprÃ¼nglichen AuslÃ¶ser dieses Fehlers zu finden.
 screen.pac4j.button.retry=Erneut versuchen
-screen.pac4j.discovery.intro=Bitte geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse an, damit CAS den richtigen Identitätsanbieter für Ihr Konto finden kann.
-screen.pac4j.discovery.unknownclient=Identitätsanbieter kann basierend auf dieser Anfrage nicht gefunden werden.
-screen.pac4j.button.selectprovider=Identitätsanbieter auswählen
+screen.pac4j.discovery.intro=Bitte geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse an, damit CAS den richtigen IdentitÃ¤tsanbieter fÃ¼r Ihr Konto finden kann.
+screen.pac4j.discovery.unknownclient=IdentitÃ¤tsanbieter kann basierend auf dieser Anfrage nicht gefunden werden.
+screen.pac4j.button.selectprovider=IdentitÃ¤tsanbieter auswÃ¤hlen
 screen.pac4j.discovery.title=Dynamische Erkennung mit delegierter Authentifizierung
-screen.pac4j.authn.SAMLException=Die vom externen Identitätsanbieter an CAS übermittelte Authentifizierungsantwort kann nicht akzeptiert werden. \
+screen.pac4j.authn.SAMLException=Die vom externen IdentitÃ¤tsanbieter an CAS Ã¼bermittelte Authentifizierungsantwort kann nicht akzeptiert werden. \
   Untersuchen Sie bitte die CAS-Serverprotokolle und -konfiguration, um die Ursache des Problems zu finden, und versuchen Sie es dann erneut.
-screen.pac4j.authn.SAMLIssueInstantException=An CAS vom externen Identitätsanbieter bereitgestellte Authentifizierungsantwort kann nicht akzeptiert werden \
-  weil der Authentifizierungszeitpunkt angesichts der gegenwärtigen CAS-Konfiguration entweder zu alt oder in der Zukunft gesetzt ist.
+screen.pac4j.authn.SAMLIssueInstantException=An CAS vom externen IdentitÃ¤tsanbieter bereitgestellte Authentifizierungsantwort kann nicht akzeptiert werden \
+  weil der Authentifizierungszeitpunkt angesichts der gegenwÃ¤rtigen CAS-Konfiguration entweder zu alt oder in der Zukunft gesetzt ist.
 
 screen.pac4j.credential-selection.title=Delegierte Authentifizierungsprofilauswahl
-screen.pac4j.credential-selection.intro=CAS hat mehrere Profile gefunden, die Ihrem Benutzerkonto zugeordnet sind. Bitte wählen Sie das Konto \
-  mit der Sie sich anmelden und fortfahren möchten.
+screen.pac4j.credential-selection.intro=CAS hat mehrere Profile gefunden, die Ihrem Benutzerkonto zugeordnet sind. Bitte wÃ¤hlen Sie das Konto \
+  mit der Sie sich anmelden und fortfahren mÃ¶chten.
 
 screen.delauthn.error.header=Delegierter Authentifizierungsfehler
-screen.delauthn.error.message=CAS kann das delegierte Authentifizierungsszenario nicht abschließen, \
-  oder zum ausgewählten Identitätsanbieter umleiten. Bitte überprüfen Sie die ursprüngliche Authentifizierungsanforderung und versuchen Sie es erneut. \
-  Möglicherweise müssen Sie Ihren Browser schließen und neu starten.
+screen.delauthn.error.message=CAS kann das delegierte Authentifizierungsszenario nicht abschlieÃŸen, \
+  oder zum ausgewÃ¤hlten IdentitÃ¤tsanbieter umleiten. Bitte Ã¼berprÃ¼fen Sie die ursprÃ¼ngliche Authentifizierungsanforderung und versuchen Sie es erneut. \
+  MÃ¶glicherweise mÃ¼ssen Sie Ihren Browser schlieÃŸen und neu starten.
 
 # GAuth
-screen.authentication.gauth.register=Ihr Konto ist nicht registiert. Nutzen Sie die Einstellungen unten, um Ihr Gerät bei CAS zu registieren.
-screen.authentication.gauth.key=Der geheime Schlüssel (secret key) zur Registerung lautet {0}
+screen.authentication.gauth.register=Ihr Konto ist nicht registiert. Nutzen Sie die Einstellungen unten, um Ihr GerÃ¤t bei CAS zu registieren.
+screen.authentication.gauth.key=Der geheime SchlÃ¼ssel (secret key) zur Registerung lautet {0}
 screen.authentication.gauth.scratchcodes=Scratch codes:
-screen.authentication.gauth.selecteddevice=Ihr ausgewähltes Gerät für die mehrstufige Authentifizierung ist: <code>{0}</code>.
-screen.authentication.gauth.selanotherdevice=Sie können ein anderes Gerät für die mehrstufige Authentifizierung auswählen, wenn <code>{0}</code> nicht Ihr aktuelles Gerät ist.
-screen.authentication.gauth.name=Gerätename:
+screen.authentication.gauth.selecteddevice=Ihr ausgewÃ¤hltes GerÃ¤t fÃ¼r die mehrstufige Authentifizierung ist: <code>{0}</code>.
+screen.authentication.gauth.selanotherdevice=Sie kÃ¶nnen ein anderes GerÃ¤t fÃ¼r die mehrstufige Authentifizierung auswÃ¤hlen, wenn <code>{0}</code> nicht Ihr aktuelles GerÃ¤t ist.
+screen.authentication.gauth.name=GerÃ¤tename:
 screen.authentication.gauth.cancel=Abbrechen
-screen.authentication.gauth.reganotherdevice=Sie können auch ein anderes Gerät zur Verwendung für die mehrstufige Authentifizierung registrieren.
-screen.authentication.gauth.selectdevice=Gerät auswählen
-screen.authentication.gauth.deletedevice=Gerät löschen
-screen.authentication.gauth.invalid=Diese Authentifizierungsanforderung kann nicht akzeptiert werden. Das ausgewählte Gerät oder die angegebenen Anmeldedaten sind ungültig.
-screen.authentication.gauth.invalidtoken=Dieses Token kann nicht akzeptiert werden. Der angegebene Token ist ungültig, gehört nicht zum Gerät oder ist abgelaufen.
-screen.authentication.gauth.confirm.title=Kontoregistrierung bestätigen
-screen.authentication.gauth.confirm.desc=Bestätigen Sie ihre Kontoregistrierung, indem Sie ein Token \
-  aus der Authenticator-App auf ihrem Gerät eintragen. Sobald das Token überprüft wurde, wird ihre Kontoregistrierung abgeschlossen.
+screen.authentication.gauth.reganotherdevice=Sie kÃ¶nnen auch ein anderes GerÃ¤t zur Verwendung fÃ¼r die mehrstufige Authentifizierung registrieren.
+screen.authentication.gauth.selectdevice=GerÃ¤t auswÃ¤hlen
+screen.authentication.gauth.deletedevice=GerÃ¤t lÃ¶schen
+screen.authentication.gauth.invalid=Diese Authentifizierungsanforderung kann nicht akzeptiert werden. Das ausgewÃ¤hlte GerÃ¤t oder die angegebenen Anmeldedaten sind ungÃ¼ltig.
+screen.authentication.gauth.invalidtoken=Dieses Token kann nicht akzeptiert werden. Der angegebene Token ist ungÃ¼ltig, gehÃ¶rt nicht zum GerÃ¤t oder ist abgelaufen.
+screen.authentication.gauth.confirm.title=Kontoregistrierung bestÃ¤tigen
+screen.authentication.gauth.confirm.desc=BestÃ¤tigen Sie ihre Kontoregistrierung, indem Sie ein Token \
+  aus der Authenticator-App auf ihrem GerÃ¤t eintragen. Sobald das Token Ã¼berprÃ¼ft wurde, wird ihre Kontoregistrierung abgeschlossen.
   
-screen.welcome.button.register-residentkey=Registrieren Sie das Gerät mit erkennbaren Anmeldeinformationen
-screen.authentication.webauthn.confirm.title=Kontoregistrierung bestätigen
-screen.authentication.webauthn.confirm.desc=Beginnen Sie die Registrierung, indem Sie ihrem FIDO2-Geärt einen Namen zuweisen.
-screen.authentication.webauthn.name=Gerätename
-screen.authentication.webauthn.login.title=Mit dem FIDO2-Gerät einloggen
-screen.authentication.webauthn.login.desc=Benutzen Sie ihr FIDO2-Geärt um sich einzuloggen. \
-  Um diesen Vorgang erfolgreich abzuschließen, muss ihr Benutzername und ihr Geräte schon bei CAS registriert sein.
+screen.welcome.button.register-residentkey=Registrieren Sie das GerÃ¤t mit erkennbaren Anmeldeinformationen
+screen.authentication.webauthn.confirm.title=Kontoregistrierung bestÃ¤tigen
+screen.authentication.webauthn.confirm.desc=Beginnen Sie die Registrierung, indem Sie ihrem FIDO2-GeÃ¤rt einen Namen zuweisen.
+screen.authentication.webauthn.name=GerÃ¤tename
+screen.authentication.webauthn.login.title=Mit dem FIDO2-GerÃ¤t einloggen
+screen.authentication.webauthn.login.desc=Benutzen Sie ihr FIDO2-GeÃ¤rt um sich einzuloggen. \
+  Um diesen Vorgang erfolgreich abzuschlieÃŸen, muss ihr Benutzername und ihr GerÃ¤te schon bei CAS registriert sein.
 screen.authentication.webauthn.authn.fail.title=Authentifizierung fehlgeschlagen
 screen.authentication.webauthn.authn.fail.desc=Der Authentifizierungsversuch ist fehlgeschlagen. Bitte stellen Sie sicher, \
-   dass ihr Benutzername und das gewählte Gerät bei CAS registriert sind.
+   dass ihr Benutzername und das gewÃ¤hlte GerÃ¤t bei CAS registriert sind.
 
 # OAuth
 screen.oauth.confirm.header=Autorisierung
@@ -432,21 +432,21 @@ screen.oauth.confirm.allow=Erlauben
 screen.oauth.confirm.deny=Verbieten
 cas.oauth.confirm.pagetitle=Zugriff genehmigen
 
-cas.oauth.device.confirm.header=Gerät verbinden
-cas.oauth.device.confirm.message=Geben Sie den auf Ihrem Gerät angezeigten Code ein, um fortzufahren.
+cas.oauth.device.confirm.header=GerÃ¤t verbinden
+cas.oauth.device.confirm.message=Geben Sie den auf Ihrem GerÃ¤t angezeigten Code ein, um fortzufahren.
 
 cas.oauth.device.confirmed.header=Code akzeptiert
-cas.oauth.device.confirmed.message=Kehren Sie zu Ihrem Gerät zurück, um fortzufahren.
+cas.oauth.device.confirmed.message=Kehren Sie zu Ihrem GerÃ¤t zurÃ¼ck, um fortzufahren.
 
 cas.oauth.error.pagetitle=OAuth Fehler
 cas.oauth.error.header=OAuth Autorisierungsfehler
 OAUTH_BAD_SESSION_REQUEST=Die OAuth-Anforderung kann nicht abgeschlossen werden, da CAS die OAuth-Umleitungs-URL nicht finden oder bestimmen kann. \
-  Dies ist normalerweise ein Hinweis auf eine veraltete oder nicht übereinstimmende Anfrage, bei der sich die Sitzungs-ID der verarbeiteten Anfrage von der \
-  aktive Sitzung unterscheidet, dies kann durch einen vollständigen Abmeldevorgang verursacht werden. Löschen Sie Cookies und Verlauf, starten Sie Ihren Browser neu und versuchen Sie es erneut.
+  Dies ist normalerweise ein Hinweis auf eine veraltete oder nicht Ã¼bereinstimmende Anfrage, bei der sich die Sitzungs-ID der verarbeiteten Anfrage von der \
+  aktive Sitzung unterscheidet, dies kann durch einen vollstÃ¤ndigen Abmeldevorgang verursacht werden. LÃ¶schen Sie Cookies und Verlauf, starten Sie Ihren Browser neu und versuchen Sie es erneut.
 
 # OIDC
-screen.oidc.confirm.infourl=Erfahren Sie mehr über {0}.
-screen.oidc.confirm.privacyurl=Erfahren Sie mehr über {0} Datenschutzregeln.
+screen.oidc.confirm.infourl=Erfahren Sie mehr Ã¼ber {0}.
+screen.oidc.confirm.privacyurl=Erfahren Sie mehr Ã¼ber {0} Datenschutzregeln.
 screen.oidc.confirm.scopes=Scopes
 screen.oidc.confirm.claims=Claims
 screen.oidc.confirm.scope.profile=Es wird Zugriff auf das Profil mit Ausnahme der Adresse und E-Mail angefordert.
@@ -454,17 +454,17 @@ screen.oidc.confirm.scope.email=Es wird Zugriff auf die E-Mail angefordert.
 screen.oidc.confirm.scope.address=Es wird Zugriff auf die Adresse angefordert.
 screen.oidc.confirm.scope.openid=Dies weist auf eine OpenID Connect-Autorisierungsanforderung hin.
 screen.oidc.confirm.scope.phone=Es wird Zugriff auf die Telefonnummer angefordert.
-screen.oidc.confirm.scope.offline_access=Dies fordert den Zugriff auf ein Aktualisierungstoken an, das für den Offlinezugriff verwendet wird.
+screen.oidc.confirm.scope.offline_access=Dies fordert den Zugriff auf ein Aktualisierungstoken an, das fÃ¼r den Offlinezugriff verwendet wird.
 
 
-screen.oidc.confirm.claim.name=Vollständiger Name des Benutzers in anzeigbarer Form, einschließlich aller Namensteile, möglicherweise einschließlich Titel und Suffixe, sortiert nach dem Gebietsschema und den Präferenzen des Benutzers.
-screen.oidc.confirm.claim.given_name=Vorname(n) des Benutzers. Beachten Sie, dass Menschen in manchen Kulturen mehrere Vornamen haben können, alle können vorhanden sein, wobei die Namen durch Leerzeichen getrennt werden.
-screen.oidc.confirm.claim.middle_name=Zweiter Vorname(n) des Benutzers. Beachten Sie, dass Menschen in manchen Kulturen mehrere Zweitnamen haben können, alle können vorhanden sein, wobei die Namen durch Leerzeichen getrennt werden. Beachten Sie auch, dass in einigen Kulturen keine zweiten Vornamen verwendet werden.
-screen.oidc.confirm.claim.family_name=Nachname(n) des Benutzers. Beachten Sie, dass Menschen in einigen Kulturen mehrere Familiennamen oder keinen Familiennamen haben können, alle können vorhanden sein, wobei die Namen durch Leerzeichen getrennt werden.
+screen.oidc.confirm.claim.name=VollstÃ¤ndiger Name des Benutzers in anzeigbarer Form, einschlieÃŸlich aller Namensteile, mÃ¶glicherweise einschlieÃŸlich Titel und Suffixe, sortiert nach dem Gebietsschema und den PrÃ¤ferenzen des Benutzers.
+screen.oidc.confirm.claim.given_name=Vorname(n) des Benutzers. Beachten Sie, dass Menschen in manchen Kulturen mehrere Vornamen haben kÃ¶nnen, alle kÃ¶nnen vorhanden sein, wobei die Namen durch Leerzeichen getrennt werden.
+screen.oidc.confirm.claim.middle_name=Zweiter Vorname(n) des Benutzers. Beachten Sie, dass Menschen in manchen Kulturen mehrere Zweitnamen haben kÃ¶nnen, alle kÃ¶nnen vorhanden sein, wobei die Namen durch Leerzeichen getrennt werden. Beachten Sie auch, dass in einigen Kulturen keine zweiten Vornamen verwendet werden.
+screen.oidc.confirm.claim.family_name=Nachname(n) des Benutzers. Beachten Sie, dass Menschen in einigen Kulturen mehrere Familiennamen oder keinen Familiennamen haben kÃ¶nnen, alle kÃ¶nnen vorhanden sein, wobei die Namen durch Leerzeichen getrennt werden.
 screen.oidc.confirm.claim.email=Bevorzugte E-Mail-Adresse des Benutzers.
-screen.oidc.confirm.claim.preferred_username=KANN eine beliebige gültige JSON-Zeichenfolge sein, einschließlich Sonderzeichen wie @, / oder Leerzeichen. Der RP DARF NICHT darauf vertrauen, dass dieser Wert eindeutig ist.
+screen.oidc.confirm.claim.preferred_username=KANN eine beliebige gÃ¼ltige JSON-Zeichenfolge sein, einschlieÃŸlich Sonderzeichen wie @, / oder Leerzeichen. Der RP DARF NICHT darauf vertrauen, dass dieser Wert eindeutig ist.
 screen.oidc.confirm.claim.profile=URL der Profilseite des Benutzers. Der Inhalt dieser Webseite sollte sich auf den Benutzer beziehen.
-screen.oidc.confirm.claim.picture=URL des Profilbildes des Benutzers. Diese URL muss auf eine Bilddatei verweisen (z. B. eine PNG-, JPEG- oder GIF-Bilddatei) und nicht auf eine Webseite, die ein Bild enthält. Beachten Sie, dass diese URL speziell auf ein Profilfoto des Benutzers verweisen sollte, das zur Anzeige geeignet ist und nicht auf ein willkürliches Foto, das vom Benutzer aufgenommen wurde.
+screen.oidc.confirm.claim.picture=URL des Profilbildes des Benutzers. Diese URL muss auf eine Bilddatei verweisen (z. B. eine PNG-, JPEG- oder GIF-Bilddatei) und nicht auf eine Webseite, die ein Bild enthÃ¤lt. Beachten Sie, dass diese URL speziell auf ein Profilfoto des Benutzers verweisen sollte, das zur Anzeige geeignet ist und nicht auf ein willkÃ¼rliches Foto, das vom Benutzer aufgenommen wurde.
 screen.oidc.confirm.claim.phone_number=Bevorzugte Telefonnummer des Benutzers. Es werden folgende Formate empfoholen. \
   Beispiel: <code>+1 (425) 555-1212</code> oder <code>+56 (2) 687 2400</code>.
     
@@ -481,11 +481,11 @@ screen.mfaDenied.heading=Der MFA-Versuch wurde vom Anbieter abgelehnt
 screen.mfaDenied.message=Ihr MFA-Anbieter hat Ihren Versuch der mehrstufigen Authentifizierung abgelehnt. \
   Wenden Sie sich an Ihren Administrator, um Hilfe bei der Wiederherstellung Ihres Kontos zu erhalten.
 
-screen.mfaUnavailable.header=MFA-Anbieter nicht verfügbar
-screen.mfaUnavailable.heading=MFA-Anbieter nicht verfügbar
+screen.mfaUnavailable.header=MFA-Anbieter nicht verfÃ¼gbar
+screen.mfaUnavailable.heading=MFA-Anbieter nicht verfÃ¼gbar
 screen.mfaUnavailable.message=CAS konnte Ihren konfigurierten MFA-Anbieter zu diesem Zeitpunkt nicht erreichen. \
-  Aufgrund von Fehlerrichtlinien, die für den Dienst konfiguriert sind, auf den Sie zugreifen möchten, kann die Authentifizierung zu diesem Zeitpunkt \
-  nicht gewährt werden.
+  Aufgrund von Fehlerrichtlinien, die fÃ¼r den Dienst konfiguriert sind, auf den Sie zugreifen mÃ¶chten, kann die Authentifizierung zu diesem Zeitpunkt \
+  nicht gewÃ¤hrt werden.
 
 #####################################################################
 # Login View
@@ -513,103 +513,103 @@ cas.acceptableusagepolicyview.pagetitle=Akzeptable Nutzungsrichtlinien
 cas.mfa.providerselection.pagetitle=Multifaktor-Anbieterauswahl
 
 cas.mfa.providerselection.mfa-duo=Duo Security
-cas.mfa.providerselection.mfa-duo.notes=Die große Auswahl an Authentifizierungsmethoden von Duo ermöglicht es jedem Benutzer, \
-  sich sicher und schnell anmelden. Duo Push, gesendet von der Duo Mobile-Authentifizierungs-App, ermöglicht es Benutzern, \
-  Push-Benachrichtigungen zu erhalten, um ihre Identität zu überprüfen.
+cas.mfa.providerselection.mfa-duo.notes=Die groÃŸe Auswahl an Authentifizierungsmethoden von Duo ermÃ¶glicht es jedem Benutzer, \
+  sich sicher und schnell anmelden. Duo Push, gesendet von der Duo Mobile-Authentifizierungs-App, ermÃ¶glicht es Benutzern, \
+  Push-Benachrichtigungen zu erhalten, um ihre IdentitÃ¤t zu Ã¼berprÃ¼fen.
 
 cas.mfa.providerselection.mfa-webauthn=FIDO2 WebAuthn
 cas.mfa.providerselection.mfa-webauthn.notes=WebAuthn ist eine API, die es einer Seite sehr einfach macht, \
-  z.B. einem Webdienst, eine starke Authentifizierung in ihre Anwendungen zu integrieren, indem die Unterstützung aller \
-  führenden Browser und Plattformen genutzt wird.
+  z.B. einem Webdienst, eine starke Authentifizierung in ihre Anwendungen zu integrieren, indem die UnterstÃ¼tzung aller \
+  fÃ¼hrenden Browser und Plattformen genutzt wird.
 
 cas.mfa.providerselection.mfa-gauth=Google Authenticator
 cas.mfa.providerselection.mfa-gauth.notes=Google Authenticator ist ein softwarebasierter Authentifikator, der \
   die mehrstufige Authentifizierung mit Hilfe einer mobilien Anwendung von Google bereitstellt.
 cas.mfa.providerselection.mfa-simple=CAS Multifactor Authentication
-cas.mfa.providerselection.mfa-simple.notes=Ermöglichen Sie es CAS als mehrstufiger Authentifizierungdienst aufzutreten, \
-  indem Tokens erstellt und über vordefinierte Wege, wie SMS oder E-Mail, versendet werden.
+cas.mfa.providerselection.mfa-simple.notes=ErmÃ¶glichen Sie es CAS als mehrstufiger Authentifizierungdienst aufzutreten, \
+  indem Tokens erstellt und Ã¼ber vordefinierte Wege, wie SMS oder E-Mail, versendet werden.
 cas.mfa.providerselection.mfa-yubikey=YubiKey Multifactor Authentication
 cas.mfa.providerselection.mfa-yubikey.notes=Yubico ist ein Cloud-basierter Dienst, der starke, benutzerfreundliche \
-   und erschwingliche Zwei-Faktor-Authentifizierung mit Einmalpasswörtern durch ihr Flaggschiffprodukt YubiKey bereitstellt.
+   und erschwingliche Zwei-Faktor-Authentifizierung mit EinmalpasswÃ¶rtern durch ihr Flaggschiffprodukt YubiKey bereitstellt.
 cas.mfa.providerselection.mfa-u2f=U2F Multifactor Authentication
-cas.mfa.providerselection.mfa-u2f.notes=U2F ist ein offener Authentifizierungsstandard, der es Internetbenutzern ermöglicht, \
-  auf eine belibiege Anzahl von Onlinediensten zuzugreifen, mit einem einzelen Gerät, sofort und erforderliche Treiber oder Client-Software.
+cas.mfa.providerselection.mfa-u2f.notes=U2F ist ein offener Authentifizierungsstandard, der es Internetbenutzern ermÃ¶glicht, \
+  auf eine belibiege Anzahl von Onlinediensten zuzugreifen, mit einem einzelen GerÃ¤t, sofort und erforderliche Treiber oder Client-Software.
 
 cas.mfa.duologin.pagetitle=Duo Security Login
 
 cas.mfa.simple.pagetitle=CAS Multifactor Authentication Login
 cas.mfa.simple.label.token=Token:
 cas.mfa.simple.label.resend=Erneut senden
-cas.mfa.simple.label.tokensent=Ein Token für die mehrstufige Authentifizierung wurde per E-Mail oder SMS gesendet. \
-  Bitte geben Sie das Token hier ein um fortzufahren. Beachten Sie, dass das Token nach kurzer Zeit abläuft \
-  und von CAS nicht mehr erkannt wird. In diesem Fall können Sie CAS bitten, Ihnen ein neues Token zuzusenden.
+cas.mfa.simple.label.tokensent=Ein Token fÃ¼r die mehrstufige Authentifizierung wurde per E-Mail oder SMS gesendet. \
+  Bitte geben Sie das Token hier ein um fortzufahren. Beachten Sie, dass das Token nach kurzer Zeit ablÃ¤uft \
+  und von CAS nicht mehr erkannt wird. In diesem Fall kÃ¶nnen Sie CAS bitten, Ihnen ein neues Token zuzusenden.
 
 cas.mfa.googleauth.pagetitle=Google Authenticator
 cas.mfa.googleauth.label.token=Token:
 
 cas.mfa.radius.pagetitle=Radius Authentication
 
-screen.authentication.yubikey.reganotherdevice=Sie können auch ein anderes Gerät zur Verwendung für die mehrstufige Authentifizierung registrieren.
-screen.authentication.yubikey.name=Gerätename:
+screen.authentication.yubikey.reganotherdevice=Sie kÃ¶nnen auch ein anderes GerÃ¤t zur Verwendung fÃ¼r die mehrstufige Authentifizierung registrieren.
+screen.authentication.yubikey.name=GerÃ¤tename:
 cas.mfa.yubikey.pagetitle=YubiKey Authentifizierung
-cas.mfa.yubikey.authenticate=Verwenden Sie Ihre registrierten YubiKey-Geräte zur Authentifizierung.
-cas.mfa.yubikey.register=Ihr Gerät ist noch nicht registriert. Verwenden Sie das folgende Formular, um Ihr Gerät bei CAS zu registrieren.
-cas.mfa.yubikey.register.fail=Ihr YubiKey-Gerät kann nicht für die Authentifizierung registriert werden. Das angegebene Token kann ungültig, abgelaufen oder anderweitig kompromittiert sein.
+cas.mfa.yubikey.authenticate=Verwenden Sie Ihre registrierten YubiKey-GerÃ¤te zur Authentifizierung.
+cas.mfa.yubikey.register=Ihr GerÃ¤t ist noch nicht registriert. Verwenden Sie das folgende Formular, um Ihr GerÃ¤t bei CAS zu registrieren.
+cas.mfa.yubikey.register.fail=Ihr YubiKey-GerÃ¤t kann nicht fÃ¼r die Authentifizierung registriert werden. Das angegebene Token kann ungÃ¼ltig, abgelaufen oder anderweitig kompromittiert sein.
 cas.mfa.yubikey.label.token=Token:
 
 cas.mfa.u2f.pagetitle=U2F Authentifizierung
-cas.mfa.u2f.authentication.device=Authentifizierungsgerät
-cas.mfa.u2f.authentication.message=<p><strong>Bitte berühren Sie jetzt das blinkende U2F-Gerät.</strong></p><p> Möglicherweise werden Sie aufgefordert, \
-  die Berechtigung für den Zugriff auf Ihre Sicherheitsschlüssel zu erteilen. Nachdem Sie die Erlaubnis erteilt haben, beginnt das Gerät zu blinken.</p>
-cas.mfa.u2f.register.device=Gerät registrieren
-cas.mfa.u2f.register.message=<p><strong>Bitte berühren Sie jetzt das blinkende U2F-Gerät.</strong></p><p> Möglicherweise werden Sie aufgefordert, \
-  die Berechtigung für den Zugriff auf Ihre Sicherheitsschlüssel zu erteilen. Nachdem Sie die Erlaubnis erteilt haben, beginnt das Gerät zu blinken.</p>
+cas.mfa.u2f.authentication.device=AuthentifizierungsgerÃ¤t
+cas.mfa.u2f.authentication.message=<p><strong>Bitte berÃ¼hren Sie jetzt das blinkende U2F-GerÃ¤t.</strong></p><p> MÃ¶glicherweise werden Sie aufgefordert, \
+  die Berechtigung fÃ¼r den Zugriff auf Ihre SicherheitsschlÃ¼ssel zu erteilen. Nachdem Sie die Erlaubnis erteilt haben, beginnt das GerÃ¤t zu blinken.</p>
+cas.mfa.u2f.register.device=GerÃ¤t registrieren
+cas.mfa.u2f.register.message=<p><strong>Bitte berÃ¼hren Sie jetzt das blinkende U2F-GerÃ¤t.</strong></p><p> MÃ¶glicherweise werden Sie aufgefordert, \
+  die Berechtigung fÃ¼r den Zugriff auf Ihre SicherheitsschlÃ¼ssel zu erteilen. Nachdem Sie die Erlaubnis erteilt haben, beginnt das GerÃ¤t zu blinken.</p>
 
-cas.mfa.webauthn.auth.fail=Das Gerät kann nicht zur Authentifizierung verifiziert werden. Bereitgestellte Daten können ungültig, abgelaufen oder anderweitig kompromittiert sein.
+cas.mfa.webauthn.auth.fail=Das GerÃ¤t kann nicht zur Authentifizierung verifiziert werden. Bereitgestellte Daten kÃ¶nnen ungÃ¼ltig, abgelaufen oder anderweitig kompromittiert sein.
 
 cas.mfa.authy.pagetitle=Authy Login
-cas.mfa.authy.error.authn=Wir können Authy nicht kontaktieren. Der CAS-Authentifizierungsversuch ist fehlgeschlagen. Ihr Konto wurde möglicherweise gesperrt \
-  und aufgrund zu vieler Fehlversuche deaktiviert. Bitte kontaktieren Sie Ihren CAS-Administrator für weitere Informationen.
+cas.mfa.authy.error.authn=Wir kÃ¶nnen Authy nicht kontaktieren. Der CAS-Authentifizierungsversuch ist fehlgeschlagen. Ihr Konto wurde mÃ¶glicherweise gesperrt \
+  und aufgrund zu vieler Fehlversuche deaktiviert. Bitte kontaktieren Sie Ihren CAS-Administrator fÃ¼r weitere Informationen.
 
-cas.mfa.registerdevice.label.title=Gerät registrieren
-cas.mfa.registerdevice.label.intro=Bitte geben Sie einen Namen für das aktuelle Gerät an.
-cas.mfa.registerdevice.pagetitle=Gerät registrieren
+cas.mfa.registerdevice.label.title=GerÃ¤t registrieren
+cas.mfa.registerdevice.label.intro=Bitte geben Sie einen Namen fÃ¼r das aktuelle GerÃ¤t an.
+cas.mfa.registerdevice.pagetitle=GerÃ¤t registrieren
 cas.mfa.registerdevice.label.name=Name
-cas.mfa.registerdevice.label.duration=Wie lange soll dieses Gerät gespeichert werden?
+cas.mfa.registerdevice.label.duration=Wie lange soll dieses GerÃ¤t gespeichert werden?
 cas.mfa.registerdevice.label.expiration=Laufzeit
 cas.mfa.registerdevice.button.register=Registrieren
-cas.mfa.registerdevice.button.skip=Überspringen
-cas.mfa.registerdevice.options.timeunit.forever=Für immer
+cas.mfa.registerdevice.button.skip=Ãœberspringen
+cas.mfa.registerdevice.options.timeunit.forever=FÃ¼r immer
 
 passwordless.token.header=Token angeben
 passwordless.token.description=Bitte geben Sie das Sicherheitstoken an, welches Ihnen per E-Mail, Telefon, etc. zugestellt wurde. \
-  Beachten Sie, dass das Token nur für ein kurzes Fenster gültig ist und nach der Übermittlung alle anderen Token ungültig gemacht und entfernt werden.
+  Beachten Sie, dass das Token nur fÃ¼r ein kurzes Fenster gÃ¼ltig ist und nach der Ãœbermittlung alle anderen Token ungÃ¼ltig gemacht und entfernt werden.
   
 passwordless.error.failure.title=Authentifizierungsfehler
-passwordless.error.failure.description=Das angegebene Token konnte nicht überprüft werden. Es kann ungültig gemacht, entfernt oder abgelaufen sein.
+passwordless.error.failure.description=Das angegebene Token konnte nicht Ã¼berprÃ¼ft werden. Es kann ungÃ¼ltig gemacht, entfernt oder abgelaufen sein.
 
 passwordless.error.unknown.user=Der angegebene Benutzername kann von CAS nicht erkannt und gefunden werden.
-passwordless.error.invalid.user=Der angegebene Benutzername enthält nicht genügend Kontaktinformationen.
+passwordless.error.invalid.user=Der angegebene Benutzername enthÃ¤lt nicht genÃ¼gend Kontaktinformationen.
 
 cas.authn.qr.fail=Authentifizierungsanfrage basierend auf einem QR-Code kann nicht bearbeitet werden. Stellen Sie sicher, dass der QR-Code korrekt gescannt wurde, \
-  und die bereitgestellten Anmeldeinformationen gültig sind, von diesem CAS-Server ausgestellt wurden und nicht abgelaufen sind.
+  und die bereitgestellten Anmeldeinformationen gÃ¼ltig sind, von diesem CAS-Server ausgestellt wurden und nicht abgelaufen sind.
 
 # Inwebo
-cas.inwebo.checkresult.title=Überprüfung der Inwebo-Authentifizierung
+cas.inwebo.checkresult.title=ÃœberprÃ¼fung der Inwebo-Authentifizierung
 cas.inwebo.checkresult.heading=Warten auf die Genehmigung der Inwebo-Benachrichtigung:
-cas.inwebo.checkresult.message=Bitte bestätigen Sie es auf Ihrem Telefon/Desktop...
+cas.inwebo.checkresult.message=Bitte bestÃ¤tigen Sie es auf Ihrem Telefon/Desktop...
 cas.inwebo.error.title=Inwebo-Authentifizierungsfehler
 cas.inwebo.error.heading=Ein Fehler ist aufgetreten.
 cas.inwebo.error.userrefusedortoolate=Sie haben die Authentifizierung abgelehnt oder nicht schnell genug validiert.
-cas.inwebo.error.usernotregistered=Vor jedem Login müssen Sie bei Inwebo registriert sein. Überprüfen Sie Ihr Postfach auf \
-  Anweisungen für den Registrierungsprozess oder geben Sie unten Ihre Aktivierungs- und PIN-Codes ein, um sich in Ihrem Browser anzumelden...
-cas.inwebo.selectauthent.title=Authentifizierung auswählen
-cas.inwebo.selectauthent.heading=Wählen Sie Ihre Authentifizierungsmethode:
+cas.inwebo.error.usernotregistered=Vor jedem Login mÃ¼ssen Sie bei Inwebo registriert sein. ÃœberprÃ¼fen Sie Ihr Postfach auf \
+  Anweisungen fÃ¼r den Registrierungsprozess oder geben Sie unten Ihre Aktivierungs- und PIN-Codes ein, um sich in Ihrem Browser anzumelden...
+cas.inwebo.selectauthent.title=Authentifizierung auswÃ¤hlen
+cas.inwebo.selectauthent.heading=WÃ¤hlen Sie Ihre Authentifizierungsmethode:
 cas.inwebo.selectauthent.browser=Browser-Authentifizierung
 cas.inwebo.selectauthent.push=Mobile/Desktop-Anwendung Authentifizierung
 cas.inwebo.browserauthent.title=Browser-Authentifizierung
 cas.inwebo.enroll.code=Aktivierungscode
-cas.inwebo.enroll.button=Registrieren Sie sich für die Browserauthentifizierung
+cas.inwebo.enroll.button=Registrieren Sie sich fÃ¼r die Browserauthentifizierung
 cas.inwebo.enroll.failure=Die Registrierung ist fehlgeschlagen
 cas.inwebo.pin=PIN-Code
 cas.inwebo.browser.heading=PIN-Code eingeben:
@@ -618,14 +618,14 @@ cas.inwebo.browser.failure=Einmalpasswort Generierungsfehler
 cas.inwebo.retry.button=Wiederholen Sie die mehrstufige Authentifizierung von Inwebo
 
 cas.screen.acct.title=Kontoregistrierung
-cas.screen.acct.intro=Bitte füllen Sie das folgende Formular aus, um Ihr neues Konto bei CAS zu registrieren. \
-  Sobald das Formular übermittelt wurde, erhalten Sie eine E-Mail mit einem Link zur Kontoaktivierung. \
+cas.screen.acct.intro=Bitte fÃ¼llen Sie das folgende Formular aus, um Ihr neues Konto bei CAS zu registrieren. \
+  Sobald das Formular Ã¼bermittelt wurde, erhalten Sie eine E-Mail mit einem Link zur Kontoaktivierung. \
   Aktivieren Sie Ihr Konto, richten Sie Ihr Passwort ein und beginnen Sie mit der Nutzung von CAS.
 cas.screen.acct.infosent=Anweisungen zur Kontoaktivierung wurden erfolgreich gesendet. \
-  Bitte überprüfen Sie Ihre E-Mails und folgen Sie den Anweisungen.
+  Bitte Ã¼berprÃ¼fen Sie Ihre E-Mails und folgen Sie den Anweisungen.
 
-cas.screen.acct.intro.complete=willkommen zurück! Vielen Dank für die Bestätigung Ihres Kontos. \
-  Bitte füllen Sie das folgende Formular aus, um Ihr neues Konto bei CAS zu registrieren.
+cas.screen.acct.intro.complete=willkommen zurÃ¼ck! Vielen Dank fÃ¼r die BestÃ¤tigung Ihres Kontos. \
+  Bitte fÃ¼llen Sie das folgende Formular aus, um Ihr neues Konto bei CAS zu registrieren.
 cas.screen.acct.intro.completed=Vielen Dank! Ihr Konto ist nun aktiviert und bei CAS registriert.
 
 cas.screen.acct.button.submit=Absenden
@@ -634,20 +634,20 @@ cas.screen.acct.button.update=Aktualisieren
 
 cas.screen.acct.error.provision=Das angeforderte Konto kann nicht bereitgestellt werden.
 cas.screen.acct.error.fail=Das angeforderte Konto kann nicht registriert oder der Link zur Kontoaktivierung nicht gesendet werden.
-cas.screen.acct.error.invalid-value=Der bereitgestellte Wert fehlt, ist ungültig oder entspricht nicht dem erforderlichen Typ.
+cas.screen.acct.error.invalid-value=Der bereitgestellte Wert fehlt, ist ungÃ¼ltig oder entspricht nicht dem erforderlichen Typ.
 
 cas.screen.acct.label.email=E-Mail Adresse
-cas.screen.acct.title.email=Dies ist Ihre primäre E-Mail-Adresse, an die der Aktivierungslink gesendet wird.
+cas.screen.acct.title.email=Dies ist Ihre primÃ¤re E-Mail-Adresse, an die der Aktivierungslink gesendet wird.
 cas.screen.acct.label.firstName=Vorhame
 cas.screen.acct.title.firstName=Ihr Vorname.
 cas.screen.acct.label.lastName=Nachname
 cas.screen.acct.title.lastName=Ihr Nachname.
 cas.screen.acct.label.username=Benutzername
-cas.screen.acct.title.username=Der Benutzername, den Sie für die Anmeldung nutzen möchten.
+cas.screen.acct.title.username=Der Benutzername, den Sie fÃ¼r die Anmeldung nutzen mÃ¶chten.
 cas.screen.acct.label.phone=Telefonnummer
 cas.screen.acct.title.phone=Dies ist Ihre Telefonnummer, an die der Aktivierungslink gesendet wird.
 cas.screen.acct.label.country=Land
-cas.screen.acct.title.country=Dies ist das mit Ihrer Telefonnummer verknüpfte Land.
+cas.screen.acct.title.country=Dies ist das mit Ihrer Telefonnummer verknÃ¼pfte Land.
 
 screen.acct.label.security.question.1=Sicherheitsfrage 1
 screen.acct.label.security.question.2=Sicherheitsfrage 2


### PR DESCRIPTION
PR #5550 changed the file enconding of the german translation to ISO-8859-1, which means, that `spring.thymeleaf.encoding=ISO-8859-1` and `cas.message-bundle.encoding=ISO-8859-1` has to be set. This seems inconsistent with all other languages files, which are UTF-8 of course.

This PR contains a UTF-8 version of all changes @ThomasSeliger did (thank you!) by using `iconv -f ISO-8859-1 -t UTF-8`.

Afterwards no more custom encoding setting via `spring.thymeleaf.encoding` and  `cas.message-bundle.encoding` is needed.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

If your pull request targets a maintenance branch and is not directed at `master`, make sure your reference the pull request that
has already ported your changes forward to the `master` branch. You may do so by including the following in your pull request description:

```
master: https://github.com/apereo/cas/pull/$PR_NUMBER
```

Do not keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

If you have questions, please [reach out](https://apereo.github.io/cas/Mailing-Lists.html).

Thanks again!
-->
