### PR TITLE
WIP - show problem with active-attribute-repository-ids

### DIFF
--- a/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.js
+++ b/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.js
@@ -63,10 +63,17 @@ const request = require('request');
     await cas.assertInnerText(page, '#content div h2', "Log In Successful");
     await cas.assertInnerTextContains(page, "#content div p", "1234567890@college.edu");
 
-    await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "casuserx509");
-    await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "someattribute");
-    await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "user-account-control");
+    // make sure attribute from attribute repository that is not active does not show up
     await cas.assertInnerTextDoesNotContain(page, "#attribute-tab-0 table#attributesTable tbody", "shouldntbehere");
+
+    // check for samaccountname attribute that should have come from ADCERT attribute repository
+    await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "casuserx509");
+
+    // check for attribute from groovy attribute repository that should be enabled
+    await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "someattribute");
+
+    // check for another attribute from ADCERT attribute repository
+    await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "user-account-control");
 
     await browser.close();
 })();

--- a/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.json
+++ b/ci/tests/puppeteer/scenarios/x509-login-ldap-attributes/script.json
@@ -13,19 +13,22 @@
     "--server.ssl.key-store-type=PKCS12",
     "--server.ssl.client-auth=want",
 
-    "--logging.level.org.apereo.cas=info",
-    "--logging.level.org.apereo.services.persondir=info",
-    "--logging.level.org.apereo.cas.persondir=info",
+    "--logging.level.org.apereo.cas=debug",
+    "--logging.level.org.apereo.services.persondir=trace",
+    "--logging.level.org.apereo.cas.persondir=trace",
+    "--logging.level.org.apereo.cas.authentication.principal.cache=trace",
+
+    "--cas.tgc.allowed-ip-addresses-pattern=127\\.0\\.0\\.1|0:0:0:0:0:0:0:1",
 
     "--cas.person-directory.active-attribute-repository-ids=ADAUTH,COMMONATTRS",
-
     "--cas.authn.x509.principal.active-attribute-repository-ids=ADCERT,COMMONATTRS",
     "--cas.authn.x509.reg-ex-trusted-issuer-dn-pattern=.*",
     "--cas.authn.x509.max-path-length-allow-unspecified=true",
     "--cas.authn.x509.principal-type=RFC822_EMAIL",
     "--cas.authn.x509.principal.principal-attribute=x509Rfc822Email,subjectDn",
     "--cas.authn.x509.subject-alt-name.alternate-principal-attribute=subjectDn",
-    
+
+    "--cas.authn.attribute-repository.core.aggregation=CASCADE",
     "--cas.authn.attribute-repository.core.merger=MULTIVALUED",
     "--cas.authn.attribute-repository.core.default-attributes-to-release=someattribute,anotherattribute,ldap-dn,uid,user-account-control,x509Rfc822Email,x509subjectUPN",
 

--- a/docs/cas-server-documentation/monitoring/Monitoring-Statistics.md
+++ b/docs/cas-server-documentation/monitoring/Monitoring-Statistics.md
@@ -18,7 +18,7 @@ for moving or controlling something. Actuators can generate a large amount of mo
 
 ## Actuator Endpoints
 
-{% assign actuators = "logfile,auditevents,beans,caches,conditions,configprops,env,httpexchanges,loggers,info,startup,threaddump,health,metrics,httptrace,mappings,scheduledtasks,heapdump,prometheus,startup,quartz" | split: "," | sort %}
+{% assign actuators = "logfile,auditevents,beans,caches,conditions,configprops,env,httpexchanges,loggers,info,threaddump,health,metrics,httptrace,mappings,scheduledtasks,heapdump,prometheus,startup,quartz" | split: "," | sort %}
 
 The following actuator endpoints are provided:
 


### PR DESCRIPTION
This puppeteer test has x509 and ldap logins, with different "active-attribute-repository-ids" depending on how the user authenticates:
```
    "--cas.person-directory.active-attribute-repository-ids=ADAUTH,COMMONATTRS",
    "--cas.authn.x509.principal.active-attribute-repository-ids=ADCERT,COMMONATTRS",
```

In 6.6.x, the test was passing with aggregation=CASCADE:
```
"--cas.authn.attribute-repository.core.aggregation=CASCADE",
```
but now if it is changed back to CASCADE, the test fails because the two lists of active attribute repositories are being merged together for x509. 

This causes there to be an extra query against LDAP with the x509 username and the LDAP attribute repository is configured for username/password authentication so nothing is returned. Besides that query being extra overhead, CASCADE by default stops if the first attribute repository doesn't have results so no attribute repositories are consulted. 

While it might be possible to re-arrange the ordering of the attribute repositories so that the first attribute repository always returned results, that wouldn't stop the extra LDAP query for x509 authentication and it would leave the ability to set different `active-attribute-repository-ids` for different authentication methods not working (or at least working differently than they did in 6.6.x). 

It looks like in `CoreAuthenticationUtils.buildPrincipalResolutionContext()` it went from; 
```
           .activeAttributeRepositoryIdentifiers(Arrays.stream(personDirectory)
                .filter(p -> StringUtils.isNotBlank(p.getActiveAttributeRepositoryIds()))
                .map(p -> org.springframework.util.StringUtils.commaDelimitedListToSet(p.getActiveAttributeRepositoryIds()))
                .filter(p -> !p.isEmpty())
                .findFirst()
                .orElse(Collections.EMPTY_SET))
```
to 
```
        val activeAttributeRepositoryIdentifiers = Arrays.stream(personDirectory)
            .filter(p -> StringUtils.isNotBlank(p.getActiveAttributeRepositoryIds()))
            .map(p -> org.springframework.util.StringUtils.commaDelimitedListToSet(p.getActiveAttributeRepositoryIds()))
            .filter(p -> !p.isEmpty())
            .flatMap(Set::stream)
            .collect(Collectors.toSet());
```
so it used to get the first non-empty set of active repository ids and now it collects all of them. Is that an intentional change? It seems like the current behavior loses the ability to skip attribute repositories that don't apply to x509 (and probably wsfed). 

There is also a documentation change that removes `startup` from list of actuators b/c it was in the list twice. 