### PR TITLE
fixed setting ssl property to redis uriBuilder

### DIFF
--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -127,7 +127,8 @@ public class RedisObjectFactory {
         val uriBuilder = RedisURI.builder()
             .withHost(redis.getHost())
             .withPort(redis.getPort())
-            .withDatabase(redis.getDatabase());
+            .withDatabase(redis.getDatabase())
+            .ssl(redis.isUseSsl());
         
         if (StringUtils.hasText(redis.getUsername()) && StringUtils.hasText(redis.getPassword())) {
             uriBuilder.withAuthentication(redis.getUsername(), redis.getPassword());

--- a/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
+++ b/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
@@ -69,6 +69,18 @@ class RedisObjectFactoryTests {
     }
 
     @Test
+    void verifyConnectionWithUsernamePasswordOverTls() throws Throwable {
+        val props = new BaseRedisProperties();
+        props.setHost("localhost");
+        props.setPort(16669);
+        props.setUsername("default");
+        props.setPassword("pAssw0rd123");
+        props.setUseSsl(true);
+        val connection = RedisObjectFactory.newRedisModulesCommands(props);
+        assertNotNull(connection);
+    }
+
+    @Test
     void verifyConnectionWithTls() throws Throwable {
         val props = new BaseRedisProperties();
         props.setHost("localhost");


### PR DESCRIPTION
Within the class RedisObjectFactory and the method newRedisModulesCommands there was a property setting missing on uriBuilder. Once the property "useSSL" has been defined and set on BaseRedisProperties object this property was never provided to the RedisURIBuilder. In our cas the missing of this setting led to connection exception to a redis instance. Also added missing test case for the change.