### PR TITLE
only run native puppeteer tests that are enabled

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -92,11 +92,11 @@ jobs:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-${{ github.sha }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
       - id: print-scenarios
-        run: ./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerScenarios | jq
+        run: ./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerNativeScenarios | jq
       - id: get-scenarios255
-        run: echo "scenarios255=$(./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerScenarios -PpuppeteerScenariosFrom=0 -PpuppeteerScenariosTo=255)" >> $GITHUB_OUTPUT
+        run: echo "scenarios255=$(./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerNativeScenarios -PpuppeteerScenariosFrom=0 -PpuppeteerScenariosTo=255)" >> $GITHUB_OUTPUT
       - id: get-scenarios511
-        run: echo "scenarios511=$(./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerScenarios -PpuppeteerScenariosFrom=255 -PpuppeteerScenariosTo=511)" >> $GITHUB_OUTPUT
+        run: echo "scenarios511=$(./gradlew --build-cache --configure-on-demand --no-daemon -q puppeteerNativeScenarios -PpuppeteerScenariosFrom=255 -PpuppeteerScenariosTo=511)" >> $GITHUB_OUTPUT
 
   ##########################################################################
   puppeteer-tests-255:

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -156,6 +156,49 @@ if (rootProject.tasks.findByName("puppeteerScenarios") == null) {
     }
 }
 
+if (rootProject.tasks.findByName("puppeteerNativeScenarios") == null) {
+    rootProject.tasks.register("puppeteerNativeScenarios") {
+        description = "Display all available native puppeteer scenarios"
+
+        def puppeteerScenariosFrom = project.providers.gradleProperty("puppeteerScenariosFrom").getOrNull()
+        def puppeteerScenariosTo = project.providers.gradleProperty("puppeteerScenariosTo").getOrNull()
+        def scenariosDirectory = rootProject.file("ci/tests/puppeteer/scenarios")
+
+        doLast {
+            def scenarios = []
+            def pattern = System.getenv().get("SCENARIO_REGEX") ?: ".*"
+            def scenarioMatchPattern = Pattern.compile(pattern, Pattern.CASE_INSENSITIVE)
+
+            scenariosDirectory.eachDirMatch(scenarioMatchPattern) {
+                def scriptFile = new File("ci/tests/puppeteer/scenarios/" + it.getName(), "script.json")
+                if (scriptFile.exists()) {
+                    def json = new groovy.json.JsonSlurper().parseText(scriptFile.text)
+                    if (json.requirements && json.requirements.graalvm) {
+                        if (Boolean.valueOf(json.requirements.graalvm.enabled)) {
+                            scenarios += it.getName()
+                        }
+                    }
+                }
+            }
+
+            Collections.sort(scenarios)
+            if (scenarios != null && puppeteerScenariosFrom != null && puppeteerScenariosTo != null) {
+                def fromScenario = Integer.parseInt(puppeteerScenariosFrom)
+                def toScenario = Integer.parseInt(puppeteerScenariosTo)
+                if (toScenario > scenarios.size())
+                    toScenario = scenarios.size()
+                if (scenarios.size() >= fromScenario) {
+                    scenarios = scenarios.subList(fromScenario, toScenario)
+                } else {
+                    scenarios = []
+                }
+            }
+//            println scenarios.size()
+            println(groovy.json.JsonOutput.toJson(scenarios))
+        }
+    }
+}
+
 TestCategories.values().each({ category ->
     def sourceTestDirs = project.sourceSets.test.java.srcDirs
     def jacocoTestExecutionResultsFile = project.layout.buildDirectory.file('jacoco/jacocoTest.exec').get().asFile


### PR DESCRIPTION
I was thinking it would be nice to only run the native puppeteer tests that are enabled, rather than running a bunch of jobs that turn out to be disabled. This parses the script.json files and looks for requirements.graalvm.enabled = true. 