### PR TITLE
add logging to catch time sync issues

### DIFF
--- a/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/RootCasException.java
+++ b/api/cas-server-core-api-authentication/src/main/java/org/apereo/cas/authentication/RootCasException.java
@@ -1,8 +1,6 @@
 package org.apereo.cas.authentication;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
@@ -18,7 +16,6 @@ import java.util.List;
  * @author Misagh Moayyed
  * @since 4.0.0
  */
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class RootCasException extends RuntimeException {
 
@@ -28,6 +25,11 @@ public class RootCasException extends RuntimeException {
     private final String code;
 
     private final List<Object> args = new ArrayList<>(0);
+
+    protected RootCasException(final String code) {
+        super(code);
+        this.code = code;
+    }
 
     protected RootCasException(final String code, final String msg) {
         super(msg);

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/InvalidTicketExceptionTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/InvalidTicketExceptionTests.java
@@ -16,6 +16,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class InvalidTicketExceptionTests {
 
     @Test
+    void verifyCodeOnlyMessageNotNull() {
+        val t = new InvalidTicketException("ST-InvalidTicketId");
+        assertEquals("INVALID_TICKET", t.getCode());
+        assertNotNull(t.getMessage());
+    }
+
+    @Test
     void verifyCodeNoThrowable() {
         val t = new InvalidTicketException(new IllegalArgumentException("FailsOp"), "InvalidTicket");
         assertEquals("INVALID_TICKET", t.getCode());

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -79,6 +79,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.Serial;
 import java.time.Clock;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -335,6 +336,23 @@ public abstract class BaseTicketRegistryTests {
         ticketRegistry.addTicket(new TicketGrantingTicketImpl(ticketGrantingTicketId,
             CoreAuthenticationTestUtils.getAuthentication(),
             NeverExpiresExpirationPolicy.INSTANCE));
+        val ticket = ticketRegistry.getTicket(ticketGrantingTicketId);
+        assertNotNull(ticket, () -> "Ticket is null. useEncryption[" + useEncryption + ']');
+        assertEquals(ticketGrantingTicketId, ticket.getId(), () -> "Ticket IDs don't match. useEncryption[" + useEncryption + ']');
+    }
+
+    /**
+     * Exercise block of code in {@link AbstractTicketRegistry#getTicket(String ticketId)} that runs when
+     * the method encounters a {@link Ticket} created in the future.
+     * Adds 10 seconds to creation time to simulate time out of sync so warning will be logged.
+     */
+    @RepeatedTest(2)
+    public void verifyGetFutureDatedTicket() throws Exception {
+        val addTicket = new TicketGrantingTicketImpl(ticketGrantingTicketId,
+            CoreAuthenticationTestUtils.getAuthentication(),
+            NeverExpiresExpirationPolicy.INSTANCE);
+        addTicket.setCreationTime(ZonedDateTime.now(addTicket.getExpirationPolicy().getClock()).plusSeconds(10));
+        ticketRegistry.addTicket(addTicket);
         val ticket = ticketRegistry.getTicket(ticketGrantingTicketId);
         assertNotNull(ticket, () -> "Ticket is null. useEncryption[" + useEncryption + ']');
         assertEquals(ticketGrantingTicketId, ticket.getId(), () -> "Ticket IDs don't match. useEncryption[" + useEncryption + ']');


### PR DESCRIPTION
Port forward of #5715 

I removed the null check in the getTicket() predicate since it was no longer there on master - may not be necessary in 6.6.x either but I will leave it in 6.6.x.