### PR TITLE
Use try-with-resource for .getEntity().getContent()

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/adaptive/intel/BlackDotIPAddressIntelligenceService.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/adaptive/intel/BlackDotIPAddressIntelligenceService.java
@@ -69,27 +69,29 @@ public class BlackDotIPAddressIntelligenceService extends BaseIPAddressIntellige
                 LOGGER.error("Exceeded the number of allowed queries");
                 return bannedResponse;
             }
-            val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-            LOGGER.debug("Received payload result after examining IP address [{}] as [{}]", clientIpAddress, result);
+            try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                LOGGER.debug("Received payload result after examining IP address [{}] as [{}]", clientIpAddress, result);
 
-            val json = MAPPER.readValue(JsonValue.readHjson(result).toString(), Map.class);
-            val status = json.getOrDefault("status", "error").toString();
-            if ("success".equalsIgnoreCase(status)) {
-                val rank = Double.parseDouble(json.getOrDefault("result", 1).toString());
-                if (rank == 1) {
-                    return bannedResponse;
+                val json = MAPPER.readValue(JsonValue.readHjson(result).toString(), Map.class);
+                val status = json.getOrDefault("status", "error").toString();
+                if ("success".equalsIgnoreCase(status)) {
+                    val rank = Double.parseDouble(json.getOrDefault("result", 1).toString());
+                    if (rank == 1) {
+                        return bannedResponse;
+                    }
+                    if (rank == 0) {
+                        return IPAddressIntelligenceResponse.allowed();
+                    }
+                    return IPAddressIntelligenceResponse.builder()
+                            .score(rank)
+                            .status(IPAddressIntelligenceResponse.IPAddressIntelligenceStatus.RANKED)
+                            .build();
                 }
-                if (rank == 0) {
-                    return IPAddressIntelligenceResponse.allowed();
-                }
-                return IPAddressIntelligenceResponse.builder()
-                    .score(rank)
-                    .status(IPAddressIntelligenceResponse.IPAddressIntelligenceStatus.RANKED)
-                    .build();
+                val message = json.getOrDefault("message", "Invalid IP address").toString();
+                LOGGER.error(message);
+                return bannedResponse;
             }
-            val message = json.getOrDefault("message", "Invalid IP address").toString();
-            LOGGER.error(message);
-            return bannedResponse;
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         } finally {

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/adaptive/intel/RestfulIPAddressIntelligenceService.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/adaptive/intel/RestfulIPAddressIntelligenceService.java
@@ -54,11 +54,13 @@ public class RestfulIPAddressIntelligenceService extends BaseIPAddressIntelligen
                 if (status.equals(HttpStatus.OK) || status.equals(HttpStatus.ACCEPTED)) {
                     return IPAddressIntelligenceResponse.allowed();
                 }
-                val score = Double.parseDouble(IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8));
-                return IPAddressIntelligenceResponse.builder()
-                    .score(score)
-                    .status(IPAddressIntelligenceResponse.IPAddressIntelligenceStatus.RANKED)
-                    .build();
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val score = Double.parseDouble(IOUtils.toString(content, StandardCharsets.UTF_8));
+                    return IPAddressIntelligenceResponse.builder()
+                            .score(score)
+                            .status(IPAddressIntelligenceResponse.IPAddressIntelligenceStatus.RANKED)
+                            .build();
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/RestfulPrincipalFactory.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/RestfulPrincipalFactory.java
@@ -60,9 +60,11 @@ public class RestfulPrincipalFactory extends DefaultPrincipalFactory {
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && response.getCode() == HttpStatus.OK.value()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                LOGGER.debug("Principal factory response received: [{}]", result);
-                return MAPPER.readValue(JsonValue.readHjson(result).toString(), SimplePrincipal.class);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    LOGGER.debug("Principal factory response received: [{}]", result);
+                    return MAPPER.readValue(JsonValue.readHjson(result).toString(), SimplePrincipal.class);
+                }
             }
         } catch (final Exception e) {
             throw new IllegalArgumentException(e.getMessage(), e);

--- a/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
+++ b/core/cas-server-core-authentication-attributes/src/main/java/org/apereo/cas/services/ReturnRestfulAttributeReleasePolicy.java
@@ -79,14 +79,16 @@ public class ReturnRestfulAttributeReleasePolicy extends BaseMappedAttributeRele
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && HttpStatus.resolve(response.getCode()).is2xxSuccessful()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                LOGGER.debug("Policy response received: [{}]", result);
-                val returnedAttributes = MAPPER.readValue(result, new TypeReference<Map<String, List<Object>>>() {
-                });
-                return FunctionUtils.doIf(getAllowedAttributes().isEmpty(),
-                        () -> returnedAttributes,
-                        () -> authorizeMappedAttributes(context, returnedAttributes))
-                    .get();
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    LOGGER.debug("Policy response received: [{}]", result);
+                    val returnedAttributes = MAPPER.readValue(result, new TypeReference<Map<String, List<Object>>>() {
+                    });
+                    return FunctionUtils.doIf(getAllowedAttributes().isEmpty(),
+                                    () -> returnedAttributes,
+                                    () -> authorizeMappedAttributes(context, returnedAttributes))
+                            .get();
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/mfa/trigger/RestEndpointMultifactorAuthenticationTrigger.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/mfa/trigger/RestEndpointMultifactorAuthenticationTrigger.java
@@ -117,8 +117,9 @@ public class RestEndpointMultifactorAuthenticationTrigger implements Multifactor
             response = HttpUtils.execute(exec);
             val status = HttpStatus.valueOf(response.getCode());
             if (status.is2xxSuccessful()) {
-                val content = ((HttpEntityContainer) response).getEntity().getContent();
-                return IOUtils.toString(content, StandardCharsets.UTF_8);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    return IOUtils.toString(content, StandardCharsets.UTF_8);
+                }
             }
         } finally {
             HttpUtils.close(response);

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/OpenFGARegisteredServiceAccessStrategy.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/OpenFGARegisteredServiceAccessStrategy.java
@@ -94,10 +94,12 @@ public class OpenFGARegisteredServiceAccessStrategy extends BaseRegisteredServic
             LOGGER.debug("Submitting authorization request to [{}] for [{}]", fgaApiUrl, checkEntity);
             response = HttpUtils.execute(exec);
             if (HttpStatus.resolve(response.getCode()).is2xxSuccessful()) {
-                val results = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                LOGGER.trace("Received response from endpoint [{}] as [{}]", url, results);
-                val payload = MAPPER.readValue(results, Map.class);
-                return (Boolean) payload.getOrDefault("allowed", Boolean.FALSE);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val results = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    LOGGER.trace("Received response from endpoint [{}] as [{}]", url, results);
+                    val payload = MAPPER.readValue(results, Map.class);
+                    return (Boolean) payload.getOrDefault("allowed", Boolean.FALSE);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/OpenPolicyAgentRegisteredServiceAccessStrategy.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/OpenPolicyAgentRegisteredServiceAccessStrategy.java
@@ -94,10 +94,12 @@ public class OpenPolicyAgentRegisteredServiceAccessStrategy extends BaseRegister
             LOGGER.debug("Submitting authorization request to [{}] for [{}]", opaUrl, checkEntity);
             response = HttpUtils.execute(exec);
             if (HttpStatus.resolve(response.getCode()).is2xxSuccessful()) {
-                val results = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                LOGGER.trace("Received response from endpoint [{}] as [{}]", url, results);
-                val payload = MAPPER.readValue(results, Map.class);
-                return (Boolean) payload.getOrDefault("result", Boolean.FALSE);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val results = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    LOGGER.trace("Received response from endpoint [{}] as [{}]", url, results);
+                    val payload = MAPPER.readValue(results, Map.class);
+                    return (Boolean) payload.getOrDefault("result", Boolean.FALSE);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/decorator/RestfulLoginWebflowDecorator.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/decorator/RestfulLoginWebflowDecorator.java
@@ -46,9 +46,11 @@ public class RestfulLoginWebflowDecorator implements WebflowDecorator {
                 response = HttpUtils.execute(exec);
                 val statusCode = response.getCode();
                 if (HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
-                    val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    val jsonObject = MAPPER.readValue(JsonValue.readHjson(result).toString(), Map.class);
-                    requestContext.getFlowScope().put("decoration", jsonObject);
+                    try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        val jsonObject = MAPPER.readValue(JsonValue.readHjson(result).toString(), Map.class);
+                        requestContext.getFlowScope().put("decoration", jsonObject);
+                    }
                 }
             } finally {
                 HttpUtils.close(response);

--- a/support/cas-server-support-audit-rest/src/main/java/org/apereo/cas/audit/RestAuditTrailManager.java
+++ b/support/cas-server-support-audit-rest/src/main/java/org/apereo/cas/audit/RestAuditTrailManager.java
@@ -91,10 +91,12 @@ public class RestAuditTrailManager extends AbstractAuditTrailManager {
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && response.getCode() == HttpStatus.SC_OK) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                val values = new TypeReference<Set<AuditActionContext>>() {
-                };
-                return MAPPER.readValue(JsonValue.readHjson(result).toString(), values);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    val values = new TypeReference<Set<AuditActionContext>>() {
+                    };
+                    return MAPPER.readValue(JsonValue.readHjson(result).toString(), values);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-aup-rest/src/main/java/org/apereo/cas/aup/RestAcceptableUsagePolicyRepository.java
+++ b/support/cas-server-support-aup-rest/src/main/java/org/apereo/cas/aup/RestAcceptableUsagePolicyRepository.java
@@ -102,9 +102,11 @@ public class RestAcceptableUsagePolicyRepository extends BaseAcceptableUsagePoli
             response = HttpUtils.execute(exec);
             val statusCode = Optional.ofNullable(response).map(HttpResponse::getCode).orElseGet(HttpStatus.SERVICE_UNAVAILABLE::value);
             if (HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                val terms = MAPPER.readValue(JsonValue.readHjson(result).toString(), AcceptableUsagePolicyTerms.class);
-                return Optional.ofNullable(terms);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    val terms = MAPPER.readValue(JsonValue.readHjson(result).toString(), AcceptableUsagePolicyTerms.class);
+                    return Optional.ofNullable(terms);
+                }
             }
             LOGGER.warn("AUP fetch policy request returned with response code [{}]", statusCode);
         } catch (final Exception e) {

--- a/support/cas-server-support-captcha-core/src/main/java/org/apereo/cas/web/BaseCaptchaValidator.java
+++ b/support/cas-server-support-captcha-core/src/main/java/org/apereo/cas/web/BaseCaptchaValidator.java
@@ -46,19 +46,21 @@ public abstract class BaseCaptchaValidator implements CaptchaValidator {
 
             response = HttpUtils.execute(exec);
             if (response != null && response.getCode() == HttpStatus.OK.value()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                if (StringUtils.isBlank(result)) {
-                    throw new IllegalArgumentException("Unable to parse empty entity response from " + recaptchaProperties.getVerifyUrl());
-                }
-                LOGGER.debug("Recaptcha verification response received: [{}]", result);
-                val node = READER.readTree(result);
-                if (node.has("score") && node.get("score").doubleValue() <= recaptchaProperties.getScore()) {
-                    LOGGER.warn("Recaptcha score received is less than the threshold score defined for CAS");
-                    return false;
-                }
-                if (node.has("success") && node.get("success").booleanValue()) {
-                    LOGGER.trace("Recaptcha has successfully verified the request");
-                    return true;
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    if (StringUtils.isBlank(result)) {
+                        throw new IllegalArgumentException("Unable to parse empty entity response from " + recaptchaProperties.getVerifyUrl());
+                    }
+                    LOGGER.debug("Recaptcha verification response received: [{}]", result);
+                    val node = READER.readTree(result);
+                    if (node.has("score") && node.get("score").doubleValue() <= recaptchaProperties.getScore()) {
+                        LOGGER.warn("Recaptcha score received is less than the threshold score defined for CAS");
+                        return false;
+                    }
+                    if (node.has("success") && node.get("success").booleanValue()) {
+                        LOGGER.trace("Recaptcha has successfully verified the request");
+                        return true;
+                    }
                 }
             }
         } catch (final Exception e) {

--- a/support/cas-server-support-configuration-cloud-rest/src/main/java/org/apereo/cas/config/RestfulPropertySourceLocator.java
+++ b/support/cas-server-support-configuration-cloud-rest/src/main/java/org/apereo/cas/config/RestfulPropertySourceLocator.java
@@ -77,10 +77,12 @@ public class RestfulPropertySourceLocator implements PropertySourceLocator {
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && ((HttpEntityContainer) response).getEntity() != null) {
-                val results = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                LOGGER.trace("Received response from endpoint [{}] as [{}]", url, results);
-                val payload = MAPPER.readValue(results, Map.class);
-                props.putAll(payload);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val results = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    LOGGER.trace("Received response from endpoint [{}] as [{}]", url, results);
+                    val payload = MAPPER.readValue(results, Map.class);
+                    props.putAll(payload);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-consent-rest/src/main/java/org/apereo/cas/consent/RestfulConsentRepository.java
+++ b/support/cas-server-support-consent-rest/src/main/java/org/apereo/cas/consent/RestfulConsentRepository.java
@@ -63,9 +63,11 @@ public class RestfulConsentRepository implements ConsentRepository {
                     .build();
                 response = HttpUtils.execute(exec);
                 if (response != null && HttpStatus.valueOf(response.getCode()).is2xxSuccessful()) {
-                    val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, ConsentDecision.class);
-                    return MAPPER.readValue(JsonValue.readHjson(result).toString(), expectedType);
+                    try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, ConsentDecision.class);
+                        return MAPPER.readValue(JsonValue.readHjson(result).toString(), expectedType);
+                    }
                 }
             } finally {
                 HttpUtils.close(response);
@@ -93,9 +95,11 @@ public class RestfulConsentRepository implements ConsentRepository {
                     .build();
                 response = HttpUtils.execute(exec);
                 if (response != null && HttpStatus.valueOf(response.getCode()).is2xxSuccessful()) {
-                    val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, ConsentDecision.class);
-                    return MAPPER.readValue(result, expectedType);
+                    try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, ConsentDecision.class);
+                        return MAPPER.readValue(result, expectedType);
+                    }
                 }
             } finally {
                 HttpUtils.close(response);
@@ -126,8 +130,10 @@ public class RestfulConsentRepository implements ConsentRepository {
                     .build();
                 response = HttpUtils.execute(exec);
                 if (response != null && HttpStatus.valueOf(response.getCode()).is2xxSuccessful()) {
-                    val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    return MAPPER.readValue(result, ConsentDecision.class);
+                    try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        return MAPPER.readValue(result, ConsentDecision.class);
+                    }
                 }
             } finally {
                 HttpUtils.close(response);

--- a/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/RestGoogleAuthenticatorTokenCredentialRepository.java
+++ b/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/credential/RestGoogleAuthenticatorTokenCredentialRepository.java
@@ -72,12 +72,14 @@ public class RestGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    if (content != null) {
-                        val values = new TypeReference<GoogleAuthenticatorAccount>() {
-                        };
-                        val result = MAPPER.readValue(JsonValue.readHjson(content).toString(), values);
-                        return decode(Objects.requireNonNull(result));
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        if (content != null) {
+                            val values = new TypeReference<GoogleAuthenticatorAccount>() {
+                            };
+                            val result = MAPPER.readValue(JsonValue.readHjson(content).toString(), values);
+                            return decode(Objects.requireNonNull(result));
+                        }
                     }
                 }
             }
@@ -111,12 +113,14 @@ public class RestGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    if (content != null) {
-                        val values = new TypeReference<GoogleAuthenticatorAccount>() {
-                        };
-                        val result = MAPPER.readValue(JsonValue.readHjson(content).toString(), values);
-                        return decode(Objects.requireNonNull(result));
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        if (content != null) {
+                            val values = new TypeReference<GoogleAuthenticatorAccount>() {
+                            };
+                            val result = MAPPER.readValue(JsonValue.readHjson(content).toString(), values);
+                            return decode(Objects.requireNonNull(result));
+                        }
                     }
                 }
             }
@@ -148,12 +152,14 @@ public class RestGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    if (content != null) {
-                        val values = new TypeReference<List<GoogleAuthenticatorAccount>>() {
-                        };
-                        val result = MAPPER.readValue(JsonValue.readHjson(content).toString(), values);
-                        return decode(Objects.requireNonNull(result));
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        if (content != null) {
+                            val values = new TypeReference<List<GoogleAuthenticatorAccount>>() {
+                            };
+                            val result = MAPPER.readValue(JsonValue.readHjson(content).toString(), values);
+                            return decode(Objects.requireNonNull(result));
+                        }
                     }
                 }
             }
@@ -184,12 +190,14 @@ public class RestGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    if (content != null) {
-                        val results = MAPPER.readValue(JsonValue.readHjson(content).toString(),
-                            new TypeReference<List<GoogleAuthenticatorAccount>>() {
-                            });
-                        return results.stream().map(this::decode).collect(Collectors.toList());
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        if (content != null) {
+                            val results = MAPPER.readValue(JsonValue.readHjson(content).toString(),
+                                    new TypeReference<List<GoogleAuthenticatorAccount>>() {
+                                    });
+                            return results.stream().map(this::decode).collect(Collectors.toList());
+                        }
                     }
                 }
             }
@@ -329,9 +337,11 @@ public class RestGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    if (content != null) {
-                        return MAPPER.readValue(JsonValue.readHjson(content).toString(), Long.class);
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        if (content != null) {
+                            return MAPPER.readValue(JsonValue.readHjson(content).toString(), Long.class);
+                        }
                     }
                 }
             }
@@ -365,9 +375,11 @@ public class RestGoogleAuthenticatorTokenCredentialRepository extends BaseGoogle
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    if (content != null) {
-                        return MAPPER.readValue(JsonValue.readHjson(content).toString(), Long.class);
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        if (content != null) {
+                            return MAPPER.readValue(JsonValue.readHjson(content).toString(), Long.class);
+                        }
                     }
                 }
             }

--- a/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/RestEndpointInterruptInquirer.java
+++ b/support/cas-server-support-interrupt-core/src/main/java/org/apereo/cas/interrupt/RestEndpointInterruptInquirer.java
@@ -79,9 +79,10 @@ public class RestEndpointInterruptInquirer extends BaseInterruptInquirer {
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && ((HttpEntityContainer) response).getEntity() != null) {
-                val content = ((HttpEntityContainer) response).getEntity().getContent();
-                val result = IOUtils.toString(content, StandardCharsets.UTF_8);
-                return MAPPER.readValue(JsonValue.readHjson(result).toString(), InterruptResponse.class);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    return MAPPER.readValue(JsonValue.readHjson(result).toString(), InterruptResponse.class);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/webfinger/userinfo/OidcRestfulWebFingerUserInfoRepository.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/webfinger/userinfo/OidcRestfulWebFingerUserInfoRepository.java
@@ -65,8 +65,10 @@ public class OidcRestfulWebFingerUserInfoRepository implements OidcWebFingerUser
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && ((HttpEntityContainer) response).getEntity() != null && response.getCode() == HttpStatus.SC_OK) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                return MAPPER.readValue(JsonValue.readHjson(result).toString(), Map.class);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    return MAPPER.readValue(JsonValue.readHjson(result).toString(), Map.class);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcRestfulJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/generator/OidcRestfulJsonWebKeystoreGeneratorService.java
@@ -54,9 +54,11 @@ public class OidcRestfulJsonWebKeystoreGeneratorService implements OidcJsonWebKe
             return null;
         }
 
-        val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-        LOGGER.debug("Received payload result from [{}] as [{}]", rest.getUrl(), result);
-        return new ByteArrayResource(result.getBytes(StandardCharsets.UTF_8), "OIDC JWKS");
+        try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+            val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+            LOGGER.debug("Received payload result from [{}] as [{}]", rest.getUrl(), result);
+            return new ByteArrayResource(result.getBytes(StandardCharsets.UTF_8), "OIDC JWKS");
+        }
     }
 
     @Override

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcDefaultClientRegistrationRequestTranslator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcDefaultClientRegistrationRequestTranslator.java
@@ -255,11 +255,13 @@ public class OidcDefaultClientRegistrationRequestTranslator implements OidcClien
                     .build();
                 sectorResponse = HttpUtils.execute(exec);
                 if (sectorResponse != null && sectorResponse.getCode() == HttpStatus.SC_OK) {
-                    val result = IOUtils.toString(((HttpEntityContainer) sectorResponse).getEntity().getContent(), StandardCharsets.UTF_8);
-                    val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, String.class);
-                    val urls = MAPPER.readValue(JsonValue.readHjson(result).toString(), expectedType);
-                    if (!urls.equals(registrationRequest.getRedirectUris())) {
-                        throw new IllegalArgumentException("Invalid sector identifier uri");
+                    try (val content = ((HttpEntityContainer) sectorResponse).getEntity().getContent()) {
+                        val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, String.class);
+                        val urls = MAPPER.readValue(JsonValue.readHjson(result).toString(), expectedType);
+                        if (!urls.equals(registrationRequest.getRedirectUris())) {
+                            throw new IllegalArgumentException("Invalid sector identifier uri");
+                        }
                     }
                 }
             } finally {

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/RestfulDelegatedIdentityProviderFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/RestfulDelegatedIdentityProviderFactory.java
@@ -65,11 +65,13 @@ public class RestfulDelegatedIdentityProviderFactory extends BaseDelegatedIdenti
         val response = HttpUtils.execute(exec);
         try {
             if (response != null && HttpStatus.valueOf(response.getCode()).is2xxSuccessful()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                if ("cas".equalsIgnoreCase(restProperties.getType())) {
-                    return buildClientsBasedCasProperties(result);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    if ("cas".equalsIgnoreCase(restProperties.getType())) {
+                        return buildClientsBasedCasProperties(result);
+                    }
+                    return buildClientsBasedPac4jProperties(result);
                 }
-                return buildClientsBasedPac4jProperties(result);
             }
             return new ArrayList<>();
         } finally {

--- a/support/cas-server-support-passwordless-api/src/main/java/org/apereo/cas/impl/account/RestfulPasswordlessUserAccountStore.java
+++ b/support/cas-server-support-passwordless-api/src/main/java/org/apereo/cas/impl/account/RestfulPasswordlessUserAccountStore.java
@@ -54,9 +54,11 @@ public class RestfulPasswordlessUserAccountStore implements PasswordlessUserAcco
             response = HttpUtils.execute(exec);
 
             if (response != null && HttpStatus.valueOf(response.getCode()).is2xxSuccessful() && ((HttpEntityContainer) response).getEntity() != null) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                val account = MAPPER.readValue(JsonValue.readHjson(result).toString(), PasswordlessUserAccount.class);
-                return Optional.ofNullable(account);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    val account = MAPPER.readValue(JsonValue.readHjson(result).toString(), PasswordlessUserAccount.class);
+                    return Optional.ofNullable(account);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-passwordless-api/src/main/java/org/apereo/cas/impl/token/RestfulPasswordlessTokenRepository.java
+++ b/support/cas-server-support-passwordless-api/src/main/java/org/apereo/cas/impl/token/RestfulPasswordlessTokenRepository.java
@@ -51,9 +51,11 @@ public class RestfulPasswordlessTokenRepository extends BasePasswordlessTokenRep
 
             response = HttpUtils.execute(exec);
             if (response != null && ((HttpEntityContainer) response).getEntity() != null) {
-                val token = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                val result = decodePasswordlessAuthenticationToken(token);
-                return Optional.of(result);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val token = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    val result = decodePasswordlessAuthenticationToken(token);
+                    return Optional.of(result);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
+++ b/support/cas-server-support-rest-service-registry/src/main/java/org/apereo/cas/services/RestfulServiceRegistry.java
@@ -69,8 +69,10 @@ public class RestfulServiceRegistry extends AbstractServiceRegistry {
                 .build();
             response = HttpUtils.execute(exec);
             if (response.getCode() == HttpStatus.OK.value()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                return this.serializer.from(result);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    return this.serializer.from(result);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
@@ -135,14 +137,16 @@ public class RestfulServiceRegistry extends AbstractServiceRegistry {
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && response.getCode() == HttpStatus.OK.value()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                val services = this.serializer.fromList(result);
-                services
-                    .stream()
-                    .map(this::invokeServiceRegistryListenerPostLoad)
-                    .filter(Objects::nonNull)
-                    .forEach(s -> publishEvent(new CasRegisteredServiceLoadedEvent(this, s, clientInfo)));
-                return services;
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    val services = this.serializer.fromList(result);
+                    services
+                            .stream()
+                            .map(this::invokeServiceRegistryListenerPostLoad)
+                            .filter(Objects::nonNull)
+                            .forEach(s -> publishEvent(new CasRegisteredServiceLoadedEvent(this, s, clientInfo)));
+                    return services;
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
@@ -166,8 +170,10 @@ public class RestfulServiceRegistry extends AbstractServiceRegistry {
                 .build();
             response = HttpUtils.execute(exec);
             if (response.getCode() == HttpStatus.OK.value()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                return serializer.from(result);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    return serializer.from(result);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-saml-idp-metadata-rest/src/main/java/org/apereo/cas/support/saml/idp/metadata/RestfulSamlIdPMetadataLocator.java
+++ b/support/cas-server-support-saml-idp-metadata-rest/src/main/java/org/apereo/cas/support/saml/idp/metadata/RestfulSamlIdPMetadataLocator.java
@@ -64,10 +64,12 @@ public class RestfulSamlIdPMetadataLocator extends AbstractSamlIdPMetadataLocato
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val entity = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    val document = MAPPER.readValue(JsonValue.readHjson(entity).toString(), SamlIdPMetadataDocument.class);
-                    if (document != null && document.isValid()) {
-                        return document;
+                    try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val entity = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        val document = MAPPER.readValue(JsonValue.readHjson(entity).toString(), SamlIdPMetadataDocument.class);
+                        if (document != null && document.isValid()) {
+                            return document;
+                        }
                     }
                 }
             }

--- a/support/cas-server-support-saml-idp-metadata-rest/src/main/java/org/apereo/cas/support/saml/metadata/resolver/RestfulSamlRegisteredServiceMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata-rest/src/main/java/org/apereo/cas/support/saml/metadata/resolver/RestfulSamlRegisteredServiceMetadataResolver.java
@@ -69,10 +69,12 @@ public class RestfulSamlRegisteredServiceMetadataResolver extends BaseSamlRegist
                 .build();
             response = HttpUtils.execute(exec);
             if (response != null && response.getCode() == HttpStatus.SC_OK) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                val doc = MAPPER.readValue(JsonValue.readHjson(result).toString(), SamlMetadataDocument.class);
-                val resolver = buildMetadataResolverFrom(service, doc);
-                return CollectionUtils.wrapList(resolver);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    val doc = MAPPER.readValue(JsonValue.readHjson(result).toString(), SamlMetadataDocument.class);
+                    val resolver = buildMetadataResolverFrom(service, doc);
+                    return CollectionUtils.wrapList(resolver);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceMessageHandler.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceMessageHandler.java
@@ -144,9 +144,11 @@ public class SamlIdPSingleLogoutServiceMessageHandler extends BaseSingleLogoutSe
                 response = HttpUtils.execute(exec);
             }
             if (response != null && response.getCode() == HttpStatus.OK.value()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                LOGGER.trace("Received logout response as [{}]", result);
-                return true;
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    LOGGER.trace("Received logout response as [{}]", result);
+                    return true;
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-saml-mdui-core/src/main/java/org/apereo/cas/support/saml/mdui/DynamicMetadataResolverAdapter.java
+++ b/support/cas-server-support-saml-mdui-core/src/main/java/org/apereo/cas/support/saml/mdui/DynamicMetadataResolverAdapter.java
@@ -66,8 +66,10 @@ public class DynamicMetadataResolverAdapter extends AbstractMetadataResolverAdap
                     .build();
                 response = HttpUtils.execute(exec);
                 if (response != null && response.getCode() == HttpStatus.SC_OK) {
-                    val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    return new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8));
+                    try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        return new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8));
+                    }
                 }
             } catch (final Exception e) {
                 LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/validation/RestfulCasSimpleMultifactorAuthenticationService.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/validation/RestfulCasSimpleMultifactorAuthenticationService.java
@@ -69,12 +69,14 @@ public class RestfulCasSimpleMultifactorAuthenticationService implements CasSimp
             response = HttpUtils.execute(exec);
             val statusCode = response.getCode();
             if (HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                val mfaFactory = (CasSimpleMultifactorAuthenticationTicketFactory) ticketFactory.get(CasSimpleMultifactorAuthenticationTicket.class);
-                LOGGER.debug("Multifactor authentication token received is [{}]", result);
-                val token = mfaFactory.create(result, service, CollectionUtils.wrap(CasSimpleMultifactorAuthenticationConstants.PROPERTY_PRINCIPAL, principal));
-                LOGGER.debug("Created multifactor authentication token [{}] for service [{}]", token.getId(), service);
-                return token;
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    val mfaFactory = (CasSimpleMultifactorAuthenticationTicketFactory) ticketFactory.get(CasSimpleMultifactorAuthenticationTicket.class);
+                    LOGGER.debug("Multifactor authentication token received is [{}]", result);
+                    val token = mfaFactory.create(result, service, CollectionUtils.wrap(CasSimpleMultifactorAuthenticationConstants.PROPERTY_PRINCIPAL, principal));
+                    LOGGER.debug("Created multifactor authentication token [{}] for service [{}]", token.getId(), service);
+                    return token;
+                }
             }
             throw new FailedLoginException("Unable to validate multifactor credential with status " + statusCode);
         } finally {
@@ -124,8 +126,10 @@ public class RestfulCasSimpleMultifactorAuthenticationService implements CasSimp
             response = HttpUtils.execute(exec);
             val statusCode = response.getCode();
             if (HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                return MAPPER.readValue(JsonValue.readHjson(result).toString(), Principal.class);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    return MAPPER.readValue(JsonValue.readHjson(result).toString(), Principal.class);
+                }
             }
             throw new FailedLoginException("Unable to validate multifactor credential with status " + statusCode);
         } finally {
@@ -148,8 +152,10 @@ public class RestfulCasSimpleMultifactorAuthenticationService implements CasSimp
             response = HttpUtils.execute(exec);
             val statusCode = response.getCode();
             if (HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                return MAPPER.readValue(JsonValue.readHjson(result).toString(), Principal.class);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    return MAPPER.readValue(JsonValue.readHjson(result).toString(), Principal.class);
+                }
             }
             throw new FailedLoginException("Unable to validate multifactor credential with status " + statusCode);
         } finally {

--- a/support/cas-server-support-sms-smsmode/src/main/java/org/apereo/cas/support/sms/SmsModeSmsSender.java
+++ b/support/cas-server-support-sms-smsmode/src/main/java/org/apereo/cas/support/sms/SmsModeSmsSender.java
@@ -58,9 +58,11 @@ public record SmsModeSmsSender(SmsModeProperties properties) implements SmsSende
             response = HttpUtils.execute(exec);
 
             val status = HttpStatus.valueOf(response.getCode());
-            val entity = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-            LOGGER.debug("Response from SmsMode: [{}]", entity);
-            return status.is2xxSuccessful();
+            try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                val entity = IOUtils.toString(content, StandardCharsets.UTF_8);
+                LOGGER.debug("Response from SmsMode: [{}]", entity);
+                return status.is2xxSuccessful();
+            }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         } finally {

--- a/support/cas-server-support-surrogate-authentication-rest/src/main/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationService.java
+++ b/support/cas-server-support-surrogate-authentication-rest/src/main/java/org/apereo/cas/authentication/surrogate/SurrogateRestAuthenticationService.java
@@ -75,9 +75,11 @@ public class SurrogateRestAuthenticationService extends BaseSurrogateAuthenticat
                 .parameters(CollectionUtils.wrap("principal", username))
                 .build();
             response = HttpUtils.execute(exec);
-            val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-            val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, String.class);
-            return MAPPER.readValue(JsonValue.readHjson(result).toString(), expectedType);
+            try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                val expectedType = MAPPER.getTypeFactory().constructParametricType(List.class, String.class);
+                return MAPPER.readValue(JsonValue.readHjson(result).toString(), expectedType);
+            }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         } finally {

--- a/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/RegisteredServiceThemeResolver.java
+++ b/support/cas-server-support-themes-core/src/main/java/org/apereo/cas/services/web/RegisteredServiceThemeResolver.java
@@ -119,8 +119,10 @@ public class RegisteredServiceThemeResolver extends AbstractThemeResolver {
                     .build();
                 response = HttpUtils.execute(exec);
                 if (response != null && response.getCode() == HttpStatus.SC_OK) {
-                    val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    return StringUtils.defaultIfBlank(result, getDefaultThemeName());
+                    try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                        return StringUtils.defaultIfBlank(result, getDefaultThemeName());
+                    }
                 }
             }
             val theme = resolveThemeForService(registeredService, request);

--- a/support/cas-server-support-thymeleaf-core/src/main/java/org/apereo/cas/web/view/RestfulUrlTemplateResolver.java
+++ b/support/cas-server-support-thymeleaf-core/src/main/java/org/apereo/cas/web/view/RestfulUrlTemplateResolver.java
@@ -71,8 +71,10 @@ public class RestfulUrlTemplateResolver extends ThemeFileTemplateResolver {
             response = HttpUtils.execute(exec);
             val statusCode = response.getCode();
             if (HttpStatus.valueOf(statusCode).is2xxSuccessful()) {
-                val result = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                return new StringTemplateResource(result);
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    return new StringTemplateResource(result);
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-webauthn-rest/src/main/java/org/apereo/cas/webauthn/RestfulWebAuthnCredentialRepository.java
+++ b/support/cas-server-support-webauthn-rest/src/main/java/org/apereo/cas/webauthn/RestfulWebAuthnCredentialRepository.java
@@ -53,9 +53,11 @@ public class RestfulWebAuthnCredentialRepository extends BaseWebAuthnCredentialR
                 .build();
             response = HttpUtils.execute(exec);
             if (Objects.requireNonNull(response).getCode() == HttpStatus.OK.value()) {
-                val result = getCipherExecutor().decode(IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8));
-                return WebAuthnUtils.getObjectMapper().readValue(result, new TypeReference<List<CredentialRegistration>>() {
-                });
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = getCipherExecutor().decode(IOUtils.toString(content, StandardCharsets.UTF_8));
+                    return WebAuthnUtils.getObjectMapper().readValue(result, new TypeReference<List<CredentialRegistration>>() {
+                    });
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
@@ -78,10 +80,12 @@ public class RestfulWebAuthnCredentialRepository extends BaseWebAuthnCredentialR
                 .build();
             response = HttpUtils.execute(exec);
             if (Objects.requireNonNull(response).getCode() == HttpStatus.OK.value()) {
-                val result = getCipherExecutor().decode(IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8));
-                val records = WebAuthnUtils.getObjectMapper().readValue(result, new TypeReference<List<CredentialRegistration>>() {
-                });
-                return records.stream();
+                try (val content = ((HttpEntityContainer) response).getEntity().getContent()) {
+                    val result = getCipherExecutor().decode(IOUtils.toString(content, StandardCharsets.UTF_8));
+                    val records = WebAuthnUtils.getObjectMapper().readValue(result, new TypeReference<List<CredentialRegistration>>() {
+                    });
+                    return records.stream();
+                }
             }
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/support/cas-server-support-yubikey-core/src/main/java/org/apereo/cas/adaptors/yubikey/registry/RestfulYubiKeyAccountRegistry.java
+++ b/support/cas-server-support-yubikey-core/src/main/java/org/apereo/cas/adaptors/yubikey/registry/RestfulYubiKeyAccountRegistry.java
@@ -152,8 +152,10 @@ public class RestfulYubiKeyAccountRegistry extends BaseYubiKeyAccountRegistry {
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    return MAPPER.readValue(content, YubiKeyAccount.class);
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        return MAPPER.readValue(content, YubiKeyAccount.class);
+                    }
                 }
             }
         } catch (final Exception e) {
@@ -178,9 +180,11 @@ public class RestfulYubiKeyAccountRegistry extends BaseYubiKeyAccountRegistry {
             if (response != null) {
                 val status = HttpStatus.valueOf(response.getCode());
                 if (status.is2xxSuccessful()) {
-                    val content = IOUtils.toString(((HttpEntityContainer) response).getEntity().getContent(), StandardCharsets.UTF_8);
-                    return MAPPER.readValue(content, new TypeReference<List<YubiKeyAccount>>() {
-                    });
+                    try (val contis = ((HttpEntityContainer) response).getEntity().getContent()) {
+                        val content = IOUtils.toString(contis, StandardCharsets.UTF_8);
+                        return MAPPER.readValue(content, new TypeReference<List<YubiKeyAccount>>() {
+                        });
+                    }
                 }
             }
         } catch (final Exception e) {


### PR DESCRIPTION
`.getEntity().getContent()` is an `InputStream` which should always be closed.

This PR surrounds this expression with a `try-with-resource`.
