### PR TITLE
fix tgt is expired then NoSuchElementException is throwed

### DIFF
--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationSingleSignOnParticipationStrategy.java
@@ -5,6 +5,7 @@ import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.principal.ClientCredential;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.AuthenticationAwareTicket;
+import org.apereo.cas.ticket.InvalidTicketException;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.CollectionUtils;
 
@@ -45,7 +46,8 @@ public class DelegatedAuthenticationSingleSignOnParticipationStrategy extends Ba
         try {
             val authentication = getTicketState(ssoRequest)
                 .map(AuthenticationAwareTicket.class::cast)
-                .map(AuthenticationAwareTicket::getAuthentication).orElseThrow();
+                .map(AuthenticationAwareTicket::getAuthentication)
+                .orElseThrow(() -> new InvalidTicketException(ticketGrantingTicketId.get()));
             AuthenticationCredentialsThreadLocalBinder.bindCurrent(authentication);
             val policy = accessStrategy.getDelegatedAuthenticationPolicy();
             val attributes = authentication.getAttributes();


### PR DESCRIPTION
[2023-11-24 17:04:33.705+08:00]-[ERROR]-[https-jsse-nio-172.18.0.44-18443-exec-5]-[dspcas_rest_1700816673684_e2b65365cd8149f0b6e52785dd7d0763]-[]-[org.apereo.cas.web.flow.actions.DelegatedClientAuthenticationAction()] No value present[N]   null:orElseThrow:-1[N]  DelegatedAuthenticationSingleSignOnParticipationStrategy.java:isParticipating:48[N]     ChainingSingleSignOnParticipationStrategy.java:lambda$isParticipating$0:46[N]

when tgt is expired after execute method org.apereo.cas.web.flow.DelegatedAuthenticationSingleSignOnEvaluator#getSingleSignOnAuthenticationFrom, org.apereo.cas.web.flow.DelegatedAuthenticationSingleSignOnParticipationStrategy#isParticipating will throw NoSuchElementException exception, singleSignOnSessionExists method can't catch this exception.