### PR TITLE
feat: make console and file log patterns consistent and more configurable

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
+++ b/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
@@ -27,22 +27,27 @@ or override log42.component.properties to turn off async
         <Property name="log.stacktraceappender">casStackTraceFile</Property>
         <Property name="log.include.location">false</Property>
 
-        <Property name="logPattern">
-            %highlight{%d{HH:mm:ss}{GMT-7} %p [%-20.80c{1.}] - &lt;%m&gt;}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=cyan, TRACE=blue}%n
-        </Property>
+        <Property name="log.pattern">%highlight{%d %p [%c] - &lt;%m&gt;%n%throwable}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=cyan, TRACE=blue}</Property>
+        <!-- properties for controlling whether to actually skip the highlighting in individual appenders: -->
+        <Property name="log.pattern.disable.highlight.console">false</Property>
+        <Property name="log.pattern.disable.highlight.file">true</Property>
+
     </Properties>
     <Appenders>
         <Null name="null" />
 
         <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%highlight{%d %p [%c] - &lt;%m&gt;}%n" alwaysWriteExceptions="${sys:log.console.stacktraces}"/>
+            <PatternLayout pattern="${sys:log.pattern}"
+                           alwaysWriteExceptions="${sys:log.console.stacktraces}"
+                           disableAnsi="${sys:log.pattern.disable.highlight.console}" />
         </Console>
 
         <RollingFile name="file" fileName="${sys:baseDir}/cas.log" append="true"
                      filePattern="${sys:baseDir}/cas-%d{yyyy-MM-dd-HH}-%i.log.gz"
                      immediateFlush="false">
-            <PatternLayout pattern="${logPattern}"
-                           alwaysWriteExceptions="${sys:log.file.stacktraces}" />
+            <PatternLayout pattern="${sys:log.pattern}"
+                           alwaysWriteExceptions="${sys:log.file.stacktraces}"
+                           disableAnsi="${sys:log.pattern.disable.highlight.file}" />
             <Policies>
                 <OnStartupTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="10 MB"/>


### PR DESCRIPTION
I believe CAS should supply somewhat more reasonable settings in the default log4j2.xml. This is the 1st package of the possible improvements, regarding the **log patterns**:

* fix: logging to file used a non-standard format (missing milliseconds, time hardcoded to "GMT-7"). Use the same log pattern with pre-defined `%highlight` for both appenders instead.
* have stacktraces colored as well (when they are turned on) - by wrapping `%throwable` into the `%highlight` as in the Log4j documentation examples
* make the highlighting being on/off configurable per appender AND switch the defaults to the more common one: highlights in console, not in file. Note: To get highlighting e.g. in IDEA console on Windows, `disableAnsi=false` needs to be set explicitly.

---

Sources:

* https://stackoverflow.com/questions/48472049/how-to-colorize-log4j2-output-on-console-in-intellij/48817692#48817692
* https://stackoverflow.com/questions/53755966/log4j2-highlight-pattern-not-working-in-text-editor/53834876#53834876
* https://logging.apache.org/log4j/2.x/manual/layouts.html (things around `disableAnsi` are not up-to-date nor complete there though)

---

This is rather for CAS developers. For those, who use the CAS overlay template, changes should be probably done into this file (which is already quite different from this one in CAS): https://github.com/apereo/cas-initializr/blame/master/app/src/main/resources/overlay/etc/cas/config/log4j2.xml.