### PR TITLE
remove unused sqlite dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -524,6 +524,7 @@ ext.libraries = [
         },
         cqengine                   : [
                 dependencies.create("com.googlecode.cqengine:cqengine:$cqEngineVersion") {
+                    exclude(group: 'org.xerial', module: "sqlite-jdbc")
                 }
         ],
         maxmind                    : [


### PR DESCRIPTION
I don't think this dependency is used by CAS and cqengine uses a fairly old version of the dependency. 

This says that users of cqengine are welcome to either exclude or update the version of the dependency. https://github.com/npgall/cqengine/issues/317

