### PR TITLE
Backport commit # 407b1423012d0bb4694a83ea3091f8b015bda884 to 6.6.x b…

### DIFF
--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationComponentSerializationConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationComponentSerializationConfiguration.java
@@ -5,6 +5,8 @@ import org.apereo.cas.authentication.DefaultAuthentication;
 import org.apereo.cas.authentication.DefaultAuthenticationHandlerExecutionResult;
 import org.apereo.cas.authentication.PreventedException;
 import org.apereo.cas.authentication.PrincipalException;
+import org.apereo.cas.authentication.adaptive.geo.GeoLocationRequest;
+import org.apereo.cas.authentication.adaptive.geo.GeoLocationResponse;
 import org.apereo.cas.authentication.credential.BasicIdentifiableCredential;
 import org.apereo.cas.authentication.credential.HttpBasedServiceCredential;
 import org.apereo.cas.authentication.credential.OneTimePasswordCredential;
@@ -79,6 +81,8 @@ public class CasCoreAuthenticationComponentSerializationConfiguration {
             plan.registerSerializableClass(UnauthorizedSsoServiceException.class);
 
             plan.registerSerializableClass(DefaultMessageDescriptor.class);
+            plan.registerSerializableClass(GeoLocationRequest.class);
+            plan.registerSerializableClass(GeoLocationResponse.class);
             plan.registerSerializableClass(PasswordExpiringWarningMessageDescriptor.class);
         };
     }


### PR DESCRIPTION
Backport commit # https://github.com/apereo/cas/commit/407b1423012d0bb4694a83ea3091f8b015bda884 from master branch to fix following error when using:

cas.ticket.registry.memcached.transcoder: KRYO

ERROR [org.apereo.cas.ticket.registry.MemcachedTicketRegistry] - <com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: org.apereo.cas.authentication.adaptive.geo.GeoLocationRequest
Note: To register this class use: kryo.register(org.apereo.cas.authentication.adaptive.geo.GeoLocationRequest.class);
Serialization trace:
properties (org.apereo.cas.authentication.metadata.BasicCredentialMetaData)
credentials (org.apereo.cas.authentication.DefaultAuthentication)
authentication (org.apereo.cas.ticket.TicketGrantingTicketImpl)
CasKryoTranscoder.java:encode:57
MemcachedClient.java:asyncStore:304
MemcachedClient.java:set:928

master: https://github.com/apereo/cas/commit/407b1423012d0bb4694a83ea3091f8b015bda884