### PR TITLE
Revert "Fix a Jakarta dependency"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2368,7 +2368,6 @@ ext.libraries = [
                     exclude(group: "org.springframework", module: "spring-context")
                     exclude(group: "org.springframework", module: "spring-context-support")
                     exclude(group: "org.springframework", module: "spring-beans")
-                    exclude(group: "org.eclipse.angus", module: "jakarta.mail")
                 },
                 dependencies.create("com.sun.mail:jakarta.mail:$jakartaMailVersion")
         ],


### PR DESCRIPTION
Reverts apereo/cas#5955

Breaks build with:

```
Caused by: java.lang.RuntimeException: Provider for jakarta.activation.spi.MimeTypeRegistryProvider cannot be found
        at jakarta.activation.FactoryFinder.find(FactoryFinder.java:95)
        at jakarta.activation.MimetypesFileTypeMap.getImplementation(MimetypesFileTypeMap.java:397)
        at jakarta.activation.MimetypesFileTypeMap.loadFile(MimetypesFileTypeMap.java:270)
        at jakarta.activation.MimetypesFileTypeMap.<init>(MimetypesFileTypeMap.java:107)
        at jakarta.activation.MimetypesFileTypeMap.<init>(MimetypesFileTypeMap.java:312)
        at org.springframework.mail.javamail.ConfigurableMimeFileTypeMap.createFileTypeMap(ConfigurableMimeFileTypeMap.java:150)
        at org.springframework.mail.javamail.ConfigurableMimeFileTypeMap.getFileTypeMap(ConfigurableMimeFileTypeMap.java:123)
        at org.springframework.mail.javamail.ConfigurableMimeFileTypeMap.afterPropertiesSet(ConfigurableMimeFileTypeMap.java:110)
        at org.springframework.mail.javamail.JavaMailSenderImpl.<init>(JavaMailSenderImpl.java:114)
        at org.springframework.boot.autoconfigure.mail.MailSenderPropertiesConfiguration.mailSender(MailSenderPropertiesConfiguration.java:44)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:140)
        ... 69 more
```