### PR TITLE
WIP - Improve MongoDB Ticket Registry by using only TTL indexes

### DIFF
--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
@@ -6,7 +6,9 @@ import org.apereo.cas.configuration.features.CasFeatureModule;
 import org.apereo.cas.mongo.MongoDbConnectionFactory;
 import org.apereo.cas.ticket.TicketCatalog;
 import org.apereo.cas.ticket.registry.MongoDbTicketRegistry;
+import org.apereo.cas.ticket.registry.NoOpTicketRegistryCleaner;
 import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.ticket.registry.TicketRegistryCleaner;
 import org.apereo.cas.ticket.serialization.TicketSerializationManager;
 import org.apereo.cas.util.CoreTicketUtils;
 import org.apereo.cas.util.MongoDbTicketRegistryFacilitator;
@@ -60,5 +62,12 @@ public class MongoDbTicketRegistryConfiguration {
         val factory = new MongoDbConnectionFactory(casSslContext.getSslContext());
         val mongo = casProperties.getTicket().getRegistry().getMongo();
         return factory.buildMongoTemplate(mongo);
+    }
+
+    @Bean
+    @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+    @ConditionalOnMissingBean(name = "mongoDbTicketRegistryCleaner")
+    public TicketRegistryCleaner ticketRegistryCleaner() {
+        return NoOpTicketRegistryCleaner.getInstance();
     }
 }

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -159,6 +159,7 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
             val collectionName = getTicketCollectionInstanceByMetadata(metadata);
             val query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).is(holder.getTicketId()));
             val update = Update.update(TicketHolder.FIELD_NAME_JSON, holder.getJson());
+            update.set(TicketHolder.FIELD_NAME_EXPIRE_AT, holder.getExpireAt());
             val result = this.mongoTemplate.updateFirst(query, update, collectionName);
             LOGGER.debug("Updated ticket [{}] with result [{}]", ticket, result);
             return result.getMatchedCount() > 0 ? ticket : null;

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/util/MongoDbTicketRegistryFacilitator.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/util/MongoDbTicketRegistryFacilitator.java
@@ -16,7 +16,6 @@ import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
 import org.springframework.data.mongodb.core.index.TextIndexDefinition;
 
-import java.time.Duration;
 import java.util.ArrayList;
 
 /**
@@ -68,11 +67,7 @@ public class MongoDbTicketRegistryFacilitator {
                 .onField(TicketHolder.FIELD_NAME_ID)
                 .build();
             val expireIndex = new Index().on(TicketHolder.FIELD_NAME_EXPIRE_AT, Sort.Direction.ASC);
-            
-            val timeout = ticket.getProperties().getStorageTimeout();
-            if (timeout > 0 && timeout != Long.MAX_VALUE) {
-                expireIndex.expire(Duration.ofSeconds(timeout));
-            }
+            expireIndex.expire(0);
 
             val expectedIndexes = new ArrayList<IndexDefinition>();
             expectedIndexes.add(expireIndex);

--- a/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.ticket.registry;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.authentication.RememberMeCredential;
 import org.apereo.cas.config.MongoDbTicketRegistryConfiguration;
 import org.apereo.cas.config.MongoDbTicketRegistryTicketCatalogConfiguration;
 import org.apereo.cas.mock.MockTicketGrantingTicket;
@@ -9,10 +10,14 @@ import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketCatalog;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
+import org.apereo.cas.ticket.expiration.AlwaysExpiresExpirationPolicy;
+import org.apereo.cas.ticket.expiration.BaseDelegatingExpirationPolicy;
 import org.apereo.cas.ticket.expiration.HardTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.expiration.NeverExpiresExpirationPolicy;
+import org.apereo.cas.ticket.expiration.RememberMeDelegatingExpirationPolicy;
 import org.apereo.cas.ticket.expiration.TimeoutExpirationPolicy;
 import org.apereo.cas.ticket.serialization.TicketSerializationManager;
+import org.apereo.cas.util.DateTimeUtils;
 import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
 
 import lombok.Getter;
@@ -28,6 +33,11 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.test.context.TestPropertySource;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -112,7 +122,7 @@ public class MongoDbTicketRegistryTests extends BaseTicketRegistryTests {
     public void verifyExpireAtTicketTimeoutExpirationPolicy() throws Exception {
         val ticket = new TicketGrantingTicketImpl(ticketGrantingTicketId,
                 CoreAuthenticationTestUtils.getAuthentication(),
-                new TimeoutExpirationPolicy(60000));
+                new TimeoutExpirationPolicy(60));
         newTicketRegistry.addTicket(ticket);
 
         val collectionName = "ticketGrantingTicketsCollection";
@@ -151,5 +161,116 @@ public class MongoDbTicketRegistryTests extends BaseTicketRegistryTests {
         val updateExpireAt = dd.getExpireAt();
 
         assertEquals(updateExpireAt, creationExpireAt);
+
+        val exp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30000);
+        val datePlus30000Secs = DateTimeUtils.dateOf(Instant.ofEpochMilli(exp));
+        assertTrue(creationExpireAt.after(datePlus30000Secs));
     }
+
+    @RepeatedTest(1)
+    @SuppressWarnings("JavaUtilDate")
+    public void verifyExpireAtTicketRememberMeDelegatingExpirationPolicy() throws Exception {
+
+        val p = new RememberMeDelegatingExpirationPolicy();
+        p.addPolicy(RememberMeDelegatingExpirationPolicy.POLICY_NAME_REMEMBER_ME, new HardTimeoutExpirationPolicy(60000));
+        p.addPolicy(BaseDelegatingExpirationPolicy.POLICY_NAME_DEFAULT, new TimeoutExpirationPolicy(60));
+
+        val ticket = new TicketGrantingTicketImpl(ticketGrantingTicketId,
+                CoreAuthenticationTestUtils.getAuthentication(),
+                p);
+        newTicketRegistry.addTicket(ticket);
+
+        val collectionName = "ticketGrantingTicketsCollection";
+
+        val query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).is(ticket.getId()));
+        val d = mongoDbTicketRegistryTemplate.findOne(query, TicketHolder.class, collectionName);
+        val creationExpireAt = d.getExpireAt();
+
+        Thread.sleep(5);
+
+        newTicketRegistry.updateTicket(ticket);
+        val dd = mongoDbTicketRegistryTemplate.findOne(query, TicketHolder.class, collectionName);
+        val updateExpireAt = dd.getExpireAt();
+
+        assertTrue(updateExpireAt.after(creationExpireAt));
+
+        val exp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30000);
+        val datePlus30000Secs = DateTimeUtils.dateOf(Instant.ofEpochMilli(exp));
+        assertFalse(creationExpireAt.after(datePlus30000Secs));
+    }
+
+    @RepeatedTest(1)
+    @SuppressWarnings("JavaUtilDate")
+    public void verifyExpireAtRememberMeTicketRememberMeDelegatingExpirationPolicy() throws Exception {
+
+        val p = new RememberMeDelegatingExpirationPolicy();
+        p.addPolicy(RememberMeDelegatingExpirationPolicy.POLICY_NAME_REMEMBER_ME, new HardTimeoutExpirationPolicy(60000));
+        p.addPolicy(BaseDelegatingExpirationPolicy.POLICY_NAME_DEFAULT, new TimeoutExpirationPolicy(60));
+
+        val ticket = new TicketGrantingTicketImpl(ticketGrantingTicketId,
+                CoreAuthenticationTestUtils.getAuthentication(CoreAuthenticationTestUtils.getPrincipal(),
+                        Collections.singletonMap(RememberMeCredential.AUTHENTICATION_ATTRIBUTE_REMEMBER_ME, List.of(true)),
+                        null),
+                p);
+        newTicketRegistry.addTicket(ticket);
+
+        val collectionName = "ticketGrantingTicketsCollection";
+
+        val query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).is(ticket.getId()));
+        val d = mongoDbTicketRegistryTemplate.findOne(query, TicketHolder.class, collectionName);
+        val creationExpireAt = d.getExpireAt();
+
+        Thread.sleep(5);
+
+        newTicketRegistry.updateTicket(ticket);
+        val dd = mongoDbTicketRegistryTemplate.findOne(query, TicketHolder.class, collectionName);
+        val updateExpireAt = dd.getExpireAt();
+
+        assertEquals(updateExpireAt, creationExpireAt);
+
+        val exp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30000);
+        val datePlus30000Secs = DateTimeUtils.dateOf(Instant.ofEpochMilli(exp));
+        assertTrue(creationExpireAt.after(datePlus30000Secs));
+    }
+
+    @RepeatedTest(1)
+    @SuppressWarnings("JavaUtilDate")
+    public void verifyExpireAtTicketNeverExpiresExpirationPolicy() throws Exception {
+
+        val ticket = new TicketGrantingTicketImpl(ticketGrantingTicketId,
+                CoreAuthenticationTestUtils.getAuthentication(),
+                new NeverExpiresExpirationPolicy());
+        newTicketRegistry.addTicket(ticket);
+
+        val collectionName = "ticketGrantingTicketsCollection";
+
+        val query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).is(ticket.getId()));
+        val d = mongoDbTicketRegistryTemplate.findOne(query, TicketHolder.class, collectionName);
+        val creationExpireAt = d.getExpireAt();
+        val exp = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(50*365);
+        val datePlus50Years = DateTimeUtils.dateOf(Instant.ofEpochMilli(exp));
+
+        assertTrue(creationExpireAt == null || creationExpireAt.after(datePlus50Years));
+    }
+
+    @RepeatedTest(1)
+    @SuppressWarnings("JavaUtilDate")
+    public void verifyExpireAtTicketAlwaysExpiresExpirationPolicy() throws Exception {
+
+        val ticket = new TicketGrantingTicketImpl(ticketGrantingTicketId,
+                CoreAuthenticationTestUtils.getAuthentication(),
+                new AlwaysExpiresExpirationPolicy());
+        newTicketRegistry.addTicket(ticket);
+
+        val collectionName = "ticketGrantingTicketsCollection";
+
+        val query = new Query(Criteria.where(TicketHolder.FIELD_NAME_ID).is(ticket.getId()));
+        val d = mongoDbTicketRegistryTemplate.findOne(query, TicketHolder.class, collectionName);
+
+        val exp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(1);
+        val nowPlus1second = DateTimeUtils.dateOf(Instant.ofEpochMilli(exp));
+
+        assertTrue(d == null || d.getExpireAt().before(nowPlus1second));
+    }
+
 }


### PR DESCRIPTION
This PR is related to the MongoDB ticket registry and its use of DefaultTicketRegistryCleaner.

Currently, even if the MongoDb Ticket Registry setup includes TTL indexes (expireAt/expireAfterSeconds), tickets stored with MongoDb Ticket Registry are actually and by default deleted via DefaultTicketRegistryCleaner.

It is important to note that the DefaultTicketRegistryCleaner retrieves all the tickets, "reads" them (and therefore decodes them if they are encoded, which is normally the case if you follow the recommendations of CAS itself), selects the tickets that it considers expired, and finally deletes them. This generic implementation is very resource-intensive, especially since by default this procedure for deleting tickets by the DefaultTicketRegistry is called every 2 minutes.

Some ticket registries in CAS disable the DefaultTicketRegistryCleaner and use their internal TTL mechanisms instead. These registries include Memcached, HazelCast, Couchbase, and CouchDB ticket registries.

This PR proposes to do the same with MongoDB.

To achieve this, the following modifications are made in the commits of this PR:

* Disable DefaultTicketRegistryCleaner, similar to the approach used by other ticket registries (mentioned above).
* Modify MongoDB's expireAfterSeconds to 0 so that the ticket expires (via MogoDB process) at the specified expireAt value; currently, expireAfterSeconds is set to the max-time-to-live-in-seconds property.
* Keep expireAt up to date; currently, expireAt is actually set to the created date plus the time-to-kill-in-seconds value and is never updated.

With these changes, the MongoDB ticket registry will consume fewer resources: there will be no need for CAS to regularly decode all the tickets to select and delete some of them.