### PR TITLE
Support DN and password for LDAP SASL.

### DIFF
--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -665,6 +665,12 @@ public class LdapUtils {
             if (StringUtils.isNotBlank(properties.getSaslSecurityStrength())) {
                 sc.setSecurityStrength(SecurityStrength.valueOf(properties.getSaslSecurityStrength()));
             }
+            if (StringUtils.isNotBlank(properties.getBindDn())) {
+                bc.setBindDn(properties.getBindDn());
+                if (StringUtils.isNotBlank(properties.getBindCredential())) {
+                    bc.setBindCredential(new Credential(properties.getBindCredential()));
+                }
+            }
             bc.setBindSaslConfig(sc);
             cc.setConnectionInitializers(bc);
         } else if (StringUtils.equals(properties.getBindCredential(), "*") && StringUtils.equals(properties.getBindDn(), "*")) {


### PR DESCRIPTION
Both DigestMD5 and CramMD5 require DN and password.
