### PR TITLE
Interrupt : fix html link id in casInterruptView.html

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
@@ -45,7 +45,7 @@
                         <input type="hidden" id="linkToRedirect" name="link"/>
                     </form>
 
-                    <span th:with="linkid=${#strings.toLowerCase(#strings.replace(link.key, ' ', ''))}"
+                    <span th:with="linkid=${#strings.toLowerCase(link.key.replaceAll('[^A-Za-z0-9]', ''))}"
                           th:each="link : ${interrupt.links}">
                         <a class="mdc-button mdc-button--outline btn btn-primary me-2"
                            th:text="${link.key}"


### PR DESCRIPTION
Fix Jquery error like "unrecognized expression: #accéderàesup-otppouractiverl'authentificationrenforcée" when setting (for example)
def links = ["Accéder à ESUP-OTP pour activer l'authentification renforcée":"https://esup-otp-manager.univ-ville.fr/preferences"] 
in interrupt.groovy script