### PR TITLE
fix: tracking policy should not delete service tickets

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultServiceTicketSessionTrackingPolicy.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultServiceTicketSessionTrackingPolicy.java
@@ -7,7 +7,6 @@ import org.apereo.cas.ticket.registry.TicketRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
-import org.jooq.lambda.Unchecked;
 
 /**
  * This is {@link DefaultServiceTicketSessionTrackingPolicy}.
@@ -52,10 +51,9 @@ public class DefaultServiceTicketSessionTrackingPolicy implements ServiceTicketS
                     return path.equals(normalizedExistingPath);
                 }).toList();
 
-            toRemove.forEach(Unchecked.consumer(entry -> {
+            toRemove.forEach(entry -> {
                 ownerTicket.getServices().remove(entry.getKey());
-                ticketRegistry.deleteTicket(entry.getKey());
-            }));
+            });
         }
         ownerTicket.getServices().put(serviceTicket.getId(), serviceTicket.getService());
     }


### PR DESCRIPTION
This reverts a hard to spot / reproduce issue introduced by 901d8895f99: If more STs/PTs are issued one right after another from the same parent ticket, validation of the first ticket(s) can fail, because it might get deleted before its validation call arrives.

In practice, this probably affects just use cases when STs/PTs are issued via CAS REST API - i.e. applications which for whatever reason don't keep a standard session with a called backend application. Anyway, it seems safer to rather rely on the short-lived tickets' automatic expiration, at least by default.

---

Note: Provided it won't be required to make the `deleteTicket()` call configurable, the `ticketRegistry` field can be removed from the policy class of course...

**Workaround:** Set `cas.ticket.tgt.core.only-track-most-recent-session` to `false`. But of course, then the TGT's `services` map will grow again, which might not be welcome performance-wise and affects the SLO functionality.