### PR TITLE
update activemq version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -173,7 +173,7 @@ bucket4jVersion=7.6.0
 ###############################
 # ActiveMQ versions
 ###############################
-activemqPoolVersion=5.17.2
+activemqPoolVersion=5.17.6
 ###############################
 # InfluxDb versions
 ###############################


### PR DESCRIPTION
activemq-5.17.2 disclose a vulnerability [CVE-2023-46604](https://activemq.apache.org/security-advisories.data/CVE-2023-46604-announcement.txt)