### PR TITLE
WIP - Handling of parallel SAML requests

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/session/SessionStorageTypes.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/session/SessionStorageTypes.java
@@ -24,5 +24,10 @@ public enum SessionStorageTypes {
      * as tickets. This state is tied to the user's agent/browser using a special cookie that would be used
      * to locate and restore that state. The cookie content may be signed and encrypted.
      */
-    TICKET_REGISTRY
+    TICKET_REGISTRY,
+    /**
+     * Authentication requests, and other session data collected as part of SAML flows and requests
+     * are passed as HTTP URL parameters.
+     */
+    URL_PARAMS
 }

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/init.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo -e "Removing previous SAML metadata directory"
+rm -Rf "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/saml-md"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/ready.sh
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/ready.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+echo "Running SAML server..."
+
+metadataDirectory="${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/saml-md"
+
+cert=$(cat "${metadataDirectory}"/idp-signing.crt | sed 's/-----BEGIN CERTIFICATE-----//g' | sed 's/-----END CERTIFICATE-----//g')
+export IDP_SIGNING_CERTIFICATE=$cert
+echo -e "Using signing certificate:\n$IDP_SIGNING_CERTIFICATE"
+
+cert=$(cat "${metadataDirectory}"/idp-encryption.crt | sed 's/-----BEGIN CERTIFICATE-----//g' | sed 's/-----END CERTIFICATE-----//g')
+export IDP_ENCRYPTION_CERTIFICATE=$cert
+echo -e "Using encryption certificate:\n$IDP_ENCRYPTION_CERTIFICATE"
+
+chmod +x "${PWD}/ci/tests/saml2/run-saml-server.sh"
+"${PWD}/ci/tests/saml2/run-saml-server.sh"
+env SP_HOST_PORT=9444 SP_SERVER_PORT=8444 "${PWD}/ci/tests/saml2/run-saml-server.sh"

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/script.js
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/script.js
@@ -1,0 +1,41 @@
+const puppeteer = require('puppeteer');
+const assert = require('assert');
+const path = require('path');
+const cas = require('../../cas.js');
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+
+    try {
+        const page = await cas.newPage(browser);
+        await cas.goto(page, "http://localhost:9443/simplesaml/module.php/core/authenticate.php?as=default-sp");
+        await page.waitForTimeout(2000);
+
+        // Make another SAML2 request before sending credentials.
+        const page2 = await cas.newPage(browser, 1);
+        page2.bringToFront();
+        await cas.goto(page2, "http://localhost:9444/simplesaml/module.php/core/authenticate.php?as=default-sp");
+        await page2.waitForTimeout(2000);
+
+        page.bringToFront();
+        await cas.screenshot(page);
+        await cas.loginWith(page, "casuser", "Mellon");
+        await page.waitForTimeout(3000);
+        await page.waitForSelector('#table_with_attributes', {visible: true});
+        await cas.assertVisibility(page, "#table_with_attributes");
+
+        // Do the same with the second tab
+        page2.bringToFront();
+        await cas.screenshot(page2);
+        await cas.loginWith(page2, "casuser", "Mellon");
+        await page2.waitForTimeout(3000);
+        await page2.waitForSelector('#table_with_attributes', {visible: true});
+        await cas.assertVisibility(page2, "#table_with_attributes");
+
+    } finally {
+        await cas.removeDirectory(path.join(__dirname, '/saml-md'));
+        await browser.close();
+    }
+})();
+
+

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/script.json
@@ -1,0 +1,37 @@
+{
+  "dependencies": "saml-idp",
+  "conditions": {
+    "docker": "true"
+  },
+  "properties": [
+    "--cas.authn.attribute-repository.stub.attributes.uid=casuser",
+    "--cas.authn.attribute-repository.stub.attributes.mail=casuser@example.org",
+    "--cas.authn.attribute-repository.stub.attributes.givenName=Apereo",
+    "--cas.authn.attribute-repository.stub.attributes.sn=CAS",
+
+    "--cas.authn.saml-idp.core.entity-id=https://cas.apereo.org/saml/idp",
+    "--cas.authn.saml-idp.metadata.file-system.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/saml-md",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--cas.http-client.host-name-verifier=none",
+    
+    "--logging.level.org.apereo.cas=info",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services",
+
+    "--cas.monitor.endpoints.endpoint.defaults.access=ANONYMOUS",
+    "--management.endpoints.web.exposure.include=health,samlIdPRegisteredServiceMetadataCache",
+    "--management.endpoint.health.show-details=always",
+    "--management.endpoints.enabled-by-default=true"
+  ],
+  "initScript": "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/init.sh",
+  "readyScript": "${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/ready.sh"
+}
+
+
+
+

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/script.json
@@ -23,6 +23,8 @@
     "--cas.service-registry.core.init-from-json=true",
     "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services",
 
+    "--cas.authn.saml-idp.core.session-storage-type=URL_PARAMS",
+
     "--cas.monitor.endpoints.endpoint.defaults.access=ANONYMOUS",
     "--management.endpoints.web.exposure.include=health,samlIdPRegisteredServiceMetadataCache",
     "--management.endpoint.health.show-details=always",

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/services/Sample-1.json
@@ -1,0 +1,13 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "http://localhost:9443/simplesaml.+",
+  "name" : "Sample",
+  "id" : 1,
+  "evaluationOrder" : 1,
+  "metadataLocation" : "http://localhost:9443/simplesaml/module.php/saml/sp/metadata.php/default-sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}
+
+

--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/services/Sample-2.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-concurrent/services/Sample-2.json
@@ -1,0 +1,13 @@
+{
+  "@class" : "org.apereo.cas.support.saml.services.SamlRegisteredService",
+  "serviceId" : "http://localhost:9444/simplesaml.+",
+  "name" : "Sample",
+  "id" : 2,
+  "evaluationOrder" : 2,
+  "metadataLocation" : "http://localhost:9444/simplesaml/module.php/saml/sp/metadata.php/default-sp",
+  "attributeReleasePolicy" : {
+    "@class" : "org.apereo.cas.services.ReturnAllAttributeReleasePolicy"
+  }
+}
+
+


### PR DESCRIPTION
Fix to allow to serve parallel SAML flows. Jerôme reported privously [here](https://groups.google.com/a/apereo.org/g/cas-user/c/fNZ82V32sio/m/RKhi5VQCAQAJ?utm_medium=email&utm_source=footer)

This request includes:
- The test that shows that CAS cannot handle this scenario
- The fix for that test

The solution is to pass SAML context and artifacts as GET parameters. I implemented another solution using the ticket store but discarded at the moment in favour of this one. 

The discussion is casuser is [here](https://groups.google.com/a/apereo.org/g/cas-user/c/AH719lwU27M)

This is an initial proposal, open to discuss.
