### PR TITLE
refactor: use `log4j2.contextSelector` instead of legacy `Log4jContextSelector` everywhere

### DIFF
--- a/core/cas-server-core-logging-api/src/main/resources/log4j2.component.properties
+++ b/core/cas-server-core-logging-api/src/main/resources/log4j2.component.properties
@@ -1,5 +1,4 @@
-# if you don't want async loggers, override this file in classpath and set Log4jContextSelector
-# to org.apache.logging.log4j.core.selector.BasicContextSelector
-# You can also specify -DLog4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector
-# or -Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector on command line
-Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+# If you don't want async loggers, override this file in classpath and set log4j2.contextSelector
+# to org.apache.logging.log4j.core.selector.BasicContextSelector.
+# You can also specify -Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector on command line.
+log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector

--- a/core/cas-server-core-logging-api/src/test/resources/log4j2.component.properties
+++ b/core/cas-server-core-logging-api/src/test/resources/log4j2.component.properties
@@ -1,2 +1,2 @@
 # turning off async file for tests so they will be non-async when testing ExceptionOnlyFilter
-Log4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector
+log4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector

--- a/docs/cas-server-documentation/logging/Logging.md
+++ b/docs/cas-server-documentation/logging/Logging.md
@@ -48,14 +48,14 @@ of the `log4j2.xml` file, in a property file called `log4j2.component.properties
 properties. If setting properties in a `log4j2.component.properties`, be sure to include:
 
 ```properties
-Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
 ```
 
 in order to keep using asynchronous logging which CAS sets by default. 
 To turn off asynchronous logging, include the following in `log4j2.component.properites` or as a system property:
 
 ```properties
-Log4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector
+log4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector
 ```
 
 ## Configuration

--- a/support/cas-server-support-gcp-logging/src/test/resources/log4j2.component.properties
+++ b/support/cas-server-support-gcp-logging/src/test/resources/log4j2.component.properties
@@ -1,1 +1,1 @@
-Log4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector
+log4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector


### PR DESCRIPTION
In Log4j 2.10, property `Log4jContextSelector` was renamed to `log4j2.contextSelector`, see https://logging.apache.org/log4j/2.x/manual/configuration.html#SystemProperties.

So we get rid of the legacy name for better clarity of the various documentation parts.