### PR TITLE
optional usage of redis sentinel password

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisSentinelProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisSentinelProperties.java
@@ -35,6 +35,11 @@ public class RedisSentinelProperties implements Serializable {
     private String master;
 
     /**
+     * Login password of the sentinel server.
+     */
+    private String password;
+
+    /**
      * list of host:port pairs.
      */
     private List<String> node = new ArrayList<>(0);

--- a/ci/tests/redis/docker-compose.yml
+++ b/ci/tests/redis/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       - REDIS_MASTER_SET=mymaster
       - REDIS_SENTINEL_QUORUM=2
       - REDIS_MASTER_HOST=localhost
+      - REDIS_PASSWORD=password123
+      - REDIS_SENTINEL_PASSWORD=password456
     depends_on:
       - redis-master
 
@@ -76,6 +78,8 @@ services:
       - REDIS_MASTER_SET=mymaster
       - REDIS_SENTINEL_QUORUM=2
       - REDIS_MASTER_HOST=localhost
+      - REDIS_PASSWORD=password123
+      - REDIS_SENTINEL_PASSWORD=password456
     depends_on:
       - redis-master
 
@@ -88,5 +92,7 @@ services:
       - REDIS_MASTER_SET=mymaster
       - REDIS_SENTINEL_QUORUM=2
       - REDIS_MASTER_HOST=localhost
+      - REDIS_PASSWORD=password123
+      - REDIS_SENTINEL_PASSWORD=password456
     depends_on:
       - redis-master

--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -293,6 +293,9 @@ public class RedisObjectFactory {
         if (StringUtils.hasText(redis.getPassword())) {
             sentinelConfig.setPassword(RedisPassword.of(redis.getPassword()));
         }
+        if (StringUtils.hasText(redis.getSentinel().getPassword())) {
+            sentinelConfig.setSentinelPassword(RedisPassword.of(redis.getSentinel().getPassword()));
+        }
         return sentinelConfig;
     }
 

--- a/support/cas-server-support-redis-service-registry/src/test/java/org/apereo/cas/adaptors/redis/services/RedisSentinelServerServiceRegistryTests.java
+++ b/support/cas-server-support-redis-service-registry/src/test/java/org/apereo/cas/adaptors/redis/services/RedisSentinelServerServiceRegistryTests.java
@@ -16,9 +16,11 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {
     "cas.service-registry.redis.host=localhost",
     "cas.service-registry.redis.port=6379",
+    "cas.service-registry.redis.port=password123",
     "cas.service-registry.redis.share-native-connections=true",
 
     "cas.service-registry.redis.sentinel.master=mymaster",
+    "cas.service-registry.redis.sentinel.password=password456",
     "cas.service-registry.redis.sentinel.node[0]=localhost:26379",
     "cas.service-registry.redis.sentinel.node[1]=localhost:26380",
     "cas.service-registry.redis.sentinel.node[2]=localhost:26381",

--- a/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisSentinelServerTicketRegistryTests.java
+++ b/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisSentinelServerTicketRegistryTests.java
@@ -14,12 +14,14 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {
     "cas.ticket.registry.redis.host=localhost",
     "cas.ticket.registry.redis.port=6379",
+    "cas.ticket.registry.redis.password=password123",
     "cas.ticket.registry.redis.read-from=MASTER",
 
     "cas.ticket.registry.redis.pool.max-active=20",
     "cas.ticket.registry.redis.pool.enabled=true",
 
     "cas.ticket.registry.redis.sentinel.master=mymaster",
+    "cas.ticket.registry.redis.sentinel.password=password456",
     "cas.ticket.registry.redis.sentinel.node[0]=localhost:26379",
     "cas.ticket.registry.redis.sentinel.node[1]=localhost:26380",
     "cas.ticket.registry.redis.sentinel.node[2]=localhost:26381",


### PR DESCRIPTION
Redis sentinel deployments can utilize separate passwords for connecting to redis and the sentinel service.
Expose property to set the sentinel password setting of on RedisSentinelConfiguration