### PR TITLE
Don't reparse script in GroovyScriptAttributeReleasePolicy

### DIFF
--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/GroovyScriptAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/GroovyScriptAttributeReleasePolicy.java
@@ -2,9 +2,9 @@ package org.apereo.cas.services;
 
 import org.apereo.cas.configuration.support.ExpressionLanguageCapable;
 import org.apereo.cas.util.LoggingUtils;
-import org.apereo.cas.util.ResourceUtils;
-import org.apereo.cas.util.scripting.ScriptingUtils;
-import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolver;
+import org.apereo.cas.util.function.FunctionUtils;
+import org.apereo.cas.util.scripting.ExecutableCompiledGroovyScript;
+import org.apereo.cas.util.spring.ApplicationContextProvider;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
@@ -19,6 +19,7 @@ import java.io.Serial;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * This is {@link GroovyScriptAttributeReleasePolicy} that attempts to release attributes
@@ -42,15 +43,40 @@ public class GroovyScriptAttributeReleasePolicy extends AbstractRegisteredServic
     @ExpressionLanguageCapable
     private String groovyScript;
 
+    private Map<String, List<Object>> fetchAttributeValueFromExternalGroovyScript(final String file,
+                                                                                  final RegisteredServiceAttributeReleasePolicyContext context,
+                                                                                  final Map<String, List<Object>> attributes) {
+        return ApplicationContextProvider.getScriptResourceCacheManager()
+            .map(cacheMgr -> {
+                val script = cacheMgr.resolveScriptableResource(file, file);
+                return FunctionUtils.doIf(script != null,
+                    () -> fetchAttributeValueFromScript(script, context, attributes),
+                    TreeMap<String, List<Object>>::new).get();
+            })
+            .orElseThrow(() -> new RuntimeException("No groovy script cache manager is available to execute attribute mappings"));
+    }
+
+    protected Map<String, List<Object>> fetchAttributeValueFromScript(
+        final ExecutableCompiledGroovyScript script,
+        final RegisteredServiceAttributeReleasePolicyContext context,
+        final Map<String, List<Object>> attributes) {
+        val args = new Object[] {attributes, LOGGER, context.getPrincipal(), context.getRegisteredService()};
+        val result = (Map<String, List<Object>>) script.execute(args, Map.class, false);
+        if (result != null) {
+            LOGGER.debug("Attribute release policy returned attributes [{}] from script [{}]", result, groovyScript);
+        } else {
+            LOGGER.warn("Attribute release policy script [{}] returned null", groovyScript);
+        }
+        return result;
+    }
+
     @Override
     public Map<String, List<Object>> getAttributesInternal(final RegisteredServiceAttributeReleasePolicyContext context,
                                                            final Map<String, List<Object>> attributes) {
         try {
-            val args = new Object[]{attributes, LOGGER, context.getPrincipal(), context.getRegisteredService()};
             LOGGER.debug("Invoking Groovy script with attributes=[{}], principal=[{}], service=[{}] and default logger",
                 attributes, context.getPrincipal(), context.getRegisteredService());
-            val resource = ResourceUtils.getResourceFrom(SpringExpressionLanguageValueResolver.getInstance().resolve(this.groovyScript));
-            return ScriptingUtils.executeGroovyScript(resource, args, Map.class, true);
+            return fetchAttributeValueFromExternalGroovyScript(groovyScript, context, attributes);
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         }

--- a/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/GroovyScriptAttributeReleasePolicyTests.java
+++ b/core/cas-server-core-authentication-attributes/src/test/java/org/apereo/cas/services/GroovyScriptAttributeReleasePolicyTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.services;
 
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.config.CasCoreUtilConfiguration;
 import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,6 +9,8 @@ import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.File;
@@ -21,6 +24,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 4.1
  */
 @Tag("GroovyServices")
+@SpringBootTest(classes = {
+    RefreshAutoConfiguration.class,
+    CasCoreUtilConfiguration.class}
+)
 class GroovyScriptAttributeReleasePolicyTests {
     private static final File JSON_FILE = new File(FileUtils.getTempDirectoryPath(), "groovyScriptAttributeReleasePolicy.json");
 


### PR DESCRIPTION
I was noticing a lot of Groovy script parsing in my deployment, and it turned out that the scripts I was mapping into CAS container via k8s config map were getting "modified" frequently but not actually changing - presumably as a result of k8s doing something but I don't know what. Those modify events were triggering script parsing of cached scripts and that was taking a long time (>5 seconds per script), possibly because of various locks and what looked like classpath scanning. Anyway, I turned off the flag that added watches to all the scripts and then I noticed that one particular type of script was still getting re-parsed every time it was accessed. I will change the way I get scripts into my container to avoid the watch/modify issue, but this change employs the `GroovyScriptResourceCacheManager` for `GroovyScriptAttributeReleasePolicy`, similar to how it is used for most other scripts. The existing unit test still passes. 
