### PR TITLE
Avoid strack traces on OAuth /profile

### DIFF
--- a/ci/tests/puppeteer/scenarios/oauth2-login-jwt-at/script.js
+++ b/ci/tests/puppeteer/scenarios/oauth2-login-jwt-at/script.js
@@ -63,6 +63,7 @@ async function executeFlow(browser, redirectUri, clientId, accessTokenSecret) {
             throw error;
         });
 
+    // we create a new JWT access token from the good one with a bad payload to make the JWT parsing internally fails
     const parts = accessToken.split('.');
     let badAccessToken;
     if (parts.length === 3) {
@@ -70,6 +71,7 @@ async function executeFlow(browser, redirectUri, clientId, accessTokenSecret) {
     } else {
         badAccessToken = parts[0] + '.' + parts[1] + '.Z' + parts[2] + '.' + parts[3] + '.' + parts[4];
     }
+
     const badParams = new URLSearchParams();
     badParams.append('access_token', badAccessToken);
 

--- a/ci/tests/puppeteer/scenarios/oauth2-login-jwt-at/script.js
+++ b/ci/tests/puppeteer/scenarios/oauth2-login-jwt-at/script.js
@@ -53,8 +53,6 @@ async function executeFlow(browser, redirectUri, clientId, accessTokenSecret) {
     const params = new URLSearchParams();
     params.append('access_token', accessToken);
 
-    cas.log('GOOD TOKEN: ' + accessToken);
-
     await cas.doPost('https://localhost:8443/cas/oauth2.0/profile', params, {},
         res => {
             let result = res.data;
@@ -74,8 +72,6 @@ async function executeFlow(browser, redirectUri, clientId, accessTokenSecret) {
     }
     const badParams = new URLSearchParams();
     badParams.append('access_token', badAccessToken);
-
-    cas.log('BAD TOKEN: ' + badAccessToken);
 
     await cas.doPost('https://localhost:8443/cas/oauth2.0/profile', badParams, {},
         res => {

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointController.java
@@ -67,7 +67,11 @@ public class OAuth20UserProfileEndpointController<T extends OAuth20Configuration
     public ResponseEntity<String> handleGetRequest(final HttpServletRequest request,
                                                    final HttpServletResponse response) throws Exception {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        val accessTokenResult = getAccessTokenFromRequest(request);
+        val accessTokenResult = FunctionUtils.doAndHandle(() -> getAccessTokenFromRequest(request));
+        if (accessTokenResult == null) {
+            LOGGER.error("Unable to get the access token from the request");
+            return buildUnauthorizedResponseEntity(OAuth20Constants.INVALID_REQUEST);
+        }
 
         val decodedAccessTokenId = accessTokenResult.getValue();
         if (StringUtils.isBlank(decodedAccessTokenId)) {

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20UserProfileEndpointControllerTests.java
@@ -15,6 +15,7 @@ import org.apereo.cas.support.oauth.OAuth20ResponseTypes;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenCipherExecutor;
 import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20RegisteredServiceJwtAccessTokenCipherExecutor;
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessTokenFactory;
+import org.apereo.cas.ticket.accesstoken.OAuth20DefaultAccessToken;
 import org.apereo.cas.ticket.accesstoken.OAuth20DefaultAccessTokenFactory;
 import org.apereo.cas.token.JwtBuilder;
 import org.apereo.cas.web.CasWebSecurityConfigurer;
@@ -127,6 +128,30 @@ class OAuth20UserProfileEndpointControllerTests extends AbstractOAuth20Tests {
     @Test
     void verifyEndpoints() throws Throwable {
         assertFalse(oauth20ProtocolEndpointConfigurer.getIgnoredEndpoints().isEmpty());
+    }
+
+    @Test
+    void verifyBadJWTAccessToken() throws Throwable {
+        val principal = CoreAuthenticationTestUtils.getPrincipal(ID);
+        val authentication = getAuthentication(principal);
+        val code = addCode(principal, addRegisteredService());
+
+        val accessToken = (OAuth20DefaultAccessToken) accessTokenFactory.create(RegisteredServiceTestUtils.getService(), authentication,
+                new MockTicketGrantingTicket("casuser"), new ArrayList<>(), code.getId(), code.getClientId(), new HashMap<>(),
+                OAuth20ResponseTypes.CODE, OAuth20GrantTypes.AUTHORIZATION_CODE);
+        val jwtAccessTokenWithBadPayload = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.xxxx.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        accessToken.setId(jwtAccessTokenWithBadPayload);
+        this.ticketRegistry.addTicket(accessToken);
+
+        val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.PROFILE_URL);
+        mockRequest.setParameter(OAuth20Constants.ACCESS_TOKEN, accessToken.getId());
+        val mockResponse = new MockHttpServletResponse();
+
+        val entity = oAuth20ProfileController.handleGetRequest(mockRequest, mockResponse);
+        assertEquals(HttpStatus.UNAUTHORIZED, entity.getStatusCode());
+        assertEquals(MediaType.APPLICATION_JSON_VALUE, mockResponse.getContentType());
+        assertNotNull(entity.getBody());
+        assertTrue(entity.getBody().toString().contains(OAuth20Constants.INVALID_REQUEST));
     }
 
     @Test


### PR DESCRIPTION
Depending on the malformed JWT access token sent to the OAuth /profile endpoint, a direct stack trace can be returned.

This PR sanitizes this issue by returning a generic "invalid_request" error.