### PR TITLE
WIP - Test basic auth for cas endpoints.

### DIFF
--- a/support/cas-server-support-webconfig/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
+++ b/support/cas-server-support-webconfig/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
@@ -37,7 +37,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
         "spring.security.user.name=casuser",
         "spring.security.user.password=Mellon",
-
         "management.endpoints.enabled-by-default=true",
         "management.endpoints.web.exposure.include=*",
 
@@ -98,12 +97,41 @@ class CasWebSecurityConfigurerAdapterWebTests {
         mvc.perform(get("/cas/actuator/health")).andExpect(status().isUnauthorized());
     }
 
+    @Test
+    /**
+     * Test page that should be on permit all list with Basic Auth.
+     * Some OIDC applications pass clientid and secret as basic authentication credentials and they need to get passed spring security.
+     * Using /cas/login instead of /cas/oidc/oidcAccessToken because the oidc module isn't configured here.
+     */
+    void verifyCasLoginBasicAuth() throws Throwable {
+        mvc.perform(post("/cas/login").with(httpBasic("casuser", "XYZ"))).andExpect(status().isOk());
+    }
+
+    @Test
+    void verifyCasLoginNoBasic() throws Throwable {
+        mvc.perform(post("/cas/login")).andExpect(status().isOk());
+    }
+
     @TestConfiguration(value = "WebTestConfiguration", proxyBeanMethods = false)
     static class WebTestConfiguration {
 
         @RestController("TestController")
         @RequestMapping("/oidc/accessToken")
         public class TestController {
+            @GetMapping
+            public ResponseEntity getMethod() {
+                return ResponseEntity.ok().build();
+            }
+
+            @PostMapping
+            public ResponseEntity postMethod() {
+                return ResponseEntity.ok().build();
+            }
+        }
+
+        @RestController("LoginController")
+        @RequestMapping("/login")
+        public class LoginController {
             @GetMapping
             public ResponseEntity getMethod() {
                 return ResponseEntity.ok().build();

--- a/support/cas-server-support-webconfig/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
+++ b/support/cas-server-support-webconfig/src/test/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapterWebTests.java
@@ -37,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
         "spring.security.user.name=casuser",
         "spring.security.user.password=Mellon",
+
         "management.endpoints.enabled-by-default=true",
         "management.endpoints.web.exposure.include=*",
 
@@ -100,11 +101,11 @@ class CasWebSecurityConfigurerAdapterWebTests {
     @Test
     /**
      * Test page that should be on permit all list with Basic Auth.
-     * Some OIDC applications pass clientid and secret as basic authentication credentials and they need to get passed spring security.
+     * Some OIDC applications pass clientid and secret as basic authentication credentials, and they need to get passed spring security.
      * Using /cas/login instead of /cas/oidc/oidcAccessToken because the oidc module isn't configured here.
      */
     void verifyCasLoginBasicAuth() throws Throwable {
-        mvc.perform(post("/cas/login").with(httpBasic("casuser", "XYZ"))).andExpect(status().isOk());
+        mvc.perform(post("/cas/login").with(httpBasic("clientid", "clientsecret"))).andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
On CAS 7.x I am seeing several OIDC applications that are passing clientid/clientSecret as Basic auth header on the `POST /cas/oidc/oidcAccessToken`. Spring Security has basic auth filter that will try to authenticate that user against default authentication provider that doesn't know about the oidc service users so it will fail authentication and spring security returns a 401. 

The test `verifyCasLoginBasicAuth()` simulates this issue using the `/login` method which is configured similarly to `/oidc/oidcAccessToken` and it would fail if not for the change I made to move all the protocol methods to the ignoring list rather than the permitAll list. I think permitAll only works if there is no credential that spring security has a filter to verify and I don't know how to get rid of the default basic authentication filter. Disabling it with a ` .httpBasic(HttpBasicConfigurer::disable) ` didn't seem to do anything. I assume basic authentication is needed for some endpoints somewhere but if all endpoints are going to be behind spring security (rather than using "ignoring"), I think there needs to be too different filter chains? 

As to why I am having this problem but none of the millions of functional tests are failing, (Sonarqube login is failing in my environment with 7.x but the puppeteer test is passing), it looks like maybe the puppeteer test is using a bearer token instead of using basic auth?
```
============================================================
OAuth/OpenID Connect Token Response
============================================================
access_token: AT-2-********Kt6WeLVCOLm5ri1aRzXi
scope: email openid profile
expires_in: 28800
token_type: Bearer
id_token: ***
status: 200 OK
============================================================
```
I know in my environment (from debug logs) it is passing a basic auth header instead but could that be because I have 
```
  "supportedGrantTypes": [ "java.util.HashSet", [ "authorization_code" ] ],
```
in the service instead of 
```
"supportedGrantTypes": [ "java.util.HashSet", [ "client_credentials", "refresh_token", "authorization_code" ] ],
```

I thought I tried the full list of grant types for at least one service that wasn't working and it didn't immediately work but I don't see any other likely differences in the service definition. `authorization_code` by itself was working in CAS 6.6 so even if there are better options, should CAS support it? I see several puppeteer tests that use only authorization_code but they might all be passing clientid and clientsecret as URL parameters instead of basic auth?



