### PR TITLE
Draft: refactor: improve dynamic JavaScript codes within Thymeleaf

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/error.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/error.html
@@ -14,7 +14,8 @@
         function showErrorDetails() {
             $("#errorMsg").hide();
             $("#errorDetails").empty();
-            $("#errorDetails").append("<p><pre style='white-space: pre-wrap;'>" + /*[[${#strings.escapeXml(trace)}]]*/ + "</pre></p>");
+            $("#errorDetails").append("<p><pre style='white-space: pre-wrap;'>" + /*[[${#strings.escapeXml(trace)}]]*/ "...trace..."
+                + "</pre></p>");
         }
         /*]]>*/
     </script>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
@@ -90,8 +90,8 @@
 
                         <script type="text/javascript" th:inline="javascript">
                             /*<![CDATA[*/
-                            let username = /*[[${@casThymeleafTemplatesDirector.getLoginFormUsername(#vars)}]]*/;
-                            let disabled = /*[[${@casThymeleafTemplatesDirector.isLoginFormUsernameInputDisabled(#vars)}]]*/;
+                            let username = /*[[${@casThymeleafTemplatesDirector.getLoginFormUsername(#vars)}]]*/ "username";
+                            let disabled = /*[[${@casThymeleafTemplatesDirector.isLoginFormUsernameInputDisabled(#vars)}]]*/ false;
 
                             if (username != null && username !== '') {
                                 $('#username').val(username);
@@ -340,11 +340,10 @@
                     <script th:inline="javascript">
                         /*<![CDATA[*/
                         function x509login() {
-                            let url =  /*[[${x509ClientAuthLoginEndpointUrl}]]*/;
+                            let url =  /*[[${x509ClientAuthLoginEndpointUrl}]]*/ "http://example.com/x509";
                             url += window.location.search;
                             window.location.assign(url)
                         }
-
                         /*]]>*/
                     </script>
                     <a id="x509LoginLink" class="mdc-button mdc-button--raised btn btn-primary"
@@ -374,9 +373,8 @@
 
             <script type="text/javascript" th:inline="javascript">
                 /*<![CDATA[*/
-                var i = /*[[@{#{screen.welcome.button.loginwip}}]]*/
-                var j = /*[[@{#{screen.welcome.button.login}}]]*/
-                    /*]]>*/
+                var i = /*[[@{#{screen.welcome.button.loginwip}}]]*/ "One moment please...";
+                var j = /*[[@{#{screen.welcome.button.login}}]]*/ "Login";
                     $(window).on('pageshow', function () {
                         $(':submit').prop('disabled', false);
                         $(':submit').attr('value', j);
@@ -388,6 +386,7 @@
                         return true;
                     });
                 });
+                /*]]>*/
             </script>
         </div>
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/scripts.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/scripts.html
@@ -12,13 +12,15 @@
 </span>
 
 <script th:inline="javascript">
+    /*<![CDATA[*/
     if (typeof resourceLoadedSuccessfully === "function") {
         resourceLoadedSuccessfully();
     }
     $(() => {
         typeof cssVars === "function" && cssVars({onlyLegacy: true});
     });
-    let trackGeoLocation = /*[[${trackGeoLocation}]]*/ === "true";
+    let trackGeoLocation = /*[[${trackGeoLocation}]]*/ false;
+    /*]]>*/
 </script>
 
 <script th:replace="~{fragments/googleanalytics :: ga}"></script>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casGenericSuccessView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casGenericSuccessView.html
@@ -143,9 +143,9 @@
 
                                         <script th:inline="javascript">
                                             /*<![CDATA[*/
-                                            let serviceId = /*[[${service.serviceId}]]*/;
+                                            let serviceId = /*[[${service.serviceId}]]*/ "http://example.com";
                                             if (isValidURL(serviceId)) {
-                                                let id = /*[[${'service' + service.id}]]*/;
+                                                let id = /*[[${'service' + service.id}]]*/ "service1";
                                                 $(`a#${id}`).attr("href", serviceId);
                                             }
                                             /*]]>*/


### PR DESCRIPTION
The main goal of this change is to diminish confusion of prospective contributors to the Thymeleaf HTML templates.

* use CDATA section consistently. Since Thymeleaf 3.0, escaping special XML chars is not strictly necessary, but at least this makes the HTML templates XML-compliant (if ever needed) and consistent.
* add some meaningful defaults after the Thymeleaf `/*[[..]]*/` expressions, so that a syntactically valid JavaScript is output when viewing HTML statically
* fix error.html: `+ "</pre></p>"` was not output - it needs to follow on another line (considered a default static value by Thymeleaf otherwise)
