### PR TITLE
Improve CAS login Accessibility

### DIFF
--- a/style/checkstyle-rules.xml
+++ b/style/checkstyle-rules.xml
@@ -357,7 +357,7 @@
         </module>
         <module name="MultipleStringLiterals">
             <property name="severity" value="info"/>
-            <property name="ignoreStringsRegexp" 
+            <property name="ignoreStringsRegexp"
                       value="(^&quot;&quot;$)|(^&quot;(no|false|\/|true|//|yes|default|\.|,|=|&amp;|\?|UTF-8|\*|\\|//)&quot;$)" />
         </module>
          -->

--- a/support/cas-server-support-palantir/client/src/index.scss
+++ b/support/cas-server-support-palantir/client/src/index.scss
@@ -1,6 +1,6 @@
 :root {
     --mdc-text-button-label-text-color: #f7f7f7;
-    --mdc-theme-error: #d9534f;
+    --mdc-theme-error: #d93d33;
     --cas-theme-primary: #153e50;
     --cas-theme-primary-bg: rgba(21, 62, 80, 0.2);
     --cas-theme-button-bg: #26418f;

--- a/support/cas-server-support-themes-collection/src/main/resources/templates/example/casLoginView.html
+++ b/support/cas-server-support-themes-collection/src/main/resources/templates/example/casLoginView.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}" th:lang="${#locale}">
 
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
     <title th:text="#{cas.login.pagetitle}">CAS Login View</title>
     <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
-
 </head>
 
 <body class="login mdc-typography">

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages.properties
@@ -290,7 +290,7 @@ screen.service.wildcard.message=This application does not have a dedicated regis
   <p/>As a security best practice, it is strongly recommended to limit the service management facility to only include the list of \
   known applications that are explicitly authorized to use CAS. Leaving the management interface open for all applications \
   may create an opportunity for security attacks and will make it difficult to audit application requirements and attribute needs.
-   
+
 screen.service.sso.error.header=Re-Authentication Required to Access this Service
 screen.service.sso.error.message=You attempted to access a service that requires authentication without re-authenticating.  Please try authenticating again</a>.
 screen.service.required.message=You attempted authentication without specifying the target application. Please re-examine the request and try again.
@@ -441,7 +441,9 @@ or redirect to the selected identity provider. Please examine the original authe
 You may need to close your browser and start again.
 
 # GAuth
-screen.authentication.gauth.register=Your account is not registered. Use the below settings to register your device with CAS.
+screen.authentication.gauth.qrimage=QR code
+screen.authentication.gauth.register=Your account is not registered.
+screen.authentication.gauth.registerdesc=Use the below settings to register your device with CAS.
 screen.authentication.gauth.key=Secret key to register is: <pre>{0}</pre>
 screen.authentication.gauth.scratchcodes=Scratch codes:
 screen.authentication.gauth.selecteddevice=Your selected device for multifactor authentication is: <code>{0}</code>.

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_de.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_de.properties
@@ -31,7 +31,7 @@ screen.welcome.button.loginx509=Anmelden mit Zertifikat
 screen.cookies.disabled.title=Cookies im Browser deaktiviert
 screen.cookies.disabled.message=Ihr Browser akzeptiert keine Cookies. Die Funktionalität Cookies zu lesen und zu schreiben \
   ist notwendig für Single-SignOn. Bitte prüfen Sie ihre Browser-Einstellungen und stellen Sie sicher das Cookies aktiviert sind.
-  
+
 screen.acct.button.signUp=Registrieren
 
 screen.pm.button.submit=Absenden
@@ -398,7 +398,9 @@ screen.delauthn.error.message=CAS kann das delegierte Authentifizierungsszenario
   Möglicherweise müssen Sie Ihren Browser schließen und neu starten.
 
 # GAuth
-screen.authentication.gauth.register=Ihr Konto ist nicht registiert. Nutzen Sie die Einstellungen unten, um Ihr Gerät bei CAS zu registieren.
+screen.authentication.gauth.qrimage=QR code
+screen.authentication.gauth.register=Ihr Konto ist nicht registiert.
+screen.authentication.gauth.registerdesc=Nutzen Sie die Einstellungen unten, um Ihr Gerät bei CAS zu registieren.
 screen.authentication.gauth.key=Der geheime Schlüssel (secret key) zur Registerung lautet {0}
 screen.authentication.gauth.scratchcodes=Scratch codes:
 screen.authentication.gauth.selecteddevice=Ihr ausgewähltes Gerät für die mehrstufige Authentifizierung ist: <code>{0}</code>.
@@ -413,7 +415,7 @@ screen.authentication.gauth.invalidtoken=Dieses Token kann nicht akzeptiert werd
 screen.authentication.gauth.confirm.title=Kontoregistrierung bestätigen
 screen.authentication.gauth.confirm.desc=Bestätigen Sie ihre Kontoregistrierung, indem Sie ein Token \
   aus der Authenticator-App auf ihrem Gerät eintragen. Sobald das Token überprüft wurde, wird ihre Kontoregistrierung abgeschlossen.
-  
+
 screen.welcome.button.register-residentkey=Registrieren Sie das Gerät mit erkennbaren Anmeldeinformationen
 screen.authentication.webauthn.confirm.title=Kontoregistrierung bestätigen
 screen.authentication.webauthn.confirm.desc=Beginnen Sie die Registrierung, indem Sie ihrem FIDO2-Geärt einen Namen zuweisen.
@@ -467,7 +469,7 @@ screen.oidc.confirm.claim.profile=URL der Profilseite des Benutzers. Der Inhalt 
 screen.oidc.confirm.claim.picture=URL des Profilbildes des Benutzers. Diese URL muss auf eine Bilddatei verweisen (z. B. eine PNG-, JPEG- oder GIF-Bilddatei) und nicht auf eine Webseite, die ein Bild enthält. Beachten Sie, dass diese URL speziell auf ein Profilfoto des Benutzers verweisen sollte, das zur Anzeige geeignet ist und nicht auf ein willkürliches Foto, das vom Benutzer aufgenommen wurde.
 screen.oidc.confirm.claim.phone_number=Bevorzugte Telefonnummer des Benutzers. Es werden folgende Formate empfoholen. \
   Beispiel: <code>+1 (425) 555-1212</code> oder <code>+56 (2) 687 2400</code>.
-    
+
 screen.oidc.confirm.asksinfo=Die Anwendung fragt nach folgenden Informationen:
 screen.oidc.confirm.dynamic=Die Anwendung wurde dynamisch am <code>{0}</code> registriert.
 
@@ -567,7 +569,7 @@ cas.mfa.registerdevice.options.timeunit.forever=Für immer
 passwordless.token.header=Token angeben
 passwordless.token.description=Bitte geben Sie das Sicherheitstoken an, welches Ihnen per E-Mail, Telefon, etc. zugestellt wurde. \
   Beachten Sie, dass das Token nur für ein kurzes Fenster gültig ist und nach der Übermittlung alle anderen Token ungültig gemacht und entfernt werden.
-  
+
 passwordless.error.failure.title=Authentifizierungsfehler
 passwordless.error.failure.description=Das angegebene Token konnte nicht überprüft werden. Es kann ungültig gemacht, entfernt oder abgelaufen sein.
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_fr.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_fr.properties
@@ -1,9 +1,9 @@
-screen.welcome.welcome=Félicitations, votre serveur est en ligne ! Pour savoir comment vous authentifier, merci de regarder la méthode d'authentification définie par défaut.
+screen.welcome.welcome=Félicitations, votre serveur est en ligne ! Pour savoir comment vous authentifier, merci de regarder la méthode d'authentification définie par défaut.
 screen.welcome.security=Pour des raisons de sécurité, veuillez vous <a href="logout">déconnecter</a> et fermer votre navigateur lorsque vous avez fini d'accéder aux services authentifiés.
 screen.welcome.instructions=Entrez votre identifiant et votre mot de passe.
-screen.welcome.label.netid=<span class="accesskey">I</span>dentifiant :
+screen.welcome.label.netid=<span class="accesskey">I</span>dentifiant :
 screen.welcome.label.netid.accesskey=i
-screen.welcome.label.password=<span class="accesskey">M</span>ot de passe :
+screen.welcome.label.password=<span class="accesskey">M</span>ot de passe :
 screen.welcome.label.password.accesskey=m
 screen.welcome.label.publicstation=Je suis sur un ordinateur public.
 screen.welcome.label.warn=<span class="accesskey">P</span>révenez-moi avant d'accéder à d'autres services.
@@ -15,7 +15,7 @@ screen.welcome.button.loginwip=Veuillez patienter...
 screen.welcome.button.register=S'enregistrer
 screen.welcome.button.print=Imprimer
 screen.welcome.button.clear=EFFACER
-screen.welcome.label.loginwith=Ou authentifiez-vous avec :
+screen.welcome.label.loginwith=Ou authentifiez-vous avec :
 
 screen.cookies.disabled.title=Cookies navigateur désactivés
 screen.cookies.disabled.message=Votre navigateur ne supporte pas les cookies. L'authentification centralisée NE FONCTIONNERA PAS.
@@ -24,7 +24,7 @@ screen.pm.button.submit=SOUMETTRE
 screen.pm.button.cancel=ANNULER
 screen.pm.button.forgotpwd=<a href="{0}">Mot de passe oublié ?</a>
 screen.pm.button.resetPassword=Réinitialiser votre mot de passe
-screen.pm.reset.username=Identifiant :
+screen.pm.reset.username=Identifiant :
 screen.pm.reset.heading=Echec de la réinitialisation du mot de passe
 screen.pm.reset.message=Votre demande de réinitialisation du mot de passe ne peut pas être traitée à l'heure actuelle
 screen.pm.reset.qstitle=Répondez aux questions de sécurité
@@ -43,22 +43,22 @@ screen.consent.cancel=ANNULER
 screen.consent.title=Consentement
 screen.consent.attributes=Attributs
 screen.consent.options=Options
-screen.consent.attributes.header=Les attributs suivants seront fournis à <strong>[{0}]</strong> :
+screen.consent.attributes.header=Les attributs suivants seront fournis à <strong>[{0}]</strong> :
 screen.consent.attributes.attribute=Attribut
 screen.consent.attributes.values=Valeur(s)
 
 screen.consent.options.header=A quelle fréquence devrais-je donner mon consentement à l'avenir ?
 screen.consent.options.always=<strong>A chaque fois</strong>
-screen.consent.options.desc.always=Afficher l''écran de consentement à chaque fois que j''accède à {0}.
+screen.consent.options.desc.always=Afficher l’écran de consentement à chaque fois que j’accède à {0}.
 screen.consent.options.attributename=<strong>Ajout/suppression d'attribut</strong>
-screen.consent.options.desc.attributename=Afficher l''écran de consentement si un attribut est ajouté ou supprimé de la liste des attributs fournis à {0}.
+screen.consent.options.desc.attributename=Afficher l’écran de consentement si un attribut est ajouté ou supprimé de la liste des attributs fournis à {0}.
 screen.consent.options.attributevalue=<strong>Ajout/suppression/modification d'attribut</strong>
-screen.consent.options.desc.attributevalue.intro=Afficher l'écran de consentement si :
+screen.consent.options.desc.attributevalue.intro=Afficher l'écran de consentement si :
 screen.consent.options.desc.attributevalue.first=Un nouvel attribut est ajouté à la liste des attributs fournis à {0}.
 screen.consent.options.desc.attributevalue.second=Un attribut est supprimé de la liste des attributs fournis à {0}.
-screen.consent.options.desc.attributevalue.third=La valeur d''un attribut fourni à {0} a changé.
+screen.consent.options.desc.attributevalue.third=La valeur d’un attribut fourni à {0} a changé.
 screen.consent.options.reminder.header=A quelle fréquence devrais-je être rappelé de donner mon consentement ?
-screen.consent.options.reminder.expl=Afficher l''écran de consentement, sous forme de rappel, dans le cas où la liste des attributs fournis à {0} n''a pas changé.
+screen.consent.options.reminder.expl=Afficher l’écran de consentement, sous forme de rappel, dans le cas où la liste des attributs fournis à {0} n’a pas changé.
 screen.consent.options.timeunit.seconds=Secondes
 screen.consent.options.timeunit.minutes=Minutes
 screen.consent.options.timeunit.hours=Heures
@@ -78,16 +78,16 @@ screen.consent.review.no=Non
 screen.consent.review.date=Date
 screen.consent.review.service=Service
 screen.consent.review.delete=SUPPRIMER
-screen.consent.review.createddate=Date de création :
-screen.consent.review.reminder=Rappel :
-screen.consent.review.option=Option :
+screen.consent.review.createddate=Date de création :
+screen.consent.review.reminder=Rappel :
+screen.consent.review.option=Option :
 screen.consent.review.options.attributename=Ajout/suppression d'attribut
 screen.consent.review.options.attributevalue=Ajout/suppression/modification d'attribut
 screen.consent.review.options.always=A chaque fois
 screen.consent.review.options.desc.always=Afficher l'écran de consentement à chaque fois que je me connecte.
 screen.consent.review.options.desc.attributename=Afficher l'écran de consentement si un attribut est ajouté ou supprimé de la liste des attributs.
 screen.consent.review.options.desc.attributevalue=Afficher l'écran de consentement si 1) un nouvel attribut est ajouté à la liste, 2) un attribut est supprimé de la liste, 3) la valeur d'un attribut a changé.
-screen.consent.review.attributes=Attributs :
+screen.consent.review.attributes=Attributs :
 screen.consent.review.data.search=Rechercher
 screen.consent.review.data.zerorecords=Aucune décision correspondante n'a été trouvée
 screen.consent.review.data.info=Affichage de _START_ à _END_ éléments sur _TOTAL_
@@ -102,14 +102,14 @@ screen.defaultauthn.title=Authentification statique
 screen.defaultauthn.heading=CAS est configuré pour accepter une liste statique d'utilisateurs pour l'authentification principale. Veuillez noter que ceci est UNIQUEMENT utile à des fins de démonstration. Il est recommandé d'utiliser CAS avec un serveur LDAP, JDBC, etc. à la place.
 logo.title=Aller à la page d'accueil Apereo
 copyright=Copyright &copy; 2005&ndash;2021 Apereo, Inc.
-screen.capslock.on=La touche Verr Maj est activée !
+screen.capslock.on=La touche Verr Maj est activée !
 screen.button.continue=Continuer
 screen.post.response.message=Vous allez être redirigé vers {0}.
 
 screen.interrupt.title=Interruption de l'authentification
-screen.interrupt.message=Le processus d''authentification a été interrompu. CAS n''a pas encore établi de session d''authentification centralisée pour <strong>{0}</strong>.
+screen.interrupt.message=Le processus d’authentification a été interrompu. CAS n’a pas encore établi de session d’authentification centralisée pour <strong>{0}</strong>.
 
-screen.mdui.infolink.text=<a href="{0}" target="_blank">Plus d''informations sur cette application</a>.
+screen.mdui.infolink.text=<a href="{0}" target="_blank">Plus d’informations sur cette application</a>.
 screen.mdui.privacylink.text=<a href="{0}" target="_blank">Politique de confidentialité de cette application</a>.
 
 screen.interrupt.btn.proceed=Continuer
@@ -148,9 +148,9 @@ screen.authentication.warning=Connexion réussie avec avertissement
 
 #Generic Success Screen Messages
 screen.success.header=Connexion réussie
-screen.success.success=Bienvenue <strong>{0}</strong>. Vous vous êtes authentifié(e) auprès du Service Central d''Authentification. Toutefois, vous voyez \
-  cette page car CAS ne connait pas votre destination finale ni comment vous y rediriger. Examinez la requête d''authentification et \
-  assurez-vous qu''une application ou service cible autorisé et enregistré auprès de CAS est spécifié.
+screen.success.success=Bienvenue <strong>{0}</strong>. Vous vous êtes authentifié(e) auprès du Service Central d’Authentification. Toutefois, vous voyez \
+  cette page car CAS ne connait pas votre destination finale ni comment vous y rediriger. Examinez la requête d’authentification et \
+  assurez-vous qu’une application ou service cible autorisé et enregistré auprès de CAS est spécifié.
 screen.success.security=Pour des raisons de sécurité, veuillez vous <a href="logout">déconnecter</a> et fermer votre navigateur lorsque vous avez fini d'accéder aux services authentifiés.
 
 #Logout Screen Messages
@@ -167,7 +167,7 @@ screen.logout.fc.success=Vous vous êtes déconnecté(e) du Service Central d'Au
 screen.logout.security=Pour des raisons de sécurité, veuillez fermer votre navigateur.
 
 screen.service.sso.error.header=Une nouvelle authentification est requise pour accéder à ce service.
-screen.service.sso.error.message=Vous avez tenté d''accéder à un service qui requiert une nouvelle authentification sans vous authentifier à nouveau.  Veuillez <a href="{0}">vous authentifier de nouveau</a>.
+screen.service.sso.error.message=Vous avez tenté d’accéder à un service qui requiert une nouvelle authentification sans vous authentifier à nouveau.  Veuillez <a href="{0}">vous authentifier de nouveau</a>.
 screen.service.required.message=Vous avez tenté de vous authentifier sans préciser d'application cible. Merci de vérifier votre requête et de recommencer.
 screen.service.initial.message=Toute tentative d'accès à CAS ou à l'application ciblée est interdite pour le moment. \
   La politique d'authentification exige que vous changiez votre application de départ \
@@ -204,8 +204,8 @@ INVALID_REQUEST=Les paramètres 'service' et 'ticket' sont tous deux nécessaire
 INVALID_TICKET=Le ticket ''{0}'' est inconnu
 INVALID_PROXY_GRANTING_TICKET=Le PGT a déjà été généré pour ce ST. Impossible de générer plus d'un PGT pour un ST donné.
 INVALID_SERVICE=Le ticket ''{0}'' ne correspond pas au service demandé. Le service original était ''{1}'' et le service demandé était ''{2}''.
-INVALID_PROXY_CALLBACK=L''url de rappel du proxy ''{0}'' n''a pu être authentifiée. Soit ''{0}'' est injoignable, soit il n''est pas autorisé à exécuter une authentification proxy.
-UNAUTHORIZED_SERVICE_PROXY=Le service utilisé ''{0}'' n''est pas autorisé à utiliser l''authentification proxy CAS.
+INVALID_PROXY_CALLBACK=L’url de rappel du proxy ''{0}'' n’a pu être authentifiée. Soit ''{0}'' est injoignable, soit il n’est pas autorisé à exécuter une authentification proxy.
+UNAUTHORIZED_SERVICE_PROXY=Le service utilisé ''{0}'' n’est pas autorisé à utiliser l’authentification proxy CAS.
 UNSATISFIED_AUTHN_POLICY=L'accès au service est refusé en raison d'une politique d'authentification non satisfaite.
 
 screen.service.error.header=Application non autorisée à utiliser CAS
@@ -250,8 +250,8 @@ screen.button.changePassword=Changer de mot de passe
 screen.pm.success.header=Changement de mot de passe réussi
 screen.pm.success.message=Le mot de passe de votre compte a été mis à jour avec succès.
 
-screen.pm.confirmpsw=Confirmez le mot de passe :
-screen.pm.enterpsw=Entrez le mot de passe :
+screen.pm.confirmpsw=Confirmez le mot de passe :
+screen.pm.enterpsw=Entrez le mot de passe :
 
 screen.pac4j.unauthz.pagetitle=Accès non autorisé
 screen.pac4j.unauthz.gotoapp=Aller à l'application
@@ -261,8 +261,10 @@ screen.pac4j.unauthz.message=Soit la requête d'authentification a été rejeté
   de permissions incorrectes, etc. Vérifiez les logs pour trouver la cause réelle du problème.
 
 # GAuth
-screen.authentication.gauth.register=Votre compte n'est pas enregistré. Utilisez les paramètres suivants pour enregistrer votre appareil auprès de CAS.
-screen.authentication.gauth.key=La clé secrète pour l''enregistrement est {0}
+screen.authentication.gauth.qrimage=QR code
+screen.authentication.gauth.register=Votre compte n'est pas enregistré.
+screen.authentication.gauth.registerdesc=Utilisez les paramètres suivants pour enregistrer votre appareil auprès de CAS.
+screen.authentication.gauth.key=La clé secrète pour l’enregistrement est {0}
 
 # OAuth
 screen.oauth.confirm.header=Autorisation
@@ -272,7 +274,7 @@ screen.oauth.confirm.deny=Refuser
 cas.oauth.confirm.pagetitle=Approbation de l'accès
 
 # OIDC
-screen.oidc.confirm.infourl=Plus d''informations sur {0}.
+screen.oidc.confirm.infourl=Plus d’informations sur {0}.
 screen.oidc.confirm.privacyurl=Consultez les règles de confidentialité de {0}.
 
 screen.oidc.confirm.scope.profile=Ceci fournit l'accès aux informations de profil excluant adresse, e-mail et téléphone.
@@ -282,12 +284,12 @@ screen.oidc.confirm.scope.openid=Ceci indique une requête d'accès OpenID Conne
 screen.oidc.confirm.scope.phone=Ceci fournit l'accès aux informations de téléphone.
 screen.oidc.confirm.scope.offline_access=Ceci fournit l'accès à un refresh token utilisé pour l'accès hors ligne.
 
-screen.oidc.confirm.asksinfo=Ce client demande l'accès aux informations suivantes :
+screen.oidc.confirm.asksinfo=Ce client demande l'accès aux informations suivantes :
 screen.oidc.confirm.dynamic=Ce client a été enregistré dynamiquement à <code>{0}</code>.
 
 # Unavailable
 screen.unavailable.header=Erreur CAS
-screen.unavailable.heading=CAS n''a pas pu traiter cette requête : "{0}:{1}"
+screen.unavailable.heading=CAS n’a pas pu traiter cette requête : "{0}:{1}"
 screen.unavailable.message=Une erreur s'est produite lors du traitement de votre requête. \
 <strong>Merci de contacter votre support ou de réessayer.</strong> \
 <div>Apereo est une fondation de gouvernance de logiciel libre à but non lucratif. Le logiciel CAS est un projet sponsorisé par Apereo \
@@ -321,7 +323,7 @@ cas.acceptableusagepolicyview.pagetitle=Politique d'utilisation acceptable
 #
 cas.attrresolutionview.pagetitle=Résolution des attributs
 cas.attrreleaseview.pagetitle=Accès aux attributs
-cas.attrresolutionview.label.uid=Identifiant :
+cas.attrresolutionview.label.uid=Identifiant :
 cas.attrresolutionview.button.submit=SOUMETTRE
 
 ##
@@ -329,13 +331,13 @@ cas.attrresolutionview.button.submit=SOUMETTRE
 ##
 cas.mfa.duologin.pagetitle=Connexion DuoSecurity
 cas.mfa.googleauth.pagetitle=Google Authenticator
-cas.mfa.googleauth.label.token=Code :
+cas.mfa.googleauth.label.token=Code :
 cas.mfa.azure.pagetitle=Microsoft Authenticator
 cas.mfa.radius.pagetitle=Authentification Radius
 cas.mfa.yubikey.pagetitle=Authentification YubiKey
 cas.mfa.yubikey.authenticate=Utilisez votre appareil YubiKey enregistré pour vous authentifier.
 cas.mfa.yubikey.register=Votre appareil n'est pas encore enregistré. Utilisez le formulaire suivant pour enregistrer votre appareil auprès de CAS.
-cas.mfa.yubikey.label.token=Code :
+cas.mfa.yubikey.label.token=Code :
 
 cas.mfa.registerdevice.label.title=Enregistrer l'appareil
 cas.mfa.registerdevice.label.intro=Veuillez nommer l'appareil actuel.
@@ -345,14 +347,14 @@ cas.mfa.registerdevice.button.register=Enregistrer
 
 # Inwebo
 cas.inwebo.checkresult.title=Vérification de l'authentification Inwebo
-cas.inwebo.checkresult.heading=En attente de l'approbation de la notification Inwebo :
+cas.inwebo.checkresult.heading=En attente de l'approbation de la notification Inwebo :
 cas.inwebo.checkresult.message=Merci de la valider sur votre application mobile ou de bureau...
 cas.inwebo.error.title=Erreur authentification Inwebo
 cas.inwebo.error.heading=Une erreur s'est produite.
 cas.inwebo.error.userrefusedortoolate=Vous avez refusé l'authentification ou ne l'avez pas validé assez rapidement.
 cas.inwebo.error.usernotregistered=Avant toute authentification, vous devez être enregistré auprès d'Inwebo. Vérifiez votre boîte mail pour suivre la procédure d'enrôlement ou saisissez votre code d'activation et votre code PIN ci-dessous pour l'enrôlement dans le navigateur...
 cas.inwebo.selectauthent.title=Selection de la méthode d'authentification
-cas.inwebo.selectauthent.heading=Sélectionnez votre méthode d'authentification :
+cas.inwebo.selectauthent.heading=Sélectionnez votre méthode d'authentification :
 cas.inwebo.selectauthent.browser=Authentification dans le navigateur
 cas.inwebo.selectauthent.push=Authentification sur application mobile ou de bureau
 cas.inwebo.browserauthent.title=Authentification browser
@@ -362,7 +364,7 @@ cas.inwebo.enroll.failure=L'enrôlement a échoué
 cas.inwebo.pin=Code PIN
 cas.inwebo.pin2=Confirmation du code PIN
 cas.inwebo.enroll.badpinconfirmation=Mauvaise confirmation de code PIN
-cas.inwebo.browser.heading=Saisissez votre code PIN :
+cas.inwebo.browser.heading=Saisissez votre code PIN :
 cas.inwebo.browser.button=S'authentifier dans le navigateur
 cas.inwebo.browser.failure=Erreur de génération de l'OTP
 cas.inwebo.retry.button=Recommencer l'authentification multi-facteur Inwebo

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_it.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_it.properties
@@ -242,10 +242,10 @@ della community di Apereo.<br/></br>Se hai problemi ad accedere utilizzando CAS,
 <strong>dovrai contattare il personale IT o l'Help Desk della tua organizzazione per ricevere assistenza</strong>. \
 <br/><br/>Vorremmo poterti essere pi\u00f9 direttamente utili.</div>
 
-
-
 # GAuth
-screen.authentication.gauth.register=Il tuo account non \u00e8 registrato. Usa le impostazioni che seguono per registrare il tuo dispositivo con CAS.
+screen.authentication.gauth.qrimage=QR code
+screen.authentication.gauth.register=Il tuo account non \u00e8 registrato.
+screen.authentication.gauth.registerdesc=Usa le impostazioni che seguono per registrare il tuo dispositivo con CAS.
 screen.authentication.gauth.key=La chiave segreta per registrarsi \u00e8: <pre>{0}</pre>
 screen.authentication.gauth.selecteddevice=Il dispositivo selezionato per l'autenticazione a pi\u00f9 fattori \u00e8: <code>{0}</code>.
 screen.authentication.gauth.selanotherdevice=Puoi selezionare un altro dispositivo per l'autenticazione a pi\u00f9 fattori, se <code>{0}</code> non \u00e8 il dispositivo che stai usando ora.

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_pl.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_pl.properties
@@ -201,11 +201,16 @@ screen.accountlocked.heading=Konto zosta\u0142o zablokowane.
 screen.accountlocked.message=Prosz\u0119 skontaktowa\u0107 si\u0119 z pomoc\u0105 techniczn\u0105 w celu uzyskania dost\u0119pu.
 screen.aup.button.accept=Akceptuj\u0119
 screen.aup.button.cancel=Anuluj
+
+# GAuth
+screen.authentication.gauth.qrimage=QR code
 screen.authentication.gauth.confirm.title=Potwierdź rejestrację konta
 screen.authentication.gauth.confirm.desc=Potwierdź rejestrację konta, podając token z aplikacji uwierzytelniającej na swoim urządzeniu. Po zweryfikowaniu tokena rejestracja konta zostanie zakończona.
 screen.authentication.gauth.invalidtoken=Nie można zaakceptować tego tokena. Podany token jest nieprawidłowy, nie należy do urządzenia lub wygasł.
 screen.authentication.gauth.key=Tajny klucz do rejestracji to {0}
-screen.authentication.gauth.register=Twoje konto nie jest zarejestrowane. U\u017Cyj poni\u017Cszych ustawie\u0144 aby zarejestrowa\u0107 swoje urz\u0105dzenie w systemie CAS.
+screen.authentication.gauth.register=Twoje konto nie jest zarejestrowane.
+screen.authentication.gauth.registerdesc=U\u017Cyj poni\u017Cszych ustawie\u0144 aby zarejestrowa\u0107 swoje urz\u0105dzenie w systemie CAS.
+
 screen.authentication.warning=Udane logowanie z ostrze\u017Ceniami.
 screen.authnblocked.heading=Pr\u00F3ba logowania zosta\u0142a zablokowana.
 screen.authnblocked.message=Twoja pr\u00F3ba logowania jest niezaufana i nieautoryzowana z Twojej obecnej stacji roboczej.

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_sk.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_sk.properties
@@ -150,7 +150,10 @@ screen.pac4j.unauthz.gotoapp=Späť na aplikáciu
 screen.pac4j.unauthz.login=Späť na CAS
 screen.pac4j.unauthz.heading=Nepotvrdený prístup
 screen.pac4j.unauthz.message=Požiadavka o prihlásenie bola odmientnutá/zrušená, alebo alebo poskytovateľ identity odmietol prístup pre interné pravidlá.
-screen.authentication.gauth.register=Vaše konto nie je registrované. Použite nastavenia nižšie pre registráciu zariadenia v CAS.
+# GAuth
+screen.authentication.gauth.qrimage=QR code
+screen.authentication.gauth.register=Vaše konto nie je registrované.
+screen.authentication.gauth.registerdesc=Použite nastavenia nižšie pre registráciu zariadenia v CAS.
 screen.authentication.gauth.key=Tajný kód pre registráciu je {0}
 # OAuth
 screen.oauth.confirm.header=Autorizácia

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages_zh_CN.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages_zh_CN.properties
@@ -293,7 +293,9 @@ screen.delauthn.error.header=委托认证失败
 screen.delauthn.error.message=CAS无法完成委托身份验证方案或重定向到选定的身份提供者。请检查原始身份验证请求然后重试，您可能需要关闭浏览器并重新开始。
 
 # GAuth
-screen.authentication.gauth.register=您的账户未注册，使用以下设置向CAS注册您的设备。
+screen.authentication.gauth.qrimage=QR code
+screen.authentication.gauth.register=您的账户未注册，
+screen.authentication.gauth.registerdesc=使用以下设置向CAS注册您的设备。
 screen.authentication.gauth.key=注册密钥是：<pre>{0}</pre>
 screen.authentication.gauth.scratchcodes=预留码：
 screen.authentication.gauth.selecteddevice=您选择的多因素身份验证设备是：<code>{0}</code>。

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -3,7 +3,7 @@
 
 :root {
     --mdc-text-button-label-text-color: #f7f7f7;
-    --mdc-theme-error: #d9534f;
+    --mdc-theme-error: #d93d33;
     --cas-theme-primary: #044561;
     --cas-theme-primary-bg: rgba(21, 62, 80, 0.2);
     --cas-theme-button-bg: #26418f;
@@ -73,13 +73,13 @@ div#content {
 .notifications-count {
     position: absolute;
     top: 10px;
-    right: 12px;
+    right: 6px;
     background-color: #b00020;
     background-color: var(--cas-theme-danger);
     color: #fff;
     border-radius: 50%;
     padding: 1px 3px;
-    font: 8px Verdana;
+    font: 10px Verdana;
 }
 
 .cas-brand {

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -11,7 +11,8 @@
     --cas-theme-primary-light: #006d85;
     --cas-theme-secondary: #74C163;
     --cas-theme-success: var(--cas-theme-secondary);
-    --cas-theme-danger: var(--mdc-theme-error);
+    --cas-theme-danger: #58151c;
+    --cas-theme-danger-bg: #f8d7da;
     --cas-theme-warning: #e6a210;
     --cas-theme-border-light: 1px solid rgba(0, 0, 0, .2);
     --mdc-theme-primary: var(--cas-theme-primary, #153e50);
@@ -75,8 +76,7 @@ div#content {
     position: absolute;
     top: 8px;
     right: 4px;
-    background-color: #b00020;
-    background-color: var(--cas-theme-danger);
+    background-color: var(--mdc-theme-error, #b00020);
     color: #fff;
     border-radius: 50%;
     padding: 1px 3px;
@@ -200,8 +200,8 @@ button.close {
 .banner-danger {
     border-color: #b00020;
     border-color: var(--cas-theme-danger, #b00020);
-    color: #D8000C;
-    background-color: #FFD2D2;
+    color: var(--cas-theme-danger, #58151c);
+    background-color: var(--cas-theme-danger-bg, #f8d7da);
 }
 
 .banner-danger .mdi {

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -9,8 +9,8 @@
     --cas-theme-primary-bg: rgba(21, 62, 80, 0.2);
     --cas-theme-button-bg: #26418f;
     --cas-theme-primary-light: #006d85;
-    --cas-theme-secondary: #74C163;
-    --cas-theme-success: var(--cas-theme-secondary);
+    --cas-theme-secondary: #018077;
+    --cas-theme-success: #74C163;
     --cas-theme-danger: #58151c;
     --cas-theme-danger-bg: #f8d7da;
     --cas-theme-warning: #e6a210;
@@ -342,8 +342,11 @@ button.close {
     color: var(--cas-theme-danger, #b00020);
 }
 
-.text-secondary, .text-success {
+.text-secondary {
     color: var(--cas-theme-secondary);
+}
+.text-success {
+    color: var(--cas-theme-success);
 }
 
 .progress-bar-danger .mdc-linear-progress__bar-inner {
@@ -416,7 +419,7 @@ button.close {
 }
 
 .mdc-button--outline:not(:disabled, .reveal-password) {
-    background-color: #428bca;
+    background-color: var(--cas-theme-secondary, #018077);
     border-radius: 12px 4px;
 }
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -79,7 +79,7 @@ div#content {
     color: #fff;
     border-radius: 50%;
     padding: 1px 3px;
-    font: 10px Verdana;
+    font: 11px Verdana;
 }
 
 .cas-brand {

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -3,6 +3,7 @@
 
 :root {
     --mdc-text-button-label-text-color: #f7f7f7;
+    --mdc-shape-small: 4px;
     --mdc-theme-error: #d93d33;
     --cas-theme-primary: #044561;
     --cas-theme-primary-bg: rgba(21, 62, 80, 0.2);
@@ -72,8 +73,8 @@ div#content {
 
 .notifications-count {
     position: absolute;
-    top: 10px;
-    right: 6px;
+    top: 8px;
+    right: 4px;
     background-color: #b00020;
     background-color: var(--cas-theme-danger);
     color: #fff;
@@ -373,7 +374,7 @@ button.close {
     border-radius: 4px;
 }
 
-.mdc-input-group .mdc-input-group-field .mdc-text-field {
+.mdc-input-group .mdc-input-group-field .mdc-notched-outline__trailing {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
 }

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/admin/casAdminLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/admin/casAdminLoginView.html
@@ -20,7 +20,7 @@
                 </div>
                 <form name="fm1" th:action="@{/adminlogin}" method="post">
                     <h3 th:utext="#{screen.welcome.instructions}">Enter your Username and Password</h3>
-                    <div th:if="${param.error}" id="errorPanel" class="banner banner-danger alert alert-danger banner-dismissible">Invalid credentials.</div>
+                    <div th:if="${param.error}" id="errorPanel" role="alert" class="banner banner-danger alert alert-danger banner-dismissible">Invalid credentials.</div>
                     <section class="cas-field my-3 form-group mdc-input-group">
                         <div class="mdc-input-group-field mdc-input-group-field-append">
                             <div class="d-flex caps-check">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/header.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/header.html
@@ -27,15 +27,15 @@
                     </button>
                 </section>
                 <section class="mdc-top-app-bar__section">
-                    <span class="cas-brand mx-auto">
-                        <span class="visually-hidden" th:text="${#strings.defaultString(#themes.code('cas.theme.name'), 'CAS')}">CAS</span>
+                    <div class="cas-brand mx-auto">
+                        <h1 class="visually-hidden" th:text="${#strings.defaultString(#themes.code('cas.theme.name'), 'CAS')}">CAS</h1>
                         <a th:href="@{/}">
                             <img id="cas-logo" class="cas-logo"
-                                 th:title="${#strings.defaultString(#themes.code('cas.theme.name'), 'CAS')}"
+                                 th:alt="${#strings.defaultString(#themes.code('cas.theme.name'), 'CAS')}"
                                  th:src="@{${#strings.defaultString(#themes.code('cas.logo.file'), '/images/cas-logo.png')}}"
                             />
                         </a>
-                    </span>
+                    </div>
                 </section>
                 <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end">
                     <button id="cas-notifications-menu"
@@ -75,13 +75,13 @@
             aria-describedby="notif-dialog-content">
         <div class="mdc-dialog__container modal-dialog">
             <div class="mdc-dialog__surface modal-content">
-                <h1 class="mdc-dialog__title mt-lg-2 modal-header modal-title" id="notif-dialog-title">
+                <h2 class="mdc-dialog__title mt-lg-2 modal-header modal-title" id="notif-dialog-title">
                     Notifications
-                </h1>
+                </h2>
                 <div class="mdc-dialog__content modal-body" id="notif-dialog-content">
                     <div class="cas-notification-message mdc-typography--body1" th:if="${staticAuthentication}">
                         <script>countMessages++;</script>
-                        <h6 class="mdc-typography--headline6 mdi mdi-alert-circle fas fa-exclamation-circle"
+                        <h3 class="mdc-typography--headline6 mdi mdi-alert-circle fas fa-exclamation-circle"
                             th:utext="#{screen.defaultauthn.title}"/>
                         <p class="text text-wrap small" th:utext="#{screen.defaultauthn.heading}">
                             <i class="mdi mdi-google fas fa-google"></i>
@@ -93,7 +93,7 @@
                     </div>
                     <div class="cas-notification-message mdc-typography--body1"
                          th:unless="${httpRequestSecure}">
-                        <h6 class="mdc-typography--headline6 mdi mdi-alert-circle fas fa-exclamation-circle"
+                        <h3 class="mdc-typography--headline6 mdi mdi-alert-circle fas fa-exclamation-circle"
                             th:utext="#{screen.nonsecure.title}"/>
                         <script>countMessages++;</script>
                         <p class="text-wrap small" th:utext="#{screen.nonsecure.message}">
@@ -102,8 +102,8 @@
                     </div>
 
                     <div id="cookiesSupportedDiv" class="cas-notification-message mdc-typography--body1" style="display: none">
-                        <h6 class="mdc-typography--headline6 mdi mdi-alert-circle fas fa-exclamation-circle"
-                            th:utext="#{screen.cookies.disabled.title}"></h6>
+                        <h3 class="mdc-typography--headline6 mdi mdi-alert-circle fas fa-exclamation-circle"
+                            th:utext="#{screen.cookies.disabled.title}"></h3>
                         <p class="text-wrap small" th:utext="#{screen.cookies.disabled.message}">
                             Cookies are not supported by this browser.
                         </p>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/logindrawer.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/logindrawer.html
@@ -17,11 +17,11 @@
                th:if="${'true' == #strings.defaultString(#themes.code('cas.drawer-menu.enabled'), 'true')}"
                class="mdc-drawer mdc-drawer--dismissible mdc-drawer--modal offcanvas offcanvas-start">
             <div class="mdc-drawer__header offcanvas-header flex-column">
-                <h3 class="mdc-drawer__title offcanvas-title" th:text="${#strings.defaultString(#themes.code('cas.theme.name'), 'CAS')}">
-                    CAS</h3>
-                <h6 class="mdc-drawer__subtitle offcanvas-title"
+                <h2 class="mdc-drawer__title offcanvas-title" th:text="${#strings.defaultString(#themes.code('cas.theme.name'), 'CAS')}">
+                    CAS</h2>
+                <div class="mdc-drawer__subtitle offcanvas-title"
                     th:text="${#strings.defaultString(#themes.code('cas.theme.description'), 'Central Authentication Service')}">
-                    Central Authentication Service</h6>
+                    Central Authentication Service</div>
             </div>
             <div class="mdc-drawer__content offcanvas-body">
                 <nav class="mdc-list list-group list-group-flush" th:with="serverprefix=${cas.server.prefix}">
@@ -74,4 +74,3 @@
 </body>
 
 </html>
-

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
@@ -34,7 +34,7 @@
 
             <form method="post" id="fm1" th:object="${credential}" action="login">
                 <div id="login-form-controls" th:unless="${loginFormViewable or loginFormEnabled}">
-                    <div id="loginErrorsPanel" class="alert alert-danger banner banner-danger banner-dismissible text-justify"
+                    <div id="loginErrorsPanel" class="alert alert-danger banner banner-danger banner-dismissible"
                          th:if="${#fields.hasErrors('*')}">
                         <p th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">Example error</p>
                         <!--<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>-->
@@ -54,8 +54,8 @@
                         <span th:utext="#{screen.welcome.instructions}">Enter your Username and Password:</span>
                     </h2>
 
-                    <div id="loginErrorsPanel" class="banner banner-danger alert alert-danger banner-dismissible text-justify"
-                         th:if="${#fields.hasErrors('*')}">
+                    <div id="loginErrorsPanel" class="banner banner-danger alert alert-danger banner-dismissible"
+                         role="alert" th:if="${#fields.hasErrors('*')}">
                         <p th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">Example error</p>
                         <!--<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>-->
                     </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-<main role="main" class="container mt-3 mb-3">
+<main class="container mt-3 mb-3">
 
     <div th:fragment="loginform" class="d-flex flex-column justify-content-between m-auto"
          th:with="loginFormEnabled=${#strings.defaultString(#themes.code('cas.login-form.enabled'), 'true') == 'true'},
@@ -43,16 +43,16 @@
 
                 <div id="login-form-controls" th:if="${loginFormViewable and loginFormEnabled}">
                     <div th:if="${existingSingleSignOnSessionAvailable}">
-                        <i class="mdi mdi-alert-decagram fas fa-exclamation-triangle"></i>&nbsp;
+                        <i class="mdi mdi-alert-decagram fas fa-exclamation-triangle" aria-hidden="true"></i>&nbsp;
                         <span id="existingSsoMsg" th:if="${registeredService}" class="mdc-button__label"
                               th:utext="#{screen.welcome.forcedsso(${existingSingleSignOnSessionPrincipal?.id},${registeredService.name})}"/>
                         <span id="existingSsoMsg" th:unless="${registeredService}" class="mdc-button__label"
                               th:utext="#{screen.welcome.forcedsso(${existingSingleSignOnSessionPrincipal?.id}, 'CAS')}"/>
                     </div>
-                    <h3 th:unless="${existingSingleSignOnSessionAvailable}" class="text-center">
-                        <i class="mdi mdi-security fas fa-shield-alt"></i>
+                    <h2 th:unless="${existingSingleSignOnSessionAvailable}" class="text-center">
+                        <i class="mdi mdi-security fas fa-shield-alt" aria-hidden="true"></i>
                         <span th:utext="#{screen.welcome.instructions}">Enter your Username and Password:</span>
-                    </h3>
+                    </h2>
 
                     <div id="loginErrorsPanel" class="banner banner-danger alert alert-danger banner-dismissible text-justify"
                          th:if="${#fields.hasErrors('*')}">
@@ -79,14 +79,14 @@
                                    autocapitalize="none"
                                    spellcheck="false"
                                    autocomplete="username" required/>
-                            <div class="mdc-text-field-helper-line invalid-feedback">
-                                <div class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg" aria-hidden="true">
+                            <span class="mdc-text-field-helper-line invalid-feedback">
+                                <span class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg" aria-hidden="true">
                                     <span id="usernameValidationMessage" th:utext="#{username.required}"></span>
-                                </div>
-                            </div>
+                                </span>
+                            </span>
                         </label>
 
-                        
+
 
                         <script type="text/javascript" th:inline="javascript">
                             /*<![CDATA[*/
@@ -122,20 +122,20 @@
                                            th:accesskey="#{screen.welcome.label.password.accesskey}"
                                            th:field="*{password}"
                                            autocomplete="off"/>
-                                    <div class="mdc-text-field-helper-line invalid-feedback">
-                                        <div class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg" aria-hidden="true">
+                                    <span class="mdc-text-field-helper-line invalid-feedback">
+                                        <span class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg" aria-hidden="true">
                                             <span id="passwordValidationMessage" th:utext="#{password.required}"></span>
-                                        </div>
-                                    </div>
+                                        </span>
+                                    </span>
                                 </label>
                                 <button
                                     class="reveal-password mdc-button mdc-button--unelevated mdc-input-group-append mdc-icon-button btn btn-primary"
                                     tabindex="-1" type="button">
-                                    <i class="mdi mdi-eye reveal-password-icon fas fa-eye"></i>
+                                    <i class="mdi mdi-eye reveal-password-icon fas fa-eye" aria-hidden="true"></i>
                                     <span class="visually-hidden">Toggle Password</span>
                                 </button>
                             </div>
-                            
+
                             <div class="mdc-text-field-helper-line caps-warn">
                                 <div
                                     class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg text-danger">
@@ -220,7 +220,7 @@
                             </label>
                         </div>
                     </section>
-                    
+
                     <section class="cas-field form-check"
                              th:if="${'true' == #strings.defaultString(#themes.code('cas.warn-on-redirect.enabled'), 'true')}">
                         <div class="mdc-form-field ">
@@ -245,7 +245,7 @@
                         </div>
                         <p/>
                     </section>
-                    
+
                     <section class="cas-field form-check"
                              th:if="${'true' == #strings.defaultString(#themes.code('cas.public-workstation.enabled'), 'true')}">
                         <div class="mdc-form-field ">
@@ -270,7 +270,7 @@
                         </div>
                         <p/>
                     </section>
-                    
+
                     <section class="cas-field form-check" th:if="${rememberMeAuthenticationEnabled}">
                         <div class="mdc-form-field ">
                             <div class="mdc-checkbox">
@@ -365,12 +365,12 @@
             </span>
 
 
-            <span th:if="${loginFormViewable and loginFormEnabled}">
+            <div th:if="${loginFormViewable and loginFormEnabled}">
                 <span th:remove="tag"
                       th:if="${'true' == #strings.defaultString(#themes.code('cas.pm-links.enabled'), 'true')}">
                     <div th:replace="~{fragments/pmlinks :: pmlinks}"/>
                 </span>
-            </span>
+            </div>
 
             <script type="text/javascript" th:inline="javascript">
                 /*<![CDATA[*/
@@ -391,9 +391,9 @@
             </script>
         </div>
 
-        <span th:if="${loginFormViewable and loginFormEnabled}">
+        <div th:if="${loginFormViewable and loginFormEnabled}">
             <div th:replace="~{fragments/loginsidebar :: loginsidebar}"/>
-        </span>
+        </div>
     </div>
 </main>
 </body>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/serviceui.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/serviceui.html
@@ -21,15 +21,15 @@
             <img th:unless="${serviceUIMetadata.logoUrl}" th:title="${serviceUIMetadata.displayName}"
                  th:alt="${serviceUIMetadata.displayName}" th:src="@{images/webapp.png}"
                  th:width="${serviceUIMetadata.logoWidth}" th:height="${serviceUIMetadata.logoHeight}"/>
-            
+
             <div class="ml-2">
                 <h2 id="serviceUIMetadataDisplayName" th:text="${serviceUIMetadata.displayName}">serviceUIMetadata.displayName</h2>
                 <p id="serviceUIMetadataDescription" th:text="${serviceUIMetadata.description}">serviceUIMetadata.description</p>
 
                 <div id="wildcardService" th:if="${wildcardedRegisteredService}">
-                    <p><i class="mdi mdi-information-slab-box"></i><span th:utext="#{screen.service.wildcard.message}" /></p>
+                    <p><i class="mdi mdi-information-slab-box" aria-hidden="true"></i><span th:utext="#{screen.service.wildcard.message}" /></p>
                 </div>
-                
+
                 <p id="serviceUIMetadataInformationUrl"
                    th:if="${serviceUIMetadata.informationURL}"
                    th:utext="#{screen.mdui.infolink.text(${serviceUIMetadata.informationURL})}">
@@ -44,10 +44,10 @@
         <div th:unless="${serviceUIMetadata}" class="d-flex align-items-center p-2">
             <img th:if="${registeredService.logo}" th:src="${registeredService.logo}"/>
             <div id="servicedesc" class="ml-2">
-                <h5><i class="mdi mdi-web"></i>[[${registeredService.name}]]</h5>
+                <strong><i class="mdi mdi-web" aria-hidden="true"></i>[[${registeredService.name}]]</strong>
                 <p th:text="${registeredService.description}">Registered Service Description</p>
                 <div id="wildcardService" th:if="${wildcardedRegisteredService}">
-                    <p><i class="mdi mdi-information-slab-box"></i><span th:utext="#{screen.service.wildcard.message}" /></p>
+                    <p><i class="mdi mdi-information-slab-box" aria-hidden="true"></i><span th:utext="#{screen.service.wildcard.message}" /></p>
                 </div>
             </div>
         </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorLoginView.html
@@ -107,7 +107,7 @@
                             <div class="mdc-dialog__content" id="notif-dialog-content">
                                 <div class="mdc-typography--body1">
                                     <div class="banner banner-danger alert alert-danger banner-dismissible"
-                                         style="display: none" id="errorPanel">
+                                         role="alert" style="display: none" id="errorPanel">
                                         <h3>Failure</h3>
                                         <p th:utext="#{screen.authentication.gauth.invalidtoken}">
                                     </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorLoginView.html
@@ -27,7 +27,7 @@
                     <div class="w-100 mdc-input-group-field mdc-input-group-field-append">
                         <div class="d-flex">
                             <input type="hidden" id="accountId" name="accountId" size="25" autocomplete="off" th:field="*{accountId}" />
-                    
+
                             <label for="token"
                                 class="mdc-text-field caps-check mdc-text-field--outlined control-label mdc-text-field--with-trailing-icon">
                                 <span class="mdc-notched-outline">
@@ -40,8 +40,8 @@
                                 <input class="mdc-text-field__input form-control pwd" type="password" name="token" id="token"
                                     th:field="*{token}" size="25" autocomplete="off" required />
                             </label>
-                    
-                    
+
+
                             <script type="text/javascript" th:inline="javascript">
                                 /*<![CDATA[*/
                                 let accountId = /*[[${registeredDevice.id}]]*/;
@@ -85,7 +85,7 @@
                 </button>
             </form>
         </span>
-        
+
         <div th:if="${gauthMultipleDeviceRegistrationEnabled}">
             <p>
             <hr width="75%">
@@ -139,11 +139,11 @@
                                                            aria-required="true"
                                                            autocomplete="off"
                                                            required />
-                                                    <div class="mdc-text-field-helper-line invalid-feedback">
-                                                        <div class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg" aria-hidden="true">
+                                                    <span class="mdc-text-field-helper-line invalid-feedback">
+                                                        <span class="mdc-text-field-helper-text mdc-text-field-helper-text--validation-msg" aria-hidden="true">
                                                             <span th:utext="#{username.required}"></span>
-                                                        </div>
-                                                    </div>
+                                                        </span>
+                                                    </span>
                                                 </label>
                                                 <button class="reveal-password align-self-end mdc-button mdc-button--raised btn btn-primary mdc-input-group-append mdc-icon-button"
                                                         tabindex="-1"
@@ -246,7 +246,7 @@
             </div>
             <!-- Confirmation Dialog -->
 
-            
+
             <script type="text/javascript">
                 (material => {
                     document.addEventListener('DOMContentLoaded', () => {
@@ -260,7 +260,7 @@
                     });
                 })(mdc);
             </script>
-            
+
         </div>
         </p>
     </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
@@ -12,7 +12,8 @@
 <body id="cas">
 <main role="main" class="container mt-3 mb-3">
     <div layout:fragment="content" id="login" class="mdc-card card p-4 m-auto w-lg-66">
-        <h4 th:text="#{screen.authentication.gauth.register}">Your account is not registered.</h4>
+        <h2 th:text="#{screen.authentication.gauth.register}">Your account is not registered.</h2>
+        <p th:text="#{screen.authentication.gauth.registerdesc}">Use the below settings to register your device with CAS.</p>
 
         <!-- Confirmation Dialog -->
         <div class="mdc-dialog" id="confirm-reg-dialog" role="alertdialog"
@@ -20,10 +21,10 @@
             <form method="post" id="fm1" class="fm-v clearfix" th:action="@{${'/' + activeFlowId} }">
                 <div class="mdc-dialog__container">
                     <div class="mdc-dialog__surface">
-                        <h1 class="mdc-dialog__title mt-lg-2" id="notif-dialog-title"
+                        <h2 class="mdc-dialog__title mt-lg-2" id="notif-dialog-title"
                             th:utext="#{screen.authentication.gauth.confirm.title}">
                             Confirm Account Registration
-                        </h1>
+                        </h2>
                         <div class="mdc-dialog__content" id="notif-dialog-content">
                             <div class="mdc-typography--body1">
                                 <div class="banner banner-danger alert alert-danger banner-dismissible" style="display: none" id="errorPanel">
@@ -135,31 +136,29 @@
 
 
         <!-- Account Information -->
-        <table>
-            <tr>
-                <td>
-                    <img id="imageQRCode" th:src="@{'data:image/jpeg;base64,' + ${QRcode}}"/>
-                </td>
-
-                <td>
-                    <div class="my-2" id="seckeypanel">
-                        <p th:utext="#{screen.authentication.gauth.key(${key.getSecretKey()})}">Secret key to register is...</p>
-                    </div>
-                    <hr>
-                    <p th:text="#{screen.authentication.gauth.scratchcodes}">Scratch codes:</p>
-                    <div class="d-flex align-items-start mb-4">
-                        <div class="mdc-chip-set" role="grid" id="scratchcodes">
-                            <div th:each="code : ${key.getScratchCodes()}" class="mdc-chip" role="row">
-                                <div class="mdc-chip__ripple"></div>
-                                <span role="gridcell">
-                                  <span class="mdc-chip__text" th:text="${code}">Chip One</span>
-                                </span>
-                            </div>
+        <div class="row">
+            <div class="col-md-5 text-center">
+                <img id="imageQRCode" th:src="@{'data:image/jpeg;base64,' + ${QRcode}}"
+                     th:alt="#{screen.authentication.gauth.qrimage}"/>
+            </div>
+            <div class="col-md-7">
+                <div class="my-2" id="seckeypanel">
+                    <p th:utext="#{screen.authentication.gauth.key(${key.getSecretKey()})}">Secret key to register is...</p>
+                </div>
+                <hr>
+                <p th:text="#{screen.authentication.gauth.scratchcodes}">Scratch codes:</p>
+                <div class="d-flex align-items-start mb-4">
+                    <div class="mdc-chip-set" role="grid" id="scratchcodes">
+                        <div th:each="code : ${key.getScratchCodes()}" class="mdc-chip" role="row">
+                            <div class="mdc-chip__ripple"></div>
+                            <span role="gridcell">
+                              <span class="mdc-chip__text" th:text="${code}">Chip One</span>
+                            </span>
                         </div>
                     </div>
-                </td>
-            </tr>
-        </table>
+                </div>
+            </div>
+        </div>
         <div class="d-flex flex-column align-items-center">
             <div class="d-flex justify-content-center">
                 <button class="mdc-button mdc-button--raised btn btn-primary me-2" name="confirm" id="confirm" accesskey="f"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/layout.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" th:lang="${#locale}">
 
 <head>
     <meta charset="UTF-8" />

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/layout.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/layout.html
@@ -33,7 +33,7 @@
     <div class="mdc-drawer-scrim"></div>
 
     <div class="mdc-drawer-app-content mdc-top-app-bar--fixed-adjust d-flex justify-content-center">
-        <main role="main" id="main-content" th:attr="class=*{mainContentClass ?: 'container-lg' + ' py-4'} ">
+        <main id="main-content" th:attr="class=*{mainContentClass ?: 'container-lg' + ' py-4'} ">
             <div layout:fragment="content" id="content">
                 CAS content will go here
             </div>
@@ -43,7 +43,7 @@
     <div th:replace="~{fragments/footer :: footer}">
         <a href="fragments/footer.html">Footer</a> fragment will go here
     </div>
-    
+
 </body>
 
 </html>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casLoginView.html
@@ -1,13 +1,9 @@
 <!DOCTYPE html>
-<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}" th:lang="${#locale}">
 
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-
     <title th:text="#{cas.login.pagetitle}">CAS Login View</title>
     <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
-
 </head>
 
 <body class="login mdc-typography">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casCompositeMfaProviderSelectionView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casCompositeMfaProviderSelectionView.html
@@ -17,11 +17,11 @@
             <div class="card-text">
                 <div th:id="${provider}" th:each="provider: ${mfaSelectableProviders}" class="border-bottom py-4">
                     <form th:name="${'fm-' + provider}" th:id="${'fm-' + provider}" method="post" th:action="@{/login}">
-                        <h4 class="d-flex align-items-center">
+                        <h3 class="d-flex align-items-center">
                             <i class="mdi mdi-laptop fas fa-laptop me-2"></i>
                             <span th:utext="#{'cas.mfa.providerselection.' + ${provider}}">Provider name goes
                                 here</span>
-                        </h4>
+                        </h3>
                         <p th:utext="#{'cas.mfa.providerselection.' + ${provider} + '.notes'}">Provider description goes
                             here</p>
                         <button th:id="${'btn-' + provider}" class="mdc-button mdc-button--raised btn btn-primary" value="Use">

--- a/webapp/cas-server-webapp-config-server/src/main/resources/application.properties
+++ b/webapp/cas-server-webapp-config-server/src/main/resources/application.properties
@@ -16,5 +16,3 @@ spring.security.user.name=casuser
 server.tomcat.additional-tld-skip-patterns=*.jar
 
 management.endpoints.web.exposure.include=env,info,health
-
-

--- a/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
+++ b/webapp/cas-server-webapp-resources/src/main/resources/log4j2.xml
@@ -21,7 +21,7 @@ or override log42.component.properties to turn off async
         <Property name="opensaml.log.level">${main:\--logging.level.org.opensaml:-warn}</Property>
         <Property name="hazelcast.log.level">${main:\--logging.level.com.hazelcast:-warn}</Property>
         <Property name="jdbc.log.level">${main:\--logging.level.org.hibernate:-error}</Property>
-        
+
         <Property name="log.console.stacktraces">true</Property>
         <Property name="log.file.stacktraces">false</Property>
         <!-- -Dlog.stacktraceappender=null to disable stacktrace log -->
@@ -170,7 +170,7 @@ or override log42.component.properties to turn off async
         <Logger name="org.pac4j" level="${sys:pac4j.log.level}"/>
 
         <Logger name="org.opensaml" level="${sys:opensaml.log.level}"/>
-        
+
         <Logger name="PROTOCOL_MESSAGE" level="info" />
 
         <Logger name="net.jradius" level="warn"/>


### PR DESCRIPTION
Hello!
Thanks for this great app.
Here is a bundle of Accessibility fixes for CAS webapp login page :

HTML:
* Remove duplicated meta tags
* Add current specified locale in html lang attribute
* Remove useless "role=main" on main tag
* Replace some span by div (span cannot  contain any block-level element (h1, div, etc...)
* Replace some div by span (label tag cannot contain any div)
* Correct headers (h1, h2, h3 hierarchy). no more skipped level
* Add "aria-hidden="true" on some icons
* add "role=alert" on some alert banners
 * Replace table layout by responsive grid in GAuth
* Add missing alt attribute on QR code image

CSS:
* Correct default contrast color (use https://app.contrast-finder.org/ ) (alert panels, buttons, etc...)
* remove border-radius between password input and reveal-password button
* Increase notification font size (no font can be below 11px for proper a11y )
* remove "text-justify" (A11y recommends to never justify text)

LANG files (messages)
* Add non breakable spaces before ":" and "!" in french strings