### PR TITLE
Support URI for Redis

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/BaseRedisProperties.java
@@ -34,6 +34,11 @@ public class BaseRedisProperties implements Serializable {
     private boolean enabled = true;
 
     /**
+     * Database URI.
+     */
+    private String uri;
+
+    /**
      * Database index used by the connection factory.
      */
     @RequiredProperty

--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -99,7 +99,10 @@ public class RedisObjectFactory {
                                                                    final boolean initialize,
                                                                    final CasSSLContext casSslContext) {
         var factory = (LettuceConnectionFactory) null;
-        if (redis.getSentinel() != null && StringUtils.hasText(redis.getSentinel().getMaster())) {
+        if (StringUtils.hasText(redis.getUri())) {
+            factory = new LettuceConnectionFactory(LettuceConnectionFactory.createRedisConfiguration(redis.getUri()),
+                    getRedisPoolClientConfig(redis, true, casSslContext));
+        } else if (redis.getSentinel() != null && StringUtils.hasText(redis.getSentinel().getMaster())) {
             factory = new LettuceConnectionFactory(getSentinelConfig(redis), getRedisPoolClientConfig(redis, true, casSslContext));
         } else if (redis.getCluster() != null && !redis.getCluster().getNodes().isEmpty()) {
             factory = new LettuceConnectionFactory(getClusterConfig(redis), getRedisPoolClientConfig(redis, true, casSslContext));

--- a/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
+++ b/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
@@ -57,6 +57,14 @@ public class RedisObjectFactoryTests {
     }
 
     @Test
+    public void verifyConnectionURI() {
+        val props = new BaseRedisProperties();
+        props.setUri("redis://localhost:6379");
+        val connection = RedisObjectFactory.newRedisConnectionFactory(props, true, CasSSLContext.disabled());
+        assertNotNull(connection);
+    }
+
+    @Test
     public void verifyClusterConnection() {
         val props = new BaseRedisProperties();
         props.getCluster().getNodes().add(new RedisClusterNodeProperties()


### PR DESCRIPTION
For some Redis cloud providers, it is useful to be able to use a Redis URI to connect to the database.

This PR allows to use a URI to connect to Redis.
