### PR TITLE
Improve style for A11y

### DIFF
--- a/support/cas-server-support-palantir/client/src/index.scss
+++ b/support/cas-server-support-palantir/client/src/index.scss
@@ -1,6 +1,6 @@
 :root {
     --mdc-text-button-label-text-color: #f7f7f7;
-    --mdc-theme-error: #d9534f;
+    --mdc-theme-error: #d93d33;
     --cas-theme-primary: #153e50;
     --cas-theme-primary-bg: rgba(21, 62, 80, 0.2);
     --cas-theme-button-bg: #26418f;

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -3,14 +3,17 @@
 
 :root {
     --mdc-text-button-label-text-color: #f7f7f7;
-    --mdc-theme-error: #d9534f;
+    --mdc-shape-small: 4px;
+    --mdc-theme-error: #d93d33;
+    --mdc-theme-error: #d93d33;;
     --cas-theme-primary: #044561;
     --cas-theme-primary-bg: rgba(21, 62, 80, 0.2);
     --cas-theme-button-bg: #26418f;
     --cas-theme-primary-light: #006d85;
-    --cas-theme-secondary: #74C163;
-    --cas-theme-success: var(--cas-theme-secondary);
-    --cas-theme-danger: var(--mdc-theme-error);
+    --cas-theme-secondary: #018077;
+    --cas-theme-success: #74C163;
+    --cas-theme-danger: #58151c;
+    --cas-theme-danger-bg: #f8d7da;
     --cas-theme-warning: #e6a210;
     --cas-theme-border-light: 1px solid rgba(0, 0, 0, .2);
     --mdc-theme-primary: var(--cas-theme-primary, #153e50);
@@ -72,14 +75,14 @@ div#content {
 
 .notifications-count {
     position: absolute;
-    top: 10px;
-    right: 12px;
+    top: 8px;
+    right: 4px;
     background-color: #b00020;
     background-color: var(--cas-theme-danger);
     color: #fff;
     border-radius: 50%;
     padding: 1px 3px;
-    font: 8px Verdana;
+    font: 11px Verdana;
 }
 
 .cas-brand {
@@ -199,8 +202,8 @@ button.close {
 .banner-danger {
     border-color: #b00020;
     border-color: var(--cas-theme-danger, #b00020);
-    color: #D8000C;
-    background-color: #FFD2D2;
+    color: var(--cas-theme-danger, #58151c);
+    background-color: var(--cas-theme-danger-bg, #f8d7da);
 }
 
 .banner-danger .mdi {
@@ -341,8 +344,12 @@ button.close {
     color: var(--cas-theme-danger, #b00020);
 }
 
-.text-secondary, .text-success {
+.text-secondary {
     color: var(--cas-theme-secondary);
+    color: var(--cas-theme-secondary);
+}
+.text-success {
+    color: var(--cas-theme-success);
 }
 
 .progress-bar-danger .mdc-linear-progress__bar-inner {
@@ -373,7 +380,7 @@ button.close {
     border-radius: 4px;
 }
 
-.mdc-input-group .mdc-input-group-field .mdc-text-field {
+.mdc-input-group .mdc-input-group-field .mdc-notched-outline__trailing {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
 }
@@ -415,7 +422,7 @@ button.close {
 }
 
 .mdc-button--outline:not(:disabled, .reveal-password) {
-    background-color: #428bca;
+    background-color: var(--cas-theme-secondary, #018077);
     border-radius: 12px 4px;
 }
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -5,7 +5,6 @@
     --mdc-text-button-label-text-color: #f7f7f7;
     --mdc-shape-small: 4px;
     --mdc-theme-error: #d93d33;
-    --mdc-theme-error: #d93d33;;
     --cas-theme-primary: #044561;
     --cas-theme-primary-bg: rgba(21, 62, 80, 0.2);
     --cas-theme-button-bg: #26418f;

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/css/cas.css
@@ -345,7 +345,6 @@ button.close {
 
 .text-secondary {
     color: var(--cas-theme-secondary);
-    color: var(--cas-theme-secondary);
 }
 .text-success {
     color: var(--cas-theme-success);

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/adaptive-authn/casRiskAuthenticationBlockedView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/adaptive-authn/casRiskAuthenticationBlockedView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-<div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+<div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
     <h2 th:utext="#{screen.risk.authnblocked.heading}">Authentication attempt is blocked.</h2>
     <p th:utext="#{screen.risk.authnblocked.message}">Your authentication attempt is untrusted and unauthorized from your
         current workstation.</p>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/adaptive-authn/casRiskAuthenticationVerifiedView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/adaptive-authn/casRiskAuthenticationVerifiedView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="mdc-card card p-4 m-auto w-lg-66">
         <div class="banner banner-danger my-2" th:if="${flowRequestContext.messageContext.hasErrorMessages()}">
             <h2>Error</h2>
             <p th:each="message : ${flowRequestContext.messageContext.allMessages}"

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnErrorView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnErrorView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{screen.delauthn.error.header}">Delegated Authentication Failure</h2>
         <p th:utext="#{screen.delauthn.error.message}">CAS is unable to complete the delegated authentication scenario,
             or redirect to the selected identity provider. Please examine the original authentication request and try again.

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnStopWebflow.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/delegated-authn/casDelegatedAuthnStopWebflow.html
@@ -12,7 +12,7 @@
 <body>
     <main role="main" class="container mt-3 mb-3">
         <div id="content" layout:fragment="content"
-             class="mdc-card card p-4 m-auto w-lg-66 text-justify">
+             class="mdc-card card p-4 m-auto w-lg-66">
             <div class="banner banner-danger alert alert-danger">
                 <h2 th:utext="#{screen.pac4j.unauthz.heading}">Unauthorized Access</h2>
                 <p th:utext="#{screen.pac4j.unauthz.message}">Either the authentication request was rejected/cancelled,
@@ -28,7 +28,7 @@
                     <span th:unless="${rootCauseException}" th:text="#{screen.pac4j.authn.unknown}">
                       Authentication response provided to CAS by the external identity provider cannot be accepted.</span>
                 </p>
-                
+
                 <div class="mdc-data-table table-responsive w-100">
                     <table id="errorTable" th:if="${error != null or reason != null or code != null or description != null}"
                         class="table table-striped w-100" aria-label="Error information">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/error/casServiceErrorView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/error/casServiceErrorView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{screen.service.error.header}">Application Not Authorized to Use CAS</h2>
         <p th:if="${rootCauseException != null and rootCauseException.code != null}"
            th:utext="#{${rootCauseException.code}}">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/error/casUnauthorizedServiceRedirectView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/error/casUnauthorizedServiceRedirectView.html
@@ -10,7 +10,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
             <h2 th:utext="#{screen.service.error.header}">Application Not Authorized to Use CAS</h2>
             <p th:utext="#{screen.service.error.redirect(${unauthorizedRedirectUrl})}"></p>
             <script th:inline="javascript">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/error/casWebflowConfigErrorView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/error/casWebflowConfigErrorView.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger mdc-card p-4 m-auto w-lg-66">
         <h2>Invalid/Unknown Webflow Configuration</h2>
         <p>You are seeing this error because the authentication flow cannot locate or validate the sequence
             of requested events and transitions and does not know how to route the flow to the next step.
@@ -19,7 +19,7 @@
         </p>
         <p>The error message is:</p>
         <code id="exceptionMessage" th:text="${rootCauseException.message}">unknown</code>
-        
+
         <p>Please examine the CAS server logs to find the root cause and additional details.</p>
     </div>
 </main>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/accountprofileoverview.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/accountprofileoverview.html
@@ -12,7 +12,7 @@
 
 <body>
 <span th:fragment="overview">
-        <div id="divOverview" class="profile-content p-1 text-justify" style="display: none;">
+        <div id="divOverview" class="profile-content p-1" style="display: none;">
             <h2>
                 <i class="mdi mdi-door-open fas fa-door-open"></i>
                 <span>Hello, <span th:text="${authentication.principal.id}"></span>!</span>
@@ -23,7 +23,7 @@
                 When you are finished, for security reasons, please <a href="logout">log out</a> and exit your web browser.
             </p>
 
-            <div id="infoMessages" class="banner banner-success banner-dismissible text-justify my-2" th:if="${flowRequestContext.messageContext.allMessages.length > 0}">
+            <div id="infoMessages" class="banner banner-success banner-dismissible my-2" th:if="${flowRequestContext.messageContext.allMessages.length > 0}">
                 <a href="#" class="close" onclick="$(this).parent().hide();" aria-label="close"><span class="mdi mdi-close-box"></span></a>
                 <span th:each="message : ${flowRequestContext.messageContext.allMessages}" th:utext="${message.text}">Message Text</span>
                 <script>autoHideElement("infoMessages");</script>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/loginform.html
@@ -34,7 +34,7 @@
 
             <form method="post" id="fm1" th:object="${credential}" action="login">
                 <div id="login-form-controls" th:unless="${loginFormViewable or loginFormEnabled}">
-                    <div id="loginErrorsPanel" class="alert alert-danger banner banner-danger banner-dismissible text-justify"
+                    <div id="loginErrorsPanel" class="alert alert-danger banner banner-danger banner-dismissible"
                          th:if="${#fields.hasErrors('*')}">
                         <p th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">Example error</p>
                         <!--<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>-->
@@ -54,7 +54,7 @@
                         <span th:utext="#{screen.welcome.instructions}">Enter your Username and Password:</span>
                     </h3>
 
-                    <div id="loginErrorsPanel" class="banner banner-danger alert alert-danger banner-dismissible text-justify"
+                    <div id="loginErrorsPanel" class="banner banner-danger alert alert-danger banner-dismissible"
                          th:if="${#fields.hasErrors('*')}">
                         <p th:each="err : ${#fields.errors('*')}" th:utext="${err + ' '}">Example error</p>
                         <!--<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>-->
@@ -86,7 +86,6 @@
                             </div>
                         </label>
 
-                        
 
                         <script type="text/javascript" th:inline="javascript">
                             /*<![CDATA[*/
@@ -135,7 +134,7 @@
                                     <span class="visually-hidden">Toggle Password</span>
                                 </button>
                             </div>
-                            
+
                             <div class="mdc-text-field-helper-line caps-warn">
                                 <div
                                     class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg text-danger">
@@ -220,7 +219,7 @@
                             </label>
                         </div>
                     </section>
-                    
+
                     <section class="cas-field form-check"
                              th:if="${'true' == #strings.defaultString(#themes.code('cas.warn-on-redirect.enabled'), 'true')}">
                         <div class="mdc-form-field ">
@@ -245,7 +244,7 @@
                         </div>
                         <p/>
                     </section>
-                    
+
                     <section class="cas-field form-check"
                              th:if="${'true' == #strings.defaultString(#themes.code('cas.public-workstation.enabled'), 'true')}">
                         <div class="mdc-form-field ">
@@ -270,7 +269,7 @@
                         </div>
                         <p/>
                     </section>
-                    
+
                     <section class="cas-field form-check" th:if="${rememberMeAuthenticationEnabled}">
                         <div class="mdc-form-field ">
                             <div class="mdc-checkbox">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login-error/casAuthenticationBlockedView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login-error/casAuthenticationBlockedView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div id="content" layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div id="content" layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{screen.authnblocked.heading}">Authentication attempt is blocked.</h2>
         <p th:utext="#{screen.authnblocked.message}">Your authentication attempt is untrusted and unauthorized from
             your current workstation.</p>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login-error/casBadHoursView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login-error/casBadHoursView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{screen.badhours.heading}">Your account is forbidden to login at this time.</h2>
         <p th:utext="#{screen.badhours.message}">Please try again later.</p>
     </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login-error/casBadWorkstationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login-error/casBadWorkstationView.html
@@ -11,7 +11,7 @@
 
 <body id="cas">
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{screen.badworkstation.heading}">You cannot login from this workstation.</h2>
         <p th:utext="#{screen.badworkstation.message}">Please contact the system administrator to regain access.</p>
     </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casGenericSuccessView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/login/casGenericSuccessView.html
@@ -16,7 +16,7 @@
                 $('table').DataTable();
             }
         </script>
-        <div class="w-100 m-auto mdc-card card p-4 text-justify">
+        <div class="w-100 m-auto mdc-card card p-4">
             <h2>
                 <i class="mdi mdi-door-open fas fa-door-open"></i>
                 <span th:utext="#{screen.success.header}">Log In Successful</span>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casMfaDeniedView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casMfaDeniedView.html
@@ -11,7 +11,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
             <h2 th:utext="#{screen.mfaDenied.heading}">MFA attempt is denied.</h2>
             <p th:utext="#{screen.mfaDenied.message}">Your MFA provider has denied your attempt at second factor
                 authentication. Contact your system administrator for help in restoring your account.</p>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casMfaUnavailableView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/mfa/casMfaUnavailableView.html
@@ -11,7 +11,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
             <h2 th:utext="#{screen.mfaUnavailable.heading}">MFA Provider Unavailable</h2>
             <p th:utext="#{screen.mfaUnavailable.message}">Your MFA provider is currently unavailable.</p>
         </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casResetPasswordErrorView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casResetPasswordErrorView.html
@@ -11,7 +11,7 @@
 
 <body>
     <main role="main" class="container mt-3 mb-3">
-        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+        <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
             <h2 th:utext="#{screen.pm.reset.heading}">Password Reset Failed</h2>
             <p th:utext="#{screen.pm.reset.message}">We were unable to process your password reset request at this time.
             </p>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casWeakPasswordDetectedView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/password-reset/casWeakPasswordDetectedView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{screen.pm.weak.heading}">Weak Password Detected</h2>
         <p th:utext="#{screen.pm.weak.message}">This is a weak password</p>
         <form method="post" id="fm1">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/protocol/oauth/sessionStaleMismatchError.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/protocol/oauth/sessionStaleMismatchError.html
@@ -6,7 +6,7 @@
 </head>
 
 <body id="cas">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{cas.oauth.error.header}">Unable to Proceed</h2>
         <p th:if="${rootCauseException != null and rootCauseException.code != null}"
             th:utext="#{${rootCauseException.code}}">

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/saml2-idp/casSamlIdPErrorView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/saml2-idp/casSamlIdPErrorView.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2>SAML2 Identity Provider Error</h2>
         <p>
             The service you are attempting to log into, has identified a problem

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/storage/casSessionStorageReadView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/storage/casSessionStorageReadView.html
@@ -27,7 +27,7 @@
                 <input type="submit" style="display: none" />
             </form>
         </div>
-        
+
         <script>new mdc.linearProgress.MDCLinearProgress(document.querySelector('.mdc-linear-progress'));</script>
         <script th:inline="javascript">
             /*<![CDATA[*/
@@ -36,7 +36,7 @@
             if (sessionStorageContext === undefined || sessionStorageContext === null || sessionStorageContext === "") {
                 sessionStorageContext = "sessionStorage";
             }
-            
+
             const payload = readFromSessionStorage(sessionStorageContext);
             document.getElementById("sessionStorage").value = payload;
             document.getElementById("fm1").submit();
@@ -48,7 +48,7 @@
                 <style type="text/css">
                     #mainPanel {display:none;}
                 </style>
-            <div class="mdc-card p-4 m-auto w-lg-50 banner banner-danger alert alert-danger text-justify">
+            <div class="mdc-card p-4 m-auto w-lg-50 banner banner-danger alert alert-danger">
                 <h2 th:utext="#{screen.browser.js.disabled.title}"></h2>
                 <p class="intro" th:utext="#{screen.browser.js.disabled.text}"></p>
             </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/storage/casSessionStorageWriteView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/storage/casSessionStorageWriteView.html
@@ -52,7 +52,7 @@
                 <style type="text/css">
                     #mainPanel {display:none;}
                 </style>
-                <div class="mdc-card p-4 m-auto w-lg-50 banner banner-danger alert alert-danger text-justify">
+                <div class="mdc-card p-4 m-auto w-lg-50 banner banner-danger alert alert-danger">
                     <h2 th:utext="#{screen.browser.js.disabled.title}"></h2>
                     <p class="intro" th:utext="#{screen.browser.js.disabled.text}"></p>
                 </div>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/wsfed/casWsFedStopWebflow.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/wsfed/casWsFedStopWebflow.html
@@ -11,7 +11,7 @@
 
 <body>
 <main role="main" class="container mt-3 mb-3">
-    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66 text-justify">
+    <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         Either the authentication request was rejected/cancelled, or
         the authentication provider denied access due to permissions, etc. Review logs to find the root cause of
         the issue.


### PR DESCRIPTION
This is the first part of Accessibility improvements for CAS. (Initiated by #5875)
This one focus only on styles changes and do not modify any CAS behavior.

Detailed corrections:
* Correct default contrast color (use https://app.contrast-finder.org/ ) (alert panels, buttons, etc...)
* Remove border-radius between password input and reveal-password button
* Increase notification font size (no font can be below 11px for proper a11y )
* Remove every "text-justify" occurences (W3C recommends to never justify text for a11y. See https://www.w3.org/WAI/GL/low-vision-a11y-tf/wiki/Supplemental_Guidance:_Text_Justification)

