### PR TITLE
Remove duplicate checker-qual

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -614,6 +614,7 @@ ext.libraries = [
                 dependencies.create("com.google.guava:guava:$guavaVersion") {
                     exclude(group: "com.google.errorprone", module: "error_prone_annotations")
                     exclude(group: "com.fasterxml.jackson.module", module: "jackson-module-jaxb-annotations")
+                    exclude(group: "org.checkerframework", module: "checker-qual")
                 }
         ],
         classgraph                 : [


### PR DESCRIPTION
`checker-qual` is pulled by `guava` in v3.33.0 and pully by `caffeine` in v3.37.0.

This PR removes the duplication.