### PR TITLE
Improve error log for PKCE

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
@@ -33,7 +33,8 @@ public class DefaultOAuth20ClientSecretValidator implements OAuth20ClientSecretV
         val clientSecretDecoded = EncodingUtils.urlDecode(clientSecret);
         val definedSecret = cipherExecutor.decode(registeredService.getClientSecret(), new Object[]{registeredService});
         if (!StringUtils.equals(definedSecret, clientSecretDecoded)) {
-            LOGGER.error("Wrong client secret for service: [{}]", registeredService.getServiceId());
+            LOGGER.error("Wrong client secret for service: [{}]. If you use PKCE and no client secret on client side, "
+                       + "you need to set \"clientSecret\": null on the CAS server side", registeredService.getServiceId());
             return false;
         }
         return true;

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
@@ -35,8 +35,8 @@ public class DefaultOAuth20ClientSecretValidator implements OAuth20ClientSecretV
         if (!StringUtils.equals(definedSecret, clientSecretDecoded)) {
             LOGGER.error("Wrong client secret for service: [{}]. Using PKCE does not require a client secret and "
                        + "requests generally must not specify a client secret to CAS.\nFurthermore, you must make sure "
-                       + "no client secret is assigned to the registered service [{}] in the CAS service registry.",
-                        registeredService.getServiceId(), registeredService);
+                       + "no client secret is assigned to this registered service in the CAS service registry.",
+                        registeredService.getServiceId());
             return false;
         }
         return true;

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
@@ -33,8 +33,10 @@ public class DefaultOAuth20ClientSecretValidator implements OAuth20ClientSecretV
         val clientSecretDecoded = EncodingUtils.urlDecode(clientSecret);
         val definedSecret = cipherExecutor.decode(registeredService.getClientSecret(), new Object[]{registeredService});
         if (!StringUtils.equals(definedSecret, clientSecretDecoded)) {
-            LOGGER.error("Wrong client secret for service: [{}]. If you use PKCE and no client secret on client side, "
-                       + "you need to set \"clientSecret\": null on the CAS server side", registeredService.getServiceId());
+            LOGGER.error("Wrong client secret for service: [{}]. Using PKCE does not require a client secret and "
+                       + "requests generally must not specify a client secret to CAS.\nFurthermore, you must make sure "
+                       + "no client secret is assigned to the registered service [{}] in the CAS service registry.",
+                        registeredService.getServiceId(), registeredService);
             return false;
         }
         return true;


### PR DESCRIPTION
On client side (pac4j), I have:

```java
oidcConfiguration.setSecret(null);
oidcConfiguration.setDisablePkce(false);
```

On the CAS server side, I have:

```java
{
  "@class" : "org.apereo.cas.services.OidcRegisteredService",
  "clientId": "myclient",
  "clientSecret": "mysecret",
  "serviceId" : "^http://localhost:.*",
  "name": "OIDC",
  "id": 1,
  "scopes" : [ "java.util.HashSet",
    [ "openid", "email", "profile" ]
  ]
}
```

And I get the following error on the _authorization_code_ grant type : _Wrong client secret for service: [xxx]_ which is quite normal.

Though, I think we could improve the error log here with an extended message related to PKCE: _Wrong client secret for service: [xxx]. If you use PKCE and no client secret on client side, you need to set "clientSecret": null on the CAS server side_

What do you think?
