### PR TITLE
Fix some Jakarta dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2368,6 +2368,7 @@ ext.libraries = [
                     exclude(group: "org.springframework", module: "spring-context")
                     exclude(group: "org.springframework", module: "spring-context-support")
                     exclude(group: "org.springframework", module: "spring-beans")
+                    exclude(group: "org.eclipse.angus", module: "jakarta.mail")
                 },
                 dependencies.create("com.sun.mail:jakarta.mail:$jakartaMailVersion")
         ],
@@ -2498,6 +2499,7 @@ ext.libraries = [
                     exclude(group: "ch.qos.logback", module: "logback-core")
                     exclude(group: "ch.qos.logback", module: "logback-classic")
                     exclude(group: "com.fasterxml.jackson.module", module: "jackson-module-jaxb-annotations")
+                    exclude(group: "io.micrometer", module: "micrometer-jakarta9")
                 },
                 dependencies.create("org.springframework.boot:spring-boot-starter-validation:$springBootVersion") {
                     exclude(group: "org.springframework.boot", module: "spring-boot-starter")
@@ -2537,6 +2539,8 @@ ext.libraries = [
                     exclude(group: "org.springframework.boot", module: "spring-boot-starter-logging")
                     exclude(group: "org.springframework.boot", module: "spring-boot-starter-web")
                     exclude(group: "com.fasterxml.jackson.module", module: "jackson-module-jaxb-annotations")
+                },
+                dependencies.create("io.micrometer:micrometer-jakarta9:$micrometerVersion") {
                 }
         ],
         springboottomcat           : [


### PR DESCRIPTION
In my basic CAS overlay based on the latest CAS WAR `7.1.0-SNAPSHOT`, I see the following dependencies:

```shell
jakarta.mail-2.0.1.jar
jakarta.mail-2.0.2.jar
micrometer-jakarta9-1.12.1.jar
micrometer-jakarta9-1.12.2.jar
```

In the CAS `gradle.properties`, there are:

```shell
jakartaMailVersion=2.0.1
micrometerVersion=1.12.2
```

This PR cleans the unwanted dependencies (`jakarta.mail-2.0.2.jar` and `micrometer-jakarta9-1.12.1.jar`).
