### PR TITLE
feat: set `log.console.stacktraces` to `true` by default

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
+++ b/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
@@ -21,7 +21,7 @@ or override log42.component.properties to turn off async
         <Property name="opensaml.log.level">${main:\--logging.level.org.opensaml:-warn}</Property>
         <Property name="hazelcast.log.level">${main:\--logging.level.com.hazelcast:-warn}</Property>
         
-        <Property name="log.console.stacktraces">false</Property>
+        <Property name="log.console.stacktraces">true</Property>
         <Property name="log.file.stacktraces">false</Property>
         <!-- -Dlog.stacktraceappender=null to disable stacktrace log -->
         <Property name="log.stacktraceappender">casStackTraceFile</Property>


### PR DESCRIPTION
This change follows the [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). This setting also defaults to `true` in the log4j2.xml of the CAS Initializr (WAR overlay) project.