### PR TITLE
 tomcat background process is needed to cleanup sessions

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/application.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/application.properties
@@ -30,7 +30,6 @@ server.tomcat.connection-timeout=PT20S
 server.tomcat.accesslog.enabled=true
 server.tomcat.accesslog.pattern=%t %a "%r" %s (%D ms)
 server.tomcat.accesslog.suffix=.log
-server.tomcat.background-processor-delay=0s
 server.tomcat.threads.min-spare=10
 server.tomcat.threads.max=200
 


### PR DESCRIPTION
With background-processor-delay=0s, tomcat background process is disabled. All org.apache.catalina.session.StandardSession objects are kept in memory, resulting in a small but steady increase in memory usage, ending in OutOfMemory after some time (one month in our case)

NB: it only impacts spring-boot embedded tomcat.

master: https://github.com/apereo/cas/pull/5652