### PR TITLE
docs: there is no "expired device registrations" cleaner for GAuth

### DIFF
--- a/docs/cas-server-documentation/mfa/GoogleAuthenticator-Authentication.md
+++ b/docs/cas-server-documentation/mfa/GoogleAuthenticator-Authentication.md
@@ -24,15 +24,6 @@ Support is enabled by including the following module in the overlay:
 
 {% include_cached casproperties.html properties="cas.authn.mfa.gauth.core" %}
 
-## Repository Cleaner
-
-A background *cleaner* process is also automatically scheduled to scan the
-repository periodically and remove expired device registration records
-based on configured parameters. In the default setting, devices
-expire after a fixed period since a user registered their device.
-
-{% include_cached casproperties.html properties="cas.authn.mfa.gauth.cleaner" %}
-
 ## Actuator Endpoints
 
 The following endpoints are provided by CAS:
@@ -46,6 +37,8 @@ tokens that are successfully used to authenticate the user.
 The repository that holds registration records and tokens is periodically 
 scanned and cleaned up so that expired and previously used tokens
 may be removed.
+
+{% include_cached casproperties.html properties="cas.authn.mfa.gauth.cleaner" %}
 
 ## Registration
 


### PR DESCRIPTION
Remove the misleading chapter "Repository Cleaner" and move the `cas.authn.mfa.gauth.cleaner` properties section to the chapter for which it is actually valid: "Token Repository".

---

I apologize if I overlooked something, but from the code for the Google Authenticator (GAuth) MFA, it really looks like there is no cleanup job for the expired device registrations (search [here](https://github.com/search?q=repo%3Aapereo%2Fcas%20%22cas.authn.mfa.gauth.cleaner%22&type=code)). Maybe it was there some time ago and got removed?