### PR TITLE
update decode method to avoid warning stack trace

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
@@ -22,6 +22,8 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -50,7 +52,7 @@ public class OAuth20JwtAccessTokenEncoder implements CipherExecutor<String, Stri
     private final String issuer;
 
     /**
-     * Doing basic check that {@link JWTParser#parse} does to reduce logging of stack traces.
+     * Doing basic checks to reduce logged stack traces when {@link JWTParser#parse} throws {@link ParseException}.
      * Encrypted tokens can have five dot delimited sections and plain or signed tokens have three.
      * @param tokenId Possibly encoded token.
      * @return true/false

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
@@ -63,7 +63,7 @@ public class OAuth20JwtAccessTokenEncoder implements CipherExecutor<String, Stri
     @Override
     public String decode(final String tokenId, final Object[] parameters) {
         if (StringUtils.isBlank(tokenId)) {
-            LOGGER.warn("No access token is provided to decode");
+            LOGGER.debug("No access token is provided to decode");
             return tokenId;
         }
         try {

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
@@ -50,21 +50,22 @@ public class OAuth20JwtAccessTokenEncoder implements CipherExecutor<String, Stri
     private final String issuer;
 
     /**
-     * Doing basic check that {@code JWTParser.parse} does to reduce logging of stack traces.
+     * Doing basic check that {@link JWTParser#parse} does to reduce logging of stack traces.
+     * Encrypted tokens can have five dot delimited sections and plain or signed tokens have three.
      * @param tokenId Possibly encoded token.
-     * @return true
+     * @return true/false
      */
     private boolean isPossiblyEncoded(final String tokenId) {
-        return tokenId.contains(".");
+        if (StringUtils.isBlank(tokenId)) {
+            LOGGER.warn("Blank access token provided to isPossiblyEncoded");
+            return false;
+        }
+        return tokenId.split("\\.").length >= 3;
     }
 
     @Override
     public String decode(final String tokenId, final Object[] parameters) {
         return FunctionUtils.doAndHandle(() -> {
-            if (StringUtils.isBlank(tokenId)) {
-                LOGGER.warn("No access token is provided to decode");
-                return null;
-            }
             if (!isPossiblyEncoded(tokenId)) {
                 LOGGER.trace("Token is not encoded, using as-is: [{}]", tokenId);
                 return tokenId;

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcJwtAccessTokenEncoderTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcJwtAccessTokenEncoderTests.java
@@ -67,6 +67,17 @@ class OidcJwtAccessTokenEncoderTests extends AbstractOidcTests {
     }
 
     @Test
+    void verifyNonEncodedToken() throws Throwable {
+        val accessToken = getAccessToken();
+        val registeredService = getRegisteredServiceForJwtAccessTokenWithKeys(accessToken);
+        val encoder = getAccessTokenEncoder(accessToken, registeredService);
+
+        val nonEncodedAccessToken = "nodotintoken";
+        val decode = encoder.decode(nonEncodedAccessToken);
+        assertEquals(nonEncodedAccessToken, decode);
+    }
+
+    @Test
     void verifyEncodingWithNoCiphersForService() throws Throwable {
         val accessToken = getAccessToken(StringUtils.EMPTY, "encoding-service-clientid");
         val registeredService = getRegisteredServiceForJwtAccessTokenWithKeys(accessToken);

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcJwtAccessTokenEncoderTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcJwtAccessTokenEncoderTests.java
@@ -12,11 +12,16 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.test.context.TestPropertySource;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * This is {@link OidcJwtAccessTokenEncoderTests}.
@@ -66,15 +71,24 @@ class OidcJwtAccessTokenEncoderTests extends AbstractOidcTests {
         assertEquals(accessToken.getId(), decoded);
     }
 
-    @Test
-    void verifyNonEncodedToken() throws Throwable {
+    public static Stream<Arguments> getNonTokenArgs() {
+        return Stream.of(
+            arguments((String) null),
+            arguments(StringUtils.EMPTY),
+            arguments("nodotintoken"),
+            arguments("bad.token.id")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getNonTokenArgs")
+    void verifyNonEncodedToken(final String tokenId) throws Throwable {
         val accessToken = getAccessToken();
         val registeredService = getRegisteredServiceForJwtAccessTokenWithKeys(accessToken);
         val encoder = getAccessTokenEncoder(accessToken, registeredService);
 
-        val nonEncodedAccessToken = "nodotintoken";
-        val decode = encoder.decode(nonEncodedAccessToken);
-        assertEquals(nonEncodedAccessToken, decode);
+        val decode = encoder.decode(tokenId);
+        assertEquals(tokenId, decode);
     }
 
     @Test


### PR DESCRIPTION
I see an exception logged fairly regularly I think, but things seem to be working. The OAuth20JwtAccessTokenEncoder.decode method seems to expect non-encoded tokens because if there is an exception it returns the token as-is, if I am reading things right. I was initially going to add logging to figure out what was wrong with the token, but the fact that the handling of the exception consists of using the token as-is, I decided to look for ways to avoid the exception or avoid logging the exception. The first thing JWTParser.parse() does is check for a "." in the token so I am doing that to avoid calling the method so FunctionUtils doesn't log the exception. An alternative would be to not use FunctionUtils in this case. 

Unrelated, but it is unfortunate that exceptions logged by FunctionUtils can't use the LOGGER of the calling class. Not sure what could be done about that other than passing in a LOGGER as an argument which would be unsightly. I may submit another PR that puts the exception class as part of the message to provide more context to the message since FunctionUtils doesn't provide much. 

```
2023-12-01 20:01:57,000 WARN [org.apereo.cas.util.function.FunctionUtils] - <Invalid JWT serialization: Missing dot delimiter(s)>
java.text.ParseException: Invalid JWT serialization: Missing dot delimiter(s)
        at com.nimbusds.jwt.JWTParser.parse(JWTParser.java:60) ~[nimbus-jose-jwt-9.37.1.jar!/:9.37.1]
        at org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenEncoder.lambda$decode$0(OAuth20JwtAccessTokenEncoder.java:59) ~[cas-server-support-oauth-core-api-7.0.0.12.jar!/:7.0.0.12]
        at org.apereo.cas.util.function.FunctionUtils.lambda$doAndHandle$12(FunctionUtils.java:409) ~[cas-server-core-util-api-7.0.0.12.jar!/:7.0.0.12]
        at org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenEncoder.decode(OAuth20JwtAccessTokenEncoder.java:62) ~[cas-server-support-oauth-core-api-7.0.0.12.jar!/:7.0.0.12]
        at org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenEncoder.decode(OAuth20JwtAccessTokenEncoder.java:36) ~[cas-server-support-oauth-core-api-7.0.0.12.jar!/:7.0.0.12]
        at org.apereo.cas.util.crypto.DecodableCipher.decode(DecodableCipher.java:40) ~[cas-server-core-api-util-7.0.0.12.jar!/:7.0.0.12]
        at org.apereo.cas.support.oauth.web.endpoints.BaseOAuth20Controller.extractAccessTokenFrom(BaseOAuth20Controller.java:39) ~[cas-server-support-oauth-core-api-7.0.0.12.jar!/:7.0.0.12]
        at org.apereo.cas.support.oauth.web.endpoints.OAuth20UserProfileEndpointController.getAccessTokenFromRequest(OAuth20UserProfileEndpointController.java:128) ~[cas-server-support-oauth-core-api-7.0.0.12.jar!/:7.0.0.12        at org.apereo.cas.support.oauth.web.endpoints.OAuth20UserProfileEndpointController.handleGetRequest(OAuth20UserProfileEndpointController.java:70) ~[cas-server-support-oauth-core-api-7.0.0.12.jar!/:7.0.0.12]
        at org.apereo.cas.oidc.web.controllers.profile.OidcUserProfileEndpointController.handleGetRequest(OidcUserProfileEndpointController.java:60) ~[cas-server-support-oidc-core-api-7.0.0.12.jar!/:7.0.0.12]
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:253) ~[spring-web-6.1.0.jar!/:6.1.0]
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:181) ~[spring-web-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:917) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:829) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
        at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:903) ~[spring-webmvc-6.1.0.jar!/:6.1.0]
```