### PR TITLE
Fix a Jakarta dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2498,6 +2498,7 @@ ext.libraries = [
                     exclude(group: "ch.qos.logback", module: "logback-core")
                     exclude(group: "ch.qos.logback", module: "logback-classic")
                     exclude(group: "com.fasterxml.jackson.module", module: "jackson-module-jaxb-annotations")
+                    exclude(group: "io.micrometer", module: "micrometer-jakarta9")
                 },
                 dependencies.create("org.springframework.boot:spring-boot-starter-validation:$springBootVersion") {
                     exclude(group: "org.springframework.boot", module: "spring-boot-starter")
@@ -2537,6 +2538,8 @@ ext.libraries = [
                     exclude(group: "org.springframework.boot", module: "spring-boot-starter-logging")
                     exclude(group: "org.springframework.boot", module: "spring-boot-starter-web")
                     exclude(group: "com.fasterxml.jackson.module", module: "jackson-module-jaxb-annotations")
+                },
+                dependencies.create("io.micrometer:micrometer-jakarta9:$micrometerVersion") {
                 }
         ],
         springboottomcat           : [


### PR DESCRIPTION
In my basic CAS overlay based on the latest CAS WAR `7.1.0-SNAPSHOT`, I see the following dependencies:

```shell
micrometer-jakarta9-1.12.1.jar
micrometer-jakarta9-1.12.2.jar
```

In the CAS `gradle.properties`, there is:

```shell
micrometerVersion=1.12.2
```

This PR cleans the unwanted dependency (`micrometer-jakarta9-1.12.1.jar`).
