### PR TITLE
optional usage of redis sentinel password

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisSentinelProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisSentinelProperties.java
@@ -35,6 +35,11 @@ public class RedisSentinelProperties implements Serializable {
     private String master;
 
     /**
+     * Login password of the sentinel server.
+     */
+    private String password;
+
+    /**
      * list of host:port pairs.
      */
     private List<String> node = new ArrayList<>(0);

--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -293,6 +293,9 @@ public class RedisObjectFactory {
         if (StringUtils.hasText(redis.getPassword())) {
             sentinelConfig.setPassword(RedisPassword.of(redis.getPassword()));
         }
+        if (StringUtils.hasText(redis.getSentinel().getPassword())) {
+            sentinelConfig.setSentinelPassword(RedisPassword.of(redis.getSentinel().getPassword()));
+        }
         return sentinelConfig;
     }
 


### PR DESCRIPTION
Redis sentinel deployments can utilize separate passwords for connecting to redis and the sentinel service.
Expose property to set the sentinel password setting of on `RedisSentinelConfiguration`
Looked at extending tests in `RedisObjectFactoryTests` but no sentinel tests exist.