### PR TITLE
remove jakartaee-migration dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2561,9 +2561,6 @@ ext.libraries = [
                 },
                 dependencies.create("org.apache.tomcat.embed:tomcat-embed-el:$tomcatVersion") {
                     exclude(group: "org.apache.tomcat", module: "tomcat-annotations-api")
-                },
-                dependencies.create("org.apache.tomcat:jakartaee-migration:1.0.7") {
-                    exclude(group: "commons-io", module: "commons-io")
                 }
         ],
         springbootjetty            : [

--- a/gradle/overrides.gradle
+++ b/gradle/overrides.gradle
@@ -81,9 +81,7 @@ configurations.configureEach {
                     details.useVersion("${undertowVersion}")
                 }
                 if (requested.group.startsWith( "org.apache.tomcat")) {
-                    if (requested.name != "jakartaee-migration") {
-                        details.useVersion("${tomcatVersion}")
-                    }
+                    details.useVersion("${tomcatVersion}")
                 }
                 if (requested.group == "org.hsqldb")  {
                     details.useVersion("${hsqlVersion}")


### PR DESCRIPTION
This jakartaee-migration dependency doesn't sound like something CAS needs (since it is a utility for upgrading tomcat from 8 to 10), and it brings in a slightly old version of commons-compress which CAS doesn't otherwise use. 

I removed the code in overrides.gradle that avoids changing the version on jakartaee-migration because if something else somewhere decides to pull it in, this would fail and we could exclude it. 

I ran a puppeteer test after removing it and it worked. 