### PR TITLE
add logging to catch time sync issues - 6.6.x

### DIFF
--- a/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/RootCasException.java
+++ b/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/RootCasException.java
@@ -1,8 +1,6 @@
 package org.apereo.cas.authentication;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
@@ -17,7 +15,6 @@ import java.util.List;
  * @author Misagh Moayyed
  * @since 4.0.0
  */
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class RootCasException extends RuntimeException {
 
@@ -26,6 +23,11 @@ public class RootCasException extends RuntimeException {
     private final String code;
 
     private final List<Object> args = new ArrayList<>(0);
+
+    protected RootCasException(final String code) {
+        super(code);
+        this.code = code;
+    }
 
     protected RootCasException(final String code, final String msg) {
         super(msg);

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/InvalidTicketExceptionTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/InvalidTicketExceptionTests.java
@@ -16,6 +16,13 @@ import static org.junit.jupiter.api.Assertions.*;
 public class InvalidTicketExceptionTests {
 
     @Test
+    public void verifyCodeOnlyMessageNotNull() {
+        val t = new InvalidTicketException("ST-InvalidTicketId");
+        assertEquals("INVALID_TICKET", t.getCode());
+        assertNotNull(t.getMessage());
+    }
+
+    @Test
     public void verifyCodeNoThrowable() {
         val t = new InvalidTicketException(new IllegalArgumentException("FailsOp"), "InvalidTicket");
         assertEquals("INVALID_TICKET", t.getCode());

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -302,7 +302,7 @@ public abstract class BaseTicketRegistryTests {
     }
 
     /**
-     * Excercise block of code in getTicket that runs when get {@code ticketRegistry.getTicket()} called.
+     * Excercise block of code in getTicket that runs when get {@link AbstractTicketRegistry#getTicket(String ticketId)} called.
      * Adds 10 seconds to creation time to simulate time out of sync so warning is logged.
      */
     @RepeatedTest(2)

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -75,6 +75,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.UUID;
@@ -295,6 +296,22 @@ public abstract class BaseTicketRegistryTests {
         ticketRegistry.addTicket(new TicketGrantingTicketImpl(ticketGrantingTicketId,
             CoreAuthenticationTestUtils.getAuthentication(),
             NeverExpiresExpirationPolicy.INSTANCE));
+        val ticket = ticketRegistry.getTicket(ticketGrantingTicketId);
+        assertNotNull(ticket, () -> "Ticket is null. useEncryption[" + useEncryption + ']');
+        assertEquals(ticketGrantingTicketId, ticket.getId(), () -> "Ticket IDs don't match. useEncryption[" + useEncryption + ']');
+    }
+
+    /**
+     * Excercise block of code in getTicket that runs when get {@code ticketRegistry.getTicket()} called.
+     * Adds 10 seconds to creation time to simulate time out of sync so warning is logged.
+     */
+    @RepeatedTest(2)
+    public void verifyGetFutureDatedTicket() throws Exception {
+        val addTicket = new TicketGrantingTicketImpl(ticketGrantingTicketId,
+            CoreAuthenticationTestUtils.getAuthentication(),
+            NeverExpiresExpirationPolicy.INSTANCE);
+        addTicket.setCreationTime(ZonedDateTime.now(addTicket.getExpirationPolicy().getClock()).plusSeconds(10));
+        ticketRegistry.addTicket(addTicket);
         val ticket = ticketRegistry.getTicket(ticketGrantingTicketId);
         assertNotNull(ticket, () -> "Ticket is null. useEncryption[" + useEncryption + ']');
         assertEquals(ticketGrantingTicketId, ticket.getId(), () -> "Ticket IDs don't match. useEncryption[" + useEncryption + ']');

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -302,8 +302,9 @@ public abstract class BaseTicketRegistryTests {
     }
 
     /**
-     * Excercise block of code in getTicket that runs when get {@link AbstractTicketRegistry#getTicket(String ticketId)} called.
-     * Adds 10 seconds to creation time to simulate time out of sync so warning is logged.
+     * Exercise block of code in {@link AbstractTicketRegistry#getTicket(String ticketId)} that runs when
+     * the method encounters a {@link Ticket} created in the future.
+     * Adds 10 seconds to creation time to simulate time out of sync so warning will be logged.
      */
     @RepeatedTest(2)
     public void verifyGetFutureDatedTicket() throws Exception {


### PR DESCRIPTION
This changes the RootCasException to print out the code rather than a null message, e.g. when InvalidTicketException is created with the code. InvalidTicketException could do something with the ticketId but it doesn't. 

I also added a check to getTicket() to warn when it sees tickets created in the future. In a cluster of two servers, if the time is out of sync between the two servers, any service tickets that originate on the ahead server will be expired on the behind server when they are validated. This might not be obvious right away because about 25% of the ticket validations will fail. By checking for future dated tickets and logging a warning, this can be prevented. Since the default service ticket is only good for 10 seconds, it doesn't take much of a time sync issue to start having tickets fail due to expiration. Given the time it takes to redirect to the other app and send ticket back to CAS, if a ticket arrives that has a created date more than 1 second in the future of the server that is processing it, it logs a warning. 

I also added more information to the debug logging that occurs when a ticket is found to be expired. It might be nice if that was logged as info level because it would be good to see how often expired tickets are asked for. 

master: https://github.com/apereo/cas/pull/5716