### PR TITLE
Fixed generateConfigurationMetadata task setup

### DIFF
--- a/api/cas-server-core-api-configuration-model/build.gradle
+++ b/api/cas-server-core-api-configuration-model/build.gradle
@@ -1,3 +1,6 @@
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
 description = "Apereo CAS Core Configuration Model"
 def skipConfigurationMetadata = providers.systemProperty("skipNestedConfigMetadataGen").present
 
@@ -30,7 +33,7 @@ dependencies {
 
 if (!skipConfigurationMetadata) {
     def outputFile = project.layout.buildDirectory.file("generated/spring-configuration-metadata/META-INF/spring-configuration-metadata.json")
-    def inputFile = project.layout.buildDirectory.file("classes/java/main/META-INF")
+    def inputFile = project.layout.buildDirectory.file("classes/java/main/META-INF/spring-configuration-metadata.json")
 
     tasks.register('generateConfigurationMetadata', JavaExec) {
         inputs.files(tasks.named('processResources'), tasks.named('compileJava'))
@@ -46,15 +49,25 @@ if (!skipConfigurationMetadata) {
         finalizedBy("copyConfigurationMetadata")
     }
 
-    tasks.register('copyConfigurationMetadata', Copy) {
-        from outputFile
-        into inputFile
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    tasks.register('copyConfigurationMetadata') {
+        dependsOn tasks.named("generateConfigurationMetadata")
+        doLast {
+            Files.copy(
+                    outputFile.get().asFile.toPath(),
+                    inputFile.get().asFile.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING
+            )
+        }
+        outputs.doNotCacheIf("Caching disabled for copying, as well as build correctness.") { true }
     }
 
     tasks.named('compileJava') {
         inputs.files(tasks.named('processResources'))
         finalizedBy("generateConfigurationMetadata")
     }
-    sourceSets.main.output.dir inputFile, builtBy: "copyConfigurationMetadata"
+
+    jar {
+        dependsOn tasks.named("copyConfigurationMetadata")
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 }


### PR DESCRIPTION
- Created an ad-hoc copy task for copying the modified spring configuration metadata to break the cyclic dependency. 
- Removed the generated file from sourceSets

The changes introduced here mean that Gradle doesn't track the inputs and outputs of the new `copyConfigurationMetadata` task - it is executed purely because of task dependencies configured - which are now configured in both ways - using `finalizedBy`, as well as `dependsOn`. I also marked `copyConfigurationMetadata` as not cacheable, as setting inputs and outputs will get picked up by the rest of the `compileJava` tasks (from modules that depend on `:api:cas-server-core-api-configuration-model`), which introduces a cyclic dependency problem.
