### PR TITLE
remove logger from functionutils

### DIFF
--- a/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/resource/CredentialsAsFirstParameterResourceResolver.java
+++ b/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/audit/spi/resource/CredentialsAsFirstParameterResourceResolver.java
@@ -10,6 +10,7 @@ import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.DigestUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.audit.AuditTrailManager.AuditFormats;
 import org.apereo.inspektr.audit.spi.AuditResourceResolver;
@@ -22,6 +23,7 @@ import org.aspectj.lang.JoinPoint;
  * @since 3.1.2
  */
 @RequiredArgsConstructor
+@Slf4j
 public class CredentialsAsFirstParameterResourceResolver implements AuditResourceResolver {
     protected final AuthenticationServiceSelectionPlan serviceSelectionStrategy;
     protected final AuditEngineProperties properties;
@@ -51,7 +53,7 @@ public class CredentialsAsFirstParameterResourceResolver implements AuditResourc
                 payload.put("registeredServiceId", registeredService.getServiceId());
                 payload.put("registeredServiceName", registeredService.getName());
                 payload.put("service", getServiceId(transaction.getService()));
-            });
+            }, LOGGER);
         }
         val auditFormat = AuditFormats.valueOf(properties.getAuditFormat().name());
         return auditFormat.serialize(payload);

--- a/core/cas-server-core-audit/src/main/java/org/apereo/cas/config/CasCoreAuditConfiguration.java
+++ b/core/cas-server-core-audit/src/main/java/org/apereo/cas/config/CasCoreAuditConfiguration.java
@@ -537,7 +537,7 @@ public class CasCoreAuditConfiguration {
                         val templateFile = casProperties.getAudit().getGroovy().getTemplate().getLocation().getFile();
                         val mgr = new GroovyAuditTrailManager(templateFile, applicationContext);
                         plan.registerAuditTrailManager(mgr);
-                    }))
+                    }, LOGGER))
                 .otherwiseProxy()
                 .get();
         }

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationBuilder.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationBuilder.java
@@ -256,8 +256,8 @@ public class DefaultAuthenticationBuilder implements AuthenticationBuilder {
                 val current = resultingCredentials.get(key);
 
                 if (current instanceof final MutableCredential currentMutable && credential instanceof final MutableCredential credentialMutable) {
-                    FunctionUtils.doIfNull(credential.getCredentialMetadata(), __ -> credentialMutable.setCredentialMetadata(new BasicCredentialMetadata(credentialMutable)));
-                    FunctionUtils.doIfNull(current.getCredentialMetadata(), __ -> currentMutable.setCredentialMetadata(new BasicCredentialMetadata(currentMutable)));
+                    FunctionUtils.doIfNull(credential.getCredentialMetadata(), __ -> credentialMutable.setCredentialMetadata(new BasicCredentialMetadata(credentialMutable)), LOGGER);
+                    FunctionUtils.doIfNull(current.getCredentialMetadata(), __ -> currentMutable.setCredentialMetadata(new BasicCredentialMetadata(currentMutable)), LOGGER);
                     current.getCredentialMetadata().putProperties(credential.getCredentialMetadata().getProperties());
                 }
                 resultingCredentials.put(key, current);

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationEventExecutionPlan.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationEventExecutionPlan.java
@@ -128,7 +128,7 @@ public class DefaultAuthenticationEventExecutionPlan implements AuthenticationEv
             }
             authenticationHandlerPrincipalResolverMap.put(handler, principalResolver);
             return true;
-        }, () -> false).get();
+        }, () -> false, LOGGER).get();
     }
 
     @Override

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationManager.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationManager.java
@@ -304,7 +304,7 @@ public class DefaultAuthenticationManager implements AuthenticationManager {
                 }
             } catch (final GeneralSecurityException e) {
                 LOGGER.debug(e.getMessage(), e);
-                FunctionUtils.doIfNotNull(e.getCause(), o -> executionResult.getFailures().add(e.getCause()));
+                FunctionUtils.doIfNotNull(e.getCause(), o -> executionResult.getFailures().add(e.getCause()), LOGGER);
             } catch (final Throwable e) {
                 LOGGER.debug(e.getMessage(), e);
                 executionResult.getFailures().add(e);

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/UsernamePasswordCredential.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/credential/UsernamePasswordCredential.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +40,7 @@ import java.util.Objects;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(exclude = "password", callSuper = true)
+@Slf4j
 public class UsernamePasswordCredential extends AbstractCredential implements MutableCredential {
     /**
      * Authentication attribute name for password.
@@ -109,7 +111,7 @@ public class UsernamePasswordCredential extends AbstractCredential implements Mu
      * @return the string
      */
     public String toPassword() {
-        return FunctionUtils.doIfNull(this.password, () -> null, () -> new String(this.password)).get();
+        return FunctionUtils.doIfNull(this.password, () -> null, () -> new String(this.password), LOGGER).get();
     }
 
     /**
@@ -121,7 +123,7 @@ public class UsernamePasswordCredential extends AbstractCredential implements Mu
         FunctionUtils.doIfNotNull(password, p -> {
             this.password = new char[p.length()];
             System.arraycopy(password.toCharArray(), 0, this.password, 0, password.length());
-        }, p -> this.password = ArrayUtils.EMPTY_CHAR_ARRAY);
+        }, p -> this.password = ArrayUtils.EMPTY_CHAR_ARRAY, LOGGER);
     }
 
 

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/support/jaas/AccountsPreDefinedLoginModule.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/support/jaas/AccountsPreDefinedLoginModule.java
@@ -6,6 +6,7 @@ import com.google.common.base.Splitter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
@@ -28,6 +29,7 @@ import java.util.Map;
  * @author Misagh Moayyed
  * @since 5.3.0
  */
+@Slf4j
 public class AccountsPreDefinedLoginModule implements LoginModule {
     private Subject subject;
 
@@ -63,7 +65,7 @@ public class AccountsPreDefinedLoginModule implements LoginModule {
             callbackHandler.handle(new Callback[]{nameCallback, passwordCallback});
         }, throwable -> {
             throw new FailedLoginException(throwable.getMessage());
-        }).accept(nameCallback);
+        }, LOGGER).accept(nameCallback);
 
         val username = nameCallback.getName();
         if (accounts.containsKey(username)) {

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGenerator.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGenerator.java
@@ -115,7 +115,7 @@ public class ShibbolethCompatiblePersistentIdGenerator implements PersistentIdGe
             () -> {
                 LOGGER.debug("Using principal id [{}] to generate persistent identifier", defaultId);
                 return defaultId;
-            }).get();
+            }, LOGGER).get();
     }
 
     @Override

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/authentication/DefaultPrincipalAttributesMapper.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/authentication/DefaultPrincipalAttributesMapper.java
@@ -34,7 +34,7 @@ public class DefaultPrincipalAttributesMapper implements PrincipalAttributesMapp
                 val script = cacheMgr.resolveScriptableResource(file, attributeName, file);
                 return FunctionUtils.doIf(script != null,
                     Unchecked.supplier(() -> fetchAttributeValueFromScript(script, attributeName, resolvedAttributes)),
-                    TreeMap<String, List<Object>>::new).get();
+                    TreeMap<String, List<Object>>::new, LOGGER).get();
             })
             .orElseThrow(() -> new RuntimeException("No groovy script cache manager is available to execute attribute mappings"));
     }

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
@@ -85,7 +85,7 @@ public class ReturnRestfulAttributeReleasePolicy extends BaseMappedAttributeRele
                 });
                 return FunctionUtils.doIf(getAllowedAttributes().isEmpty(),
                         () -> returnedAttributes,
-                        () -> authorizeMappedAttributes(context, returnedAttributes))
+                        () -> authorizeMappedAttributes(context, returnedAttributes), LOGGER)
                     .get();
             }
         } catch (final Exception e) {

--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/bypass/GroovyMultifactorAuthenticationProviderBypassEvaluator.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/bypass/GroovyMultifactorAuthenticationProviderBypassEvaluator.java
@@ -46,7 +46,7 @@ public class GroovyMultifactorAuthenticationProviderBypassEvaluator extends Base
                 principal.getId(), registeredService, provider, watchableScript.getResource());
             val args = new Object[]{authentication, principal, registeredService, provider, LOGGER, request};
             return watchableScript.execute(args, Boolean.class);
-        }, e -> true).get();
+        }, e -> true, LOGGER).get();
 
     }
 }

--- a/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationHandlersConfiguration.java
+++ b/core/cas-server-core-authentication/src/main/java/org/apereo/cas/config/CasCoreAuthenticationHandlersConfiguration.java
@@ -246,10 +246,10 @@ public class CasCoreAuthenticationHandlersConfiguration {
                     h.setRealm(jaas.getRealm());
                     h.setPasswordEncoder(PasswordEncoderUtils.newPasswordEncoder(jaas.getPasswordEncoder(), applicationContext));
 
-                    FunctionUtils.doIfNotBlank(jaas.getLoginConfigType(), __ -> h.setLoginConfigType(jaas.getLoginConfigType()));
+                    FunctionUtils.doIfNotBlank(jaas.getLoginConfigType(), __ -> h.setLoginConfigType(jaas.getLoginConfigType()), LOGGER);
 
                     if (StringUtils.isNotBlank(jaas.getLoginConfigurationFile())) {
-                        val file = FunctionUtils.doAndHandle(() -> ResourceUtils.getResourceFrom(jaas.getLoginConfigurationFile()).getFile());
+                        val file = FunctionUtils.doAndHandle(() -> ResourceUtils.getResourceFrom(jaas.getLoginConfigurationFile()).getFile(), LOGGER);
                         LOGGER.debug("Using JAAS login configuration file [{}] for realm [{}]", file, jaas.getRealm());
                         h.setLoginConfigurationFile(file);
                     }

--- a/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/CasConfigurationPropertiesEnvironmentManager.java
+++ b/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/CasConfigurationPropertiesEnvironmentManager.java
@@ -62,9 +62,9 @@ public record CasConfigurationPropertiesEnvironmentManager(ConfigurationProperti
     public static CompositePropertySource configureEnvironmentPropertySources(final ConfigurableEnvironment environment) {
         val nativePropertySources = new CompositePropertySource("casNativeCompositeSource");
         val propertySources = environment.getPropertySources();
-        FunctionUtils.doIfNotNull(propertySources.get("commandLineArgs"), nativePropertySources::addFirstPropertySource);
-        FunctionUtils.doIfNotNull(propertySources.get("systemProperties"), nativePropertySources::addPropertySource);
-        FunctionUtils.doIfNotNull(propertySources.get("systemEnvironment"), nativePropertySources::addPropertySource);
+        FunctionUtils.doIfNotNull(propertySources.get("commandLineArgs"), nativePropertySources::addFirstPropertySource, LOGGER);
+        FunctionUtils.doIfNotNull(propertySources.get("systemProperties"), nativePropertySources::addPropertySource, LOGGER);
+        FunctionUtils.doIfNotNull(propertySources.get("systemEnvironment"), nativePropertySources::addPropertySource, LOGGER);
         return nativePropertySources;
     }
 }

--- a/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/CasConfigurationPropertiesValidator.java
+++ b/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/CasConfigurationPropertiesValidator.java
@@ -62,7 +62,7 @@ public class CasConfigurationPropertiesValidator {
     }
 
     private List<String> validateCasConfiguration() {
-        return FunctionUtils.doAndHandle(() -> validateConfiguration(CasConfigurationProperties.class));
+        return FunctionUtils.doAndHandle(() -> validateConfiguration(CasConfigurationProperties.class), LOGGER);
     }
 
     private List<String> validateConfiguration(final Class clazz) {

--- a/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
+++ b/core/cas-server-core-configuration-api/src/main/java/org/apereo/cas/configuration/DefaultCasConfigurationPropertiesSourceLocator.java
@@ -80,7 +80,7 @@ public class DefaultCasConfigurationPropertiesSourceLocator implements CasConfig
             }
         } else {
             LOGGER.info("Configuration directory [{}] is not a directory or cannot be found at the specific path",
-                 FunctionUtils.doIfNotNull(config, () -> config, () -> "unspecified").get());
+                 FunctionUtils.doIfNotNull(config, () -> config, () -> "unspecified", LOGGER).get());
         }
 
         val embeddedProperties = loadEmbeddedProperties(resourceLoader, environment);

--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieUtils.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/CookieUtils.java
@@ -12,6 +12,7 @@ import org.apereo.cas.web.cookie.CookieValueManager;
 import org.apereo.cas.web.support.gen.CookieRetrievingCookieGenerator;
 
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
@@ -24,6 +25,7 @@ import jakarta.servlet.http.HttpServletRequest;
  * @since 5.1.0
  */
 @UtilityClass
+@Slf4j
 public class CookieUtils {
 
     /**
@@ -87,7 +89,7 @@ public class CookieUtils {
             return FunctionUtils.doAndHandle(() -> {
                 val state = ticketRegistry.getTicket(cookieValue, TicketGrantingTicket.class);
                 return state == null || state.isExpired() ? null : state;
-            });
+            }, LOGGER);
         }
         return null;
     }

--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
@@ -224,6 +224,6 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator implements 
                 val path = StringUtils.removeEndIgnoreCase(StringUtils.defaultIfBlank(givenPath, DEFAULT_COOKIE_PATH), "/");
                 return StringUtils.defaultIfBlank(path, "/");
             },
-            () -> StringUtils.defaultIfBlank(givenPath, DEFAULT_COOKIE_PATH)).get();
+            () -> StringUtils.defaultIfBlank(givenPath, DEFAULT_COOKIE_PATH), LOGGER).get();
     }
 }

--- a/core/cas-server-core-cookie/src/main/java/org/apereo/cas/config/CasCookieConfiguration.java
+++ b/core/cas-server-core-cookie/src/main/java/org/apereo/cas/config/CasCookieConfiguration.java
@@ -55,7 +55,7 @@ public class CasCookieConfiguration {
             return FunctionUtils.doIf(casProperties.getTgc().getCrypto().isEnabled(),
                 () -> new DefaultCasCookieValueManager(cookieCipherExecutor, geoLocationService,
                     DefaultCookieSameSitePolicy.INSTANCE, casProperties.getTgc()),
-                CookieValueManager::noOp).get();
+                CookieValueManager::noOp, LOGGER).get();
         }
 
         @ConditionalOnMissingBean(name = "cookieCipherExecutor")

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
@@ -53,7 +53,7 @@ public class CasAuthenticationAuthenticationEventListener implements CasAuthenti
             dto.putAgent(clientInfo.getUserAgent());
             val location = determineGeoLocationFor(clientInfo);
             dto.putGeoLocation(location);
-        });
+        }, LOGGER);
         return dto;
     }
 

--- a/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
+++ b/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
@@ -70,14 +70,14 @@ public class DefaultCasConfigurationEventListener implements CasConfigurationEve
                 servlet.setApplicationContext(applicationContext);
                 servlet.init();
             }
-        });
+        }, LOGGER);
     }
 
     private void rebind() {
         LOGGER.info("Refreshing CAS configuration. Stand by...");
         val ctx = FunctionUtils.doIfNotNull(configurationPropertiesEnvironmentManager,
                 () -> configurationPropertiesEnvironmentManager.rebindCasConfigurationProperties(applicationContext),
-                () -> CasConfigurationPropertiesEnvironmentManager.rebindCasConfigurationProperties(binder, applicationContext))
+                () -> CasConfigurationPropertiesEnvironmentManager.rebindCasConfigurationProperties(binder, applicationContext), LOGGER)
             .get();
         Objects.requireNonNull(ctx);
         initializeBeansEagerly();

--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
@@ -4,6 +4,7 @@ import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.web.cookie.CasCookieBuilder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
@@ -30,6 +31,7 @@ import java.util.UUID;
  * @since 5.0.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class ThreadContextMDCServletFilter implements Filter {
 
     private final ObjectProvider<TicketRegistrySupport> ticketRegistrySupport;
@@ -86,11 +88,11 @@ public class ThreadContextMDCServletFilter implements Filter {
             Collections.list(request.getAttributeNames()).forEach(a -> addContextAttribute(a, request.getAttribute(a)));
             val requestHeaderNames = request.getHeaderNames();
             FunctionUtils.doIfNotNull(requestHeaderNames,
-                __ -> Collections.list(requestHeaderNames).forEach(h -> addContextAttribute(h, request.getHeader(h))));
+                __ -> Collections.list(requestHeaderNames).forEach(h -> addContextAttribute(h, request.getHeader(h))), LOGGER);
             val cookieValue = ticketGrantingTicketCookieGenerator.getObject().retrieveCookieValue(request);
             if (StringUtils.isNotBlank(cookieValue)) {
                 val p = ticketRegistrySupport.getObject().getAuthenticatedPrincipalFrom(cookieValue);
-                FunctionUtils.doIfNotNull(p, __ -> addContextAttribute("principal", p.getId()));
+                FunctionUtils.doIfNotNull(p, __ -> addContextAttribute("principal", p.getId()), LOGGER);
             }
             filterChain.doFilter(servletRequest, servletResponse);
         } finally {

--- a/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultLogoutRedirectionStrategy.java
+++ b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultLogoutRedirectionStrategy.java
@@ -41,7 +41,7 @@ public class DefaultLogoutRedirectionStrategy implements LogoutRedirectionStrate
             .or(() -> {
                 val redirectUrl = casProperties.getView().getDefaultRedirectUrl();
                 return FunctionUtils.doIf(StringUtils.isNotBlank(redirectUrl),
-                    () -> Optional.of(serviceFactory.createService(redirectUrl)), Optional::<WebApplicationService>empty).get();
+                    () -> Optional.of(serviceFactory.createService(redirectUrl)), Optional::<WebApplicationService>empty, LOGGER).get();
             })
             .filter(service -> singleLogoutServiceLogoutUrlBuilder.isServiceAuthorized(service, Optional.of(request), Optional.of(response)))
             .ifPresentOrElse(service -> {

--- a/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/AbstractCacheHealthIndicator.java
+++ b/core/cas-server-core-monitor/src/main/java/org/apereo/cas/monitor/AbstractCacheHealthIndicator.java
@@ -5,6 +5,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
  */
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Slf4j
 public abstract class AbstractCacheHealthIndicator extends AbstractHealthIndicator {
 
     private final long evictionThreshold;
@@ -65,7 +67,7 @@ public abstract class AbstractCacheHealthIndicator extends AbstractHealthIndicat
         }, throwable -> {
             builder.down(throwable);
             return builder;
-        }).accept(builder);
+        }, LOGGER).accept(builder);
     }
 
     /**

--- a/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/DefaultCommunicationsManager.java
+++ b/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/DefaultCommunicationsManager.java
@@ -67,7 +67,7 @@ public class DefaultCommunicationsManager implements CommunicationsManager {
         return FunctionUtils.doIf(isMailSenderDefined() && emailRequest.getEmailProperties().isDefined() && !recipients.isEmpty(),
             Unchecked.supplier(() -> emailSender.send(emailRequest)),
             () -> EmailCommunicationResult.builder().success(false)
-                .to(recipients).body(emailRequest.getBody()).build()).get();
+                .to(recipients).body(emailRequest.getBody()).build(), LOGGER).get();
     }
 
     @Override

--- a/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/call/PhoneCallRequest.java
+++ b/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/call/PhoneCallRequest.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.notifications.call;
 
+
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.function.FunctionUtils;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.With;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import java.util.Optional;
@@ -21,6 +23,7 @@ import java.util.Optional;
 @Getter
 @With
 @RequiredArgsConstructor
+@Slf4j
 public class PhoneCallRequest {
     private final Principal principal;
 
@@ -61,7 +64,7 @@ public class PhoneCallRequest {
     public String getRecipient() {
         return FunctionUtils.doIf(hasAttributeValue(),
             () -> getAttributeValue().map(Object::toString).orElseGet(this::getTo),
-            this::getTo).get();
+            this::getTo, LOGGER).get();
     }
 
     /**

--- a/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/mail/DefaultEmailSender.java
+++ b/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/mail/DefaultEmailSender.java
@@ -3,6 +3,7 @@ package org.apereo.cas.notifications.mail;
 import org.apereo.cas.util.function.FunctionUtils;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.context.HierarchicalMessageSource;
@@ -16,6 +17,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;
  * @since 7.0.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class DefaultEmailSender implements EmailSender {
     private final JavaMailSender mailSender;
 
@@ -38,7 +40,7 @@ public class DefaultEmailSender implements EmailSender {
         helper.setSubject(subject);
 
         helper.setFrom(emailRequest.getEmailProperties().getFrom());
-        FunctionUtils.doIfNotBlank(emailRequest.getEmailProperties().getReplyTo(), __ -> helper.setReplyTo(emailRequest.getEmailProperties().getReplyTo()));
+        FunctionUtils.doIfNotBlank(emailRequest.getEmailProperties().getReplyTo(), __ -> helper.setReplyTo(emailRequest.getEmailProperties().getReplyTo()), LOGGER);
         helper.setValidateAddresses(emailRequest.getEmailProperties().isValidateAddresses());
         helper.setPriority(emailRequest.getEmailProperties().getPriority());
         helper.setCc(emailRequest.getEmailProperties().getCc().toArray(ArrayUtils.EMPTY_STRING_ARRAY));

--- a/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/sms/SmsRequest.java
+++ b/core/cas-server-core-notifications-api/src/main/java/org/apereo/cas/notifications/sms/SmsRequest.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.With;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 
@@ -23,6 +24,7 @@ import java.util.Optional;
 @Getter
 @With
 @RequiredArgsConstructor
+@Slf4j
 public class SmsRequest {
     private final Principal principal;
 
@@ -63,7 +65,7 @@ public class SmsRequest {
     public String getRecipient() {
         return FunctionUtils.doIf(hasAttributeValue(),
             () -> getAttributeValue().map(Object::toString).orElseGet(this::getTo),
-            this::getTo).get();
+            this::getTo, LOGGER).get();
     }
 
     /**

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGenerator.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/authentication/principal/ShibbolethCompatiblePersistentIdGenerator.java
@@ -115,7 +115,7 @@ public class ShibbolethCompatiblePersistentIdGenerator implements PersistentIdGe
             () -> {
                 LOGGER.debug("Using principal id [{}] to generate persistent identifier", defaultId);
                 return defaultId;
-            }).get();
+            }, LOGGER).get();
     }
 
     @Override

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/BaseRegisteredServiceUsernameAttributeProvider.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/BaseRegisteredServiceUsernameAttributeProvider.java
@@ -78,11 +78,11 @@ public abstract class BaseRegisteredServiceUsernameAttributeProvider implements 
     }
 
     protected String removePatternFromUsernameIfNecessary(final String username) {
-        return FunctionUtils.doIfNotNull(removePattern, () -> RegExUtils.removePattern(username, removePattern), () -> username).get();
+        return FunctionUtils.doIfNotNull(removePattern, () -> RegExUtils.removePattern(username, removePattern), () -> username, LOGGER).get();
     }
 
     protected String scopeUsernameIfNecessary(final String resolved) {
-        return FunctionUtils.doIfNotNull(scope, () -> String.format("%s@%s", resolved, scope), () -> resolved).get();
+        return FunctionUtils.doIfNotNull(scope, () -> String.format("%s@%s", resolved, scope), () -> resolved, LOGGER).get();
     }
 
     protected String encryptResolvedUsername(final RegisteredServiceUsernameProviderContext context, final String username) {

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/PrincipalAttributeRegisteredServiceUsernameProvider.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/PrincipalAttributeRegisteredServiceUsernameProvider.java
@@ -54,7 +54,7 @@ public class PrincipalAttributeRegisteredServiceUsernameProvider extends BaseReg
 
         FunctionUtils.doIfNull(context.getReleasingAttributes(),
             __ -> releasePolicyAttributes.putAll(getPrincipalAttributesFromReleasePolicy(context)),
-            releasePolicyAttributes::putAll);
+            releasePolicyAttributes::putAll, LOGGER);
 
         LOGGER.debug("Attributes resolved by the release policy available for selection of username attribute [{}] are [{}].",
             usernameAttribute, releasePolicyAttributes);

--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractServiceFactory.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractServiceFactory.java
@@ -110,19 +110,19 @@ public abstract class AbstractServiceFactory<T extends Service> implements Servi
             .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
         attributes.putAll(extractQueryParameters(service));
 
-        FunctionUtils.doIfNotBlank(request.getPathInfo(), value -> collectHttpRequestProperty("pathInfo", value, attributes));
-        FunctionUtils.doIfNotBlank(request.getMethod(), value -> collectHttpRequestProperty("httpMethod", value, attributes));
-        FunctionUtils.doIfNotBlank(request.getRequestURL(), value -> collectHttpRequestProperty("requestURL", value.toString(), attributes));
-        FunctionUtils.doIfNotBlank(request.getRequestURI(), value -> collectHttpRequestProperty("requestURI", value, attributes));
-        FunctionUtils.doIfNotBlank(request.getRequestId(), value -> collectHttpRequestProperty("requestId", value, attributes));
-        FunctionUtils.doIfNotBlank(request.getContentType(), value -> collectHttpRequestProperty("contentType", value, attributes));
-        FunctionUtils.doIfNotBlank(request.getContextPath(), value -> collectHttpRequestProperty("contextPath", value, attributes));
-        FunctionUtils.doIfNotBlank(request.getLocalName(), value -> collectHttpRequestProperty("localeName", value, attributes));
+        FunctionUtils.doIfNotBlank(request.getPathInfo(), value -> collectHttpRequestProperty("pathInfo", value, attributes), LOGGER);
+        FunctionUtils.doIfNotBlank(request.getMethod(), value -> collectHttpRequestProperty("httpMethod", value, attributes), LOGGER);
+        FunctionUtils.doIfNotBlank(request.getRequestURL(), value -> collectHttpRequestProperty("requestURL", value.toString(), attributes), LOGGER);
+        FunctionUtils.doIfNotBlank(request.getRequestURI(), value -> collectHttpRequestProperty("requestURI", value, attributes), LOGGER);
+        FunctionUtils.doIfNotBlank(request.getRequestId(), value -> collectHttpRequestProperty("requestId", value, attributes), LOGGER);
+        FunctionUtils.doIfNotBlank(request.getContentType(), value -> collectHttpRequestProperty("contentType", value, attributes), LOGGER);
+        FunctionUtils.doIfNotBlank(request.getContextPath(), value -> collectHttpRequestProperty("contextPath", value, attributes), LOGGER);
+        FunctionUtils.doIfNotBlank(request.getLocalName(), value -> collectHttpRequestProperty("localeName", value, attributes), LOGGER);
         FunctionUtils.doIfNotNull(request.getCookies(), __ -> Arrays.stream(request.getCookies())
-            .forEach(cookie -> collectHttpRequestProperty("cookie-%s".formatted(cookie.getName()), cookie.getValue(), attributes)));
+            .forEach(cookie -> collectHttpRequestProperty("cookie-%s".formatted(cookie.getName()), cookie.getValue(), attributes)), LOGGER);
         FunctionUtils.doIfNotNull(request.getHeaderNames(), __ -> StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(request.getHeaderNames().asIterator(), Spliterator.ORDERED), false)
-            .forEach(header -> collectHttpRequestProperty("header-%s".formatted(header), request.getHeader(header), attributes)));
+            .forEach(header -> collectHttpRequestProperty("header-%s".formatted(header), request.getHeader(header), attributes)), LOGGER);
 
         LOGGER.trace("Extracted attributes [{}] for service [{}]", attributes, service.getId());
         service.setAttributes(new HashMap(attributes));

--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractWebApplicationServiceResponseBuilder.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractWebApplicationServiceResponseBuilder.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.authentication.principal;
 
+
 import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.services.CasModelRegisteredService;
 import org.apereo.cas.services.ServicesManager;
@@ -11,6 +12,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +31,7 @@ import java.util.Optional;
 @Getter
 @Setter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public abstract class AbstractWebApplicationServiceResponseBuilder implements ResponseBuilder<WebApplicationService> {
     @Serial
     private static final long serialVersionUID = -4584738964007702423L;
@@ -74,7 +77,7 @@ public abstract class AbstractWebApplicationServiceResponseBuilder implements Re
                 val registeredService = servicesManager.findServiceBy(finalService);
                 return registeredService instanceof final CasModelRegisteredService casService ? casService.getResponseType() : null;
             },
-            __ -> methodRequest);
+            __ -> methodRequest, LOGGER);
         val method = func.apply(methodRequest);
         if (StringUtils.isBlank(method) || !EnumUtils.isValidEnum(Response.ResponseType.class, method.toUpperCase(Locale.ENGLISH))) {
             return Response.ResponseType.REDIRECT;

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/replication/DefaultRegisteredServiceReplicationStrategy.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/replication/DefaultRegisteredServiceReplicationStrategy.java
@@ -45,7 +45,7 @@ public class DefaultRegisteredServiceReplicationStrategy implements RegisteredSe
 
     @Override
     public void destroy() {
-        FunctionUtils.doIfNotNull(distributedCacheManager, DistributedCacheManager::close);
+        FunctionUtils.doIfNotNull(distributedCacheManager, DistributedCacheManager::close, LOGGER);
     }
 
     @Override

--- a/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/resource/AbstractResourceBasedServiceRegistry.java
+++ b/core/cas-server-core-services-registry/src/main/java/org/apereo/cas/services/resource/AbstractResourceBasedServiceRegistry.java
@@ -156,7 +156,7 @@ public abstract class AbstractResourceBasedServiceRegistry extends AbstractServi
 
             initializeRegistry(Paths.get(file.getCanonicalPath()), serializers,
                 registeredServiceReplicationStrategy, resourceNamingStrategy, serviceRegistryConfigWatcher);
-        });
+        }, LOGGER);
     }
 
     private Resource prepareRegisteredServicesDirectory(final Resource configDirectory) throws IOException {

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/factory/DefaultServiceTicketFactory.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/factory/DefaultServiceTicketFactory.java
@@ -57,7 +57,7 @@ public class DefaultServiceTicketFactory implements ServiceTicketFactory {
             val encoded = cipherExecutor.encode(ticketId);
             LOGGER.debug("Encoded service ticket id [{}]", encoded);
             return encoded;
-        }, () -> ticketId).get();
+        }, () -> ticketId, LOGGER).get();
         return produceTicket(ticketGrantingTicket, service, credentialProvided, result, clazz);
     }
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistrySupport.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistrySupport.java
@@ -7,6 +7,7 @@ import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.Optional;
  */
 @RequiredArgsConstructor
 @Getter
+@Slf4j
 public class DefaultTicketRegistrySupport implements TicketRegistrySupport {
 
     private final TicketRegistry ticketRegistry;
@@ -52,7 +54,7 @@ public class DefaultTicketRegistrySupport implements TicketRegistrySupport {
         return FunctionUtils.doAndHandle(() -> {
             val state = ticketRegistry.getTicket(ticketId, Ticket.class);
             return state == null || state.isExpired() ? null : state;
-        });
+        }, LOGGER);
     }
 
     @Override

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/util/CoreTicketUtils.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/util/CoreTicketUtils.java
@@ -54,8 +54,8 @@ public class CoreTicketUtils {
                     registry.getEncryption().getKey());
                 return Boolean.TRUE;
             },
-            registry::isEnabled
-        ).get();
+            registry::isEnabled,
+            LOGGER).get();
 
 
         if (enabled || forceIfBlankKeys) {

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsConfiguration.java
@@ -122,7 +122,7 @@ public class CasCoreTicketsConfiguration {
         public TicketTrackingPolicy descendantTicketsTrackingPolicy(
                 final CasConfigurationProperties casProperties) {
             return FunctionUtils.doIf(casProperties.getTicket().isTrackDescendantTickets(),
-                DefaultDescendantTicketsTrackingPolicy::new, TicketTrackingPolicy::noOp).get();
+                DefaultDescendantTicketsTrackingPolicy::new, TicketTrackingPolicy::noOp, LOGGER).get();
         }
 
         @ConditionalOnMissingBean(name = TicketRegistrySupport.BEAN_NAME)
@@ -227,7 +227,7 @@ public class CasCoreTicketsConfiguration {
         public PublisherIdentifier messageQueueTicketRegistryIdentifier(final CasConfigurationProperties casProperties) {
             val bean = new PublisherIdentifier();
             val amqp = casProperties.getTicket().getRegistry().getCore();
-            FunctionUtils.doIfNotBlank(amqp.getQueueIdentifier(), __ -> bean.setId(amqp.getQueueIdentifier()));
+            FunctionUtils.doIfNotBlank(amqp.getQueueIdentifier(), __ -> bean.setId(amqp.getQueueIdentifier()), LOGGER);
             return bean;
         }
 

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
@@ -98,7 +98,7 @@ public class CasCoreTicketsSchedulingConfiguration {
             fixedDelayString = "${cas.ticket.registry.cleaner.schedule.repeat-interval:PT120S}")
         @Override
         public void run() {
-            FunctionUtils.doAndHandle(__ -> ticketRegistryCleaner.clean());
+            FunctionUtils.doAndHandle(__ -> ticketRegistryCleaner.clean(), LOGGER);
         }
     }
 }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CasVersion.java
@@ -3,6 +3,7 @@ package org.apereo.cas.util;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.nativex.CasRuntimeHintsRegistrar;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import java.net.URL;
@@ -18,6 +19,7 @@ import java.util.jar.Manifest;
  * @since 3.0.0
  */
 @UtilityClass
+@Slf4j
 @SuppressWarnings("CatchAndPrintStackTrace")
 public class CasVersion {
     private static final String IMPLEMENTATION_DATE;
@@ -64,6 +66,6 @@ public class CasVersion {
                 val manifest = new Manifest(new URL(manifestPath).openStream());
                 val attributes = manifest.getMainAttributes();
                 return StringUtils.defaultIfBlank(attributes.getValue("Implementation-Date"), ZonedDateTime.now(Clock.systemUTC()).toString());
-            });
+            }, LOGGER);
     }
 }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CompressionUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CompressionUtils.java
@@ -93,7 +93,7 @@ public class CompressionUtils {
             val resultLength = inflater.inflate(xmlMessageBytes);
             inflater.end();
             return new String(xmlMessageBytes, 0, resultLength, StandardCharsets.UTF_8);
-        }, throwable -> null).get();
+        }, throwable -> null, LOGGER).get();
     }
 
     /**

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DateTimeUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/DateTimeUtils.java
@@ -1,8 +1,10 @@
 package org.apereo.cas.util;
 
+
 import org.apereo.cas.util.function.FunctionUtils;
 
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 import java.sql.Timestamp;
@@ -33,6 +35,7 @@ import java.util.concurrent.TimeUnit;
  */
 @SuppressWarnings("JavaUtilDate")
 @UtilityClass
+@Slf4j
 public class DateTimeUtils {
 
     /**
@@ -150,7 +153,7 @@ public class DateTimeUtils {
         val parsers = List.of(DateTimeFormatter.ISO_ZONED_DATE_TIME, DateTimeFormatter.RFC_1123_DATE_TIME);
         return parsers
             .stream()
-            .map(parser -> FunctionUtils.doAndHandle(() -> ZonedDateTime.parse(value, parser), throwable -> null).get())
+            .map(parser -> FunctionUtils.doAndHandle(() -> ZonedDateTime.parse(value, parser), throwable -> null, LOGGER).get())
             .filter(Objects::nonNull)
             .findFirst()
             .orElse(null);

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/InetAddressUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/InetAddressUtils.java
@@ -34,7 +34,7 @@ public class InetAddressUtils {
         }, e -> {
             LOGGER.trace("Host name could not be determined automatically.", e);
             return null;
-        }).get();
+        }, LOGGER).get();
     }
 
 
@@ -51,7 +51,7 @@ public class InetAddressUtils {
                 return hostName.substring(0, index);
             }
             return hostName;
-        }, throwable -> "unknown").get();
+        }, throwable -> "unknown", LOGGER).get();
     }
 
     /**

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/JsonUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/JsonUtils.java
@@ -5,6 +5,7 @@ import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.jooq.lambda.Unchecked;
 import org.springframework.http.MediaType;
@@ -24,6 +25,7 @@ import java.util.Map;
  * @since 4.1
  */
 @UtilityClass
+@Slf4j
 public class JsonUtils {
     private static final ObjectMapper MAPPER = JacksonObjectMapperFactory.builder().build().toObjectMapper();
 
@@ -96,6 +98,6 @@ public class JsonUtils {
      * @return true/false
      */
     public boolean isValidJson(final String json) {
-        return FunctionUtils.doAndHandle(() -> !MAPPER.readTree(json).isEmpty(), t -> false).get();
+        return FunctionUtils.doAndHandle(() -> !MAPPER.readTree(json).isEmpty(), t -> false, LOGGER).get();
     }
 }

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/SystemUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/SystemUtils.java
@@ -2,6 +2,7 @@ package org.apereo.cas.util;
 
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -24,6 +25,7 @@ import java.util.Properties;
  * @since 5.3.0
  */
 @UtilityClass
+@Slf4j
 public class SystemUtils {
     private static final GitProperties GIT_PROPERTIES;
 
@@ -57,15 +59,15 @@ public class SystemUtils {
 
         val info = new LinkedHashMap<String, Object>();
 
-        FunctionUtils.doIfNotNull(CasVersion.getVersion(), t -> info.put("CAS Version", t));
+        FunctionUtils.doIfNotNull(CasVersion.getVersion(), t -> info.put("CAS Version", t), LOGGER);
         info.put("CAS Branch", StringUtils.defaultIfBlank(GIT_PROPERTIES.getBranch(), "master"));
-        FunctionUtils.doIfNotNull(GIT_PROPERTIES.getCommitId(), t -> info.put("CAS Commit Id", t));
-        FunctionUtils.doIfNotNull(CasVersion.getDateTime(), t -> info.put("CAS Build Date/Time", t));
+        FunctionUtils.doIfNotNull(GIT_PROPERTIES.getCommitId(), t -> info.put("CAS Commit Id", t), LOGGER);
+        FunctionUtils.doIfNotNull(CasVersion.getDateTime(), t -> info.put("CAS Build Date/Time", t), LOGGER);
 
         info.put("Spring Boot Version", SpringBootVersion.getVersion());
         info.put("Spring Version", SpringVersion.getVersion());
 
-        FunctionUtils.doIfNotNull(properties.get("java.home"), t -> info.put("Java Home", t));
+        FunctionUtils.doIfNotNull(properties.get("java.home"), t -> info.put("Java Home", t), LOGGER);
         info.put("Java Vendor", properties.get("java.vendor"));
         info.put("Java Version", properties.get("java.version"));
         info.put("Servlet Version", HttpServlet.class.getPackage().getImplementationVersion());

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseStringCipherExecutor.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseStringCipherExecutor.java
@@ -265,7 +265,7 @@ public abstract class BaseStringCipherExecutor extends AbstractCipherExecutor<Se
         val encoded = FunctionUtils.doIf(this.signingEnabled, () -> {
             LOGGER.trace("Attempting to verify signature based on signing key defined by [{}]", getSigningKeySetting());
             return verifySignature(currentValue, signingKey);
-        }, () -> currentValue).get();
+        }, () -> currentValue, LOGGER).get();
         return new String(encoded, StandardCharsets.UTF_8);
     }
 
@@ -274,7 +274,7 @@ public abstract class BaseStringCipherExecutor extends AbstractCipherExecutor<Se
         val encoded = FunctionUtils.doIf(this.signingEnabled, () -> {
             LOGGER.trace("Attempting to verify signature based on signing key defined by [{}]", getSigningKeySetting());
             return verifySignature(currentValue, signingKey);
-        }, () -> currentValue).get();
+        }, () -> currentValue, LOGGER).get();
 
         if (encoded != null && encoded.length > 0) {
             val encodedObj = new String(encoded, StandardCharsets.UTF_8);
@@ -294,7 +294,7 @@ public abstract class BaseStringCipherExecutor extends AbstractCipherExecutor<Se
                 LOGGER.trace("Attempting to encrypt value based on encryption key defined by [{}]", getEncryptionKeySetting());
                 return encryptValueAsJwt(encryptionKey, value);
             },
-            value::toString).get();
+            value::toString, LOGGER).get();
 
         if (this.signingEnabled) {
             LOGGER.trace("Attempting to sign value based on signing key defined by [{}]", getSigningKeySetting());
@@ -311,15 +311,15 @@ public abstract class BaseStringCipherExecutor extends AbstractCipherExecutor<Se
                 val signed = sign(value.toString().getBytes(StandardCharsets.UTF_8), signingKey);
                 return new String(signed, StandardCharsets.UTF_8);
             },
-            value::toString
-        ).get();
+            value::toString,
+            LOGGER).get();
 
         return FunctionUtils.doIf(isEncryptionPossible(encryptionKey),
             () -> {
                 LOGGER.trace("Attempting to encrypt value based on encryption key defined by [{}]", getEncryptionKeySetting());
                 return encryptValueAsJwt(encryptionKey, encoded);
             },
-            () -> encoded).get();
+            () -> encoded, LOGGER).get();
     }
 
     /**

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/concurrent/CasReentrantLock.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/concurrent/CasReentrantLock.java
@@ -39,7 +39,7 @@ public class CasReentrantLock {
     public boolean tryLock() {
         return FunctionUtils.doAndHandle(
             () -> lock.tryLock(LOCK_TIMEOUT_SECONDS, TimeUnit.SECONDS),
-            e -> false).get();
+            e -> false, LOGGER).get();
     }
 
     /**

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/http/HttpUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/http/HttpUtils.java
@@ -114,7 +114,7 @@ public class HttpUtils {
      */
     public void close(final HttpResponse response) {
         if (response instanceof final CloseableHttpResponse closeableHttpResponse) {
-            FunctionUtils.doAndHandle(__ -> closeableHttpResponse.close());
+            FunctionUtils.doAndHandle(__ -> closeableHttpResponse.close(), LOGGER);
         }
     }
 

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/jwt/JsonWebTokenEncryptor.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/jwt/JsonWebTokenEncryptor.java
@@ -74,7 +74,7 @@ public class JsonWebTokenEncryptor {
                 jwe.setKeyIdHeaderValue(idk.getId());
                 jwe.setKey(idk.getKey());
             } else {
-                FunctionUtils.doIfNotNull(this.keyId, jwe::setKeyIdHeaderValue);
+                FunctionUtils.doIfNotNull(this.keyId, jwe::setKeyIdHeaderValue, LOGGER);
                 jwe.setKey(this.key);
             }
             headers.forEach((k, v) -> jwe.setHeader(k, v.toString()));

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/jwt/JsonWebTokenSigner.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/jwt/JsonWebTokenSigner.java
@@ -94,7 +94,7 @@ public class JsonWebTokenSigner {
             jws.setKeyIdHeaderValue(idk.getId());
         } else {
             jws.setKey(key);
-            FunctionUtils.doIfNotNull(this.keyId, jws::setKeyIdHeaderValue);
+            FunctionUtils.doIfNotNull(this.keyId, jws::setKeyIdHeaderValue, LOGGER);
         }
         headers.forEach((header, value) -> jws.setHeader(header, value.toString()));
         LOGGER.trace("Signing id token with key id header value [{}] and algorithm header value [{}]",

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/scripting/ScriptingUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/scripting/ScriptingUtils.java
@@ -295,7 +295,7 @@ public class ScriptingUtils {
             val shell = new GroovyShell();
             LOGGER.debug("Parsing groovy script [{}]", script);
             return shell.parse(script);
-        });
+        }, LOGGER);
     }
 
     /**

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/AbstractJacksonBackedStringSerializer.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/AbstractJacksonBackedStringSerializer.java
@@ -70,7 +70,7 @@ public abstract class AbstractJacksonBackedStringSerializer<T> implements String
                 ? JsonValue.readHjson(json).toString()
                 : String.join("\n", IOUtils.readLines(json));
             return readObjectFromString(data);
-        }, throwable -> null).get();
+        }, throwable -> null, LOGGER).get();
     }
 
     @Override
@@ -78,7 +78,7 @@ public abstract class AbstractJacksonBackedStringSerializer<T> implements String
         return FunctionUtils.doAndHandle(() -> {
             val jsonString = readJsonFrom(json);
             return readObjectFromString(jsonString);
-        }, throwable -> null).get();
+        }, throwable -> null, LOGGER).get();
     }
 
     @Override
@@ -88,7 +88,7 @@ public abstract class AbstractJacksonBackedStringSerializer<T> implements String
                 ? JsonValue.readHjson(FileUtils.readFileToString(json, StandardCharsets.UTF_8)).toString()
                 : FileUtils.readFileToString(json, StandardCharsets.UTF_8);
             return readObjectFromString(data);
-        }, throwable -> null).get();
+        }, throwable -> null, LOGGER).get();
     }
 
     @Override

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/ApplicationContextProvider.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/ApplicationContextProvider.java
@@ -6,6 +6,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.scripting.ExecutableCompiledGroovyScript;
 import org.apereo.cas.util.scripting.ScriptResourceCacheManager;
 import org.apereo.cas.util.text.MessageSanitizer;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
 import org.springframework.context.ApplicationContext;
@@ -24,6 +25,7 @@ import java.util.Optional;
  * @author Misagh Moayyed
  * @since 3.0.0.
  */
+@Slf4j
 public class ApplicationContextProvider implements ApplicationContextAware {
     private static ApplicationContext APPLICATION_CONTEXT;
 
@@ -168,6 +170,6 @@ public class ApplicationContextProvider implements ApplicationContextAware {
                 return Optional.of(applicationContext.getBean(name, clazz));
             }
             return Optional.<T>empty();
-        }, e -> Optional.<T>empty()).get();
+        }, e -> Optional.<T>empty(), LOGGER).get();
     }
 }

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/function/FunctionUtilsTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/function/FunctionUtilsTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.util.function;
 
 import com.google.common.base.Suppliers;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.jooq.lambda.fi.util.function.CheckedFunction;
 import org.junit.jupiter.api.Tag;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 6.2.0
  */
 @Tag("Utility")
+@Slf4j
 class FunctionUtilsTests {
 
     @Test
@@ -36,7 +38,7 @@ class FunctionUtilsTests {
         assertFalse(FunctionUtils.doIf(input -> {
                 throw new IllegalArgumentException();
             },
-            Suppliers.ofInstance(Boolean.TRUE), Suppliers.ofInstance(Boolean.FALSE)).apply(Void.class));
+            Suppliers.ofInstance(Boolean.TRUE), Suppliers.ofInstance(Boolean.FALSE), LOGGER).apply(Void.class));
     }
 
     @Test
@@ -48,7 +50,7 @@ class FunctionUtilsTests {
             }
         };
         assertFalse(FunctionUtils.doIf(true,
-            trueFunction, Suppliers.ofInstance(Boolean.FALSE)).get());
+            trueFunction, Suppliers.ofInstance(Boolean.FALSE), LOGGER).get());
     }
 
     @Test
@@ -59,19 +61,19 @@ class FunctionUtilsTests {
             t -> null,
             (CheckedFunction<Object, Boolean>) t -> {
                 throw new IllegalArgumentException();
-            }).apply(Void.class));
+            }, LOGGER).apply(Void.class));
     }
 
     @Test
     void verifyDoIfNull() throws Throwable {
         var supplier = FunctionUtils.doIfNotNull(new Object(), () -> {
             throw new IllegalArgumentException();
-        }, Suppliers.ofInstance(Boolean.FALSE));
+        }, Suppliers.ofInstance(Boolean.FALSE), LOGGER);
         assertFalse(supplier.get());
 
-        supplier = FunctionUtils.doIfNotNull(null, () -> Boolean.TRUE, Suppliers.ofInstance(Boolean.FALSE));
+        supplier = FunctionUtils.doIfNotNull(null, () -> Boolean.TRUE, Suppliers.ofInstance(Boolean.FALSE), LOGGER);
         assertFalse(supplier.get());
-        supplier = FunctionUtils.doIfNotNull(new Object(), () -> Boolean.TRUE, Suppliers.ofInstance(Boolean.FALSE));
+        supplier = FunctionUtils.doIfNotNull(new Object(), () -> Boolean.TRUE, Suppliers.ofInstance(Boolean.FALSE), LOGGER);
         assertTrue(supplier.get());
     }
 
@@ -79,21 +81,21 @@ class FunctionUtilsTests {
     void verifyDoIfNull1() throws Throwable {
         assertDoesNotThrow(() -> FunctionUtils.doIfNotNull(Boolean.TRUE, result -> {
             throw new IllegalArgumentException();
-        }));
+        }, LOGGER));
         val supplier = FunctionUtils.doIfNull(null, () -> {
             throw new IllegalArgumentException();
-        }, Suppliers.ofInstance(Boolean.FALSE));
+        }, Suppliers.ofInstance(Boolean.FALSE), LOGGER);
         assertFalse(supplier.get());
         assertDoesNotThrow(() -> FunctionUtils.doIfNotNull(null, __ -> {
             throw new IllegalArgumentException();
-        }));
+        }, LOGGER));
     }
 
     @Test
     void verifyDoIfNull2() throws Throwable {
         assertTrue(FunctionUtils.doIfNull(new Object(), () -> {
             throw new IllegalArgumentException();
-        }, Suppliers.ofInstance(Boolean.TRUE)).get());
+        }, Suppliers.ofInstance(Boolean.TRUE), LOGGER).get());
     }
 
     @Test
@@ -103,11 +105,11 @@ class FunctionUtilsTests {
                 throw new IllegalArgumentException();
             }, o -> {
                 throw new IllegalArgumentException();
-            }).apply(Void.class));
+            }, LOGGER).apply(Void.class));
 
         assertFalse(FunctionUtils.doAndHandle((CheckedFunction<Object, Boolean>) o -> {
             throw new IllegalArgumentException();
-        }, o -> false).apply(Void.class));
+        }, o -> false, LOGGER).apply(Void.class));
     }
 
     @Test
@@ -117,12 +119,12 @@ class FunctionUtilsTests {
                 throw new IllegalArgumentException();
             }, o -> {
                 throw new IllegalArgumentException();
-            });
+            }, LOGGER);
         assertThrows(IllegalArgumentException.class, supplier::get);
         supplier = FunctionUtils.doAndHandle(
             () -> {
                 throw new IllegalArgumentException();
-            }, o -> false);
+            }, o -> false, LOGGER);
         assertFalse((Boolean) supplier.get());
     }
 
@@ -130,7 +132,7 @@ class FunctionUtilsTests {
     void verifyDoWithoutThrows() throws Throwable {
         val supplier = FunctionUtils.doWithoutThrows(o -> {
             throw new IllegalArgumentException();
-        });
+        }, LOGGER);
         assertFalse(supplier);
     }
 }

--- a/core/cas-server-core-util/src/main/java/org/apereo/cas/nativex/CasCoreUtilRuntimeHints.java
+++ b/core/cas-server-core-util/src/main/java/org/apereo/cas/nativex/CasCoreUtilRuntimeHints.java
@@ -9,6 +9,7 @@ import org.apereo.cas.util.nativex.CasRuntimeHintsRegistrar;
 import org.apereo.cas.util.serialization.ComponentSerializationPlanConfigurer;
 import org.apereo.cas.util.thread.Cleanable;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ClassUtils;
 import org.springframework.aot.hint.MemberCategory;
@@ -81,6 +82,7 @@ import java.util.stream.IntStream;
  * @author Misagh Moayyed
  * @since 7.0.0
  */
+@Slf4j
 public class CasCoreUtilRuntimeHints implements CasRuntimeHintsRegistrar {
     private static final int GROOVY_DGM_CLASS_COUNTER = 1500;
 
@@ -215,7 +217,7 @@ public class CasCoreUtilRuntimeHints implements CasRuntimeHintsRegistrar {
             val clazz = ClassUtils.getClass("nonapi.io.github.classgraph.classloaderhandler.ClassLoaderHandler", false);
             registerReflectionHintForAll(hints,
                 findSubclassesInPackage(clazz, "nonapi.io.github.classgraph.classloaderhandler"));
-        });
+        }, LOGGER);
 
         registerReflectionHintForAll(hints,
             List.of(
@@ -245,7 +247,7 @@ public class CasCoreUtilRuntimeHints implements CasRuntimeHintsRegistrar {
             clazz = ClassUtils.getClass("com.github.benmanes.caffeine.cache.LocalCache", false);
             registerReflectionHintForConstructors(hints,
                 findSubclassesInPackage(clazz, "com.github.benmanes.caffeine.cache"));
-        });
+        }, LOGGER);
     }
 
     private static void registerSerializationHints(final RuntimeHints hints) {

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/view/AbstractDelegatingCasView.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/services/web/view/AbstractDelegatingCasView.java
@@ -67,7 +67,7 @@ public abstract class AbstractDelegatingCasView extends AbstractCasView {
                 LOGGER.debug(message);
                 responseWrapper.copyBodyToResponse();
             }
-        });
+        }, LOGGER);
     }
 
     /**

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/FetchTicketGrantingTicketAction.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/actions/FetchTicketGrantingTicketAction.java
@@ -34,7 +34,7 @@ public class FetchTicketGrantingTicketAction extends BaseCasWebflowAction {
         Optional.ofNullable(cookieResult).ifPresent(cookie -> {
             LOGGER.debug("Attempting to locate ticket-granting ticket from cookie value [{}]", cookie);
             val ticket = FunctionUtils.doAndHandle(
-                () -> ticketRegistry.getTicket(cookie, TicketGrantingTicket.class), throwable -> null).get();
+                () -> ticketRegistry.getTicket(cookie, TicketGrantingTicket.class), throwable -> null, LOGGER).get();
             if (ticket != null) {
                 LOGGER.debug("Found ticket-granting ticket [{}]", ticket.getId());
                 WebUtils.putTicketGrantingTicket(requestContext, ticket);

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/configurer/AbstractCasWebflowConfigurer.java
@@ -140,7 +140,7 @@ public abstract class AbstractCasWebflowConfigurer implements CasWebflowConfigur
             } else {
                 LOGGER.info("Webflow auto-configuration is disabled for [{}]", getClass().getName());
             }
-        }, throwable -> null).accept(this);
+        }, throwable -> null, LOGGER).accept(this);
     }
 
     @Override

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/AbstractCasWebflowEventResolver.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/AbstractCasWebflowEventResolver.java
@@ -65,7 +65,7 @@ public abstract class AbstractCasWebflowEventResolver implements CasWebflowEvent
         val targetState = WebUtils.getTargetTransition(context);
         return FunctionUtils.doIf(StringUtils.isNotBlank(targetState) && event.getId().equals(CasWebflowConstants.TRANSITION_ID_SUCCESS),
                 () -> new EventFactorySupport().event(this, targetState),
-                () -> event)
+                () -> event, LOGGER)
             .get();
     }
 

--- a/support/cas-server-support-account-mgmt-core/src/main/java/org/apereo/cas/acct/provision/RestfulAccountRegistrationProvisioner.java
+++ b/support/cas-server-support-account-mgmt-core/src/main/java/org/apereo/cas/acct/provision/RestfulAccountRegistrationProvisioner.java
@@ -11,6 +11,7 @@ import org.apereo.cas.util.http.HttpUtils;
 import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @since 6.5.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class RestfulAccountRegistrationProvisioner implements AccountRegistrationProvisioner {
     private static final ObjectMapper MAPPER = JacksonObjectMapperFactory.builder()
         .defaultTypingEnabled(true)
@@ -47,7 +49,7 @@ public class RestfulAccountRegistrationProvisioner implements AccountRegistratio
             response.set(executeRequest(request));
             return FunctionUtils.doIfNull(response.get(),
                     AccountRegistrationResponse::new,
-                    () -> buildAccountRegistrationResponse(response.get()))
+                    () -> buildAccountRegistrationResponse(response.get()), LOGGER)
                 .get();
         } finally {
             HttpUtils.close(response.get());

--- a/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/logout/LogoutAction.java
+++ b/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/logout/LogoutAction.java
@@ -45,7 +45,7 @@ public class LogoutAction extends AbstractLogoutAction {
                 () -> Objects.requireNonNull(logoutRequests)
                     .stream()
                     .anyMatch(logoutRequest -> logoutRequest.getStatus() == LogoutRequestStatus.NOT_ATTEMPTED),
-                () -> Boolean.FALSE)
+                () -> Boolean.FALSE, LOGGER)
             .get();
 
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);

--- a/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/logout/LogoutViewSetupAction.java
+++ b/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/logout/LogoutViewSetupAction.java
@@ -10,6 +10,7 @@ import org.apereo.cas.web.cookie.CasCookieBuilder;
 import org.apereo.cas.web.support.ArgumentExtractor;
 import org.apereo.cas.web.support.WebUtils;
 import org.apereo.cas.web.view.DynamicHtmlView;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
@@ -20,6 +21,7 @@ import org.springframework.webflow.execution.RequestContext;
  * @author Misagh Moayyed
  * @since 5.3.0
  */
+@Slf4j
 public class LogoutViewSetupAction extends AbstractLogoutAction {
 
     /**
@@ -49,8 +51,8 @@ public class LogoutViewSetupAction extends AbstractLogoutAction {
         val continuation = (SingleLogoutContinuation) request.getAttribute(SingleLogoutContinuation.class.getName());
         FunctionUtils.doIfNotNull(continuation, __ -> {
             context.getFlowScope().put(FLOW_SCOPE_ATTRIBUTE_PROCEED, Boolean.TRUE);
-            FunctionUtils.doIfNotBlank(continuation.getContent(), cnt -> context.getFlowScope().put(DynamicHtmlView.class.getName(), cnt));
-        });
+            FunctionUtils.doIfNotBlank(continuation.getContent(), cnt -> context.getFlowScope().put(DynamicHtmlView.class.getName(), cnt), LOGGER);
+        }, LOGGER);
         return null;
     }
 }

--- a/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/logout/TerminateSessionAction.java
+++ b/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/logout/TerminateSessionAction.java
@@ -91,7 +91,7 @@ public class TerminateSessionAction extends BaseCasWebflowAction {
     protected Event doExecuteInternal(final RequestContext requestContext) throws Exception {
         val terminateSession = FunctionUtils.doIf(logoutProperties.isConfirmLogout(),
                 () -> isLogoutRequestConfirmed(requestContext),
-                () -> Boolean.TRUE)
+                () -> Boolean.TRUE, LOGGER)
             .get();
 
         if (terminateSession) {
@@ -153,7 +153,7 @@ public class TerminateSessionAction extends BaseCasWebflowAction {
             .toList();
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
         val session = request.getSession(false);
-        FunctionUtils.doIfNotNull(session, HttpSession::invalidate);
+        FunctionUtils.doIfNotNull(session, HttpSession::invalidate, LOGGER);
         terminationHandlers.forEach(processor -> processor.afterSessionTermination(terminationResults, requestContext));
     }
 

--- a/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/config/CasJdbcAuditConfiguration.java
+++ b/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/config/CasJdbcAuditConfiguration.java
@@ -16,6 +16,7 @@ import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 import org.apereo.cas.util.thread.Cleanable;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.inspektr.audit.AuditTrailManager;
@@ -58,6 +59,7 @@ import javax.sql.DataSource;
 @EnableTransactionManagement(proxyTargetClass = false)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Audit, module = "jdbc")
 @AutoConfiguration
+@Slf4j
 public class CasJdbcAuditConfiguration {
     private static final BeanCondition CONDITION = BeanCondition.on("cas.audit.jdbc.url").evenIfMissing();
 
@@ -174,9 +176,9 @@ public class CasJdbcAuditConfiguration {
                     manager.setAsynchronous(jdbc.isAsynchronous());
                     manager.setColumnLength(jdbc.getColumnLength());
                     manager.setTableName(getAuditTableNameFrom(jdbc));
-                    FunctionUtils.doIfNotBlank(jdbc.getSelectSqlQueryTemplate(), manager::setSelectByDateSqlTemplate);
-                    FunctionUtils.doIfNotBlank(jdbc.getDateFormatterPattern(), manager::setDateFormatterPattern);
-                    FunctionUtils.doIfNotBlank(jdbc.getDateFormatterFunction(), manager::setDateFormatterFunction);
+                    FunctionUtils.doIfNotBlank(jdbc.getSelectSqlQueryTemplate(), manager::setSelectByDateSqlTemplate, LOGGER);
+                    FunctionUtils.doIfNotBlank(jdbc.getDateFormatterPattern(), manager::setDateFormatterPattern, LOGGER);
+                    FunctionUtils.doIfNotBlank(jdbc.getDateFormatterFunction(), manager::setDateFormatterFunction, LOGGER);
                     return manager;
                 })
                 .otherwiseProxy()

--- a/support/cas-server-support-aup-rest/src/main/java/org/apereo/cas/aup/RestAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-rest/src/main/java/org/apereo/cas/aup/RestAcceptableUsagePolicyRepository.java
@@ -62,7 +62,7 @@ public class RestAcceptableUsagePolicyRepository extends BaseAcceptableUsagePoli
                 "username", principal.getId(),
                 "locale", request.getLocale().toString());
             val service = WebUtils.getService(requestContext);
-            FunctionUtils.doIfNotNull(service, __ -> parameters.put("service", service.getId()));
+            FunctionUtils.doIfNotNull(service, __ -> parameters.put("service", service.getId()), LOGGER);
             LOGGER.debug("Sending AUP acceptance payload [{}] to [{}]", rest.getUrl(), parameters);
             val exec = HttpExecutionRequest.builder()
                 .basicAuthPassword(rest.getBasicAuthPassword())
@@ -130,7 +130,7 @@ public class RestAcceptableUsagePolicyRepository extends BaseAcceptableUsagePoli
                     "username", principal.getId(),
                     "locale", request.getLocale().toString());
                 val service = WebUtils.getService(requestContext);
-                FunctionUtils.doIfNotNull(service, __ -> parameters.put("service", service.getId()));
+                FunctionUtils.doIfNotNull(service, __ -> parameters.put("service", service.getId()), LOGGER);
 
                 val exec = HttpExecutionRequest.builder()
                     .basicAuthPassword(rest.getBasicAuthPassword())

--- a/support/cas-server-support-aws/src/main/java/org/apereo/cas/aws/authz/AmazonVerifiedPermissionsRegisteredServiceAccessStrategy.java
+++ b/support/cas-server-support-aws/src/main/java/org/apereo/cas/aws/authz/AmazonVerifiedPermissionsRegisteredServiceAccessStrategy.java
@@ -97,7 +97,7 @@ public class AmazonVerifiedPermissionsRegisteredServiceAccessStrategy extends Ba
                 LOGGER.debug("Authorization response [{}], evaluated policies [{}]",
                     authorizedResponse.decisionAsString(), authorizedResponse.determiningPolicies());
                 return authorizedResponse.decision() == Decision.ALLOW;
-            }, e -> false).get();
+            }, e -> false, LOGGER).get();
         }
     }
 

--- a/support/cas-server-support-azuread-authentication/src/main/java/org/apereo/cas/config/AzureActiveDirectoryAuthenticationConfiguration.java
+++ b/support/cas-server-support-azuread-authentication/src/main/java/org/apereo/cas/config/AzureActiveDirectoryAuthenticationConfiguration.java
@@ -18,6 +18,7 @@ import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolver;
 import org.apereo.cas.util.spring.beans.BeanCondition;
 import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.services.persondir.IPersonAttributeDao;
@@ -43,6 +44,7 @@ import java.util.List;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Authentication, module = "azuread")
 @AutoConfiguration
+@Slf4j
 public class AzureActiveDirectoryAuthenticationConfiguration {
 
     @Configuration(value = "AzureActiveDirectoryAttributeConfiguration", proxyBeanMethods = false)
@@ -59,14 +61,14 @@ public class AzureActiveDirectoryAuthenticationConfiguration {
                 .filter(msft -> StringUtils.isNotBlank(msft.getClientId()) && StringUtils.isNotBlank(msft.getClientSecret()))
                 .forEach(msft -> {
                     val dao = new MicrosoftGraphPersonAttributeDao();
-                    FunctionUtils.doIfNotNull(msft.getId(), id -> dao.setId(id));
-                    FunctionUtils.doIfNotNull(msft.getApiBaseUrl(), dao::setApiBaseUrl);
-                    FunctionUtils.doIfNotNull(msft.getGrantType(), dao::setGrantType);
-                    FunctionUtils.doIfNotNull(msft.getLoginBaseUrl(), dao::setLoginBaseUrl);
-                    FunctionUtils.doIfNotNull(msft.getLoggingLevel(), dao::setLoggingLevel);
-                    FunctionUtils.doIfNotNull(msft.getAttributes(), dao::setProperties);
-                    FunctionUtils.doIfNotNull(msft.getResource(), dao::setResource);
-                    FunctionUtils.doIfNotNull(msft.getScope(), dao::setScope);
+                    FunctionUtils.doIfNotNull(msft.getId(), id -> dao.setId(id), LOGGER);
+                    FunctionUtils.doIfNotNull(msft.getApiBaseUrl(), dao::setApiBaseUrl, LOGGER);
+                    FunctionUtils.doIfNotNull(msft.getGrantType(), dao::setGrantType, LOGGER);
+                    FunctionUtils.doIfNotNull(msft.getLoginBaseUrl(), dao::setLoginBaseUrl, LOGGER);
+                    FunctionUtils.doIfNotNull(msft.getLoggingLevel(), dao::setLoggingLevel, LOGGER);
+                    FunctionUtils.doIfNotNull(msft.getAttributes(), dao::setProperties, LOGGER);
+                    FunctionUtils.doIfNotNull(msft.getResource(), dao::setResource, LOGGER);
+                    FunctionUtils.doIfNotNull(msft.getScope(), dao::setScope, LOGGER);
 
                     dao.setTenant(resolver.resolve(msft.getTenant()));
                     dao.setDomain(resolver.resolve(msft.getDomain()));

--- a/support/cas-server-support-basic/src/main/java/org/apereo/cas/web/flow/BasicAuthenticationAction.java
+++ b/support/cas-server-support-basic/src/main/java/org/apereo/cas/web/flow/BasicAuthenticationAction.java
@@ -36,6 +36,6 @@ public class BasicAuthenticationAction extends AbstractNonInteractiveCredentials
         return FunctionUtils.doIfNotNull(token, () -> {
             LOGGER.debug("Received basic authentication request from credentials [{}]", token.getPrincipal());
             return new UsernamePasswordCredential(token.getPrincipal().toString(), token.getCredentials().toString());
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-bucket4j-core/src/main/java/org/apereo/cas/bucket4j/consumer/DefaultBucketConsumer.java
+++ b/support/cas-server-support-bucket4j-core/src/main/java/org/apereo/cas/bucket4j/consumer/DefaultBucketConsumer.java
@@ -48,7 +48,7 @@ public class DefaultBucketConsumer implements BucketConsumer {
                 LoggingUtils.error(LOGGER, e);
                 Thread.currentThread().interrupt();
                 return false;
-            }).get();
+            }, LOGGER).get();
 
             val headers = new LinkedHashMap<String, String>();
             val availableTokens = bucket.getAvailableTokens();

--- a/support/cas-server-support-configuration-cloud-gcp-secretsmanager/src/main/java/org/apereo/cas/config/GoogleCloudSecretsManagerCloudConfigBootstrapConfiguration.java
+++ b/support/cas-server-support-configuration-cloud-gcp-secretsmanager/src/main/java/org/apereo/cas/config/GoogleCloudSecretsManagerCloudConfigBootstrapConfiguration.java
@@ -68,7 +68,7 @@ public class GoogleCloudSecretsManagerCloudConfigBootstrapConfiguration {
             return new SecretManagerPropertySource(getClass().getSimpleName(), googleCloudSecretsManagerTemplate, projectIdProvider) {
                 @Override
                 public Object getProperty(final String name) {
-                    var propertyValue = FunctionUtils.doAndHandle(() -> super.getProperty(name), e -> null).get();
+                    var propertyValue = FunctionUtils.doAndHandle(() -> super.getProperty(name), e -> null, LOGGER).get();
                     return Optional.ofNullable(propertyValue)
                         .map(ByteString.class::cast)
                         .map(ByteString::toStringUtf8)

--- a/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/DefaultConsentEngine.java
+++ b/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/DefaultConsentEngine.java
@@ -75,7 +75,7 @@ public class DefaultConsentEngine implements ConsentEngine {
         val decisionFound = findConsentDecision(service, registeredService, authentication);
         val supplier = FunctionUtils.doIfNull(decisionFound,
             () -> consentDecisionBuilder.build(service, registeredService, principalId, attributes),
-            () -> consentDecisionBuilder.update(decisionFound, attributes));
+            () -> consentDecisionBuilder.update(decisionFound, attributes), LOGGER);
 
         val decision = supplier.get();
         decision.setOptions(options);

--- a/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/JsonConsentRepository.java
+++ b/support/cas-server-support-consent-core/src/main/java/org/apereo/cas/consent/JsonConsentRepository.java
@@ -9,6 +9,7 @@ import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.hjson.JsonValue;
 import org.jooq.lambda.Unchecked;
@@ -30,6 +31,7 @@ import java.util.Set;
  * @since 5.2.0
  */
 @Getter
+@Slf4j
 public class JsonConsentRepository extends BaseConsentRepository implements DisposableBean {
     @Serial
     private static final long serialVersionUID = -402728417464783825L;
@@ -53,7 +55,7 @@ public class JsonConsentRepository extends BaseConsentRepository implements Disp
 
     @Override
     public void destroy() {
-        FunctionUtils.doIfNotNull(watcherService, WatcherService::close);
+        FunctionUtils.doIfNotNull(watcherService, WatcherService::close, LOGGER);
     }
 
     @Override
@@ -93,7 +95,7 @@ public class JsonConsentRepository extends BaseConsentRepository implements Disp
                 }
             }
             return new LinkedHashSet<>(0);
-        }, throwable -> new LinkedHashSet<>(0)).get();
+        }, throwable -> new LinkedHashSet<>(0), LOGGER).get();
     }
 
     private void writeAccountToJsonResource() {

--- a/support/cas-server-support-consent-ldap/src/main/java/org/apereo/cas/consent/LdapConsentRepository.java
+++ b/support/cas-server-support-consent-ldap/src/main/java/org/apereo/cas/consent/LdapConsentRepository.java
@@ -53,7 +53,7 @@ public class LdapConsentRepository implements ConsentRepository, DisposableBean 
         return FunctionUtils.doAndHandle(() -> {
             LOGGER.trace("Mapping JSON value [{}] to consent object", json);
             return MAPPER.readValue(JsonValue.readHjson(json).toString(), ConsentDecision.class);
-        }, throwable -> null).get();
+        }, throwable -> null, LOGGER).get();
     }
 
     private static String mapToJson(final ConsentDecision consent) throws Exception {

--- a/support/cas-server-support-discovery-profile-core/src/main/java/org/apereo/cas/discovery/DefaultCasServerProfileRegistrar.java
+++ b/support/cas-server-support-discovery-profile-core/src/main/java/org/apereo/cas/discovery/DefaultCasServerProfileRegistrar.java
@@ -14,6 +14,7 @@ import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.util.ReflectionUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.context.ApplicationContext;
 import java.lang.reflect.Modifier;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
  * @since 5.2.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class DefaultCasServerProfileRegistrar implements CasServerProfileRegistrar {
     protected final CasConfigurationProperties casProperties;
     protected final Set<String> availableAttributes;
@@ -44,7 +46,7 @@ public class DefaultCasServerProfileRegistrar implements CasServerProfileRegistr
             .map(type -> FunctionUtils.doAndHandle(() -> {
                 val service = (RegisteredService) type.getDeclaredConstructor().newInstance();
                 return service.getFriendlyName() + '@' + service.getClass().getName();
-            }))
+            }, LOGGER))
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
     }

--- a/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/authn/DefaultDuoSecurityAdminApiService.java
+++ b/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/authn/DefaultDuoSecurityAdminApiService.java
@@ -14,6 +14,7 @@ import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolver;
 import com.duosecurity.client.Http;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import okhttp3.OkHttpClient;
 import org.apache.commons.lang3.StringUtils;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
  */
 @EqualsAndHashCode
 @RequiredArgsConstructor
+@Slf4j
 public class DefaultDuoSecurityAdminApiService implements DuoSecurityAdminApiService {
     private static final long TIMEOUT_SECONDS = 60;
 
@@ -56,16 +58,16 @@ public class DefaultDuoSecurityAdminApiService implements DuoSecurityAdminApiSer
     private static DuoSecurityUserAccount mapDuoSecurityUserAccount(final JSONObject userJson) throws JSONException {
         val user = new DuoSecurityUserAccount(userJson.getString("username"));
         user.setStatus(DuoSecurityUserAccountStatus.from(userJson.getString("status")));
-        FunctionUtils.doIfNotNull(userJson.get("email"), value -> user.addAttribute("email", value.toString()));
-        FunctionUtils.doIfNotNull(userJson.getString("user_id"), value -> user.addAttribute("user_id", value));
-        FunctionUtils.doIfNotNull(userJson.get("firstname"), value -> user.addAttribute("firstname", value.toString()));
-        FunctionUtils.doIfNotNull(userJson.get("lastname"), value -> user.addAttribute("lastname", value.toString()));
-        FunctionUtils.doIfNotNull(userJson.get("realname"), value -> user.addAttribute("realname", value.toString()));
-        FunctionUtils.doIfNotNull(userJson.getBoolean("is_enrolled"), value -> user.addAttribute("is_enrolled", value.toString()));
-        FunctionUtils.doIfNotNull(userJson.getLong("last_login"), value -> user.addAttribute("last_login", value.toString()));
-        FunctionUtils.doIfNotNull(userJson.getLong("created"), value -> user.addAttribute("created", value.toString()));
-        FunctionUtils.doIfNotNull(userJson.optString("alias1"), value -> user.addAttribute("alias1", value));
-        FunctionUtils.doIfNotNull(userJson.optString("alias2"), value -> user.addAttribute("alias2", value));
+        FunctionUtils.doIfNotNull(userJson.get("email"), value -> user.addAttribute("email", value.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.getString("user_id"), value -> user.addAttribute("user_id", value), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.get("firstname"), value -> user.addAttribute("firstname", value.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.get("lastname"), value -> user.addAttribute("lastname", value.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.get("realname"), value -> user.addAttribute("realname", value.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.getBoolean("is_enrolled"), value -> user.addAttribute("is_enrolled", value.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.getLong("last_login"), value -> user.addAttribute("last_login", value.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.getLong("created"), value -> user.addAttribute("created", value.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.optString("alias1"), value -> user.addAttribute("alias1", value), LOGGER);
+        FunctionUtils.doIfNotNull(userJson.optString("alias2"), value -> user.addAttribute("alias2", value), LOGGER);
         if (user.getStatus() != DuoSecurityUserAccountStatus.DENY && !user.isEnrolled()) {
             user.setStatus(DuoSecurityUserAccountStatus.ENROLL);
         }

--- a/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/DuoSecurityUniversalPromptPrepareLoginAction.java
+++ b/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/DuoSecurityUniversalPromptPrepareLoginAction.java
@@ -66,11 +66,11 @@ public class DuoSecurityUniversalPromptPrepareLoginAction extends AbstractMultif
         properties.put(AuthenticationResultBuilder.class.getSimpleName(), WebUtils.getAuthenticationResultBuilder(requestContext));
         properties.put(AuthenticationResult.class.getSimpleName(), WebUtils.getAuthenticationResult(requestContext));
         properties.put(Credential.class.getSimpleName(), WebUtils.getMultifactorAuthenticationParentCredential(requestContext));
-        FunctionUtils.doIfNotNull(service, __ -> properties.put(Service.class.getSimpleName(), service));
+        FunctionUtils.doIfNotNull(service, __ -> properties.put(Service.class.getSimpleName(), service), LOGGER);
         properties.put(DuoSecurityAuthenticationService.class.getSimpleName(), state);
 
         val targetState = WebUtils.getTargetTransition(requestContext);
-        FunctionUtils.doIfNotNull(targetState, __ -> properties.put(CasWebflowConstants.ATTRIBUTE_TARGET_TRANSITION, targetState));
+        FunctionUtils.doIfNotNull(targetState, __ -> properties.put(CasWebflowConstants.ATTRIBUTE_TARGET_TRANSITION, targetState), LOGGER);
 
         properties.put(FlowScope.class.getSimpleName(), requestContext.getFlowScope().asMap());
         properties.put(FlashScope.class.getSimpleName(), requestContext.getFlashScope().asMap());

--- a/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/DuoSecurityUniversalPromptValidateLoginAction.java
+++ b/support/cas-server-support-duo-core/src/main/java/org/apereo/cas/adaptors/duo/web/flow/action/DuoSecurityUniversalPromptValidateLoginAction.java
@@ -155,7 +155,7 @@ public class DuoSecurityUniversalPromptValidateLoginAction extends DuoSecurityAu
 
     protected void populateContextWithAuthentication(final RequestContext requestContext, final BrowserWebStorageSessionStore sessionStorage) throws Throwable {
         val authenticationResultBuilder = (AuthenticationResultBuilder) sessionStorage.getSessionAttributes().get(AuthenticationResultBuilder.class.getSimpleName());
-        FunctionUtils.doIfNotNull(authenticationResultBuilder, value -> WebUtils.putAuthenticationResultBuilder(value, requestContext));
+        FunctionUtils.doIfNotNull(authenticationResultBuilder, value -> WebUtils.putAuthenticationResultBuilder(value, requestContext), LOGGER);
         val authenticationResult = authenticationResultBuilder.build(authenticationSystemSupport.getPrincipalElectionStrategy());
         WebUtils.putAuthenticationResult(authenticationResult, requestContext);
         Objects.requireNonNull(authenticationResult.getAuthentication());

--- a/support/cas-server-support-dynamodb-core/src/main/java/org/apereo/cas/dynamodb/DynamoDbHealthIndicator.java
+++ b/support/cas-server-support-dynamodb-core/src/main/java/org/apereo/cas/dynamodb/DynamoDbHealthIndicator.java
@@ -4,6 +4,7 @@ import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
@@ -22,6 +23,7 @@ import java.util.HashMap;
  * @since 7.0.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class DynamoDbHealthIndicator extends AbstractHealthIndicator {
     private final ApplicationContext applicationContext;
 
@@ -39,9 +41,9 @@ public class DynamoDbHealthIndicator extends AbstractHealthIndicator {
                         "itemCount", table.itemCount(),
                         "tableSizeInBytes", table.tableSizeBytes(),
                         "tableArn", table.tableArn());
-                    FunctionUtils.doIfNotNull(table.billingModeSummary(), summary -> details.put("billingMode", summary.billingModeAsString()));
-                    FunctionUtils.doIfNotNull(table.provisionedThroughput(), tp -> details.put("readCapacity", tp.readCapacityUnits()));
-                    FunctionUtils.doIfNotNull(table.provisionedThroughput(), tp -> details.put("writeCapacity", tp.writeCapacityUnits()));
+                    FunctionUtils.doIfNotNull(table.billingModeSummary(), summary -> details.put("billingMode", summary.billingModeAsString()), LOGGER);
+                    FunctionUtils.doIfNotNull(table.provisionedThroughput(), tp -> details.put("readCapacity", tp.readCapacityUnits()), LOGGER);
+                    FunctionUtils.doIfNotNull(table.provisionedThroughput(), tp -> details.put("writeCapacity", tp.writeCapacityUnits()), LOGGER);
                     entries.put(tableName, details);
                 }
             }));

--- a/support/cas-server-support-dynamodb-core/src/main/java/org/apereo/cas/dynamodb/DynamoDbTableUtils.java
+++ b/support/cas-server-support-dynamodb-core/src/main/java/org/apereo/cas/dynamodb/DynamoDbTableUtils.java
@@ -204,7 +204,7 @@ public class DynamoDbTableUtils {
                 .build();
             LOGGER.debug("Submitting request [{}] to get record with expression filters [{}]", scanRequest, filterExpression);
             return dynamoDbClient.scan(scanRequest);
-        }, e -> ScanResponse.builder().items(Map.of()).build()).get();
+        }, e -> ScanResponse.builder().items(Map.of()).build(), LOGGER).get();
     }
 
     /**

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
@@ -87,7 +87,7 @@ public class DynamoDbTicketRegistry extends AbstractTicketRegistry {
         FunctionUtils.doAndHandle(__ -> {
             val toPut = toSave.map(Unchecked.function(this::toTicketPayload));
             dbTableService.put(toPut);
-        });
+        }, LOGGER);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class DynamoDbTicketRegistry extends AbstractTicketRegistry {
             LOGGER.debug("Adding ticket [{}] with ttl [{}s]", ticket.getId(),
                 ticket.getExpirationPolicy().getTimeToLive());
             dbTableService.put(toTicketPayload(ticket));
-        });
+        }, LOGGER);
     }
 
     private DynamoDbTicketRegistryFacilitator.TicketPayload toTicketPayload(final Ticket ticket) throws Exception {

--- a/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/web/flow/GoogleAuthenticatorSaveRegistrationAction.java
+++ b/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/web/flow/GoogleAuthenticatorSaveRegistrationAction.java
@@ -51,7 +51,7 @@ public class GoogleAuthenticatorSaveRegistrationAction extends OneTimeTokenAccou
             }
             LOGGER.warn("Unable to authorize given token [{}] for account [{}]", token, account);
             return false;
-        }, e -> false)
+        }, e -> false, LOGGER)
         .apply(account);
     }
 

--- a/support/cas-server-support-gcp-firestore-service-registry/src/main/java/org/apereo/cas/services/GoogleCloudFirestoreServiceRegistry.java
+++ b/support/cas-server-support-gcp-firestore-service-registry/src/main/java/org/apereo/cas/services/GoogleCloudFirestoreServiceRegistry.java
@@ -72,7 +72,7 @@ public class GoogleCloudFirestoreServiceRegistry extends AbstractServiceRegistry
         FunctionUtils.doAndHandle(__ -> {
             val col = firestore.collection(collectionName);
             firestore.recursiveDelete(col).get();
-        });
+        }, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudFirestoreTicketRegistry.java
+++ b/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudFirestoreTicketRegistry.java
@@ -128,7 +128,7 @@ public class GoogleCloudFirestoreTicketRegistry extends AbstractTicketRegistry {
                 .update(ticketDocument.asUpdatableMap())
                 .get();
             LOGGER.debug("Added ticket [{}] to [{}] @ [{}]", ticket.getId(), collectionName, writeResult.getUpdateTime());
-        });
+        }, LOGGER);
         return ticket;
     }
 
@@ -164,7 +164,7 @@ public class GoogleCloudFirestoreTicketRegistry extends AbstractTicketRegistry {
                     .get();
                 LOGGER.debug("Added ticket [{}] to [{}] @ [{}]", ticket.getId(), collectionName, writeResult.getUpdateTime());
             }
-        });
+        }, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-gcp-logging/src/main/java/org/apereo/cas/logging/GoogleCloudAppender.java
+++ b/support/cas-server-support-gcp-logging/src/main/java/org/apereo/cas/logging/GoogleCloudAppender.java
@@ -9,6 +9,7 @@ import org.apereo.cas.util.text.MessageSanitizer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.spring.core.DefaultGcpProjectIdProvider;
 import com.google.cloud.spring.logging.StackdriverTraceConstants;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.Filter;
@@ -39,6 +40,7 @@ import java.util.concurrent.TimeUnit;
  * @since 7.0.0
  */
 @Plugin(name = "GoogleCloudAppender", category = "Core", elementType = "appender", printObject = true)
+@Slf4j
 public class GoogleCloudAppender extends AbstractAppender {
     private static final ObjectMapper MAPPER = JacksonObjectMapperFactory.builder()
         .defaultTypingEnabled(false).build().toObjectMapper();
@@ -63,7 +65,7 @@ public class GoogleCloudAppender extends AbstractAppender {
         this.projectId = FunctionUtils.doIfNull(projectId, () -> {
             val projectIdProvider = new DefaultGcpProjectIdProvider();
             return projectIdProvider.getProjectId();
-        }, () -> projectId).get();
+        }, () -> projectId, LOGGER).get();
     }
 
     /**

--- a/support/cas-server-support-gcp-pubsub-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudTicketRegistryMessageQueueConsumer.java
+++ b/support/cas-server-support-gcp-pubsub-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudTicketRegistryMessageQueueConsumer.java
@@ -49,6 +49,6 @@ public class GoogleCloudTicketRegistryMessageQueueConsumer implements Consumer<B
         }, (CheckedFunction<Throwable, Object>) e -> {
             LoggingUtils.error(LOGGER, e);
             return message.nack();
-        }).accept(message);
+        }, LOGGER).accept(message);
     }
 }

--- a/support/cas-server-support-gcp-pubsub-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudTicketRegistryQueuePublisher.java
+++ b/support/cas-server-support-gcp-pubsub-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudTicketRegistryQueuePublisher.java
@@ -45,6 +45,6 @@ public class GoogleCloudTicketRegistryQueuePublisher implements QueueableTicketR
             Objects.requireNonNull(future);
             val publishedMessage = future.get();
             LOGGER.trace("Sent message [{}] from ticket registry id [{}]", publishedMessage, cmd.getId());
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/adaptors/generic/remote/RemoteAddressAuthenticationHandler.java
+++ b/support/cas-server-support-generic-remote-webflow/src/main/java/org/apereo/cas/adaptors/generic/remote/RemoteAddressAuthenticationHandler.java
@@ -120,11 +120,11 @@ public class RemoteAddressAuthenticationHandler extends AbstractAuthenticationHa
                 FunctionUtils.doAndHandle(__ -> {
                     this.inetNetworkRange = InetAddress.getByName(network);
                     LOGGER.debug("InetAddress network: [{}]", this.inetNetworkRange.toString());
-                });
+                }, LOGGER);
                 FunctionUtils.doAndHandle(__ -> {
                     this.inetNetmask = InetAddress.getByName(netmask);
                     LOGGER.debug("InetAddress netmask: [{}]", this.inetNetmask.toString());
-                });
+                }, LOGGER);
             }
         }
     }

--- a/support/cas-server-support-geolocation-maxmind/src/main/java/org/apereo/cas/config/CasGeoLocationMaxmindConfiguration.java
+++ b/support/cas-server-support-geolocation-maxmind/src/main/java/org/apereo/cas/config/CasGeoLocationMaxmindConfiguration.java
@@ -12,6 +12,7 @@ import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 import com.maxmind.db.CHMCache;
 import com.maxmind.db.Reader;
 import com.maxmind.geoip2.DatabaseReader;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.jooq.lambda.Unchecked;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,6 +33,7 @@ import org.springframework.core.io.Resource;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.GeoLocation, module = "maxmind")
 @AutoConfiguration
+@Slf4j
 public class CasGeoLocationMaxmindConfiguration {
 
     private static DatabaseReader readDatabase(final Resource maxmindDatabase) throws Exception {
@@ -41,7 +43,7 @@ public class CasGeoLocationMaxmindConfiguration {
                         .fileMode(Reader.FileMode.MEMORY)
                         .withCache(new CHMCache())
                         .build()),
-                () -> null)
+                () -> null, LOGGER)
             .get();
     }
 

--- a/support/cas-server-support-geolocation-maxmind/src/main/java/org/apereo/cas/support/geo/maxmind/MaxmindDatabaseGeoLocationService.java
+++ b/support/cas-server-support-geolocation-maxmind/src/main/java/org/apereo/cas/support/geo/maxmind/MaxmindDatabaseGeoLocationService.java
@@ -53,12 +53,12 @@ public class MaxmindDatabaseGeoLocationService extends AbstractGeoLocationServic
                 val response = cityDatabaseReader.city(address);
                 location.addAddress(response.getCity().getName());
                 collectGeographicalPosition(location, response);
-            });
+            }, LOGGER);
 
             FunctionUtils.doIfNotNull(countryDatabaseReader, __ -> {
                 val response = countryDatabaseReader.country(address);
                 location.addAddress(response.getCountry().getName());
-            });
+            }, LOGGER);
 
             if (location.getAddresses().isEmpty() && properties.getAccountId() > 0 && StringUtils.isNotBlank(properties.getLicenseKey())) {
                 try (val client = buildWebServiceClient()) {

--- a/support/cas-server-support-geolocation/src/main/java/org/apereo/cas/support/geo/AbstractGeoLocationService.java
+++ b/support/cas-server-support-geolocation/src/main/java/org/apereo/cas/support/geo/AbstractGeoLocationService.java
@@ -21,7 +21,7 @@ import java.net.InetAddress;
 public abstract class AbstractGeoLocationService implements GeoLocationService {
     @Override
     public GeoLocationResponse locate(final String address) {
-        return FunctionUtils.doAndHandle(() -> locate(InetAddress.getByName(address)), e -> null).get();
+        return FunctionUtils.doAndHandle(() -> locate(InetAddress.getByName(address)), e -> null, LOGGER).get();
     }
 
     @Override

--- a/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
+++ b/support/cas-server-support-git-service-registry/src/test/java/org/apereo/cas/services/GitServiceRegistryTests.java
@@ -90,12 +90,12 @@ class GitServiceRegistryTests extends AbstractServiceRegistryTests {
             val gitRepoSampleDir = new File(FileUtils.getTempDirectory(), "cas-sample-data");
             if (gitRepoSampleDir.exists()) {
                 FunctionUtils.doAndHandle(
-                    __ -> PathUtils.deleteDirectory(gitRepoSampleDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                    __ -> PathUtils.deleteDirectory(gitRepoSampleDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
             }
             val gitDir = new File(FileUtils.getTempDirectory(), GitServiceRegistryProperties.DEFAULT_CAS_SERVICE_REGISTRY_NAME);
             if (gitDir.exists()) {
                 FunctionUtils.doAndHandle(
-                    __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                    __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
             }
             try (val gitSampleRepo = Git.init().setDirectory(gitRepoSampleDir).setBare(false).call()) {
                 FileUtils.write(new File(gitRepoSampleDir, "readme.txt"), "text", StandardCharsets.UTF_8);
@@ -119,11 +119,11 @@ class GitServiceRegistryTests extends AbstractServiceRegistryTests {
         try {
             val gitRepoDir = new File(FileUtils.getTempDirectory(), "cas-sample-data");
             FunctionUtils.doAndHandle(
-                __ -> PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                __ -> PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
             val gitDir = new File(FileUtils.getTempDirectory(), GitServiceRegistryProperties.DEFAULT_CAS_SERVICE_REGISTRY_NAME);
             if (gitDir.exists()) {
                 FunctionUtils.doAndHandle(
-                    __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                    __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-grouper/src/main/java/org/apereo/cas/config/CasPersonDirectoryGrouperConfiguration.java
+++ b/support/cas-server-support-grouper/src/main/java/org/apereo/cas/config/CasPersonDirectoryGrouperConfiguration.java
@@ -53,7 +53,7 @@ public class CasPersonDirectoryGrouperConfiguration {
             dao.setEnabled(gp.getState() != AttributeRepositoryStates.DISABLED);
             dao.putTag(PersonDirectoryAttributeRepositoryPlanConfigurer.class.getSimpleName(),
                 gp.getState() == AttributeRepositoryStates.ACTIVE);
-            FunctionUtils.doIfNotNull(gp.getId(), id -> dao.setId(id));
+            FunctionUtils.doIfNotNull(gp.getId(), id -> dao.setId(id), LOGGER);
             LOGGER.debug("Configured Grouper attribute source");
             list.add(dao);
             return BeanContainer.of(list);

--- a/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
+++ b/support/cas-server-support-hazelcast-core/src/main/java/org/apereo/cas/hz/HazelcastConfigurationFactory.java
@@ -163,17 +163,17 @@ public class HazelcastConfigurationFactory {
         val ssl = hz.getCluster().getNetwork().getSsl();
         val sslConfig = new SSLConfig();
         sslConfig.setFactoryClassName(BasicSSLContextFactory.class.getName());
-        FunctionUtils.doIfNotNull(ssl.getKeystore(), value -> sslConfig.setProperty("keystore", value));
-        FunctionUtils.doIfNotNull(ssl.getProtocol(), value -> sslConfig.setProperty("protocol", value));
-        FunctionUtils.doIfNotNull(ssl.getKeystorePassword(), value -> sslConfig.setProperty("keystorePassword", value));
-        FunctionUtils.doIfNotNull(ssl.getKeyStoreType(), value -> sslConfig.setProperty("keyStoreType", value));
-        FunctionUtils.doIfNotNull(ssl.getTrustStore(), value -> sslConfig.setProperty("trustStore", value));
-        FunctionUtils.doIfNotNull(ssl.getTrustStoreType(), value -> sslConfig.setProperty("trustStoreType", value));
-        FunctionUtils.doIfNotNull(ssl.getTrustStorePassword(), value -> sslConfig.setProperty("trustStorePassword", value));
-        FunctionUtils.doIfNotNull(ssl.getMutualAuthentication(), value -> sslConfig.setProperty("mutualAuthentication", value));
-        FunctionUtils.doIfNotNull(ssl.getCipherSuites(), value -> sslConfig.setProperty("cipherSuites", value));
-        FunctionUtils.doIfNotNull(ssl.getTrustManagerAlgorithm(), value -> sslConfig.setProperty("trustManagerAlgorithm", value));
-        FunctionUtils.doIfNotNull(ssl.getKeyManagerAlgorithm(), value -> sslConfig.setProperty("keyManagerAlgorithm", value));
+        FunctionUtils.doIfNotNull(ssl.getKeystore(), value -> sslConfig.setProperty("keystore", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getProtocol(), value -> sslConfig.setProperty("protocol", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getKeystorePassword(), value -> sslConfig.setProperty("keystorePassword", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getKeyStoreType(), value -> sslConfig.setProperty("keyStoreType", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getTrustStore(), value -> sslConfig.setProperty("trustStore", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getTrustStoreType(), value -> sslConfig.setProperty("trustStoreType", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getTrustStorePassword(), value -> sslConfig.setProperty("trustStorePassword", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getMutualAuthentication(), value -> sslConfig.setProperty("mutualAuthentication", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getCipherSuites(), value -> sslConfig.setProperty("cipherSuites", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getTrustManagerAlgorithm(), value -> sslConfig.setProperty("trustManagerAlgorithm", value), LOGGER);
+        FunctionUtils.doIfNotNull(ssl.getKeyManagerAlgorithm(), value -> sslConfig.setProperty("keyManagerAlgorithm", value), LOGGER);
         sslConfig.setProperty("validateIdentity", String.valueOf(ssl.isValidateIdentity()));
         networkConfig.setSSLConfig(sslConfig);
     }

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -232,7 +232,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements A
         FunctionUtils.doAndHandle(__ -> {
             LOGGER.info("Shutting down Hazelcast instance [{}]", hazelcastInstance.getConfig().getInstanceName());
             hazelcastInstance.shutdown();
-        });
+        }, LOGGER);
     }
 
     @Override
@@ -258,6 +258,6 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements A
             val inst = hazelcastInstance.<String, HazelcastTicketHolder>getMap(mapName);
             LOGGER.debug("Located Hazelcast map instance [{}]", mapName);
             return inst;
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/config/CasInterruptConfiguration.java
+++ b/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/config/CasInterruptConfiguration.java
@@ -93,7 +93,7 @@ public class CasInterruptConfiguration {
             return FunctionUtils.doIf(props.getCrypto().isEnabled(),
                 () -> new DefaultCasCookieValueManager(cookieCipherExecutor, geoLocationService,
                     DefaultCookieSameSitePolicy.INSTANCE, props),
-                CookieValueManager::noOp).get();
+                CookieValueManager::noOp, LOGGER).get();
         }
 
         @Bean

--- a/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/SimpleInterruptTrackingEngine.java
+++ b/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/SimpleInterruptTrackingEngine.java
@@ -51,7 +51,7 @@ public class SimpleInterruptTrackingEngine implements InterruptTrackingEngine {
             return StringUtils.isNotBlank(cookieValue)
                 ? Optional.ofNullable(MAPPER.readValue(EncodingUtils.decodeBase64ToString(cookieValue), InterruptResponse.class))
                 : Optional.<InterruptResponse>empty();
-        }, e -> Optional.<InterruptResponse>empty()).apply(requestContext);
+        }, e -> Optional.<InterruptResponse>empty(), LOGGER).apply(requestContext);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class SimpleInterruptTrackingEngine implements InterruptTrackingEngine {
                     val authentication = WebUtils.getAuthentication(requestContext);
                     return interruptResponse.stream().anyMatch(InterruptResponse::isInterrupt)
                         || (authentication != null && authentication.containsAttribute(AUTHENTICATION_ATTRIBUTE_FINALIZED_INTERRUPT));
-                }, e -> false)
+                }, e -> false, LOGGER)
             .apply(requestContext);
     }
 }

--- a/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/adaptors/jdbc/QueryAndEncodeDatabasePasswordEncoder.java
+++ b/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/adaptors/jdbc/QueryAndEncodeDatabasePasswordEncoder.java
@@ -4,6 +4,7 @@ import org.apereo.cas.configuration.model.support.jdbc.authn.QueryEncodeJdbcAuth
 import org.apereo.cas.util.DigestUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import java.nio.charset.StandardCharsets;
@@ -16,6 +17,7 @@ import java.util.Map;
  * @since 7.0.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class QueryAndEncodeDatabasePasswordEncoder implements DatabasePasswordEncoder {
     protected final QueryEncodeJdbcAuthenticationProperties properties;
 
@@ -39,7 +41,7 @@ public class QueryAndEncodeDatabasePasswordEncoder implements DatabasePasswordEn
     protected byte[] getStaticSalt(final Map<String, Object> queryValues) {
         return FunctionUtils.doIfNotBlank(properties.getStaticSalt(),
             () -> properties.getStaticSalt().getBytes(StandardCharsets.UTF_8),
-            () -> ArrayUtils.EMPTY_BYTE_ARRAY);
+            () -> ArrayUtils.EMPTY_BYTE_ARRAY, LOGGER);
     }
 
     protected byte[] getDynamicSalt(final Map<String, Object> queryValues) {

--- a/support/cas-server-support-jpa-hibernate/src/main/java/org/apereo/cas/hibernate/CasHibernateJpaBeanFactory.java
+++ b/support/cas-server-support-jpa-hibernate/src/main/java/org/apereo/cas/hibernate/CasHibernateJpaBeanFactory.java
@@ -9,6 +9,7 @@ import org.apereo.cas.jpa.JpaPersistenceProviderConfigurer;
 import org.apereo.cas.jpa.JpaPersistenceProviderContext;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -40,6 +41,7 @@ import java.util.stream.Stream;
  * @since 6.2.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class CasHibernateJpaBeanFactory implements JpaBeanFactory {
     private final ConfigurableApplicationContext applicationContext;
 
@@ -83,7 +85,7 @@ public class CasHibernateJpaBeanFactory implements JpaBeanFactory {
                     aware.setApplicationContext(applicationContext);
                 }
                 properties.put(MappingSettings.PHYSICAL_NAMING_STRATEGY, namingStrategy);
-            });
+            }, LOGGER);
         properties.putAll(jpaProperties.getProperties());
 
         val bean = JpaBeans.newEntityManagerFactoryBean(config);

--- a/support/cas-server-support-jpa-util/src/main/java/org/apereo/cas/configuration/support/JpaBeans.java
+++ b/support/cas-server-support-jpa-util/src/main/java/org/apereo/cas/configuration/support/JpaBeans.java
@@ -88,7 +88,7 @@ public class JpaBeans {
         }
 
         val bean = new HikariDataSource();
-        FunctionUtils.doIfNotBlank(jpaProperties.getDriverClass(), __ -> bean.setDriverClassName(jpaProperties.getDriverClass()));
+        FunctionUtils.doIfNotBlank(jpaProperties.getDriverClass(), __ -> bean.setDriverClassName(jpaProperties.getDriverClass()), LOGGER);
 
         val url = SpringExpressionLanguageValueResolver.getInstance().resolve(jpaProperties.getUrl());
         bean.setJdbcUrl(url);
@@ -131,7 +131,7 @@ public class JpaBeans {
             bean.setPersistenceProvider(config.getPersistenceProvider());
         }
 
-        FunctionUtils.doIfNotBlank(config.getPersistenceUnitName(), __ -> bean.setPersistenceUnitName(config.getPersistenceUnitName()));
+        FunctionUtils.doIfNotBlank(config.getPersistenceUnitName(), __ -> bean.setPersistenceUnitName(config.getPersistenceUnitName()), LOGGER);
         if (!config.getPackagesToScan().isEmpty()) {
             bean.setPackagesToScan(config.getPackagesToScan().toArray(ArrayUtils.EMPTY_STRING_ARRAY));
         }

--- a/support/cas-server-support-json-service-registry/src/main/java/org/apereo/cas/config/JsonServiceRegistryConfiguration.java
+++ b/support/cas-server-support-json-service-registry/src/main/java/org/apereo/cas/config/JsonServiceRegistryConfiguration.java
@@ -12,6 +12,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.io.WatcherService;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -39,6 +40,7 @@ import java.util.Optional;
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.ServiceRegistry, module = "json")
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE + 1)
 @AutoConfiguration
+@Slf4j
 public class JsonServiceRegistryConfiguration {
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
@@ -74,6 +76,6 @@ public class JsonServiceRegistryConfiguration {
         final ServiceRegistry jsonServiceRegistry) {
         val registry = casProperties.getServiceRegistry().getJson();
         return plan -> FunctionUtils.doIfNotNull(registry.getLocation(),
-            input -> plan.registerServiceRegistry(jsonServiceRegistry));
+            input -> plan.registerServiceRegistry(jsonServiceRegistry), LOGGER);
     }
 }

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapConnectionFactory.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapConnectionFactory.java
@@ -60,7 +60,7 @@ public class LdapConnectionFactory implements Closeable {
             val response = operation.execute(new AddRequest(entry.getDn(), entry.getAttributes()));
             LOGGER.debug("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
             return response.getResultCode() == ResultCode.SUCCESS;
-        }, e -> false).get();
+        }, e -> false, LOGGER).get();
     }
 
 
@@ -77,7 +77,7 @@ public class LdapConnectionFactory implements Closeable {
             val response = delete.execute(request);
             LOGGER.debug("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
             return response.getResultCode() == ResultCode.SUCCESS;
-        }, e -> false).get();
+        }, e -> false, LOGGER).get();
     }
 
 
@@ -105,7 +105,7 @@ public class LdapConnectionFactory implements Closeable {
             val response = operation.execute(request);
             LOGGER.debug("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
             return response.getResultCode() == ResultCode.SUCCESS;
-        }, e -> false).get();
+        }, e -> false, LOGGER).get();
     }
 
     /**

--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -593,7 +593,7 @@ public class LdapUtils {
                 cfg.setTrustStoreType(properties.getTrustStoreType());
                 val password = SpringExpressionLanguageValueResolver.getInstance().resolve(properties.getTrustStorePassword());
                 cfg.setTrustStorePassword(password);
-            });
+            }, LOGGER);
             FunctionUtils.doIfNotNull(properties.getKeystore(), store -> {
                 val activeStore = SpringExpressionLanguageValueResolver.getInstance().resolve(store);
                 LOGGER.trace("Creating LDAP SSL configuration via keystore [{}]", activeStore);
@@ -601,7 +601,7 @@ public class LdapUtils {
                 cfg.setKeyStoreType(properties.getKeystoreType());
                 val password = SpringExpressionLanguageValueResolver.getInstance().resolve(properties.getKeystorePassword());
                 cfg.setKeyStorePassword(password);
-            });
+            }, LOGGER);
             connectionConfig.setSslConfig(new SslConfig(cfg));
         } else {
             LOGGER.debug("Creating LDAP SSL configuration via the native JVM truststore");
@@ -630,7 +630,7 @@ public class LdapUtils {
             val initializer = new BindConnectionInitializer();
             val saslConfig = getSaslConfigFrom(properties);
 
-            FunctionUtils.doIfNotBlank(properties.getSaslAuthorizationId(), __ -> saslConfig.setAuthorizationId(properties.getSaslAuthorizationId()));
+            FunctionUtils.doIfNotBlank(properties.getSaslAuthorizationId(), __ -> saslConfig.setAuthorizationId(properties.getSaslAuthorizationId()), LOGGER);
             saslConfig.setMutualAuthentication(properties.getSaslMutualAuth());
             if (StringUtils.isNotBlank(properties.getSaslQualityOfProtection())) {
                 saslConfig.setQualityOfProtection(QualityOfProtection.valueOf(properties.getSaslQualityOfProtection()));
@@ -980,7 +980,7 @@ public class LdapUtils {
                         () -> {
                             LOGGER.debug("Creating active directory authentication response handler with warning period [{}]", warningPeriod);
                             return new ActiveDirectoryAuthenticationResponseHandler(warningPeriod);
-                        })
+                        }, LOGGER)
                     .get();
                 responseHandlers.add(handler);
                 Arrays.stream(ActiveDirectoryAuthenticationResponseHandler.ATTRIBUTES).forEach(attr -> {
@@ -1073,7 +1073,7 @@ public class LdapUtils {
         }
 
         FunctionUtils.doIfNotBlank(props.getPrincipalDnAttributeName(),
-            __ -> handler.setPrincipalDnAttributeName(props.getPrincipalDnAttributeName()));
+            __ -> handler.setPrincipalDnAttributeName(props.getPrincipalDnAttributeName()), LOGGER);
         handler.setAllowMultiplePrincipalAttributeValues(props.isAllowMultiplePrincipalAttributeValues());
         handler.setAllowMissingPrincipalAttributeValue(props.isAllowMissingPrincipalAttributeValue());
         handler.setPasswordEncoder(PasswordEncoderUtils.newPasswordEncoder(props.getPasswordEncoder(), applicationContext));
@@ -1118,7 +1118,7 @@ public class LdapUtils {
                         throwable -> {
                             LoggingUtils.warn(LOGGER, throwable);
                             return null;
-                        })
+                        }, LOGGER)
                     .get())
                 .filter(Objects::nonNull)
                 .findFirst()
@@ -1136,7 +1136,7 @@ public class LdapUtils {
                         throwable -> {
                             LoggingUtils.warn(LOGGER, throwable);
                             return null;
-                        })
+                        }, LOGGER)
                     .get())
                 .filter(Objects::nonNull)
                 .findFirst()

--- a/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
+++ b/support/cas-server-support-ldap/src/main/java/org/apereo/cas/config/LdapAuthenticationConfiguration.java
@@ -127,7 +127,7 @@ public class LdapAuthenticationConfiguration {
 
             @Override
             public void destroy() {
-                FunctionUtils.doIfNotNull(endpointLdapAuthenticationProvider, EndpointLdapAuthenticationProvider::destroy);
+                FunctionUtils.doIfNotNull(endpointLdapAuthenticationProvider, EndpointLdapAuthenticationProvider::destroy, LOGGER);
             }
 
             @Override

--- a/support/cas-server-support-logging-config-cloudwatch/src/main/java/org/apereo/cas/logging/CloudWatchAppender.java
+++ b/support/cas-server-support-logging-config-cloudwatch/src/main/java/org/apereo/cas/logging/CloudWatchAppender.java
@@ -365,7 +365,7 @@ public class CloudWatchAppender extends AbstractAppender implements Serializable
                 throwable -> {
                     LOGGER.error(throwable.getMessage(), throwable);
                     return null;
-                }).get();
+                }, LOGGER).get();
 
             var createLogGroup = true;
             if (describeLogGroupsResult != null && describeLogGroupsResult.hasLogGroups()) {
@@ -391,7 +391,7 @@ public class CloudWatchAppender extends AbstractAppender implements Serializable
             throwable -> {
                 LOGGER.error(throwable.getMessage(), throwable);
                 return null;
-            }).get();
+            }, LOGGER).get();
         if (describeLogStreamsResult != null && describeLogStreamsResult.hasLogStreams()) {
             for (val ls : describeLogStreamsResult.logStreams()) {
                 if (logStreamName.equals(ls.logStreamName())) {

--- a/support/cas-server-support-notifications-slack/src/main/java/org/apereo/cas/notifications/SlackNotificationSender.java
+++ b/support/cas-server-support-notifications-slack/src/main/java/org/apereo/cas/notifications/SlackNotificationSender.java
@@ -43,7 +43,7 @@ public class SlackNotificationSender implements NotificationSender {
         val body = buildNotificationMessageBody(messageData);
         val slackUsernames = FunctionUtils.doIfNotBlank(slackProperties.getUsernameAttribute(),
             () -> principal.getAttributes().get(slackProperties.getUsernameAttribute()),
-            () -> List.of(principal.getId()));
+            () -> List.of(principal.getId()), LOGGER);
         return slackUsernames
             .stream()
             .allMatch(Unchecked.predicate(slackUsername -> {
@@ -58,8 +58,8 @@ public class SlackNotificationSender implements NotificationSender {
                 LOGGER.trace(response.toString());
                 FunctionUtils.doIfNotBlank(response.getError(),
                     __ -> LoggingUtils.error(LOGGER, "Error: %s, Provided: %s, Needed: %s"
-                        .formatted(response.getError(), response.getProvided(), response.getNeeded())));
-                FunctionUtils.doIfNotBlank(response.getWarning(), LOGGER::warn);
+                        .formatted(response.getError(), response.getProvided(), response.getNeeded())), LOGGER);
+                FunctionUtils.doIfNotBlank(response.getWarning(), LOGGER::warn, LOGGER);
                 return response.isOk();
             }));
     }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
@@ -179,7 +179,7 @@ public class OAuth20ClientIdClientSecretAuthenticator implements Authenticator {
             val token = FunctionUtils.doAndHandle(() -> {
                 val state = ticketRegistry.getTicket(code.get(), OAuth20Code.class);
                 return state == null || state.isExpired() ? null : state;
-            });
+            }, LOGGER);
 
             if (token != null && StringUtils.isNotEmpty(token.getCodeChallenge())) {
                 LOGGER.debug("The OAuth code [{}] issued contains code challenge which requires PKCE Authentication", code.get());

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20RefreshTokenAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20RefreshTokenAuthenticator.java
@@ -79,7 +79,7 @@ public class OAuth20RefreshTokenAuthenticator extends OAuth20ClientIdClientSecre
         val refreshToken = FunctionUtils.doAndHandle(() -> {
             val state = getTicketRegistry().getTicket(token, OAuth20RefreshToken.class);
             return state == null || state.isExpired() ? null : state;
-        });
+        }, LOGGER);
         val clientId = credentials.getUsername();
         if (refreshToken == null || refreshToken.isExpired() || !StringUtils.equals(refreshToken.getClientId(), clientId)) {
             LOGGER.error("Refresh token [{}] is either not found in the ticket registry, has expired or does not belong to the client [{}]", token, clientId);

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20X509Authenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20X509Authenticator.java
@@ -88,6 +88,6 @@ public class OAuth20X509Authenticator implements Authenticator {
                 val values = CollectionUtils.toCollection(profile.getAttribute(attribute));
                 return !values.isEmpty() && values.stream().anyMatch(email -> RegexUtils.find(pattern, email.toString()));
             },
-            () -> Boolean.TRUE);
+            () -> Boolean.TRUE, LOGGER);
     }
 }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/util/OAuth20Utils.java
@@ -112,7 +112,7 @@ public class OAuth20Utils {
                 val query = RegisteredServiceQuery.of(OAuthRegisteredService.class, "clientId", clientId).withIncludeAssignableTypes(true);
                 return servicesManager.findServicesBy(query).findFirst().map(OAuthRegisteredService.class::cast).orElse(null);
             },
-            () -> null);
+            () -> null, LOGGER);
     }
 
     /**
@@ -127,7 +127,7 @@ public class OAuth20Utils {
         validateRedirectUri(redirectUri);
         return FunctionUtils.doIfNotBlank(redirectUri,
             () -> getRegisteredOAuthServiceByPredicate(servicesManager, service -> service.matches(redirectUri)),
-            () -> null);
+            () -> null, LOGGER);
     }
 
     private static OAuthRegisteredService getRegisteredOAuthServiceByPredicate(final ServicesManager servicesManager,

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20AuthorizationCodeGrantTypeTokenRequestValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20AuthorizationCodeGrantTypeTokenRequestValidator.java
@@ -59,7 +59,7 @@ public class OAuth20AuthorizationCodeGrantTypeTokenRequestValidator extends Base
             val token = FunctionUtils.doAndHandle(() -> {
                 val state = getConfigurationContext().getTicketRegistry().getTicket(code.get(), OAuth20Code.class);
                 return state == null || state.isExpired() ? null : state;
-            });
+            }, LOGGER);
             val removeTokens = getConfigurationContext().getCasProperties().getAuthn().getOauth().getCode().isRemoveRelatedAccessTokens();
             if (token == null || token.isExpired()) {
                 if (removeTokens) {

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20DeviceCodeResponseTypeRequestValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/token/OAuth20DeviceCodeResponseTypeRequestValidator.java
@@ -64,7 +64,7 @@ public class OAuth20DeviceCodeResponseTypeRequestValidator implements OAuth20Tok
         }, t -> {
             LOGGER.warn("Registered service access is not allowed for service definition for client id [{}]", clientId);
             return false;
-        }).get();
+        }, LOGGER).get();
     }
 
     @Override

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/DefaultOAuth20RequestParameterResolver.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/DefaultOAuth20RequestParameterResolver.java
@@ -229,7 +229,7 @@ public class DefaultOAuth20RequestParameterResolver implements OAuth20RequestPar
 
         val claims = FunctionUtils.doIf(supported,
             () -> resolveRequestParameter(context, OAuth20Constants.CLAIMS).map(String::valueOf).orElse(StringUtils.EMPTY),
-            () -> StringUtils.EMPTY).get();
+            () -> StringUtils.EMPTY, LOGGER).get();
 
         if (StringUtils.isBlank(claims)) {
             return new HashMap<>(0);

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20RevocationEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20RevocationEndpointController.java
@@ -113,7 +113,7 @@ public class OAuth20RevocationEndpointController<T extends OAuth20ConfigurationC
         val registryToken = FunctionUtils.doAndHandle(() -> {
             val state = getConfigurationContext().getTicketRegistry().getTicket(token, OAuth20Token.class);
             return state == null || state.isExpired() ? null : state;
-        });
+        }, LOGGER);
         if (registryToken == null) {
             LOGGER.error("Provided token [{}] has not been found in the ticket registry", token);
         } else if (isRefreshToken(registryToken) || isAccessToken(registryToken)) {

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
@@ -78,7 +78,7 @@ public class OAuth20UserProfileEndpointController<T extends OAuth20Configuration
         val accessTokenTicket = FunctionUtils.doAndHandle(() -> {
             val state = getConfigurationContext().getTicketRegistry().getTicket(decodedAccessTokenId, OAuth20AccessToken.class);
             return state == null || state.isExpired() ? null : state;
-        });
+        }, LOGGER);
         if (accessTokenTicket == null || accessTokenTicket.isExpired()) {
             LOGGER.error("Access token [{}] cannot be found in the ticket registry or has expired.", decodedAccessTokenId);
             return buildUnauthorizedResponseEntity(OAuth20Constants.EXPIRED_ACCESS_TOKEN);
@@ -98,7 +98,7 @@ public class OAuth20UserProfileEndpointController<T extends OAuth20Configuration
             val map = getConfigurationContext().getUserProfileDataCreator().createFrom(accessTokenTicket, context);
             return getConfigurationContext().getUserProfileViewRenderer().render(map, accessTokenTicket, response);
         },
-            e -> buildUnauthorizedResponseEntity(OAuth20Constants.INVALID_REQUEST)).get();
+            e -> buildUnauthorizedResponseEntity(OAuth20Constants.INVALID_REQUEST), LOGGER).get();
     }
 
     protected void validateAccessToken(final String accessTokenId, final OAuth20AccessToken accessToken,

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/OAuth20DefaultTokenGenerator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/OAuth20DefaultTokenGenerator.java
@@ -168,9 +168,9 @@ public class OAuth20DefaultTokenGenerator implements OAuth20TokenGenerator {
         requestedClaims.forEach(authnBuilder::addAttribute);
 
         FunctionUtils.doIfNotNull(holder.getDpop(),
-            __ -> authnBuilder.addAttribute(OAuth20Constants.DPOP, holder.getDpop()));
+            __ -> authnBuilder.addAttribute(OAuth20Constants.DPOP, holder.getDpop()), LOGGER);
         FunctionUtils.doIfNotNull(holder.getDpopConfirmation(),
-            __ -> authnBuilder.addAttribute(OAuth20Constants.DPOP_CONFIRMATION, holder.getDpopConfirmation()));
+            __ -> authnBuilder.addAttribute(OAuth20Constants.DPOP_CONFIRMATION, holder.getDpopConfirmation()), LOGGER);
         
         val authentication = authnBuilder.build();
         LOGGER.debug("Creating access token for [{}]", holder);
@@ -193,7 +193,7 @@ public class OAuth20DefaultTokenGenerator implements OAuth20TokenGenerator {
             () -> {
                 LOGGER.debug("Service [{}] is not able/allowed to receive refresh tokens", holder.getService());
                 return null;
-            }).get();
+            }, LOGGER).get();
 
         return Pair.of(accessToken, refreshToken);
     }
@@ -269,7 +269,7 @@ public class OAuth20DefaultTokenGenerator implements OAuth20TokenGenerator {
                     LOGGER.error("Provided user code [{}] is invalid or expired and cannot be found in the ticket registry",
                         deviceCodeTicket.getUserCode());
                     throw new InvalidOAuth20DeviceTokenException(deviceCodeTicket.getUserCode());
-                })
+                }, LOGGER)
             .get();
     }
 
@@ -279,7 +279,7 @@ public class OAuth20DefaultTokenGenerator implements OAuth20TokenGenerator {
                 throwable -> {
                     LoggingUtils.error(LOGGER, throwable);
                     throw new InvalidOAuth20DeviceTokenException(deviceCode);
-                })
+                }, LOGGER)
             .get();
     }
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20JwtAccessTokenEncoder.java
@@ -59,7 +59,7 @@ public class OAuth20JwtAccessTokenEncoder implements CipherExecutor<String, Stri
             val header = JWTParser.parse(tokenId).getHeader();
             val claims = accessTokenJwtBuilder.unpack(Optional.ofNullable(resolveRegisteredService(header)), tokenId);
             return claims.getJWTID();
-        }, e -> tokenId).get();
+        }, e -> tokenId, LOGGER).get();
     }
 
     @Override

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20RegisteredServiceJwtAccessTokenCipherExecutor.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/accesstoken/response/OAuth20RegisteredServiceJwtAccessTokenCipherExecutor.java
@@ -6,6 +6,7 @@ import org.apereo.cas.support.oauth.services.OAuthRegisteredService;
 import org.apereo.cas.token.cipher.JwtTicketCipherExecutor;
 import org.apereo.cas.token.cipher.RegisteredServiceJwtTicketCipherExecutor;
 import org.apereo.cas.util.function.FunctionUtils;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import java.util.Optional;
 
@@ -15,6 +16,7 @@ import java.util.Optional;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
+@Slf4j
 public class OAuth20RegisteredServiceJwtAccessTokenCipherExecutor extends RegisteredServiceJwtTicketCipherExecutor {
     @Override
     protected RegisteredServiceProperty.RegisteredServiceProperties getSigningKeyRegisteredServiceProperty() {
@@ -73,7 +75,7 @@ public class OAuth20RegisteredServiceJwtAccessTokenCipherExecutor extends Regist
     protected JwtTicketCipherExecutor prepareCipherExecutor(final JwtTicketCipherExecutor cipher,
                                                             final RegisteredService registeredService) {
         if (registeredService instanceof final OAuthRegisteredService oauthRegisteredService) {
-            FunctionUtils.doIfNotBlank(oauthRegisteredService.getJwtAccessTokenSigningAlg(), cipher::setSigningAlgorithm);
+            FunctionUtils.doIfNotBlank(oauthRegisteredService.getJwtAccessTokenSigningAlg(), cipher::setSigningAlgorithm, LOGGER);
         }
         return cipher;
     }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20AuthorizationCodeAuthorizationResponseBuilder.java
@@ -58,7 +58,7 @@ public class OAuth20AuthorizationCodeAuthorizationResponseBuilder extends BaseOA
         }, (CheckedFunction<Throwable, TicketGrantingTicket>) throwable -> {
             LOGGER.error("Unable to update ticket-granting-ticket [{}]", ticketGrantingTicket, throwable);
             return null;
-        }).accept(tgt));
+        }, LOGGER).accept(tgt));
         return buildCallbackViewViaRedirectUri(holder, code);
     }
 

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/code/OAuth20DefaultOAuthCodeFactory.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/ticket/code/OAuth20DefaultOAuthCodeFactory.java
@@ -75,7 +75,7 @@ public class OAuth20DefaultOAuthCodeFactory implements OAuth20CodeFactory {
             val encoded = cipherExecutor.encode(codeId);
             LOGGER.debug("Encoded OAuth code [{}]", encoded);
             return encoded;
-        }, () -> codeId).get();
+        }, () -> codeId, LOGGER).get();
 
         val oauthCode = new OAuth20DefaultCode(codeIdToUse, service, authentication,
             expirationPolicyToUse, ticketGrantingTicket, scopes,

--- a/support/cas-server-support-oauth-uma-core/src/main/java/org/apereo/cas/uma/ticket/rpt/UmaRequestingPartyTokenSigningService.java
+++ b/support/cas-server-support-oauth-uma-core/src/main/java/org/apereo/cas/uma/ticket/rpt/UmaRequestingPartyTokenSigningService.java
@@ -40,7 +40,7 @@ public class UmaRequestingPartyTokenSigningService extends BaseTokenSigningAndEn
                 () -> {
                     LOGGER.warn("JWKS file for UMA RPT tokens cannot be located. Tokens will not be signed");
                     return new JsonWebKeySet();
-                })
+                }, LOGGER)
             .get();
         this.casProperties = properties;
     }

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -216,7 +216,7 @@ public class CasOAuth20Configuration {
                             + "the token encryption/signing functionality.");
                         return Boolean.TRUE;
                     },
-                    crypto::isEnabled)
+                    crypto::isEnabled, LOGGER)
                 .get();
 
             if (enabled) {
@@ -642,7 +642,7 @@ public class CasOAuth20Configuration {
                         ? CipherExecutorUtils.newStringCipherExecutor(crypto, OAuth20DistributedSessionCookieCipherExecutor.class)
                         : CipherExecutor.noOp();
                 },
-                CipherExecutor::noOp).get();
+                CipherExecutor::noOp, LOGGER).get();
         }
 
         @ConditionalOnMissingBean(name = "oauthDistributedSessionCookieGenerator")
@@ -800,7 +800,7 @@ public class CasOAuth20Configuration {
                             + "are defined for operations. CAS will proceed to enable the encryption/signing functionality.");
                         return Boolean.TRUE;
                     },
-                    crypto::isEnabled)
+                    crypto::isEnabled, LOGGER)
                 .get();
 
             if (enabled) {

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/assurance/AssuranceVerificationJsonSource.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/assurance/AssuranceVerificationJsonSource.java
@@ -75,6 +75,6 @@ public class AssuranceVerificationJsonSource implements AssuranceVerificationSou
             });
             verifications.clear();
             verifications.addAll(results);
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/audit/OidcIdTokenAuditResourceResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/audit/OidcIdTokenAuditResourceResolver.java
@@ -8,6 +8,7 @@ import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken;
 import org.apereo.cas.util.DigestUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.audit.spi.support.ReturnValueAsStringResourceResolver;
 import org.aspectj.lang.JoinPoint;
@@ -21,6 +22,7 @@ import java.util.HashMap;
  * @since 7.0.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class OidcIdTokenAuditResourceResolver extends ReturnValueAsStringResourceResolver {
     private final AuditEngineProperties properties;
 
@@ -33,11 +35,11 @@ public class OidcIdTokenAuditResourceResolver extends ReturnValueAsStringResourc
         val userProfile = (UserProfile) auditableTarget.getArgs()[1];
         values.put(OAuth20Constants.CLIENT_ID, accessToken.getClientId());
         values.put(OAuth20Constants.SCOPE, accessToken.getScopes());
-        FunctionUtils.doIfNotNull(userProfile, __ -> values.put("username", userProfile.getId()));
-        FunctionUtils.doIfNotNull(accessToken.getService(), svc -> values.put("service", svc));
+        FunctionUtils.doIfNotNull(userProfile, __ -> values.put("username", userProfile.getId()), LOGGER);
+        FunctionUtils.doIfNotNull(accessToken.getService(), svc -> values.put("service", svc), LOGGER);
         if (idToken.claims().hasClaim(OidcConstants.TXN)) {
             val txn = FunctionUtils.doUnchecked(() -> idToken.claims().getStringClaimValue(OidcConstants.TXN));
-            FunctionUtils.doIfNotNull(txn, __ -> values.put(OidcConstants.TXN, txn));
+            FunctionUtils.doIfNotNull(txn, __ -> values.put(OidcConstants.TXN, txn), LOGGER);
             values.put("authn_methods", accessToken.getAuthentication().getSuccesses().keySet());
         }
         return new String[]{auditFormat.serialize(values)};

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/authn/OidcAccessTokenAuthenticator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/authn/OidcAccessTokenAuthenticator.java
@@ -45,7 +45,7 @@ public class OidcAccessTokenAuthenticator extends OAuth20AccessTokenAuthenticato
             val profile = super.buildUserProfile(tokenCredentials, callContext, accessToken);
             validateIdTokenIfAny(accessToken, profile);
             return profile;
-        });
+        }, LOGGER);
     }
 
     protected void validateIdTokenIfAny(final OAuth20AccessToken accessToken, final CommonProfile profile) throws Exception {

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/authn/OidcJwtAuthenticator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/authn/OidcJwtAuthenticator.java
@@ -134,7 +134,7 @@ public class OidcJwtAuthenticator implements Authenticator {
         }, e -> {
             LoggingUtils.error(LOGGER, e);
             return Optional.<Credentials>empty();
-        }).get();
+        }, LOGGER).get();
     }
 
     protected OidcRegisteredService getOidcRegisteredService(final CallContext callContext) throws Throwable {
@@ -144,7 +144,7 @@ public class OidcJwtAuthenticator implements Authenticator {
         val oauthCode = FunctionUtils.doAndHandle(() -> {
             val givenCode = ticketRegistry.getTicket(code, OAuth20Code.class);
             return givenCode == null || givenCode.isExpired() ? null : givenCode;
-        });
+        }, LOGGER);
         val clientId = oauthCode == null ? webContext.getRequestParameter(OAuth20Constants.CLIENT_ID).orElse(null) : oauthCode.getClientId();
         val registeredService = (OidcRegisteredService) OAuth20Utils.getRegisteredOAuthServiceByClientId(servicesManager, clientId);
         val audit = AuditableContext.builder()
@@ -162,7 +162,7 @@ public class OidcJwtAuthenticator implements Authenticator {
             userProfile.setId(jwt.getSubject());
             userProfile.addAttributes(jwt.getClaimsMap());
             credentials.setUserProfile(userProfile);
-        });
+        }, LOGGER);
     }
 
     protected boolean validateJwtAlgorithm(final Algorithm alg) {

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeyStoreUtils.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeyStoreUtils.java
@@ -76,7 +76,7 @@ public class OidcJsonWebKeyStoreUtils {
                 (CheckedFunction<Throwable, Optional<JsonWebKeySet>>) throwable -> {
                     LoggingUtils.error(LOGGER, throwable);
                     return Optional.empty();
-                })
+                }, LOGGER)
             .get();
     }
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcDefaultJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcDefaultJsonWebKeystoreGeneratorService.java
@@ -45,7 +45,7 @@ public class OidcDefaultJsonWebKeystoreGeneratorService implements OidcJsonWebKe
 
     @Override
     public void destroy() {
-        FunctionUtils.doIfNotNull(resourceWatcherService, WatcherService::close);
+        FunctionUtils.doIfNotNull(resourceWatcherService, WatcherService::close, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcRestfulJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcRestfulJsonWebKeystoreGeneratorService.java
@@ -75,7 +75,7 @@ public class OidcRestfulJsonWebKeystoreGeneratorService implements OidcJsonWebKe
         val response = HttpUtils.execute(exec);
         FunctionUtils.doIfNotNull(response,
             httpResponse -> LOGGER.debug("Storing JWKS resource via [{}] returned [{}]",
-                rest.getUrl(), response.getReasonPhrase()));
+                rest.getUrl(), response.getReasonPhrase()), LOGGER);
         return jsonWebKeySet;
     }
 }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcUserProfileViewRenderer.java
@@ -66,7 +66,7 @@ public class OidcUserProfileViewRenderer extends OAuth20DefaultUserProfileViewRe
                 return signAndEncryptUserProfileClaims(userProfile, response, registeredService);
             }
             return buildPlainUserProfileClaims(userProfile, response, registeredService);
-        }, e -> ResponseEntity.badRequest().body("Unable to produce user profile claims")).get();
+        }, e -> ResponseEntity.badRequest().body("Unable to produce user profile claims"), LOGGER).get();
     }
 
     protected ResponseEntity<String> buildPlainUserProfileClaims(final Map<String, Object> userProfile,

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/ticket/OidcPushedAuthorizationRequestValidator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/ticket/OidcPushedAuthorizationRequestValidator.java
@@ -12,6 +12,7 @@ import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.util.function.FunctionUtils;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.pac4j.core.context.WebContext;
 
@@ -21,6 +22,7 @@ import org.pac4j.core.context.WebContext;
  * @author Misagh Moayyed
  * @since 6.5.0
  */
+@Slf4j
 public class OidcPushedAuthorizationRequestValidator extends BaseOAuth20AuthorizationRequestValidator {
     private final TicketRegistry ticketRegistry;
     private final TicketFactory ticketFactory;
@@ -48,7 +50,7 @@ public class OidcPushedAuthorizationRequestValidator extends BaseOAuth20Authoriz
             context.setRequestAttribute(OidcPushedAuthorizationRequest.class.getName(), holder);
             val givenClientId = getClientIdFromRequest(context);
             return givenClientId.equals(holder.getClientId()) && verifyRegisteredServiceByClientId(context, holder.getClientId()) != null;
-        }, throwable -> false).get();
+        }, throwable -> false, LOGGER).get();
     }
 
     @Override

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcCallbackAuthorizeViewResolver.java
@@ -65,7 +65,7 @@ public class OidcCallbackAuthorizeViewResolver implements OAuth20CallbackAuthori
             val responseType = oauthRequestParameterResolver.resolveResponseModeType(context);
             val redirect = FunctionUtils.doIf(OAuth20ResponseModeFactory.isResponseModeTypeFormPost(registeredService, responseType),
                     originalRedirectUrl::get,
-                    () -> OidcRequestSupport.getRedirectUrlWithError(originalRedirectUrl.get(), OidcConstants.LOGIN_REQUIRED, context))
+                    () -> OidcRequestSupport.getRedirectUrlWithError(originalRedirectUrl.get(), OidcConstants.LOGIN_REQUIRED, context), LOGGER)
                 .get();
             return FunctionUtils.doUnchecked(() -> {
                 LOGGER.warn("Unable to detect authenticated user profile for prompt-less login attempts. Redirecting to URL [{}]", redirect);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcDefaultClientRegistrationRequestTranslator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcDefaultClientRegistrationRequestTranslator.java
@@ -105,7 +105,7 @@ public class OidcDefaultClientRegistrationRequestTranslator implements OidcClien
         }
 
         FunctionUtils.doIfNotBlank(registrationRequest.getTokenEndpointAuthMethod(),
-            __ -> registeredService.setTokenEndpointAuthenticationMethod(registrationRequest.getTokenEndpointAuthMethod()));
+            __ -> registeredService.setTokenEndpointAuthenticationMethod(registrationRequest.getTokenEndpointAuthMethod()), LOGGER);
 
         if (StringUtils.isBlank(registeredService.getClientId())) {
             registeredService.setClientId(context.getClientIdGenerator().getNewString());
@@ -118,9 +118,9 @@ public class OidcDefaultClientRegistrationRequestTranslator implements OidcClien
             registrationRequest.getPostLogoutRedirectUris());
         registeredService.setLogoutUrl(urls);
 
-        FunctionUtils.doIfNotBlank(registrationRequest.getLogo(), __ -> registeredService.setLogo(registrationRequest.getLogo()));
-        FunctionUtils.doIfNotBlank(registrationRequest.getPolicyUri(), __ -> registeredService.setInformationUrl(registrationRequest.getPolicyUri()));
-        FunctionUtils.doIfNotBlank(registrationRequest.getTermsOfUseUri(), __ -> registeredService.setPrivacyUrl(registrationRequest.getTermsOfUseUri()));
+        FunctionUtils.doIfNotBlank(registrationRequest.getLogo(), __ -> registeredService.setLogo(registrationRequest.getLogo()), LOGGER);
+        FunctionUtils.doIfNotBlank(registrationRequest.getPolicyUri(), __ -> registeredService.setInformationUrl(registrationRequest.getPolicyUri()), LOGGER);
+        FunctionUtils.doIfNotBlank(registrationRequest.getTermsOfUseUri(), __ -> registeredService.setPrivacyUrl(registrationRequest.getTermsOfUseUri()), LOGGER);
 
         processUserInfoSigningAndEncryption(registrationRequest, registeredService);
         processScopesAndResponsesAndGrants(registrationRequest, registeredService);
@@ -144,20 +144,20 @@ public class OidcDefaultClientRegistrationRequestTranslator implements OidcClien
 
     private static void processTlsClientAuthentication(final OidcClientRegistrationRequest registrationRequest,
                                                        final OidcRegisteredService registeredService) {
-        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanDns(), registeredService::setTlsClientAuthSanDns);
-        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanEmail(), registeredService::setTlsClientAuthSanEmail);
-        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanIp(), registeredService::setTlsClientAuthSanIp);
-        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanUri(), registeredService::setTlsClientAuthSanUri);
-        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSubjectDn(), registeredService::setTlsClientAuthSubjectDn);
+        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanDns(), registeredService::setTlsClientAuthSanDns, LOGGER);
+        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanEmail(), registeredService::setTlsClientAuthSanEmail, LOGGER);
+        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanIp(), registeredService::setTlsClientAuthSanIp, LOGGER);
+        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSanUri(), registeredService::setTlsClientAuthSanUri, LOGGER);
+        FunctionUtils.doIfNotNull(registrationRequest.getTlsClientAuthSubjectDn(), registeredService::setTlsClientAuthSubjectDn, LOGGER);
     }
 
     private void processScopesAndResponsesAndGrants(final OidcClientRegistrationRequest registrationRequest,
                                                     final OidcRegisteredService registeredService) {
         val context = configurationContext.getObject();
         FunctionUtils.doIfNotNull(registrationRequest.getGrantTypes(),
-            __ -> registeredService.setSupportedGrantTypes(new HashSet<>(registrationRequest.getGrantTypes())));
+            __ -> registeredService.setSupportedGrantTypes(new HashSet<>(registrationRequest.getGrantTypes())), LOGGER);
         FunctionUtils.doIfNotNull(registrationRequest.getResponseTypes(),
-            __ -> registeredService.setSupportedResponseTypes(new HashSet<>(registrationRequest.getResponseTypes())));
+            __ -> registeredService.setSupportedResponseTypes(new HashSet<>(registrationRequest.getResponseTypes())), LOGGER);
 
         val properties = context.getCasProperties();
         val supportedScopes = new HashSet<>(properties.getAuthn().getOidc().getDiscovery().getScopes());
@@ -189,13 +189,13 @@ public class OidcDefaultClientRegistrationRequestTranslator implements OidcClien
     private static void processIntrospectionSigningAndEncryption(final OidcClientRegistrationRequest registrationRequest,
                                                                  final OidcRegisteredService registeredService) {
         FunctionUtils.doIfNotBlank(registrationRequest.getIntrospectionSignedResponseAlg(),
-            __ -> registeredService.setIntrospectionSignedResponseAlg(registrationRequest.getIntrospectionSignedResponseAlg()));
+            __ -> registeredService.setIntrospectionSignedResponseAlg(registrationRequest.getIntrospectionSignedResponseAlg()), LOGGER);
 
         FunctionUtils.doIfNotBlank(registrationRequest.getIntrospectionEncryptedResponseAlg(),
-            __ -> registeredService.setIntrospectionEncryptedResponseAlg(registrationRequest.getIntrospectionEncryptedResponseAlg()));
+            __ -> registeredService.setIntrospectionEncryptedResponseAlg(registrationRequest.getIntrospectionEncryptedResponseAlg()), LOGGER);
 
         FunctionUtils.doIfNotBlank(registrationRequest.getIntrospectionEncryptedResponseEncoding(),
-            __ -> registeredService.setIntrospectionEncryptedResponseEncoding(registrationRequest.getIntrospectionEncryptedResponseEncoding()));
+            __ -> registeredService.setIntrospectionEncryptedResponseEncoding(registrationRequest.getIntrospectionEncryptedResponseEncoding()), LOGGER);
     }
 
     private static void processIdTokenSigningAndEncryption(final OidcClientRegistrationRequest registrationRequest,

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcInitialAccessTokenController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcInitialAccessTokenController.java
@@ -159,6 +159,6 @@ public class OidcInitialAccessTokenController extends BaseOidcController {
             val accessToken = accessTokenResult.getAccessToken().get();
             getConfigurationContext().getTicketRegistry().addTicket(accessToken);
             return Optional.of(accessToken);
-        }, e -> Optional.<OAuth20AccessToken>empty()).get();
+        }, e -> Optional.<OAuth20AccessToken>empty(), LOGGER).get();
     }
 }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/introspection/OidcIntrospectionEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/introspection/OidcIntrospectionEndpointController.java
@@ -121,7 +121,7 @@ public class OidcIntrospectionEndpointController extends OAuth20IntrospectionEnd
                         return signAndEncryptIntrospection(context, introspect, registeredService);
                     }
                     return buildPlainIntrospectionClaims(context, introspect, registeredService);
-                }, e -> ResponseEntity.badRequest().body("Unable to produce introspection JWT claims")).get();
+                }, e -> ResponseEntity.badRequest().body("Unable to produce introspection JWT claims"), LOGGER).get();
             })
             .orElse(responseEntity);
     }

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcConfiguration.java
@@ -534,7 +534,7 @@ public class OidcConfiguration {
                     cipher.setEncryptionEnabled(crypto.isEncryptionEnabled());
                     return cipher;
                 },
-                CipherExecutor::noOpOfSerializableToString).get();
+                CipherExecutor::noOpOfSerializableToString, LOGGER).get();
         }
 
     }
@@ -1083,7 +1083,7 @@ public class OidcConfiguration {
                     cipher.setEncryptionEnabled(crypto.isEncryptionEnabled());
                     return cipher;
                 },
-                CipherExecutor::noOpOfSerializableToString).get();
+                CipherExecutor::noOpOfSerializableToString, LOGGER).get();
         }
 
         @Bean
@@ -1101,7 +1101,7 @@ public class OidcConfiguration {
             return FunctionUtils.doIf(crypto.isEnabled(),
                 () -> new OidcRegisteredServiceJwtResponseModeCipherExecutor(oidcDefaultJsonWebKeystoreCache,
                     oidcServiceJsonWebKeystoreCache, oidcIssuerService),
-                RegisteredServiceCipherExecutor::noOp).get();
+                RegisteredServiceCipherExecutor::noOp, LOGGER).get();
         }
 
         @Bean
@@ -1132,7 +1132,7 @@ public class OidcConfiguration {
             final CasConfigurationProperties casProperties) {
             val source = casProperties.getAuthn().getOidc().getIdentityAssurance().getVerificationSource().getLocation();
             return FunctionUtils.doIfNotNull(source,
-                () -> new AssuranceVerificationJsonSource(source), AssuranceVerificationSource::empty).get();
+                () -> new AssuranceVerificationJsonSource(source), AssuranceVerificationSource::empty, LOGGER).get();
         }
     }
 

--- a/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/config/OktaPersonDirectoryConfiguration.java
+++ b/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/config/OktaPersonDirectoryConfiguration.java
@@ -13,6 +13,7 @@ import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
 import com.okta.sdk.client.Client;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.apereo.services.persondir.support.SimpleUsernameAttributeProvider;
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.PersonDirectory, module = "okta")
 @AutoConfiguration
+@Slf4j
 public class OktaPersonDirectoryConfiguration {
     private static final BeanCondition CONDITION = BeanCondition.on("cas.authn.attribute-repository.okta.organization-url");
 
@@ -68,7 +70,7 @@ public class OktaPersonDirectoryConfiguration {
                 val dao = new OktaPersonAttributeDao(oktaPersonDirectoryClient);
                 dao.setUsernameAttributeProvider(new SimpleUsernameAttributeProvider(properties.getUsernameAttribute()));
                 dao.setOrder(properties.getOrder());
-                FunctionUtils.doIfNotNull(properties.getId(), id -> dao.setId(id));
+                FunctionUtils.doIfNotNull(properties.getId(), id -> dao.setId(id), LOGGER);
                 return BeanContainer.of(CollectionUtils.wrapList(dao));
             })
             .otherwise(BeanContainer::empty)

--- a/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/okta/OktaAuthenticationStateHandlerAdapter.java
+++ b/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/okta/OktaAuthenticationStateHandlerAdapter.java
@@ -64,11 +64,11 @@ public class OktaAuthenticationStateHandlerAdapter extends AuthenticationStateHa
             val user = successResponse.getUser();
             this.username = user.getLogin();
 
-            FunctionUtils.doIfNotNull(successResponse.getSessionToken(), value -> userAttributes.put("oktaSessionToken", CollectionUtils.wrapList(value)));
-            FunctionUtils.doIfNotNull(successResponse.getStatusString(), value -> userAttributes.put("oktaStatus", CollectionUtils.wrapList(value)));
-            FunctionUtils.doIfNotNull(successResponse.getType(), value -> userAttributes.put("oktaType", CollectionUtils.wrapList(value)));
-            FunctionUtils.doIfNotNull(successResponse.getExpiresAt(), value -> userAttributes.put("oktaExpiration", CollectionUtils.wrapList(value)));
-            FunctionUtils.doIfNotNull(successResponse.getRecoveryType(), value -> userAttributes.put("oktaRecoveryType", CollectionUtils.wrapList(value)));
+            FunctionUtils.doIfNotNull(successResponse.getSessionToken(), value -> userAttributes.put("oktaSessionToken", CollectionUtils.wrapList(value)), LOGGER);
+            FunctionUtils.doIfNotNull(successResponse.getStatusString(), value -> userAttributes.put("oktaStatus", CollectionUtils.wrapList(value)), LOGGER);
+            FunctionUtils.doIfNotNull(successResponse.getType(), value -> userAttributes.put("oktaType", CollectionUtils.wrapList(value)), LOGGER);
+            FunctionUtils.doIfNotNull(successResponse.getExpiresAt(), value -> userAttributes.put("oktaExpiration", CollectionUtils.wrapList(value)), LOGGER);
+            FunctionUtils.doIfNotNull(successResponse.getRecoveryType(), value -> userAttributes.put("oktaRecoveryType", CollectionUtils.wrapList(value)), LOGGER);
             
             user.getProfile().forEach((key, value) -> userAttributes.put(key, CollectionUtils.wrapList(value)));
         } else {

--- a/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/okta/OktaConfigurationFactory.java
+++ b/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/okta/OktaConfigurationFactory.java
@@ -11,6 +11,7 @@ import com.okta.sdk.authc.credentials.TokenClientCredentials;
 import com.okta.sdk.client.AuthorizationMode;
 import com.okta.sdk.client.Client;
 import com.okta.sdk.client.Clients;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -22,6 +23,7 @@ import java.nio.charset.StandardCharsets;
  * @author Misagh Moayyed
  * @since 6.4.0
  */
+@Slf4j
 public class OktaConfigurationFactory {
 
     /**
@@ -35,7 +37,7 @@ public class OktaConfigurationFactory {
             .setOrgUrl(properties.getOrganizationUrl())
             .setConnectionTimeout(properties.getConnectionTimeout());
 
-        FunctionUtils.doIfNotNull(properties.getApiToken(), token -> clientBuilder.setClientCredentials(new TokenClientCredentials(token)));
+        FunctionUtils.doIfNotNull(properties.getApiToken(), token -> clientBuilder.setClientCredentials(new TokenClientCredentials(token)), LOGGER);
         FunctionUtils.doIfNotNull(properties.getPrivateKey().getLocation(), path -> {
             val resource = IOUtils.toString(path.getInputStream(), StandardCharsets.UTF_8);
             clientBuilder
@@ -43,7 +45,7 @@ public class OktaConfigurationFactory {
                 .setPrivateKey(resource)
                 .setClientId(properties.getClientId())
                 .setScopes(CollectionUtils.wrapHashSet(properties.getScopes()));
-        });
+        }, LOGGER);
 
         if (StringUtils.isNotBlank(properties.getProxyHost()) && properties.getProxyPort() > 0) {
             if (StringUtils.isNotBlank(properties.getProxyUsername()) && StringUtils.isNotBlank(properties.getProxyPassword())) {

--- a/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/okta/OktaPersonAttributeDao.java
+++ b/support/cas-server-support-okta-authentication/src/main/java/org/apereo/cas/okta/OktaPersonAttributeDao.java
@@ -7,6 +7,7 @@ import com.okta.sdk.client.Client;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.services.persondir.IPersonAttributeDaoFilter;
 import org.apereo.services.persondir.IPersonAttributes;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Getter
 @Setter
+@Slf4j
 public class OktaPersonAttributeDao extends BasePersonAttributeDao {
     private IUsernameAttributeProvider usernameAttributeProvider = new SimpleUsernameAttributeProvider();
 
@@ -50,44 +52,44 @@ public class OktaPersonAttributeDao extends BasePersonAttributeDao {
         val attributes = new HashMap<String, Object>();
         val user = oktaClient.getUser(uid);
 
-        FunctionUtils.doIfNotNull(user.getActivated(), attribute -> attributes.put("oktaUserActivatedDate", user.getActivated().getTime()));
-        FunctionUtils.doIfNotNull(user.getCreated(), attribute -> attributes.put("oktaUserCreatedDate", user.getCreated().getTime()));
-        FunctionUtils.doIfNotNull(user.getLastLogin(), attribute -> attributes.put("oktaUserLastLoginDate", user.getLastLogin().getTime()));
-        FunctionUtils.doIfNotNull(user.getLastUpdated(), attribute -> attributes.put("oktaUserLastUpdatedDate", user.getLastUpdated().getTime()));
-        FunctionUtils.doIfNotNull(user.getPasswordChanged(), attribute -> attributes.put("oktaUserPasswordChangedDate", user.getPasswordChanged().getTime()));
-        FunctionUtils.doIfNotNull(user.getId(), attribute -> attributes.put("oktaUserId", attribute));
-        FunctionUtils.doIfNotNull(user.getStatus(), attribute -> attributes.put("oktaUserStatus", attribute.toString()));
-        FunctionUtils.doIfNotNull(user.getType(), attribute -> attributes.put("oktaUserType", attribute));
+        FunctionUtils.doIfNotNull(user.getActivated(), attribute -> attributes.put("oktaUserActivatedDate", user.getActivated().getTime()), LOGGER);
+        FunctionUtils.doIfNotNull(user.getCreated(), attribute -> attributes.put("oktaUserCreatedDate", user.getCreated().getTime()), LOGGER);
+        FunctionUtils.doIfNotNull(user.getLastLogin(), attribute -> attributes.put("oktaUserLastLoginDate", user.getLastLogin().getTime()), LOGGER);
+        FunctionUtils.doIfNotNull(user.getLastUpdated(), attribute -> attributes.put("oktaUserLastUpdatedDate", user.getLastUpdated().getTime()), LOGGER);
+        FunctionUtils.doIfNotNull(user.getPasswordChanged(), attribute -> attributes.put("oktaUserPasswordChangedDate", user.getPasswordChanged().getTime()), LOGGER);
+        FunctionUtils.doIfNotNull(user.getId(), attribute -> attributes.put("oktaUserId", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(user.getStatus(), attribute -> attributes.put("oktaUserStatus", attribute.toString()), LOGGER);
+        FunctionUtils.doIfNotNull(user.getType(), attribute -> attributes.put("oktaUserType", attribute), LOGGER);
 
         val profile = user.getProfile();
-        FunctionUtils.doIfNotNull(profile.getCity(), attribute -> attributes.put("oktaCity", attribute));
-        FunctionUtils.doIfNotNull(profile.getCostCenter(), attribute -> attributes.put("oktaCostCenter", attribute));
-        FunctionUtils.doIfNotNull(profile.getCountryCode(), attribute -> attributes.put("oktaCountryCode", attribute));
-        FunctionUtils.doIfNotNull(profile.getDepartment(), attribute -> attributes.put("oktaDepartment", attribute));
-        FunctionUtils.doIfNotNull(profile.getDisplayName(), attribute -> attributes.put("oktaDisplayName", attribute));
-        FunctionUtils.doIfNotNull(profile.getDivision(), attribute -> attributes.put("oktaDivision", attribute));
-        FunctionUtils.doIfNotNull(profile.getEmail(), attribute -> attributes.put("oktaEmail", attribute));
-        FunctionUtils.doIfNotNull(profile.getEmployeeNumber(), attribute -> attributes.put("oktaEmployeeNumber", attribute));
-        FunctionUtils.doIfNotNull(profile.getFirstName(), attribute -> attributes.put("oktaFirstName", attribute));
-        FunctionUtils.doIfNotNull(profile.getHonorificPrefix(), attribute -> attributes.put("oktaPrefix", attribute));
-        FunctionUtils.doIfNotNull(profile.getHonorificSuffix(), attribute -> attributes.put("oktaSuffix", attribute));
-        FunctionUtils.doIfNotNull(profile.getLastName(), attribute -> attributes.put("oktaLastName", attribute));
-        FunctionUtils.doIfNotNull(profile.getLocale(), attribute -> attributes.put("oktaLocale", attribute));
-        FunctionUtils.doIfNotNull(profile.getManager(), attribute -> attributes.put("oktaManager", attribute));
-        FunctionUtils.doIfNotNull(profile.getManagerId(), attribute -> attributes.put("oktaManagerId", attribute));
-        FunctionUtils.doIfNotNull(profile.getMiddleName(), attribute -> attributes.put("oktaMiddleName", attribute));
-        FunctionUtils.doIfNotNull(profile.getMobilePhone(), attribute -> attributes.put("oktaMobilePhone", attribute));
-        FunctionUtils.doIfNotNull(profile.getNickName(), attribute -> attributes.put("oktaNickName", attribute));
-        FunctionUtils.doIfNotNull(profile.getOrganization(), attribute -> attributes.put("oktaOrganization", attribute));
-        FunctionUtils.doIfNotNull(profile.getPostalAddress(), attribute -> attributes.put("oktaPostalAddress", attribute));
-        FunctionUtils.doIfNotNull(profile.getPreferredLanguage(), attribute -> attributes.put("oktaPreferredLanguage", attribute));
-        FunctionUtils.doIfNotNull(profile.getPrimaryPhone(), attribute -> attributes.put("oktaPrimaryPhone", attribute));
-        FunctionUtils.doIfNotNull(profile.getSecondEmail(), attribute -> attributes.put("oktaSecondEmail", attribute));
-        FunctionUtils.doIfNotNull(profile.getState(), attribute -> attributes.put("oktaState", attribute));
-        FunctionUtils.doIfNotNull(profile.getStreetAddress(), attribute -> attributes.put("oktaStreetAddress", attribute));
-        FunctionUtils.doIfNotNull(profile.getTimezone(), attribute -> attributes.put("oktaTimezone", attribute));
-        FunctionUtils.doIfNotNull(profile.getTitle(), attribute -> attributes.put("oktaTitle", attribute));
-        FunctionUtils.doIfNotNull(profile.getLogin(), attribute -> attributes.put("oktaLogin", attribute));
+        FunctionUtils.doIfNotNull(profile.getCity(), attribute -> attributes.put("oktaCity", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getCostCenter(), attribute -> attributes.put("oktaCostCenter", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getCountryCode(), attribute -> attributes.put("oktaCountryCode", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getDepartment(), attribute -> attributes.put("oktaDepartment", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getDisplayName(), attribute -> attributes.put("oktaDisplayName", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getDivision(), attribute -> attributes.put("oktaDivision", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getEmail(), attribute -> attributes.put("oktaEmail", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getEmployeeNumber(), attribute -> attributes.put("oktaEmployeeNumber", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getFirstName(), attribute -> attributes.put("oktaFirstName", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getHonorificPrefix(), attribute -> attributes.put("oktaPrefix", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getHonorificSuffix(), attribute -> attributes.put("oktaSuffix", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getLastName(), attribute -> attributes.put("oktaLastName", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getLocale(), attribute -> attributes.put("oktaLocale", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getManager(), attribute -> attributes.put("oktaManager", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getManagerId(), attribute -> attributes.put("oktaManagerId", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getMiddleName(), attribute -> attributes.put("oktaMiddleName", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getMobilePhone(), attribute -> attributes.put("oktaMobilePhone", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getNickName(), attribute -> attributes.put("oktaNickName", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getOrganization(), attribute -> attributes.put("oktaOrganization", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getPostalAddress(), attribute -> attributes.put("oktaPostalAddress", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getPreferredLanguage(), attribute -> attributes.put("oktaPreferredLanguage", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getPrimaryPhone(), attribute -> attributes.put("oktaPrimaryPhone", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getSecondEmail(), attribute -> attributes.put("oktaSecondEmail", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getState(), attribute -> attributes.put("oktaState", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getStreetAddress(), attribute -> attributes.put("oktaStreetAddress", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getTimezone(), attribute -> attributes.put("oktaTimezone", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getTitle(), attribute -> attributes.put("oktaTitle", attribute), LOGGER);
+        FunctionUtils.doIfNotNull(profile.getLogin(), attribute -> attributes.put("oktaLogin", attribute), LOGGER);
 
         return new CaseInsensitiveNamedPersonImpl(uid, stuffAttributesIntoList(attributes));
     }

--- a/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/repository/credentials/BaseOneTimeTokenCredentialRepository.java
+++ b/support/cas-server-support-otp-mfa-core/src/main/java/org/apereo/cas/otp/repository/credentials/BaseOneTimeTokenCredentialRepository.java
@@ -6,6 +6,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 import java.util.Collection;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
  * @since 5.0.0
  */
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public abstract class BaseOneTimeTokenCredentialRepository implements OneTimeTokenCredentialRepository {
     /**
      * The Token credential cipher.
@@ -61,7 +63,7 @@ public abstract class BaseOneTimeTokenCredentialRepository implements OneTimeTok
         val decodedSecret = tokenCredentialCipher.decode(account.getSecretKey());
         val decodedScratchCodes = account.getScratchCodes()
             .stream()
-            .map(code -> FunctionUtils.doAndHandle(() -> scratchCodesCipher.decode(code), t -> code).get())
+            .map(code -> FunctionUtils.doAndHandle(() -> scratchCodesCipher.decode(code), t -> code, LOGGER).get())
             .collect(Collectors.toList());
         val newAccount = account.clone();
         newAccount.setSecretKey(decodedSecret);

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/handler/support/DelegatedClientAuthenticationHandler.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/handler/support/DelegatedClientAuthenticationHandler.java
@@ -96,7 +96,7 @@ public class DelegatedClientAuthenticationHandler extends BaseDelegatedClientAut
             return createResult(clientCredentials, userProfile, client, service);
         }, e -> {
             throw new PreventedException(e);
-        }).get();
+        }, LOGGER).get();
     }
 
     @Override

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/authentication/principal/DefaultDelegatedAuthenticationCredentialExtractor.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/authentication/principal/DefaultDelegatedAuthenticationCredentialExtractor.java
@@ -52,7 +52,7 @@ public class DefaultDelegatedAuthenticationCredentialExtractor implements Delega
                 .map(cc -> client.validateCredentials(callContext, cc))
                 .filter(Optional::isPresent)
                 .map(Optional::get);
-        }, e -> Optional.<Credentials>empty()).get();
+        }, e -> Optional.<Credentials>empty(), LOGGER).get();
 
     }
 }

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DefaultDelegatedClientAuthenticationWebflowManager.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DefaultDelegatedClientAuthenticationWebflowManager.java
@@ -233,7 +233,7 @@ public class DefaultDelegatedClientAuthenticationWebflowManager implements Deleg
         }, e -> {
             LoggingUtils.error(LOGGER, e);
             throw UnauthorizedServiceException.denied("Rejected: %s".formatted(clientId));
-        }).get();
+        }, LOGGER).get();
     }
 
     protected String getDelegatedClientId(final WebContext webContext, final Client client) {

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DefaultDelegatedClientIdentityProviderConfigurationProducer.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DefaultDelegatedClientIdentityProviderConfigurationProducer.java
@@ -112,7 +112,7 @@ public class DefaultDelegatedClientIdentityProviderConfigurationProducer impleme
                     .resolve();
             }
             return Optional.<DelegatedClientIdentityProviderConfiguration>empty();
-        }, throwable -> Optional.<DelegatedClientIdentityProviderConfiguration>empty()).get();
+        }, throwable -> Optional.<DelegatedClientIdentityProviderConfiguration>empty(), LOGGER).get();
     }
 
     protected void initializeClientIdentityProvider(final IndirectClient client) throws Throwable {

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluator.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluator.java
@@ -60,7 +60,7 @@ public class DefaultDelegatedClientAuthenticationFailureEvaluator implements Del
             LOGGER.debug("Delegation request has failed. Details are [{}]", model);
             return Optional.of(new ModelAndView(CasWebflowConstants.VIEW_ID_DELEGATED_AUTHENTICATION_STOP_WEBFLOW, model));
         },
-            Optional::<ModelAndView>empty)
+            Optional::<ModelAndView>empty, LOGGER)
         .get();
     }
 }

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/logout/DelegatedProfileTerminationHandler.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/logout/DelegatedProfileTerminationHandler.java
@@ -32,8 +32,8 @@ public class DelegatedProfileTerminationHandler implements SessionTerminationHan
         val manager = new ProfileManager(context, new JEESessionStore());
         manager.removeProfiles();
         val session = request.getSession(false);
-        val url = FunctionUtils.doIfNotNull(session, () -> (String) session.getAttribute(Pac4jConstants.REQUESTED_URL));
-        return FunctionUtils.doIfNotNull(url, () -> List.of(new Pac4jRequestedUrl(url)), List::<Pac4jRequestedUrl>of).get();
+        val url = FunctionUtils.doIfNotNull(session, () -> (String) session.getAttribute(Pac4jConstants.REQUESTED_URL), LOGGER);
+        return FunctionUtils.doIfNotNull(url, () -> List.of(new Pac4jRequestedUrl(url)), List::<Pac4jRequestedUrl>of, LOGGER).get();
     }
 
     @Override

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationEventExecutionPlanConfiguration.java
@@ -139,7 +139,7 @@ public class DelegatedAuthenticationEventExecutionPlanConfiguration {
                         ? CipherExecutorUtils.newStringCipherExecutor(crypto, DelegatedClientAuthenticationDistributedSessionCookieCipherExecutor.class)
                         : CipherExecutor.noOp();
                 },
-                CipherExecutor::noOp).get();
+                CipherExecutor::noOp, LOGGER).get();
         }
 
         @ConditionalOnMissingBean(name = "delegatedClientDistributedSessionCookieGenerator")

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationWebflowConfiguration.java
@@ -86,6 +86,7 @@ import org.apereo.cas.web.flow.resolver.CasWebflowEventResolver;
 import org.apereo.cas.web.saml2.DelegatedSaml2ClientMetadataController;
 import org.apereo.cas.web.support.ArgumentExtractor;
 import org.apereo.cas.web.support.CookieUtils;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.pac4j.core.context.session.SessionStore;
@@ -132,6 +133,7 @@ import java.util.stream.Collectors;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.DelegatedAuthentication)
 @AutoConfiguration
+@Slf4j
 public class DelegatedAuthenticationWebflowConfiguration {
     @Configuration(value = "DelegatedAuthenticationWebflowErrorConfiguration", proxyBeanMethods = false)
     @EnableConfigurationProperties({CasConfigurationProperties.class, WebProperties.class, WebMvcProperties.class})
@@ -302,7 +304,7 @@ public class DelegatedAuthenticationWebflowConfiguration {
             val strategy = casProperties.getAuthn().getPac4j().getCore().getGroovyRedirectionStrategy();
             FunctionUtils.doIfNotNull(strategy.getLocation(),
                 resource -> chain.addStrategy(new GroovyDelegatedClientIdentityProviderRedirectionStrategy(servicesManager,
-                    new WatchableGroovyScriptResource(resource), applicationContext)));
+                    new WatchableGroovyScriptResource(resource), applicationContext)), LOGGER);
             chain.addStrategy(new DefaultDelegatedClientIdentityProviderRedirectionStrategy(servicesManager,
                 delegatedAuthenticationCookieGenerator, casProperties, applicationContext));
             return chain;

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/DelegatedClientAuthenticationAction.java
@@ -183,7 +183,7 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
                 }
                 return populateContextWithClientCredential(client, context);
             },
-            Optional::empty);
+            Optional::empty, LOGGER);
     }
 
     protected Event finalizeDelegatedClientAuthentication(final RequestContext context,

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/DelegatedClientAuthenticationStoreWebflowStateAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/DelegatedClientAuthenticationStoreWebflowStateAction.java
@@ -82,7 +82,7 @@ public class DelegatedClientAuthenticationStoreWebflowStateAction extends BaseCa
                     val message = String.format("Authentication request was denied from the provider %s", clientName);
                     LoggingUtils.warn(LOGGER, message, throwable);
                     throw UnauthorizedServiceException.wrap(throwable);
-                })
+                }, LOGGER)
             .get();
     }
 

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/logout/DelegatedAuthenticationClientFinishLogoutAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/logout/DelegatedAuthenticationClientFinishLogoutAction.java
@@ -60,7 +60,7 @@ public class DelegatedAuthenticationClientFinishLogoutAction extends BaseCasWebf
                             val result = client.getLogoutProcessor().processLogout(callContext, logoutCredentials);
                             JEEHttpActionAdapter.INSTANCE.adapt(result, context);
                         });
-                    }));
+                    }, LOGGER));
             }
         } else {
             val logoutRedirect = WebUtils.getLogoutRedirectUrl(requestContext, String.class);

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryGroovyConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryGroovyConfiguration.java
@@ -66,7 +66,7 @@ public class CasPersonDirectoryGroovyConfiguration {
                             dao.setEnabled(groovy.getState() != AttributeRepositoryStates.DISABLED);
                             dao.putTag(PersonDirectoryAttributeRepositoryPlanConfigurer.class.getSimpleName(),
                                 groovy.getState() == AttributeRepositoryStates.ACTIVE);
-                            FunctionUtils.doIfNotNull(groovy.getId(), id -> dao.setId(id));
+                            FunctionUtils.doIfNotNull(groovy.getId(), id -> dao.setId(id), LOGGER);
                             LOGGER.debug("Configured Groovy attribute sources from [{}]", groovy.getLocation());
                             list.add(dao);
                         });

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryJdbcConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryJdbcConfiguration.java
@@ -70,7 +70,7 @@ public class CasPersonDirectoryJdbcConfiguration {
                         .filter(jdbc -> StringUtils.isNotBlank(jdbc.getSql()) && StringUtils.isNotBlank(jdbc.getUrl()))
                         .forEach(jdbc -> {
                             val jdbcDao = createJdbcPersonAttributeDao(jdbc);
-                            FunctionUtils.doIfNotNull(jdbc.getId(), id -> jdbcDao.setId(id));
+                            FunctionUtils.doIfNotNull(jdbc.getId(), id -> jdbcDao.setId(id), LOGGER);
 
                             val queryAttributes = CollectionUtils.wrap("username", jdbc.getUsername());
                             queryAttributes.putAll(jdbc.getQueryAttributes());

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryJsonConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryJsonConfiguration.java
@@ -70,7 +70,7 @@ public class CasPersonDirectoryJsonConfiguration {
                                 dao.setResourceWatcherService(watcherService);
                             }
                             dao.setOrder(json.getOrder());
-                            FunctionUtils.doIfNotNull(json.getId(), id -> dao.setId(id));
+                            FunctionUtils.doIfNotNull(json.getId(), id -> dao.setId(id), LOGGER);
                             dao.setEnabled(json.getState() != AttributeRepositoryStates.DISABLED);
                             dao.putTag(PersonDirectoryAttributeRepositoryPlanConfigurer.class.getSimpleName(),
                                 json.getState() == AttributeRepositoryStates.ACTIVE);

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryLdapConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryLdapConfiguration.java
@@ -73,7 +73,7 @@ public class CasPersonDirectoryLdapConfiguration {
                         .filter(ldap -> StringUtils.isNotBlank(ldap.getBaseDn()) && StringUtils.isNotBlank(ldap.getLdapUrl()))
                         .forEach(ldap -> {
                             val dao = new LdaptivePersonAttributeDao();
-                            FunctionUtils.doIfNotNull(ldap.getId(), id -> dao.setId(id));
+                            FunctionUtils.doIfNotNull(ldap.getId(), id -> dao.setId(id), LOGGER);
                             LOGGER.debug("Configured LDAP attribute source for [{}] and baseDn [{}]", ldap.getLdapUrl(), ldap.getBaseDn());
                             dao.setConnectionFactory(LdapUtils.newLdaptiveConnectionFactory(ldap));
                             dao.setBaseDN(ldap.getBaseDn());

--- a/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryRestConfiguration.java
+++ b/support/cas-server-support-person-directory/src/main/java/org/apereo/cas/config/CasPersonDirectoryRestConfiguration.java
@@ -67,7 +67,7 @@ public class CasPersonDirectoryRestConfiguration {
                             val dao = new RestfulPersonAttributeDao();
                             dao.setCaseInsensitiveUsername(rest.isCaseInsensitive());
                             dao.setOrder(rest.getOrder());
-                            FunctionUtils.doIfNotNull(rest.getId(), id -> dao.setId(id));
+                            FunctionUtils.doIfNotNull(rest.getId(), id -> dao.setId(id), LOGGER);
                             dao.setUrl(rest.getUrl());
                             dao.setMethod(Objects.requireNonNull(HttpMethod.valueOf(rest.getMethod())).name());
                             dao.setEnabled(rest.getState() != AttributeRepositoryStates.DISABLED);

--- a/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/pm/LdapPasswordManagementService.java
+++ b/support/cas-server-support-pm-ldap/src/main/java/org/apereo/cas/pm/LdapPasswordManagementService.java
@@ -175,7 +175,7 @@ public class LdapPasswordManagementService extends BasePasswordManagementService
                     return Boolean.FALSE;
                 }).toList();
             return results.stream().allMatch(result -> result);
-        }, e -> false).get();
+        }, e -> false, LOGGER).get();
     }
 
     /**

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendForgotUsernameInstructionsAction.java
@@ -108,7 +108,7 @@ public class SendForgotUsernameInstructionsAction extends BaseCasWebflowAction {
         val result = sendForgotUsernameEmailToAccount(query, requestContext);
         return FunctionUtils.doIf(result.isSuccess(),
                 () -> success(result),
-                () -> getErrorEvent("username.failed", "Cannot send the username to given email address", requestContext))
+                () -> getErrorEvent("username.failed", "Cannot send the username to given email address", requestContext), LOGGER)
             .get();
     }
 

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/SendPasswordResetInstructionsAction.java
@@ -218,7 +218,7 @@ public class SendPasswordResetInstructionsAction extends BaseCasWebflowAction {
             val credential = new BasicIdentifiableCredential();
             credential.setId(username);
             val person = principalResolver.resolve(credential);
-            FunctionUtils.doIfNotNull(person, principal -> parameters.put("principal", principal));
+            FunctionUtils.doIfNotNull(person, principal -> parameters.put("principal", principal), LOGGER);
             val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
             val locale = Optional.ofNullable(RequestContextUtils.getLocaleResolver(request))
                 .map(resolver -> resolver.resolveLocale(request));

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/VerifyPasswordResetRequestAction.java
@@ -92,7 +92,7 @@ public class VerifyPasswordResetRequestAction extends BasePasswordManagementActi
             .map(PasswordResetRequest::getPasswordResetTicket)
             .filter(Objects::nonNull)
             .filter(r -> r.getExpirationPolicy().isExpired(r))
-            .ifPresent(token -> FunctionUtils.doAndHandle(__ -> ticketRegistrySupport.getTicketRegistry().deleteTicket(token)));
+            .ifPresent(token -> FunctionUtils.doAndHandle(__ -> ticketRegistrySupport.getTicketRegistry().deleteTicket(token), LOGGER));
     }
 
     private PasswordResetRequest getPasswordResetRequestFrom(final String tgt) {

--- a/support/cas-server-support-redis-authentication/src/main/java/org/apereo/cas/config/RedisAuthenticationConfiguration.java
+++ b/support/cas-server-support-redis-authentication/src/main/java/org/apereo/cas/config/RedisAuthenticationConfiguration.java
@@ -22,6 +22,7 @@ import org.apereo.cas.util.spring.beans.BeanContainer;
 import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.services.persondir.IPersonAttributeDao;
@@ -46,6 +47,7 @@ import java.util.stream.Collectors;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Authentication, module = "redis")
 @AutoConfiguration
+@Slf4j
 public class RedisAuthenticationConfiguration {
     private static final BeanCondition CONDITION = BeanCondition.on("cas.authn.redis.enabled").isTrue().evenIfMissing();
 
@@ -154,7 +156,7 @@ public class RedisAuthenticationConfiguration {
                         template.initialize();
                         val cb = new RedisPersonAttributeDao(template);
                         cb.setOrder(r.getOrder());
-                        FunctionUtils.doIfNotNull(r.getId(), id -> cb.setId(id));
+                        FunctionUtils.doIfNotNull(r.getId(), id -> cb.setId(id), LOGGER);
                         return cb;
                     })
                     .collect(Collectors.toList()));

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/RedisTicketRegistryConfiguration.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/RedisTicketRegistryConfiguration.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.config;
 
+
 import org.apereo.cas.authentication.CasSSLContext;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
@@ -33,6 +34,7 @@ import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.redis.lettucemod.api.sync.RedisModulesCommands;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -66,6 +68,7 @@ import java.util.Optional;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.TicketRegistry, module = "redis")
 @AutoConfiguration
+@Slf4j
 public class RedisTicketRegistryConfiguration {
 
     private static final BeanCondition CONDITION = BeanCondition.on("cas.ticket.registry.redis.enabled").isTrue().evenIfMissing();
@@ -115,7 +118,7 @@ public class RedisTicketRegistryConfiguration {
             final CasConfigurationProperties casProperties) {
             val bean = new PublisherIdentifier();
             val redis = casProperties.getTicket().getRegistry().getRedis();
-            FunctionUtils.doIfNotBlank(redis.getQueueIdentifier(), bean::setId);
+            FunctionUtils.doIfNotBlank(redis.getQueueIdentifier(), bean::setId, LOGGER);
             return bean;
         }
 

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -164,7 +164,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry implements Clean
             LOGGER.debug("Updating ticket [{}]", ticket);
             addOrUpdateTicket(ticket);
             messagePublisher.update(ticket);
-        });
+        }, LOGGER);
         return ticket;
     }
 
@@ -175,7 +175,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry implements Clean
             val redisTicketsKey = redisKeyGeneratorFactory.getRedisKeyGenerator(Ticket.class.getName())
                 .orElseThrow().forEntry(ticketPrefix, digestIdentifier(ticketId));
             return getTicketFromRedisByKey(predicate, redisTicketsKey);
-        });
+        }, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-rest-services/src/main/java/org/apereo/cas/support/rest/RegisteredServiceResource.java
+++ b/support/cas-server-support-rest-services/src/main/java/org/apereo/cas/support/rest/RegisteredServiceResource.java
@@ -107,6 +107,6 @@ public class RegisteredServiceResource {
                 throw new BadRestRequestException("Unable to establish authentication using provided credentials for " + upc.getUsername());
             }
             return result.getAuthentication();
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
+++ b/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/AbstractSaml20ObjectBuilder.java
@@ -361,11 +361,11 @@ public abstract class AbstractSaml20ObjectBuilder extends AbstractSamlObjectBuil
         val confirmation = newSamlObject(SubjectConfirmation.class);
         confirmation.setMethod(SubjectConfirmation.METHOD_BEARER);
         val data = newSamlObject(SubjectConfirmationData.class);
-        FunctionUtils.doIfNotBlank(recipient, data::setRecipient);
-        FunctionUtils.doIfNotBlank(inResponseTo, data::setInResponseTo);
-        FunctionUtils.doIfNotNull(address, __ -> data.setAddress(address.getHostAddress()));
-        FunctionUtils.doIfNotNull(notOnOrAfter, __ -> data.setNotOnOrAfter(notOnOrAfter.toInstant()));
-        FunctionUtils.doIfNotNull(notBefore, __ -> data.setNotBefore(notBefore.toInstant()));
+        FunctionUtils.doIfNotBlank(recipient, data::setRecipient, LOGGER);
+        FunctionUtils.doIfNotBlank(inResponseTo, data::setInResponseTo, LOGGER);
+        FunctionUtils.doIfNotNull(address, __ -> data.setAddress(address.getHostAddress()), LOGGER);
+        FunctionUtils.doIfNotNull(notOnOrAfter, __ -> data.setNotOnOrAfter(notOnOrAfter.toInstant()), LOGGER);
+        FunctionUtils.doIfNotNull(notBefore, __ -> data.setNotBefore(notBefore.toInstant()), LOGGER);
         confirmation.setSubjectConfirmationData(data);
         return confirmation;
     }

--- a/support/cas-server-support-saml-googleapps-core/src/main/java/org/apereo/cas/support/saml/authentication/principal/GoogleAccountsServiceResponseBuilder.java
+++ b/support/cas-server-support-saml-googleapps-core/src/main/java/org/apereo/cas/support/saml/authentication/principal/GoogleAccountsServiceResponseBuilder.java
@@ -92,7 +92,7 @@ public class GoogleAccountsServiceResponseBuilder extends AbstractWebApplication
         FunctionUtils.doAndHandle(__ -> {
             createGoogleAppsPrivateKey();
             createGoogleAppsPublicKey();
-        });
+        }, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/SamlIdPUtils.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/SamlIdPUtils.java
@@ -326,7 +326,7 @@ public class SamlIdPUtils {
                     LOGGER.trace("Resolving entity id from SAML2 IdP metadata to determine issuer for [{}]", samlRegisteredService.getName());
                     val entityDescriptor = Objects.requireNonNull(samlIdPMetadataResolver.resolveSingle(criteriaSet));
                     return entityDescriptor.getEntityID();
-                }))
+                }), LOGGER)
             .get();
         LOGGER.debug("Using name qualifier [{}] for the Name ID", nameQualifier);
         return nameQualifier;

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/idp/DefaultSamlIdPCasEventListener.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/idp/DefaultSamlIdPCasEventListener.java
@@ -30,7 +30,7 @@ public class DefaultSamlIdPCasEventListener implements SamlIdPCasEventListener {
         }, e -> {
             LoggingUtils.error(LOGGER, e);
             return null;
-        }).get();
+        }, LOGGER).get();
         LOGGER.trace("Generated SAML IdP metadata document is [{}]", document);
     }
 }

--- a/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/BaseSamlRegisteredServiceAttributeReleasePolicy.java
+++ b/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/services/BaseSamlRegisteredServiceAttributeReleasePolicy.java
@@ -94,9 +94,9 @@ public abstract class BaseSamlRegisteredServiceAttributeReleasePolicy extends Re
             }, throwable -> {
                 LoggingUtils.error(LOGGER, throwable);
                 return null;
-            })
+            }, LOGGER)
                 .apply(svcParam),
-            () -> null).get();
+            () -> null, LOGGER).get();
     }
 
     protected static Optional<AuthnRequest> getSamlAuthnRequest(final RegisteredServiceAttributeReleasePolicyContext context) {

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataGeneratorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataGeneratorTests.java
@@ -45,7 +45,7 @@ class GitSamlIdPMetadataGeneratorTests extends BaseGitSamlMetadataTests {
             val gitDir = new File(FileUtils.getTempDirectory(), "cas-saml-metadata");
             if (gitDir.exists()) {
                 FunctionUtils.doAndHandle(
-                    __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                    __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
             }
             if (!gitDir.mkdir()) {
                 throw new IllegalArgumentException("Git repository directory location " + gitDir + " cannot be located/created");
@@ -67,7 +67,7 @@ class GitSamlIdPMetadataGeneratorTests extends BaseGitSamlMetadataTests {
         val gitDir = new File(FileUtils.getTempDirectory(), "cas-saml-metadata");
         if (gitDir.exists()) {
             FunctionUtils.doAndHandle(
-                __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                __ -> PathUtils.deleteDirectory(gitDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
         }
     }
 

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataLocatorTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/idp/metadata/GitSamlIdPMetadataLocatorTests.java
@@ -63,13 +63,13 @@ class GitSamlIdPMetadataLocatorTests extends BaseGitSamlMetadataTests {
         val gitRepoDir = new File(FileUtils.getTempDirectory(), "cas-metadata-idp");
         if (gitRepoDir.exists()) {
             FunctionUtils.doAndHandle(
-                __ -> PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                __ -> PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
         }
         val cloneDirectory = "cas-saml-metadata-gsimlt";
         val gitCloneRepoDir = new File(FileUtils.getTempDirectory(), cloneDirectory);
         if (gitCloneRepoDir.exists()) {
             FunctionUtils.doAndHandle(
-                __ -> PathUtils.deleteDirectory(gitCloneRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                __ -> PathUtils.deleteDirectory(gitCloneRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
         }
     }
 

--- a/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolverTests.java
+++ b/support/cas-server-support-saml-idp-metadata-git/src/test/java/org/apereo/cas/support/saml/metadata/resolver/GitSamlRegisteredServiceMetadataResolverTests.java
@@ -75,13 +75,13 @@ class GitSamlRegisteredServiceMetadataResolverTests extends BaseGitSamlMetadataT
         val gitRepoDir = new File(FileUtils.getTempDirectory(), "cas-metadata-data");
         if (gitRepoDir.exists()) {
             FunctionUtils.doAndHandle(
-                __ -> PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                __ -> PathUtils.deleteDirectory(gitRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
         }
         val cloneDirectory = "cas-saml-metadata-gsrsmrt";
         val gitCloneRepoDir = new File(FileUtils.getTempDirectory(), cloneDirectory);
         if (gitCloneRepoDir.exists()) {
             FunctionUtils.doAndHandle(
-                __ -> PathUtils.deleteDirectory(gitCloneRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                __ -> PathUtils.deleteDirectory(gitCloneRepoDir.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
         }
     }
 

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/SamlIdPEntityIdAuthenticationServiceSelectionStrategy.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/SamlIdPEntityIdAuthenticationServiceSelectionStrategy.java
@@ -66,6 +66,6 @@ public class SamlIdPEntityIdAuthenticationServiceSelectionStrategy extends BaseA
                 .stream()
                 .filter(p -> p.getName().equals(SamlProtocolConstants.PARAMETER_ENTITY_ID))
                 .findFirst();
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/FileSystemResourceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/FileSystemResourceMetadataResolver.java
@@ -56,7 +56,7 @@ public class FileSystemResourceMetadataResolver extends BaseSamlRegisteredServic
             val metadataResolver = getMetadataResolver(metadataResource, metadataFile);
             configureAndInitializeSingleMetadataResolver(metadataResolver, service);
             return CollectionUtils.wrap(metadataResolver);
-        }, (CheckedFunction<Throwable, Collection<? extends MetadataResolver>>) throwable -> new ArrayList<>(0)).get();
+        }, (CheckedFunction<Throwable, Collection<? extends MetadataResolver>>) throwable -> new ArrayList<>(0), LOGGER).get();
     }
 
     @Override
@@ -65,7 +65,7 @@ public class FileSystemResourceMetadataResolver extends BaseSamlRegisteredServic
             val metadataLocation = SpringExpressionLanguageValueResolver.getInstance().resolve(service.getMetadataLocation());
             val metadataResource = ResourceUtils.isUrl(metadataLocation) ? null : ResourceUtils.getResourceFrom(metadataLocation);
             return metadataResource instanceof FileSystemResource;
-        }, throwable -> false).get();
+        }, throwable -> false, LOGGER).get();
     }
 
     @Override

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/MetadataQueryProtocolMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/MetadataQueryProtocolMetadataResolver.java
@@ -86,7 +86,7 @@ public class MetadataQueryProtocolMetadataResolver extends UrlResourceMetadataRe
             val path = backupFile.toPath();
             val etag = response.getFirstHeader("ETag").getValue();
             Files.setAttribute(path, "user:ETag", ByteBuffer.wrap(etag.getBytes(StandardCharsets.UTF_8)));
-        });
+        }, LOGGER);
     }
 
     @Override
@@ -102,7 +102,7 @@ public class MetadataQueryProtocolMetadataResolver extends UrlResourceMetadataRe
                 val etag = new String((byte[]) Files.getAttribute(path, "user:ETag"), StandardCharsets.UTF_8).trim();
                 headers.put("If-None-Match", etag);
             }
-        });
+        }, LOGGER);
         LOGGER.trace("Fetching metadata via MDQ for [{}]", metadataLocation);
         val exec = HttpExecutionRequest.builder()
             .basicAuthPassword(metadata.getBasicAuthnPassword())

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/services/idp/metadata/cache/resolver/UrlResourceMetadataResolver.java
@@ -87,7 +87,7 @@ public class UrlResourceMetadataResolver extends BaseSamlRegisteredServiceMetada
                 + "This is likely due to a permission issue", metadataBackupDirectory);
             LOGGER.debug(e.getMessage(), e);
             return metadataBackupDirectory;
-        }).accept(metadataBackupDirectory);
+        }, LOGGER).accept(metadataBackupDirectory);
     }
 
     @Audit(action = AuditableActions.SAML2_METADATA_RESOLUTION,

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/metadata/SamlRegisteredServiceCachedMetadataEndpoint.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/metadata/SamlRegisteredServiceCachedMetadataEndpoint.java
@@ -172,7 +172,7 @@ public class SamlRegisteredServiceCachedMetadataEndpoint extends BaseCasActuator
                     .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
                 return ResponseEntity.ok(body);
             })).orElseThrow(() -> new SamlException("Unable to locate and resolve metadata for service " + registeredService.getName()));
-        }, e -> ResponseEntity.badRequest().body(Map.of("error", e.getMessage()))).get();
+        }, e -> ResponseEntity.badRequest().body(Map.of("error", e.getMessage())), LOGGER).get();
     }
 
     protected SamlRegisteredService findRegisteredService(final String serviceId) throws Throwable {

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlIdPProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlIdPProfileHandlerController.java
@@ -455,7 +455,7 @@ public abstract class AbstractSamlIdPProfileHandlerController {
                 decoder.decode();
                 return decoder.getMessageContext();
             }
-        }, throwable -> null).get();
+        }, throwable -> null, LOGGER).get();
     }
 
     protected void autoConfigureCookiePath(final HttpServletRequest request) {
@@ -489,7 +489,7 @@ public abstract class AbstractSamlIdPProfileHandlerController {
                 .orElseThrow(() -> new IllegalArgumentException("Unable to extract SAML request"));
             val context = Pair.of((AuthnRequest) result.getLeft(), result.getRight());
             return initiateAuthenticationRequest(context, response, request);
-        }, WebUtils::produceErrorView).get();
+        }, WebUtils::produceErrorView, LOGGER).get();
     }
 
     protected final Pair<? extends RequestAbstractType, MessageContext> retrieveAuthenticationRequest(

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/assertion/SamlProfileSamlAssertionBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/assertion/SamlProfileSamlAssertionBuilder.java
@@ -95,7 +95,7 @@ public class SamlProfileSamlAssertionBuilder extends AbstractSaml20ObjectBuilder
                     LOGGER.trace("Resolving entity id from SAML2 IdP metadata to determine issuer for [{}]", context.getRegisteredService().getName());
                     val entityDescriptor = Objects.requireNonNull(samlIdPMetadataResolver.resolveSingle(criteriaSet));
                     return entityDescriptor.getEntityID();
-                }))
+                }), LOGGER)
             .get();
 
         val id = '_' + String.valueOf(RandomUtils.nextLong());

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/authn/SamlProfileAuthnContextClassRefBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/authn/SamlProfileAuthnContextClassRefBuilder.java
@@ -102,7 +102,7 @@ public class SamlProfileAuthnContextClassRefBuilder extends AbstractSaml20Object
                                 script.setBinding(args);
                                 return script.execute(args.values().toArray(), String.class, true);
                             },
-                            () -> null).get();
+                            () -> null, LOGGER).get();
                     })
                     .orElseThrow(() -> new RuntimeException("Unable to locate script cache manager"));
             }

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/SamlIdPObjectEncrypter.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/SamlIdPObjectEncrypter.java
@@ -255,7 +255,7 @@ public class SamlIdPObjectEncrypter {
                 });
         }, e -> {
             throw new SamlException(e.getMessage(), e);
-        }).get();
+        }, LOGGER).get();
     }
 
     /**
@@ -283,7 +283,7 @@ public class SamlIdPObjectEncrypter {
                 });
         }, e -> {
             throw new IllegalArgumentException(e);
-        }).get();
+        }, LOGGER).get();
     }
 
     /**

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/validate/SamlObjectSignatureValidator.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/validate/SamlObjectSignatureValidator.java
@@ -196,7 +196,7 @@ public class SamlObjectSignatureValidator {
             }, e -> {
                 LOGGER.debug(e.getMessage(), e);
                 return false;
-            }).get();
+            }, LOGGER).get();
         }
 
         FunctionUtils.throwIf(!foundValidCredential, () -> {

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/SamlProfileSaml2ResponseBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/response/SamlProfileSaml2ResponseBuilder.java
@@ -74,7 +74,7 @@ public class SamlProfileSaml2ResponseBuilder extends BaseSamlProfileSamlResponse
                     LOGGER.trace("Resolving entity id from SAML2 IdP metadata to determine issuer for [{}]", context.getRegisteredService().getName());
                     val entityDescriptor = Objects.requireNonNull(getConfigurationContext().getSamlIdPMetadataResolver().resolveSingle(criteriaSet));
                     return entityDescriptor.getEntityID();
-                }))
+                }), LOGGER)
             .get();
 
         samlResponse.setIssuer(buildSamlResponseIssuer(issuerId));

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/ecp/ECPSamlIdPProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/ecp/ECPSamlIdPProfileHandlerController.java
@@ -138,6 +138,6 @@ public class ECPSamlIdPProfileHandlerController extends AbstractSamlIdPProfileHa
         return FunctionUtils.doIfNotNull(token, () -> {
             LOGGER.debug("Received basic authentication ECP request from credentials [{}]", token.getPrincipal());
             return new UsernamePasswordCredential(token.getPrincipal().toString(), token.getCredentials().toString());
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPHttpRedirectDeflateEncoder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPHttpRedirectDeflateEncoder.java
@@ -58,7 +58,7 @@ public class SamlIdPHttpRedirectDeflateEncoder extends HTTPRedirectDeflateEncode
         removeSignature(samlObject);
         encodedRequest = deflateAndBase64Encode(samlObject);
         messageContext.setMessage(request);
-        FunctionUtils.doIfNotNull(relayState, value -> SAMLBindingSupport.setRelayState(messageContext, value));
+        FunctionUtils.doIfNotNull(relayState, value -> SAMLBindingSupport.setRelayState(messageContext, value), LOGGER);
 
         this.redirectUrl = buildRedirectURL(messageContext, endpointUrl, encodedRequest);
         LOGGER.debug("Created redirect URL [{}] based on endpoint [{}]", this.redirectUrl, endpointUrl);

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategy.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutRedirectionStrategy.java
@@ -168,7 +168,7 @@ public class SamlIdPSingleLogoutRedirectionStrategy implements LogoutRedirection
 
         val data = CollectionUtils.<String, Object>wrap(SamlProtocolConstants.PARAMETER_SAML_RESPONSE, message);
         val relayState = request.getParameter(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE);
-        FunctionUtils.doIfNotNull(relayState, value -> data.put(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE, value));
+        FunctionUtils.doIfNotNull(relayState, value -> data.put(SamlProtocolConstants.PARAMETER_SAML_RELAY_STATE, value), LOGGER);
         return LogoutRedirectionResponse.builder().logoutPostUrl(Optional.ofNullable(location)).logoutPostData(data).build();
     }
 

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/web/SamlIdPSingleSignOnParticipationStrategy.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/web/SamlIdPSingleSignOnParticipationStrategy.java
@@ -68,7 +68,7 @@ public class SamlIdPSingleSignOnParticipationStrategy extends BaseSingleSignOnPa
                     return initialResult && result.isSuccess() && validatedProvider.isPresent()
                            && !registeredService.getMultifactorAuthenticationPolicy().isForceExecution();
                 })
-            .orElse(initialResult), throwable -> false).get();
+            .orElse(initialResult), throwable -> false, LOGGER).get();
     }
 
     protected Optional<MultifactorAuthenticationProvider> resolveMultifactorAuthenticationTrigger(

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPEndpointsConfiguration.java
@@ -494,7 +494,7 @@ public class SamlIdPEndpointsConfiguration {
                         ? CipherExecutorUtils.newStringCipherExecutor(crypto, SamlIdPDistributedSessionCookieCipherExecutor.class)
                         : CipherExecutor.noOp();
                 },
-                CipherExecutor::noOp).get();
+                CipherExecutor::noOp, LOGGER).get();
         }
 
         @ConditionalOnMissingBean(name = "samlIdPDistributedSessionCookieGenerator")

--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlRegisteredServiceTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/SamlRegisteredServiceTests.java
@@ -19,6 +19,7 @@ import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.file.PathUtils;
@@ -46,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 5.0.0
  */
 @Tag("SAML2")
+@Slf4j
 class SamlRegisteredServiceTests extends BaseSamlIdPConfigurationTests {
 
     private static final File JSON_FILE = new File(FileUtils.getTempDirectoryPath(), "samlRegisteredService.json");
@@ -66,7 +68,7 @@ class SamlRegisteredServiceTests extends BaseSamlIdPConfigurationTests {
         val jsonFolder = new File(FileUtils.getTempDirectory(), JSON_SERVICE_REGISTRY_FOLDER);
         if (jsonFolder.isDirectory()) {
             FunctionUtils.doAndHandle(
-                __ -> PathUtils.deleteDirectory(jsonFolder.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY));
+                __ -> PathUtils.deleteDirectory(jsonFolder.toPath(), StandardDeleteOption.OVERRIDE_READ_ONLY), LOGGER);
             jsonFolder.delete();
         }
         if (!jsonFolder.mkdir()) {

--- a/support/cas-server-support-saml-sp-integrations/src/main/java/org/apereo/cas/util/SamlSPUtils.java
+++ b/support/cas-server-support-saml-sp-integrations/src/main/java/org/apereo/cas/util/SamlSPUtils.java
@@ -70,7 +70,7 @@ public class SamlSPUtils {
             service.setUsernameAttributeProvider(new PrincipalAttributeRegisteredServiceUsernameProvider(sp.getNameIdAttribute()));
         }
 
-        FunctionUtils.doIfNotBlank(sp.getNameIdFormat(), __ -> service.setRequiredNameIdFormat(sp.getNameIdFormat()));
+        FunctionUtils.doIfNotBlank(sp.getNameIdFormat(), __ -> service.setRequiredNameIdFormat(sp.getNameIdFormat()), LOGGER);
 
         val attributes = CoreAuthenticationUtils.transformPrincipalAttributesListIntoMultiMap(attributesToRelease);
         val policy = new ChainingAttributeReleasePolicy();
@@ -82,7 +82,7 @@ public class SamlSPUtils {
         service.setMetadataCriteriaRemoveRolelessEntityDescriptors(true);
 
 
-        FunctionUtils.doIfNotBlank(sp.getSignatureLocation(), __ -> service.setMetadataSignatureLocation(sp.getSignatureLocation()));
+        FunctionUtils.doIfNotBlank(sp.getSignatureLocation(), __ -> service.setMetadataSignatureLocation(sp.getSignatureLocation()), LOGGER);
 
         val entityIDList = determineEntityIdList(sp, resolver, service);
 

--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/support/saml/web/view/AbstractSaml10ResponseView.java
@@ -101,6 +101,6 @@ public abstract class AbstractSaml10ResponseView extends AbstractCasView {
         if (service == null || StringUtils.isBlank(service.getId())) {
             return "UNKNOWN";
         }
-        return FunctionUtils.doAndHandle(() -> new URI(service.getId()).getHost());
+        return FunctionUtils.doAndHandle(() -> new URI(service.getId()).getHost(), LOGGER);
     }
 }

--- a/support/cas-server-support-sendgrid/src/main/java/org/apereo/cas/mail/SendGridEmailSender.java
+++ b/support/cas-server-support-sendgrid/src/main/java/org/apereo/cas/mail/SendGridEmailSender.java
@@ -48,7 +48,7 @@ public class SendGridEmailSender implements EmailSender {
                     .details(response.getHeaders())
                     .build();
             },
-                e -> EmailCommunicationResult.builder().success(false).body(e.getMessage()).build()).get())
+                e -> EmailCommunicationResult.builder().success(false).body(e.getMessage()).build(), LOGGER).get())
             .toList();
 
         return results

--- a/support/cas-server-support-shell-core/src/main/java/org/apereo/cas/shell/commands/saml/GenerateSamlIdPMetadataCommand.java
+++ b/support/cas-server-support-shell-core/src/main/java/org/apereo/cas/shell/commands/saml/GenerateSamlIdPMetadataCommand.java
@@ -90,7 +90,7 @@ public class GenerateSamlIdPMetadataCommand {
             () -> {
                 LOGGER.warn("Metadata artifacts are available at the specified location [{}]", metadataLocation);
                 return force;
-            }).get();
+            }, LOGGER).get();
 
         if (generateMetadata) {
             val props = new CasConfigurationProperties();

--- a/support/cas-server-support-shell-core/src/main/java/org/apereo/cas/shell/commands/util/ValidateEndpointCommand.java
+++ b/support/cas-server-support-shell-core/src/main/java/org/apereo/cas/shell/commands/util/ValidateEndpointCommand.java
@@ -67,7 +67,7 @@ public class ValidateEndpointCommand {
                     val proxyAddr = new InetSocketAddress(proxyUrl.getHost(), proxyUrl.getPort());
                     return constructedUrl.openConnection(new Proxy(Proxy.Type.HTTP, proxyAddr));
                 }),
-                Unchecked.supplier(constructedUrl::openConnection))
+                Unchecked.supplier(constructedUrl::openConnection), LOGGER)
             .get();
     }
 
@@ -125,8 +125,8 @@ public class ValidateEndpointCommand {
                     certificate.checkValidity();
                     return "valid";
                 },
-                e -> "invalid: " + e.getMessage()
-            ).apply(certificate);
+                e -> "invalid: " + e.getMessage(),
+                LOGGER).apply(certificate);
 
             LOGGER.info("\tsubject: [{}]", certificate.getSubjectDN().getName());
             LOGGER.info("\tissuer: [{}]", certificate.getIssuerDN().getName());

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/CasSimpleMultifactorAuthenticationHandler.java
@@ -66,6 +66,6 @@ public class CasSimpleMultifactorAuthenticationHandler extends AbstractPreAndPos
             val resolvedPrincipal = resolvePrincipal(applicationContext, credentialPrincipal);
             val principal = multifactorAuthenticationService.validate(resolvedPrincipal, tokenCredential);
             return createHandlerResult(tokenCredential, principal);
-        }, e -> new FailedLoginException(e.getMessage()));
+        }, e -> new FailedLoginException(e.getMessage()), LOGGER);
     }
 }

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/CasSimpleMultifactorAuthenticationEndpoint.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/CasSimpleMultifactorAuthenticationEndpoint.java
@@ -68,7 +68,7 @@ public class CasSimpleMultifactorAuthenticationEndpoint extends BaseCasActuatorE
             val givenService = extractService(service);
             val result = generateToken(credential, givenService);
             return ResponseEntity.ok(result);
-        }, e -> ResponseEntity.badRequest().body("Invalid or unauthenticated request")).get();
+        }, e -> ResponseEntity.badRequest().body("Invalid or unauthenticated request"), LOGGER).get();
     }
 
     protected MultifactorAuthenticationTokenResponse generateToken(final Credential credential, final Service givenService) throws Throwable {

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorMakePhoneCall.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorMakePhoneCall.java
@@ -11,6 +11,7 @@ import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.jooq.lambda.Unchecked;
 import org.springframework.webflow.execution.RequestContext;
@@ -22,6 +23,7 @@ import java.util.Map;
  * @author Misagh Moayyed
  * @since 7.0.0
  */
+@Slf4j
 @RequiredArgsConstructor(staticName = "of", access = AccessLevel.PROTECTED)
 class CasSimpleMultifactorMakePhoneCall {
     private final CommunicationsManager communicationsManager;
@@ -42,7 +44,7 @@ class CasSimpleMultifactorMakePhoneCall {
                     .text(messageBody)
                     .build();
                 return communicationsManager.phoneCall(callRequest);
-            }), () -> false).get();
+            }), () -> false, LOGGER).get();
     }
 
     protected String buildMessageBody(final PhoneProperties phoneProperties, final String token,
@@ -53,6 +55,6 @@ class CasSimpleMultifactorMakePhoneCall {
                 .parameters(Map.of("token", token, "tokenWithoutPrefix", tokenWithoutPrefix))
                 .build()
                 .get(),
-            () -> token);
+            () -> token, LOGGER);
     }
 }

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorSendEmail.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorSendEmail.java
@@ -14,6 +14,7 @@ import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolver;
 import org.apereo.cas.web.support.WebUtils;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.servlet.support.RequestContextUtils;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
  */
 @RequiredArgsConstructor(staticName = "of",
                          access = AccessLevel.PROTECTED)
+@Slf4j
 class CasSimpleMultifactorSendEmail {
     private final CommunicationsManager communicationsManager;
     private final CasSimpleMultifactorAuthenticationProperties properties;
@@ -42,7 +44,7 @@ class CasSimpleMultifactorSendEmail {
                 val body = prepareEmailMessageBody(principal, tokenTicket, requestContext);
                 return List.of(sendEmail(requestContext, body, principal, recipients));
             },
-            () -> List.<EmailCommunicationResult>of(EmailCommunicationResult.builder().success(false).build())).get();
+            () -> List.<EmailCommunicationResult>of(EmailCommunicationResult.builder().success(false).build()), LOGGER).get();
         return new EmailCommunicationResults(results);
     }
 
@@ -57,7 +59,7 @@ class CasSimpleMultifactorSendEmail {
                     .map(attribute -> sendEmail(requestContext, body, principal, attribute))
                     .collect(Collectors.toList());
             },
-            () -> List.<EmailCommunicationResult>of(EmailCommunicationResult.builder().success(false).build())).get();
+            () -> List.<EmailCommunicationResult>of(EmailCommunicationResult.builder().success(false).build()), LOGGER).get();
         return new EmailCommunicationResults(results);
     }
 

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorSendSms.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/web/flow/CasSimpleMultifactorSendSms.java
@@ -11,6 +11,7 @@ import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.jooq.lambda.Unchecked;
 import org.springframework.webflow.execution.RequestContext;
@@ -23,6 +24,7 @@ import java.util.Map;
  * @since 7.0.0
  */
 @RequiredArgsConstructor(staticName = "of", access = AccessLevel.PROTECTED)
+@Slf4j
 class CasSimpleMultifactorSendSms {
     private final CommunicationsManager communicationsManager;
     private final CasSimpleMultifactorAuthenticationProperties properties;
@@ -41,7 +43,7 @@ class CasSimpleMultifactorSendSms {
                     .text(smsText)
                     .build();
                 return communicationsManager.sms(smsRequest);
-            }), () -> false).get();
+            }), () -> false, LOGGER).get();
     }
 
     protected String buildTextMessageBody(final SmsProperties smsProperties, final String token,
@@ -52,6 +54,6 @@ class CasSimpleMultifactorSendSms {
                 .parameters(Map.of("token", token, "tokenWithoutPrefix", tokenWithoutPrefix))
                 .build()
                 .get(),
-            () -> token);
+            () -> token, LOGGER);
     }
 }

--- a/support/cas-server-support-sms-textmagic/src/main/java/org/apereo/cas/support/sms/TextMagicSmsSender.java
+++ b/support/cas-server-support-sms-textmagic/src/main/java/org/apereo/cas/support/sms/TextMagicSmsSender.java
@@ -31,21 +31,21 @@ public class TextMagicSmsSender implements SmsSender {
                               final Optional<HttpClient> httpClient) {
         val client = new ApiClient();
 
-        FunctionUtils.doIfNotBlank(properties.getUsername(), __ -> client.setUsername(properties.getUsername()));
+        FunctionUtils.doIfNotBlank(properties.getUsername(), __ -> client.setUsername(properties.getUsername()), LOGGER);
 
-        FunctionUtils.doIfNotBlank(properties.getToken(), __ -> client.setAccessToken(properties.getToken()));
+        FunctionUtils.doIfNotBlank(properties.getToken(), __ -> client.setAccessToken(properties.getToken()), LOGGER);
         client.setDebugging(properties.isDebugging());
         client.setVerifyingSsl(properties.isVerifyingSsl());
 
 
-        FunctionUtils.doIfNotBlank(properties.getPassword(), __ -> client.setPassword(properties.getPassword()));
+        FunctionUtils.doIfNotBlank(properties.getPassword(), __ -> client.setPassword(properties.getPassword()), LOGGER);
 
         client.setReadTimeout(properties.getReadTimeout());
         client.setConnectTimeout(properties.getConnectTimeout());
         client.setWriteTimeout(properties.getWriteTimeout());
 
 
-        FunctionUtils.doIfNotBlank(properties.getUserAgent(), __ -> client.setUserAgent(properties.getUserAgent()));
+        FunctionUtils.doIfNotBlank(properties.getUserAgent(), __ -> client.setUserAgent(properties.getUserAgent()), LOGGER);
 
         if (StringUtils.isNotBlank(properties.getApiKey())) {
             client.setApiKey(properties.getApiKey());

--- a/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/surrogate/JsonResourceSurrogateAuthenticationService.java
+++ b/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/surrogate/JsonResourceSurrogateAuthenticationService.java
@@ -7,6 +7,7 @@ import org.apereo.cas.util.io.WatcherService;
 import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.core.io.Resource;
 
@@ -20,6 +21,7 @@ import java.util.Map;
  * @author Misagh Moayyed
  * @since 5.1.0
  */
+@Slf4j
 public class JsonResourceSurrogateAuthenticationService extends SimpleSurrogateAuthenticationService implements DisposableBean {
     private static final ObjectMapper MAPPER = JacksonObjectMapperFactory.builder()
         .defaultTypingEnabled(false).build().toObjectMapper();
@@ -45,7 +47,7 @@ public class JsonResourceSurrogateAuthenticationService extends SimpleSurrogateA
         FunctionUtils.doAndHandle(__ -> {
             getEligibleAccounts().clear();
             getEligibleAccounts().putAll(readAccountsFromFile(file));
-        });
+        }, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-surrogate-webflow/src/main/java/org/apereo/cas/web/flow/action/SurrogateInitialAuthenticationAction.java
+++ b/support/cas-server-support-surrogate-webflow/src/main/java/org/apereo/cas/web/flow/action/SurrogateInitialAuthenticationAction.java
@@ -34,7 +34,7 @@ public class SurrogateInitialAuthenticationAction extends BaseCasWebflowAction {
             val surrogateRequest = surrogateCredentialParser.parse(credential);
             surrogateRequest.ifPresentOrElse(payload -> addSurrogateInformation(context, payload),
                 () -> removeSurrogateInformation(context, Objects.requireNonNull(credential)));
-        });
+        }, LOGGER);
         return null;
     }
 

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/SyncopePersonDirectoryConfiguration.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/SyncopePersonDirectoryConfiguration.java
@@ -11,6 +11,7 @@ import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
 import com.google.common.base.Splitter;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.services.persondir.IPersonAttributeDao;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,6 +32,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.PersonDirectory, module = "syncope")
 @AutoConfiguration
+@Slf4j
 public class SyncopePersonDirectoryConfiguration {
     private static final BeanCondition CONDITION = BeanCondition.on("cas.authn.attribute-repository.syncope.url").isUrl();
 
@@ -53,7 +55,7 @@ public class SyncopePersonDirectoryConfiguration {
                     .map(domain -> {
                         val dao = new SyncopePersonAttributeDao(properties);
                         dao.setOrder(properties.getOrder());
-                        FunctionUtils.doIfNotNull(properties.getId(), id -> dao.setId(id));
+                        FunctionUtils.doIfNotNull(properties.getId(), id -> dao.setId(id), LOGGER);
                         return dao;
                     })
                     .toList();

--- a/support/cas-server-support-themes/src/main/java/org/apereo/cas/config/CasThemesConfiguration.java
+++ b/support/cas-server-support-themes/src/main/java/org/apereo/cas/config/CasThemesConfiguration.java
@@ -131,7 +131,7 @@ public class CasThemesConfiguration {
                     registration.addResourceLocations(locations);
                     registration.addResourceLocations(webProperties.getResources().getStaticLocations());
 
-                    FunctionUtils.doIfNotNull(webProperties.getResources().getCache().getPeriod(), period -> registration.setCachePeriod((int) period.getSeconds()));
+                    FunctionUtils.doIfNotNull(webProperties.getResources().getCache().getPeriod(), period -> registration.setCachePeriod((int) period.getSeconds()), LOGGER);
                     registration.setCacheControl(webProperties.getResources().getCache().getCachecontrol().toHttpCacheControl());
                     registration.setUseLastModified(true);
                     val cache = thymeleafProperties != null && thymeleafProperties.isCache();

--- a/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/token/authentication/TokenAuthenticationPostProcessor.java
+++ b/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/token/authentication/TokenAuthenticationPostProcessor.java
@@ -10,6 +10,7 @@ import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.token.TokenConstants;
 import org.apereo.cas.util.function.FunctionUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.core.Ordered;
 
@@ -20,6 +21,7 @@ import org.springframework.core.Ordered;
  * @since 7.0.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class TokenAuthenticationPostProcessor implements AuthenticationPostProcessor {
     private final ServicesManager servicesManager;
     private final AuditableExecution registeredServiceAccessStrategyEnforcer;
@@ -38,7 +40,7 @@ public class TokenAuthenticationPostProcessor implements AuthenticationPostProce
             accessResult.throwExceptionIfNeeded();
             val token = TokenAuthenticationSecurity.forRegisteredService(registeredService).generateTokenFor(authentication);
             builder.addAttribute(TokenConstants.PARAMETER_NAME_TOKEN, token);
-        });
+        }, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/token/authentication/TokenAuthenticationSecurity.java
+++ b/support/cas-server-support-token-authentication/src/main/java/org/apereo/cas/token/authentication/TokenAuthenticationSecurity.java
@@ -97,8 +97,8 @@ public class TokenAuthenticationSecurity {
      */
     public JwtGenerator toGenerator() {
         val generator = new JwtGenerator();
-        FunctionUtils.doIfNotNull(securityConfiguration.getSignatureConfiguration(), generator::setSignatureConfiguration);
-        FunctionUtils.doIfNotNull(securityConfiguration.getEncryptionConfiguration(), generator::setEncryptionConfiguration);
+        FunctionUtils.doIfNotNull(securityConfiguration.getSignatureConfiguration(), generator::setSignatureConfiguration, LOGGER);
+        FunctionUtils.doIfNotNull(securityConfiguration.getEncryptionConfiguration(), generator::setEncryptionConfiguration, LOGGER);
         return generator;
     }
 
@@ -109,8 +109,8 @@ public class TokenAuthenticationSecurity {
      */
     public JwtAuthenticator toAuthenticator() {
         val authn = new JwtAuthenticator();
-        FunctionUtils.doIfNotNull(securityConfiguration.getEncryptionConfiguration(), authn::setEncryptionConfiguration);
-        FunctionUtils.doIfNotNull(securityConfiguration.getSignatureConfiguration(), authn::setSignatureConfiguration);
+        FunctionUtils.doIfNotNull(securityConfiguration.getEncryptionConfiguration(), authn::setEncryptionConfiguration, LOGGER);
+        FunctionUtils.doIfNotNull(securityConfiguration.getSignatureConfiguration(), authn::setSignatureConfiguration, LOGGER);
         return authn;
     }
 

--- a/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/JwtBuilder.java
+++ b/support/cas-server-support-token-core-api/src/main/java/org/apereo/cas/token/JwtBuilder.java
@@ -138,7 +138,7 @@ public class JwtBuilder {
                         return parse(defaultTokenCipherExecutor.decode(jwtJson));
                     }, () -> {
                         throw new IllegalArgumentException("Unable to validate JWT signature");
-                    }).get();
+                    }, LOGGER).get();
             }
             return parse(jwtJson);
         });

--- a/support/cas-server-support-token-core/src/main/java/org/apereo/cas/config/TokenCoreConfiguration.java
+++ b/support/cas-server-support-token-core/src/main/java/org/apereo/cas/config/TokenCoreConfiguration.java
@@ -83,7 +83,7 @@ public class TokenCoreConfiguration {
                     LOGGER.warn("Token encryption/signing is not enabled explicitly in the configuration, yet signing/encryption keys "
                                 + "are defined for operations. CAS will proceed to enable the token encryption/signing functionality.");
                     return Boolean.TRUE;
-                }, crypto::isEnabled).get();
+                }, crypto::isEnabled, LOGGER).get();
             if (enabled) {
                 return CipherExecutorUtils.newStringCipherExecutor(crypto, JwtTicketCipherExecutor.class);
             }

--- a/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/JsonMultifactorAuthenticationTrustStorage.java
+++ b/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/JsonMultifactorAuthenticationTrustStorage.java
@@ -64,7 +64,7 @@ public class JsonMultifactorAuthenticationTrustStorage extends BaseMultifactorAu
 
     @Override
     public void destroy() {
-        FunctionUtils.doIfNotNull(watcherService, WatcherService::close);
+        FunctionUtils.doIfNotNull(watcherService, WatcherService::close, LOGGER);
     }
 
     @Override

--- a/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
+++ b/support/cas-server-support-trusted-mfa-core/src/main/java/org/apereo/cas/trusted/authentication/storage/MultifactorAuthenticationTrustStorageCleaner.java
@@ -31,6 +31,6 @@ public class MultifactorAuthenticationTrustStorageCleaner implements Cleanable {
         FunctionUtils.doAndHandle(__ -> {
             LOGGER.trace("Proceeding to clean up expired trusted authentication records...");
             storage.remove();
-        });
+        }, LOGGER);
     }
 }

--- a/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/config/MultifactorAuthnTrustConfiguration.java
+++ b/support/cas-server-support-trusted-mfa/src/main/java/org/apereo/cas/config/MultifactorAuthnTrustConfiguration.java
@@ -106,7 +106,7 @@ public class MultifactorAuthnTrustConfiguration {
                 return new InMemoryMultifactorAuthenticationTrustStorage(
                     casProperties.getAuthn().getMfa().getTrusted(),
                     mfaTrustCipherExecutor, storage, mfaTrustRecordKeyGenerator);
-            }).get();
+            }, LOGGER).get();
         }
 
         @ConditionalOnMissingBean(name = "transactionManagerMfaAuthnTrust")

--- a/support/cas-server-support-validation-core/src/main/java/org/apereo/cas/web/ServiceValidationViewFactory.java
+++ b/support/cas-server-support-validation-core/src/main/java/org/apereo/cas/web/ServiceValidationViewFactory.java
@@ -5,6 +5,7 @@ import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.validation.ValidationResponseType;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -23,6 +24,7 @@ import java.util.function.Function;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
+@Slf4j
 public class ServiceValidationViewFactory {
 
     /**
@@ -172,7 +174,7 @@ public class ServiceValidationViewFactory {
         val format = request.getParameter(CasProtocolConstants.PARAMETER_FORMAT);
         final Function<String, ValidationResponseType> func = FunctionUtils.doIf(StringUtils::isNotBlank,
             t -> ValidationResponseType.valueOf(t.toUpperCase(Locale.ENGLISH)),
-            __ -> service != null ? service.getFormat() : ValidationResponseType.XML);
+            __ -> service != null ? service.getFormat() : ValidationResponseType.XML, LOGGER);
         return func.apply(format);
     }
 }

--- a/support/cas-server-support-webauthn/src/main/java/org/apereo/cas/config/WebAuthnConfiguration.java
+++ b/support/cas-server-support-webauthn/src/main/java/org/apereo/cas/config/WebAuthnConfiguration.java
@@ -375,7 +375,7 @@ public class WebAuthnConfiguration {
                     val location = webauthn.getJson().getLocation();
                     return FunctionUtils.doIfNotNull(location,
                         () -> new JsonResourceWebAuthnCredentialRepository(casProperties, location, webAuthnCredentialRegistrationCipherExecutor),
-                        () -> new InMemoryRegistrationStorage(casProperties, webAuthnCredentialRegistrationCipherExecutor)).get();
+                        () -> new InMemoryRegistrationStorage(casProperties, webAuthnCredentialRegistrationCipherExecutor), LOGGER).get();
                 })
                 .otherwiseProxy()
                 .get();

--- a/support/cas-server-support-webconfig/src/main/java/org/apereo/cas/config/CasPropertiesConfiguration.java
+++ b/support/cas-server-support-webconfig/src/main/java/org/apereo/cas/config/CasPropertiesConfiguration.java
@@ -6,6 +6,7 @@ import org.apereo.cas.util.CasVersion;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -26,6 +27,7 @@ import java.util.Properties;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.CasConfiguration)
 @AutoConfiguration
+@Slf4j
 @Lazy(false)
 public class CasPropertiesConfiguration {
     @Bean
@@ -33,8 +35,8 @@ public class CasPropertiesConfiguration {
         return () -> {
             val sysProps = System.getProperties();
             val properties = new Properties();
-            FunctionUtils.doIfNotNull(CasVersion.getVersion(), value -> properties.put("info.cas.version", value));
-            FunctionUtils.doIfNotNull(sysProps.get("java.home"), value -> properties.put("info.cas.java.home", value));
+            FunctionUtils.doIfNotNull(CasVersion.getVersion(), value -> properties.put("info.cas.version", value), LOGGER);
+            FunctionUtils.doIfNotNull(sysProps.get("java.home"), value -> properties.put("info.cas.java.home", value), LOGGER);
             properties.put("info.cas.java.vendor", sysProps.get("java.vendor"));
             properties.put("info.cas.java.version", sysProps.get("java.version"));
             val src = new PropertiesPropertySource(CasVersion.class.getName(), properties);

--- a/support/cas-server-support-webconfig/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
+++ b/support/cas-server-support-webconfig/src/main/java/org/apereo/cas/web/security/CasWebSecurityConfigurerAdapter.java
@@ -133,7 +133,7 @@ public class CasWebSecurityConfigurerAdapter {
         configureEndpointAccessByFormLogin(requests);
 
         val jaas = casProperties.getMonitor().getEndpoints().getJaas();
-        FunctionUtils.doIfNotNull(jaas.getLoginConfig(), __ -> configureJaasAuthenticationProvider(http, jaas));
+        FunctionUtils.doIfNotNull(jaas.getLoginConfig(), __ -> configureJaasAuthenticationProvider(http, jaas), LOGGER);
 
         http.securityContext(securityContext -> securityContext.securityContextRepository(securityContextRepository));
         webSecurityConfigurers

--- a/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/WSFederationValidateRequestCallbackController.java
+++ b/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/WSFederationValidateRequestCallbackController.java
@@ -95,7 +95,7 @@ public class WSFederationValidateRequestCallbackController extends BaseWSFederat
                     LOGGER.debug("No security token is yet available. Invoking security token service to issue token");
                     return fetchSecurityTokenFromAssertion(assertion, targetService);
                 }),
-                () -> securityTokenReq)
+                () -> securityTokenReq, LOGGER)
             .get();
         addSecurityTokenTicketToRegistry(request, securityToken);
         val rpToken = produceRelyingPartyToken(request, targetService, fedRequest, securityToken, assertion);

--- a/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/WSFederationValidateRequestController.java
+++ b/support/cas-server-support-ws-idp/src/main/java/org/apereo/cas/ws/idp/web/WSFederationValidateRequestController.java
@@ -68,7 +68,7 @@ public class WSFederationValidateRequestController extends BaseWSFederationReque
                     return getConfigContext().getCasProperties()
                         .getServer().getLogoutUrl().concat("?").concat(logoutParam).concat("=").concat(service.getId());
                 },
-                () -> getConfigContext().getCasProperties().getServer().getLogoutUrl())
+                () -> getConfigContext().getCasProperties().getServer().getLogoutUrl(), LOGGER)
             .get();
         response.sendRedirect(logoutUrl);
     }

--- a/support/cas-server-support-ws-sts-api/src/main/java/org/apereo/cas/authentication/SecurityTokenServiceClientBuilder.java
+++ b/support/cas-server-support-ws-sts-api/src/main/java/org/apereo/cas/authentication/SecurityTokenServiceClientBuilder.java
@@ -7,6 +7,7 @@ import org.apereo.cas.ws.idp.WSFederationConstants;
 import org.apereo.cas.ws.idp.services.WSFederationRegisteredService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.BusFactory;
@@ -27,6 +28,7 @@ import java.util.HashMap;
  * @since 5.1.0
  */
 @RequiredArgsConstructor
+@Slf4j
 public class SecurityTokenServiceClientBuilder {
     private final WsFederationProperties wsFederationProperties;
 
@@ -51,7 +53,7 @@ public class SecurityTokenServiceClientBuilder {
         sts.setKeyType(WSFederationConstants.HTTP_DOCS_OASIS_OPEN_ORG_WS_SX_WS_TRUST_200512_BEARER);
         sts.setWsdlLocation(prepareWsdlLocation(service));
 
-        FunctionUtils.doIfNotBlank(service.getPolicyNamespace(), __ -> sts.setWspNamespace(service.getPolicyNamespace()));
+        FunctionUtils.doIfNotBlank(service.getPolicyNamespace(), __ -> sts.setWspNamespace(service.getPolicyNamespace()), LOGGER);
         val namespace = StringUtils.defaultIfBlank(service.getNamespace(),
             WSFederationConstants.HTTP_DOCS_OASIS_OPEN_ORG_WS_SX_WS_TRUST_200512);
         sts.setServiceQName(new QName(namespace, StringUtils.defaultIfBlank(service.getWsdlService(),
@@ -62,7 +64,7 @@ public class SecurityTokenServiceClientBuilder {
         sts.getProperties().putAll(new HashMap<>(0));
         sts.setTokenType(StringUtils.defaultIfBlank(service.getTokenType(), WSS4JConstants.WSS_SAML2_TOKEN_TYPE));
 
-        FunctionUtils.doIfNotBlank(service.getPolicyNamespace(), __ -> sts.setWspNamespace(service.getPolicyNamespace()));
+        FunctionUtils.doIfNotBlank(service.getPolicyNamespace(), __ -> sts.setWspNamespace(service.getPolicyNamespace()), LOGGER);
         val tlsClientParams = getTlsClientParameters();
         sts.setTlsClientParameters(tlsClientParams);
         val configurer = new CasHTTPConduitConfigurer(tlsClientParams);

--- a/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CoreWsSecuritySecurityTokenServiceConfiguration.java
+++ b/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CoreWsSecuritySecurityTokenServiceConfiguration.java
@@ -25,6 +25,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 import org.apereo.cas.ws.idp.WSFederationConstants;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxws.context.WebServiceContextImpl;
@@ -98,6 +99,7 @@ import java.util.Map;
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.WsFederationIdentityProvider)
 @ImportResource(locations = "classpath:jaxws-realms.xml")
 @AutoConfiguration
+@Slf4j
 public class CoreWsSecuritySecurityTokenServiceConfiguration {
 
     @Configuration(value = "CoreWsSecuritySecurityTokenServiceDelegationConfiguration", proxyBeanMethods = false)
@@ -185,7 +187,7 @@ public class CoreWsSecuritySecurityTokenServiceConfiguration {
             val subProvider = new DefaultSubjectProvider();
 
             FunctionUtils.doIfNotBlank(wsfed.getSubjectNameQualifier(),
-                __ -> subProvider.setSubjectNameQualifier(wsfed.getSubjectNameQualifier()));
+                __ -> subProvider.setSubjectNameQualifier(wsfed.getSubjectNameQualifier()), LOGGER);
             switch (wsfed.getSubjectNameIdFormat().trim().toLowerCase(Locale.ENGLISH)) {
                 case "email" -> subProvider.setSubjectNameIDFormat(NameIDType.EMAIL);
                 case "entity" -> subProvider.setSubjectNameIDFormat(NameIDType.ENTITY);

--- a/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/config/WsFedAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/config/WsFedAuthenticationEventExecutionPlanConfiguration.java
@@ -100,7 +100,7 @@ public class WsFedAuthenticationEventExecutionPlanConfiguration {
             config.setName(wsfed.getName());
             config.setTolerance(Beans.newDuration(wsfed.getTolerance()).toMillis());
             config.setCookieGenerator(getCookieGeneratorForWsFederationConfig(wsfed, applicationContext));
-            FunctionUtils.doIfNotNull(wsfed.getId(), config::setId);
+            FunctionUtils.doIfNotNull(wsfed.getId(), config::setId, LOGGER);
             return config;
         }
 
@@ -121,7 +121,7 @@ public class WsFedAuthenticationEventExecutionPlanConfiguration {
                                 + "MAY NOT be safe in a production environment. "
                                 + "Consider using other choices to handle encryption, signing and verification of delegated authentication cookie.");
                     return CipherExecutor.noOp();
-                }).get();
+                }, LOGGER).get();
         }
 
         @ConditionalOnMissingBean(name = "wsFederationConfigurations")

--- a/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/support/wsfederation/WsFederationHelper.java
+++ b/support/cas-server-support-wsfederation/src/main/java/org/apereo/cas/support/wsfederation/WsFederationHelper.java
@@ -109,7 +109,7 @@ public class WsFederationHelper {
                     Unchecked.supplier(() -> {
                         LOGGER.debug("Extracting a keypair from the private key");
                         return converter.getKeyPair((PEMKeyPair) privateKeyPemObject);
-                    }))
+                    }), LOGGER)
                 .apply(privateKeyPemObject);
 
             val certParser = new X509CertParser();
@@ -348,7 +348,7 @@ public class WsFederationHelper {
                 LOGGER.error("Could not extract or decrypt an assertion based on the security token provided");
                 return null;
             },
-            () -> securityTokenFromAssertion);
+            () -> securityTokenFromAssertion, LOGGER);
 
         return func.apply(securityTokenFromAssertion);
     }

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/handler/support/X509CredentialsAuthenticationHandler.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/handler/support/X509CredentialsAuthenticationHandler.java
@@ -286,7 +286,7 @@ public class X509CredentialsAuthenticationHandler extends AbstractPreAndPostProc
             f -> {
                 LOGGER.debug("KeyUsage digitalSignature=%s, Returning true since keyUsage validation not required by configuration.");
                 return Boolean.TRUE;
-            });
+            }, LOGGER);
         return func.apply(certificate);
     }
 

--- a/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509UPNExtractorUtils.java
+++ b/support/cas-server-support-x509-core/src/main/java/org/apereo/cas/adaptors/x509/authentication/principal/X509UPNExtractorUtils.java
@@ -60,7 +60,7 @@ public class X509UPNExtractorUtils {
 
             val func = FunctionUtils.doIf(Predicates.instanceOf(ASN1TaggedObject.class),
                 () -> ASN1TaggedObject.getInstance(primitiveObj).getBaseObject(),
-                () -> primitiveObj);
+                () -> primitiveObj, LOGGER);
             val prim = func.apply(primitiveObj);
 
             if (prim instanceof final ASN1OctetString instance) {

--- a/support/cas-server-support-yaml-service-registry/src/main/java/org/apereo/cas/config/YamlServiceRegistryConfiguration.java
+++ b/support/cas-server-support-yaml-service-registry/src/main/java/org/apereo/cas/config/YamlServiceRegistryConfiguration.java
@@ -12,6 +12,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.io.WatcherService;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -37,6 +38,7 @@ import java.util.Optional;
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.ServiceRegistry, module = "yaml")
 @AutoConfiguration
+@Slf4j
 public class YamlServiceRegistryConfiguration {
 
     @Configuration(value = "YamlServiceRegistryCoreConfiguration", proxyBeanMethods = false)
@@ -79,7 +81,7 @@ public class YamlServiceRegistryConfiguration {
             final ServiceRegistry yamlServiceRegistry) {
             val registry = casProperties.getServiceRegistry().getYaml();
             return plan -> FunctionUtils.doIfNotNull(registry.getLocation(),
-                input -> plan.registerServiceRegistry(yamlServiceRegistry));
+                input -> plan.registerServiceRegistry(yamlServiceRegistry), LOGGER);
         }
     }
 }


### PR DESCRIPTION
It is slightly bothersome seeing FunctionUtils as the context in the logs because it is doesn't provide a good context for the message, and you have to consult stack trace in another file to see the real context. I wanted to see what it would look like code-wise if the LOGGER from the calling class was passed in to all the methods in FunctionsUtils that use a logger and once I started I kept going. It would be nice if there was a lombok annotation that created a logger style instance of a utility class that included the local logger. I feel like any utility class would be better off using the logger of its caller. I am somewhat ambivalent about this change and I am fine if you want to close this. 