### PR TITLE
Adds a documentation warning about incompatibility between Hazelcast …

### DIFF
--- a/docs/cas-server-documentation/ticketing/Hazelcast-Ticket-Registry.md
+++ b/docs/cas-server-documentation/ticketing/Hazelcast-Ticket-Registry.md
@@ -31,6 +31,13 @@ instance used by the ticket registry implementation to build and retrieve Hazelc
 maps for its distributed tickets storage. Some aspects of hazelcast configuration in 
 this auto-configuration mode are controlled by CAS properties.
 
+<div class="alert alert-warning"><strong>Features compatibility</strong><p>Be aware that Hazelcast
+ticket registry is NOT compatible with Spring beans refresh. This implies
+<a href="../configuration/Configuration-Management-Reload.html">Configuration Management Reload</a>
+cannot be used with Hazelcast ticket registry, nor any other mechanisme that would rely on 
+<code>@RefreshScope</code> annotated beans.
+</p></div>
+
 {% include_cached {{ version }}/hazelcast-configuration.md configKey="cas.ticket.registry.hazelcast" %}
 
 <div class="alert alert-warning">:warning: <strong>Session Monitoring</strong><p>Be aware that under 


### PR DESCRIPTION
…Ticket Registry and Configuration Management Reload features

Hi there!

This is a small pull request just to add a documentation warning about two Apereo CAS feature that are incompatible: the Hazelcast Ticket Registry and the hot configuration reload.

The root configuration cause is an entangled integration problem between (1) Spring Boot internal mechanisms, (2) Apereo CAS Spring beans definition and (3) the way Hazelcast handles its instances.

In `org.apereo.cas.config.HazelcastTicketRegistryConfiguration#casTicketRegistryHazelcastInstance(TicketCatalog, CasConfigurationProperties)` the `HazelcastInstance` is created by calling the Hazelcast-lib method `com.hazelcast.instance.impl.HazelcastInstanceFactory.getOrCreateHazelcastInstance(Config)`.

This works fine as long as no Spring beens refresh called, because the beans recreation cinematic is this one:

1. Spring re-creates all the beans with the new configuration.
2. The `HazelcastInstance` bean creation calls `HazelcastInstanceFactory.getOrCreateHazelcastInstance()` that will return the already existing Hazelcast instance, as it exists and is already in the internal `HazelcastInstanceFactory` cache.
3. This old Hazelcast instance is propagated in all required beans (see: body method of `HazelcastTicketRegistryConfiguration#casTicketRegistryHazelcastInstance()`, bean usages for `HazelcastInstance`).
4. **Then** the old beans are destroyed. This particular order (creation then destroy) is mandatory to avoid interruption of service, especially on large projects as Apereo CAS, since beans recreation can take several seconds.
5. The bean destroy procedure will call `org.apereo.cas.ticket.registry.HazelcastTicketRegistry#shutdown()` that will call `shutdown()` on the Hazelcast instance. As the same instance is shared between old and new Spring beans, new Spring beans will fail due to try using a stopped Hazelcast instance.

I’m afraid there is no simple way to fix this problem.

We can’t simply deactivate the Hazelcast shutdown process, as this won’t work if a goal of configuration changes is to change Hazelcast configuration, and will lead to remaining running Hazelcast instances in all cases.

A solution would be to systematically check, on Hazelcast instance _usage_, if the instance exists and if not, create it. This leads to two problems: performance, and lot of Hazelcast instance usage in code (see: body method of `HazelcastTicketRegistryConfiguration#casTicketRegistryHazelcastInstance()`, bean usages for `HazelcastInstance` for references).

Another solution would be to hack the Spring bean creation order to force `HazelcastInstance` dependant beans (including hardcoded references from body method of `HazelcastTicketRegistryConfiguration#casTicketRegistryHazelcastInstance()`) to be recreated **after** Hazelcast Instance shutdown. I don’t know if this is even possible.

Note the `HazelcastInstanceFactory` (from Hazelcast lib) offers methods to have a fine usage of Hazelcast instances, if required.

Problem test procedure:

1. Configure a CAS instance to use Hazelcast Ticket Registry **and** to allow [reload through actuator](https://apereo.github.io/cas/6.6.x/configuration/Configuration-Management-Reload.html).
2. Check everything is OK, e.g. by log with the web interface.
3. Call `HTTP POST /cas/actuator/refresh`. You don’t need actual configuration changes, this actuator will call the configuration reload anyway.
4. Any usage of ticket registry should fail by complaining that Hazelcast instance is stopped.

**Note:** this has actually been tested on 6.6.x branch (I create another merge request for it), but there is no reason this would have been fixed on 7.0.x branch. I don’t have the time to check it by myself.