### PR TITLE
fix NoSuchElementException is throwed when tgt is expired 

### DIFF
--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DelegatedAuthenticationSingleSignOnParticipationStrategy.java
@@ -4,6 +4,7 @@ import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.principal.ClientCredential;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.AuthenticationAwareTicket;
+import org.apereo.cas.ticket.InvalidTicketException;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.CollectionUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,8 @@ public class DelegatedAuthenticationSingleSignOnParticipationStrategy extends Ba
 
         val authentication = getTicketState(ssoRequest)
             .map(AuthenticationAwareTicket.class::cast)
-            .map(AuthenticationAwareTicket::getAuthentication).orElseThrow();
+            .map(AuthenticationAwareTicket::getAuthentication)
+            .orElseThrow(() -> new InvalidTicketException(ticketGrantingTicketId.get()));
         val policy = accessStrategy.getDelegatedAuthenticationPolicy();
         val attributes = authentication.getAttributes();
         if (attributes.containsKey(ClientCredential.AUTHENTICATION_ATTRIBUTE_CLIENT_NAME)) {

--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/web/flow/DelegatedAuthenticationSingleSignOnParticipationStrategyTests.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/web/flow/DelegatedAuthenticationSingleSignOnParticipationStrategyTests.java
@@ -18,6 +18,7 @@ import org.apereo.cas.services.RegisteredServicesTemplatesManager;
 import org.apereo.cas.services.ServicesManagerConfigurationContext;
 import org.apereo.cas.services.mgmt.DefaultServicesManager;
 import org.apereo.cas.ticket.DefaultTicketCatalog;
+import org.apereo.cas.ticket.InvalidTicketException;
 import org.apereo.cas.ticket.registry.DefaultTicketRegistry;
 import org.apereo.cas.ticket.registry.DefaultTicketRegistrySupport;
 import org.apereo.cas.ticket.registry.TicketRegistry;
@@ -184,6 +185,44 @@ class DelegatedAuthenticationSingleSignOnParticipationStrategyTests {
             .build();
         assertTrue(strategy.supports(ssoRequest));
         assertFalse(strategy.isParticipating(ssoRequest));
+    }
+
+    @Test
+    public void verifyTgtIsExpired() throws Exception {
+        val appCtx = new StaticApplicationContext();
+        appCtx.refresh();
+
+        val context = new MockRequestContext();
+        val request = new MockHttpServletRequest();
+        val response = new MockHttpServletResponse();
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, response));
+
+        val svc = RegisteredServiceTestUtils.getRegisteredService("serviceid1", Map.of());
+        val policy = new DefaultRegisteredServiceAccessStrategy();
+        policy.setDelegatedAuthenticationPolicy(
+            new DefaultRegisteredServiceDelegatedAuthenticationPolicy()
+                .setExclusive(true)
+                .setAllowedProviders(List.of("CAS")));
+        svc.setAccessStrategy(policy);
+
+        val ticketRegistry = new DefaultTicketRegistry();
+        val strategy = getSingleSignOnStrategy(svc, ticketRegistry);
+
+        WebUtils.putServiceIntoFlowScope(context, RegisteredServiceTestUtils.getService("serviceid1"));
+        val authentication = CoreAuthenticationTestUtils.getAuthentication(Map.of());
+
+        val tgt = new MockTicketGrantingTicket(authentication);
+        tgt.markTicketExpired();
+        ticketRegistry.addTicketInternal(tgt);
+        WebUtils.putTicketGrantingTicketInScopes(context, tgt);
+
+        val ssoRequest = SingleSignOnParticipationRequest.builder()
+            .httpServletRequest(request)
+            .httpServletResponse(response)
+            .requestContext(context)
+            .build();
+        assertTrue(strategy.supports(ssoRequest));
+        assertThrows(InvalidTicketException.class, () -> strategy.isParticipating(ssoRequest));
     }
 
     private static DefaultTicketRegistry buildTicketRegistryInstance() {


### PR DESCRIPTION
[2023-11-24 17:04:33.705+08:00]-[ERROR]-[https-jsse-nio-172.18.0.44-18443-exec-5]-[dspcas_rest_1700816673684_e2b65365cd8149f0b6e52785dd7d0763]-[]-[org.apereo.cas.web.flow.actions.DelegatedClientAuthenticationAction()] No value present[N] null:orElseThrow:-1[N] DelegatedAuthenticationSingleSignOnParticipationStrategy.java:isParticipating:48[N] ChainingSingleSignOnParticipationStrategy.java:lambda$isParticipating$0:46[N]

When tgt is expired after execute method org.apereo.cas.web.flow.DelegatedAuthenticationSingleSignOnEvaluator#getSingleSignOnAuthenticationFrom, org.apereo.cas.web.flow.DelegatedAuthenticationSingleSignOnParticipationStrategy#isParticipating will throw NoSuchElementException exception, singleSignOnSessionExists method can't catch this exception.