### PR TITLE
update javadoc and close stream resources

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ResourceUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ResourceUtils.java
@@ -124,8 +124,10 @@ public class ResourceUtils {
             if (res.isFile() && FileUtils.isDirectory(res.getFile())) {
                 return true;
             }
-            IOUtils.read(res.getInputStream(), new byte[1]);
-            return res.contentLength() > 0;
+            try (val input = res.getInputStream()) {
+                IOUtils.read(input, new byte[1]);
+                return res.contentLength() > 0;
+            }
         } catch (final FileNotFoundException e) {
             LOGGER.trace(e.getMessage());
             return false;
@@ -188,8 +190,9 @@ public class ResourceUtils {
                 LOGGER.trace("Deleting resource directory [{}]", destination);
                 FileUtils.forceDelete(destination);
             }
-            try (val out = new FileOutputStream(destination)) {
-                resource.getInputStream().transferTo(out);
+            try (val out = new FileOutputStream(destination);
+                 val input = resource.getInputStream()) {
+                input.transferTo(out);
             }
         });
         return new FileSystemResource(destination);

--- a/core/cas-server-core-util/src/test/java/org/apereo/cas/util/ResourceUtilsTests.java
+++ b/core/cas-server-core-util/src/test/java/org/apereo/cas/util/ResourceUtilsTests.java
@@ -43,6 +43,18 @@ class ResourceUtilsTests {
             new DefaultResourceLoader(ResourceUtilsTests.class.getClassLoader())));
     }
 
+    /**
+     * This test takes about 8 seconds to run with no leak or 12 seconds if a stream is left unclosed, but then
+     * the JVM runs for another 90 seconds while it is garbage collecting and closing all the unclosed streams.
+     */
+    @Test
+    void verifyResourceExistsDoesNotLeak() {
+        for (int i=0; i < 100000; i++) {
+            assertTrue(ResourceUtils.doesResourceExist("./src/test/java/org/apereo/cas/util/ResourceUtilsTests.java"));
+            assertFalse(ResourceUtils.doesResourceExist("./src/test/java/org/apereo/cas/util/ResourceUtilsTests2.java"));
+        }
+    }
+
     @Test
     void verifyResourceOnClasspath() {
         val res = new ClassPathResource("valid.json");

--- a/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/RegisteredServiceThemeResolver.java
+++ b/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/RegisteredServiceThemeResolver.java
@@ -38,8 +38,21 @@ import java.nio.charset.StandardCharsets;
  * ThemeResolver to determine the theme for CAS based on the service provided.
  * The theme resolver will extract the service parameter from the Request object
  * and attempt to match the URL provided to a Service Id. If the service is
- * found, the theme associated with it will be used. If not, these is associated
- * with the service or the service was not found, a default theme will be used.
+ * found and there is no theme specified or access to the service is not allowed, the default
+ * theme will be used.
+ * If the service does have a theme associated with it but the theme is a path to a
+ * {@code FileSystemResource} system resource that exists, it will be executed as a
+ * Groovy script that should return the name of the theme.
+ * If the theme value is an HTTP {@code URLResource}, then the contents referenced by the URL
+ * will be read and the response used as the theme name.
+ * Blank values returned from the script or the URL will result in the default theme
+ * being used.
+ * If the theme attribute in the service is not a file or URL resource, it will be evaluated as
+ * a Spring expression and then a search for property files with the theme name as the base name
+ * is done using configured template prefix locations.
+ * If nothing is found in template prefix locations, the {@code ResourceBundle.getBundle()} method
+ * using the locale of the request is used to look for the theme properties to ensure it exists.
+ * If theme properties don't exist for the specified theme name then the default theme will be used.
  *
  * @author Scott Battaglia
  * @since 3.0.0
@@ -142,10 +155,7 @@ public class RegisteredServiceThemeResolver extends AbstractThemeResolver {
 
     protected String resolveThemeForService(final WebBasedRegisteredService registeredService,
                                             final HttpServletRequest request) {
-        val messageSource = new CasThemeResourceBundleMessageSource();
         val theme = SpringExpressionLanguageValueResolver.getInstance().resolve(registeredService.getTheme());
-        messageSource.setBasename(theme);
-
         if (casProperties.getObject().getView().getTemplatePrefixes()
             .stream()
             .map(prefix -> StringUtils.appendIfMissing(prefix, "/").concat(theme).concat(".properties"))
@@ -153,12 +163,13 @@ public class RegisteredServiceThemeResolver extends AbstractThemeResolver {
             LOGGER.trace("Found custom external theme [{}] for service [{}]", theme, registeredService.getName());
             return theme;
         }
-
+        val messageSource = new CasThemeResourceBundleMessageSource();
+        messageSource.setBasename(theme);
         if (messageSource.doGetBundle(theme, request.getLocale()) != null) {
             LOGGER.trace("Found custom theme [{}] for service [{}]", theme, registeredService.getName());
             return theme;
         }
-        
+
         LOGGER.warn("Theme [{}] for service [{}] cannot be located", theme, registeredService.getName());
         return null;
     }


### PR DESCRIPTION
I was looking at this class and the Javadoc had a sentence that didn't make sense, so I tried to describe what the logic was in the class. While doing so I noticed that if the theme is returned from a script or url, there is no check to make sure a property file exists for that theme. It wouldn't be hard to pass the theme to `resolveThemeForService()` and check for the file in the prefix locations or as a resource bundle, but I didn't do that.

I also noticed two places in ResourceUtils where a stream is passed to a method that doesn't close it and it is outside of a resource try block. I was sort of on the lookout for resource leaks because I had a CAS server in dev stop working due to what looked like a resource leak shortly after I configured template prefixes and `AggregateCasThemeSource`, both of which use `ResourceUtils::doesResourceExist` and I think it gets called a fair amount. When the problem happened, I turned off those settings and I haven't seen the problem since. 

If this is merged, I would like to backport it to 6.6.x. 