### PR TITLE
fix sonarqube functional test

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/init.sh
+++ b/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/init.sh
@@ -16,14 +16,14 @@ kubectl create secret generic -n sonarqube cas-cert --from-file=cas-cert.crt=${C
 helm upgrade sonarqube sonarqube/sonarqube -n sonarqube --install \
   --values ${SCENARIO_DIR}/sonarqube-test-values.yaml \
   --set annotations.releaseTime="$( date --rfc-3339=seconds)"
-sleep 5
-
+sleep 15
 # we don't want to stop after this point so if it times out coming up, we can see status and logs
 set +e
+
 echo "Waiting for sonarqube pods to be ready"
-kubectl wait --namespace sonarqube --for condition=ready pod --selector=statefulset.kubernetes.io/pod-name=sonarqube-sonarqube-0 --timeout=600s
+kubectl wait --namespace sonarqube --for condition=ready pod --selector=statefulset.kubernetes.io/pod-name=sonarqube-sonarqube-0 --timeout=300s
 echo "Showing sonarqube pods status"
 kubectl get pods -n sonarqube
-kubectl logs -n sonarqube sonarqube-sonarqube-0
+kubectl logs -n sonarqube sonarqube-sonarqube-0 --all-containers=true
 kubectl get pods -A
 curl -ksv -o /dev/null "https://host.k3d.internal"

--- a/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/sonarqube-test-values.yaml
+++ b/ci/tests/puppeteer/scenarios/oidc-login-sonarqube/sonarqube-test-values.yaml
@@ -2,8 +2,7 @@
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  ingressClassName: nginx
   hosts:
     - name: localhost
     - name: host.k3d.internal
@@ -14,7 +13,7 @@ readinessProbe:
   failureThreshold: 10
 
 startupProbe:
-  initialDelaySeconds: 15
+  initialDelaySeconds: 30
   periodSeconds: 10
   failureThreshold: 25
 
@@ -31,9 +30,10 @@ prometheusExporter:
 image:
   repository: sonarqube
   tag: lts-community
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   
 plugins:
+  image: "curlimages/curl:latest"
   install:
     - https://github.com/vaulttec/sonar-auth-oidc/releases/download/v2.1.1/sonar-auth-oidc-plugin-2.1.1.jar
 


### PR DESCRIPTION
This test was failing because the init container that installs the oidc plugin didn't have curl to download the plugin. 