### PR TITLE
fixed setting ssl property to redis uriBuilder

### DIFF
--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -127,7 +127,8 @@ public class RedisObjectFactory {
         val uriBuilder = RedisURI.builder()
             .withHost(redis.getHost())
             .withPort(redis.getPort())
-            .withDatabase(redis.getDatabase());
+            .withDatabase(redis.getDatabase())
+            .ssl(redis.isUseSsl());
         
         if (StringUtils.hasText(redis.getUsername()) && StringUtils.hasText(redis.getPassword())) {
             uriBuilder.withAuthentication(redis.getUsername(), redis.getPassword());


### PR DESCRIPTION
Description:
- Within the class RedisObjectFactory and the method newRedisModulesCommands there was a property setting missing on uriBuilder. Once the property "useSSL" has been defined and set on BaseRedisProperties object this property was never provided to the RedisURIBuilder. In our cas the missing of this setting led to connection exception to a redis instance.
