### PR TITLE
Fix passwordless + reset password

### DIFF
--- a/ci/tests/puppeteer/cas.js
+++ b/ci/tests/puppeteer/cas.js
@@ -830,7 +830,7 @@ exports.goto = async (page, url, retryCount = 5) => {
 exports.gotoLogin = async(page, service = undefined, port = 8443, renew = undefined) => {
     let queryString = (service === undefined ? "" : `service=${service}&`);
     queryString += (renew === undefined ? "" : "renew=true&");
-    const url = `https://localhost:${port}/cas/login?${queryString}`;
+    const url = `https://localhost:${port}/cas/login?${queryString}&locale=en`;
     return this.goto(page, url);
 };
 

--- a/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/accounts.json
+++ b/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/accounts.json
@@ -1,0 +1,12 @@
+{
+  "@class" : "java.util.LinkedHashMap",
+  "casuser" : {
+    "@class" : "org.apereo.cas.api.PasswordlessUserAccount",
+    "username": "casuser",
+    "email": "casuser@example.org",
+    "phoneNumber": "1234567890",
+    "name" : "CAS",
+    "requestPassword": true
+  }
+}
+

--- a/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/passwords.json
+++ b/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/passwords.json
@@ -1,0 +1,6 @@
+{
+  "casuser" : {
+    "email" : "casuser@example.org",
+    "password" : "Jv!e0mKD&dCNl^Q"
+  }
+}

--- a/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/script.js
+++ b/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/script.js
@@ -1,0 +1,48 @@
+const puppeteer = require("puppeteer");
+const assert = require("assert");
+
+const cas = require("../../cas.js");
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    await cas.gotoLogin(page);
+
+    const pswd = await page.$("#password");
+    assert(pswd === null);
+
+    await cas.type(page,"#username", "casuser");
+    await cas.pressEnter(page);
+    await page.waitForNavigation();
+
+    await page.waitForTimeout(2000);
+
+    await cas.assertInvisibility(page, "#username");
+    await cas.assertVisibility(page, "#password");
+    await cas.assertVisibility(page, "#forgotPasswordLink");
+
+    await cas.click(page, "#forgotPasswordLink");
+    await page.waitForTimeout(1000);
+
+    await cas.type(page,"#username", "casuser");
+    await cas.pressEnter(page);
+    await page.waitForNavigation();
+    await page.waitForTimeout(2000);
+
+    const page2 = await browser.newPage();
+    await page2.goto("http://localhost:8282");
+    await page2.waitForTimeout(1000);
+    await cas.click(page2, "table tbody td a");
+    await page2.waitForTimeout(1000);
+    const pwdResetUrl =  await cas.textContent(page2, "div[name=bodyPlainText] .well");
+    await page2.close();
+
+    await page.goto(pwdResetUrl);
+    await page.waitForTimeout(1000);
+
+    await cas.assertInnerText(page, "#content h3", "Hello, casuser. You must change your password.");
+    await page.waitForTimeout(2000);
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/script.json
+++ b/ci/tests/puppeteer/scenarios/passwordless-login-with-reset-password/script.json
@@ -1,0 +1,33 @@
+{
+  "dependencies": "passwordless-webflow,pm-webflow",
+
+  "properties": [
+    "--cas.audit.engine.enabled=true",
+    "--cas.audit.slf4j.use-single-line=true",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.authn.passwordless.accounts.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/accounts.json",
+
+    "--cas.authn.pm.core.enabled=true",
+    "--cas.authn.pm.core.password-policy-pattern=.+",
+    "--cas.authn.pm.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/passwords.json",
+
+    "--cas.authn.pm.reset.mail.from=cas@apereo.org",
+    "--cas.authn.pm.reset.mail.text=${url}",
+    "--cas.authn.pm.reset.mail.subject=Reset your password",
+    "--cas.authn.pm.reset.mail.attribute-name=mail",
+    "--cas.authn.pm.reset.security-questions-enabled=false",
+
+    "--spring.mail.host=localhost",
+    "--spring.mail.port=25000",
+
+    "--cas.authn.attribute-repository.stub.attributes.phone=13477464523",
+    "--cas.authn.attribute-repository.stub.attributes.mail=casuser@example.org"
+  ],
+  "jvmArgs": "-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true",
+  "initScript": "${PWD}/ci/tests/mail/run-mail-server.sh"
+}

--- a/support/cas-server-support-passwordless-webflow/build.gradle
+++ b/support/cas-server-support-passwordless-webflow/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     implementation project(":support:cas-server-support-passwordless-authentication")
     implementation project(":support:cas-server-support-pac4j-core")
     implementation project(":support:cas-server-support-pac4j-api")
-    implementation project(":support:cas-server-support-pm-core")
 
     compileOnly project(":support:cas-server-support-pac4j-webflow")
 

--- a/support/cas-server-support-passwordless-webflow/build.gradle
+++ b/support/cas-server-support-passwordless-webflow/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(":support:cas-server-support-passwordless-authentication")
     implementation project(":support:cas-server-support-pac4j-core")
     implementation project(":support:cas-server-support-pac4j-api")
+    implementation project(":support:cas-server-support-pm-core")
 
     compileOnly project(":support:cas-server-support-pac4j-webflow")
 

--- a/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationAction.java
+++ b/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationAction.java
@@ -1,7 +1,10 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.pm.PasswordManagementService;
 
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.action.EventFactorySupport;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
@@ -20,6 +23,11 @@ public class PrepareForPasswordlessAuthenticationAction extends BasePasswordless
 
     @Override
     protected Event doExecuteInternal(final RequestContext requestContext) {
+        val pwdresetTicket = requestContext.getRequestParameters().get(PasswordManagementService.PARAMETER_PASSWORD_RESET_TOKEN);
+        if (StringUtils.isNotBlank(pwdresetTicket)) {
+            return success();
+        }
+
         PasswordlessWebflowUtils.putPasswordlessAuthenticationEnabled(requestContext, Boolean.TRUE);
         if (!PasswordlessWebflowUtils.hasPasswordlessAuthenticationAccount(requestContext) && isLoginFlowActive(requestContext)) {
             return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_PASSWORDLESS_GET_USERID);

--- a/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationAction.java
+++ b/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationAction.java
@@ -1,10 +1,7 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.pm.PasswordManagementService;
 
-import lombok.val;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.webflow.action.EventFactorySupport;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
@@ -23,11 +20,6 @@ public class PrepareForPasswordlessAuthenticationAction extends BasePasswordless
 
     @Override
     protected Event doExecuteInternal(final RequestContext requestContext) {
-        val pwdresetTicket = requestContext.getRequestParameters().get(PasswordManagementService.PARAMETER_PASSWORD_RESET_TOKEN);
-        if (StringUtils.isNotBlank(pwdresetTicket)) {
-            return success();
-        }
-
         PasswordlessWebflowUtils.putPasswordlessAuthenticationEnabled(requestContext, Boolean.TRUE);
         if (!PasswordlessWebflowUtils.hasPasswordlessAuthenticationAccount(requestContext) && isLoginFlowActive(requestContext)) {
             return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_PASSWORDLESS_GET_USERID);

--- a/support/cas-server-support-passwordless-webflow/src/test/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationActionTests.java
+++ b/support/cas-server-support-passwordless-webflow/src/test/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationActionTests.java
@@ -1,16 +1,22 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.api.PasswordlessUserAccount;
+import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.util.MockRequestContext;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.webflow.context.servlet.ServletExternalContext;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.execution.Action;
 import org.springframework.webflow.test.MockFlowExecutionContext;
 import org.springframework.webflow.test.MockFlowSession;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -24,6 +30,18 @@ class PrepareForPasswordlessAuthenticationActionTests extends BasePasswordlessAu
     @Autowired
     @Qualifier(CasWebflowConstants.ACTION_ID_PASSWORDLESS_PREPARE_LOGIN)
     private Action prepareLoginAction;
+
+    @Test
+    void verifyPasswordReset() throws Throwable {
+        val response = new MockHttpServletResponse();
+        val request = new MockHttpServletRequest();
+        request.setParameter(PasswordManagementService.PARAMETER_PASSWORD_RESET_TOKEN, "TST-000");
+
+        val context = MockRequestContext.create(applicationContext);
+        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, response));
+
+        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, prepareLoginAction.execute(context).getId());
+    }
 
     @Test
     void verifyAction() throws Throwable {

--- a/support/cas-server-support-passwordless-webflow/src/test/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationActionTests.java
+++ b/support/cas-server-support-passwordless-webflow/src/test/java/org/apereo/cas/web/flow/PrepareForPasswordlessAuthenticationActionTests.java
@@ -1,22 +1,16 @@
 package org.apereo.cas.web.flow;
 
 import org.apereo.cas.api.PasswordlessUserAccount;
-import org.apereo.cas.pm.PasswordManagementService;
 import org.apereo.cas.util.MockRequestContext;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.mock.web.MockServletContext;
-import org.springframework.webflow.context.servlet.ServletExternalContext;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.execution.Action;
 import org.springframework.webflow.test.MockFlowExecutionContext;
 import org.springframework.webflow.test.MockFlowSession;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -32,18 +26,6 @@ class PrepareForPasswordlessAuthenticationActionTests extends BasePasswordlessAu
     private Action prepareLoginAction;
 
     @Test
-    void verifyPasswordReset() throws Throwable {
-        val response = new MockHttpServletResponse();
-        val request = new MockHttpServletRequest();
-        request.setParameter(PasswordManagementService.PARAMETER_PASSWORD_RESET_TOKEN, "TST-000");
-
-        val context = MockRequestContext.create(applicationContext);
-        context.setExternalContext(new ServletExternalContext(new MockServletContext(), request, response));
-
-        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, prepareLoginAction.execute(context).getId());
-    }
-
-    @Test
     void verifyAction() throws Throwable {
         val flow = new Flow(CasWebflowConfigurer.FLOW_ID_LOGIN);
         flow.setApplicationContext(applicationContext);
@@ -53,11 +35,11 @@ class PrepareForPasswordlessAuthenticationActionTests extends BasePasswordlessAu
         assertEquals(CasWebflowConstants.TRANSITION_ID_PASSWORDLESS_GET_USERID, prepareLoginAction.execute(context).getId());
 
         val account = PasswordlessUserAccount.builder()
-            .email("email")
-            .phone("phone")
-            .username("casuser")
-            .name("casuser")
-            .build();
+                .email("email")
+                .phone("phone")
+                .username("casuser")
+                .name("casuser")
+                .build();
         PasswordlessWebflowUtils.putPasswordlessAuthenticationAccount(context, account);
         assertNull(prepareLoginAction.execute(context));
     }

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/ValidatePasswordResetTokenAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/ValidatePasswordResetTokenAction.java
@@ -41,6 +41,7 @@ public class ValidatePasswordResetTokenAction extends BaseCasWebflowAction {
                 if (StringUtils.isBlank(username)) {
                     throw new IllegalArgumentException("Password reset token could not be verified to determine username");
                 }
+                return new EventFactorySupport().event(this, CasWebflowConstants.TRANSITION_ID_RESET_PASSWORD);
             }
             val doChange = requestContext.getRequestParameters()
                 .get(PasswordManagementService.PARAMETER_DO_CHANGE_PASSWORD);


### PR DESCRIPTION
Currently, there is a bug when using the passwordless and the reset password features.

After typing a user identifier, on the password page, we can ask for "Reset your password". But the link received by email to reset the password never goes to the reset password page, it still displays the passwordless userid page.

This PR fixes the problem. A Puppeteer test and a unit test have been added to confirm the fix.
