### PR TITLE
Missing resource fields in UMA RPT

### DIFF
--- a/ci/tests/puppeteer/scenarios/uma-authorization/script.js
+++ b/ci/tests/puppeteer/scenarios/uma-authorization/script.js
@@ -180,7 +180,9 @@ const cas = require('../../cas.js');
         res => {
             assert(res.data.active === true);
             assert(res.data.grant_type === 'urn:ietf:params:oauth:grant-type:uma-ticket');
-            assert(res.data.sub === 'casuser')
+            assert(res.data.sub === 'casuser');
+            assert(res.data.permissions[0].resource_id === resource.resourceId);
+            // more permission checks...
         }, error => {
             throw `Introspection operation failed: ${error}`;
         });


### PR DESCRIPTION
Hey there,

according to the [UMA spec (link)](https://docs.kantarainitiative.org/uma/wg/rec-oauth-uma-federated-authz-2.0.html#rfc.section.5.1.1), upon successful token introspection the authorization server should respond to the resource server with a JSON response, including at least `resource_id` and `resource_scopes`. However since a regular Access Token is used, CAS currently does not include resource information in the response, making it impossible for the resource server to determine the validity of the user request.

For now this PR only provides a change to your puppeteer test to point out the problem. We would be happy to provide a solution for this, but need to know whether you are interested in it or rather prefer to fix it yourselves.

Kind regards,
Fabian