### PR TITLE
Fix the 'forgot username' feature

### DIFF
--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
@@ -798,6 +798,16 @@ public class WebUtils {
     }
 
     /**
+     * Put forgot username enabled into flow scope.
+     *
+     * @param context the context
+     * @param value   the value
+     */
+    public static void putForgotUsernameEnabled(final RequestContext context, final Boolean value) {
+        context.getFlowScope().put("forgotUsernameEnabled", value);
+    }
+
+    /**
      * Put account profile management enabled.
      *
      * @param context the context

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/WebUtils.java
@@ -838,6 +838,16 @@ public class WebUtils {
     }
 
     /**
+     * Is forgot username enabled.
+     *
+     * @param context the context
+     * @return true/false
+     */
+    public static boolean isForgotUsernameEnabled(final RequestContext context) {
+        return context.getFlowScope().get("forgotUsernameEnabled", Boolean.class);
+    }
+
+    /**
      * Put principal.
      *
      * @param requestContext          the request context

--- a/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
+++ b/core/cas-server-core-web/src/test/java/org/apereo/cas/web/support/WebUtilsTests.java
@@ -85,6 +85,7 @@ class WebUtilsTests {
             WebUtils.putExistingSingleSignOnSessionPrincipal(context, CoreAuthenticationTestUtils.getPrincipal());
             WebUtils.putAvailableAuthenticationHandleNames(context, List.of());
             WebUtils.putPasswordManagementEnabled(context, true);
+            WebUtils.putForgotUsernameEnabled(context, true);
             WebUtils.putRecaptchaPropertiesFlowScope(context, new GoogleRecaptchaProperties().setEnabled(true));
             WebUtils.putLogoutUrls(context, Map.of());
             val ac = OneTimeTokenAccount.builder()

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurer.java
@@ -265,6 +265,7 @@ public class PasswordManagementWebflowConfigurer extends AbstractCasWebflowConfi
         val action = new ConsumerExecutionAction(context -> {
             WebUtils.putAccountProfileManagementEnabled(context, applicationContext.containsBean(CasWebflowConstants.BEAN_NAME_ACCOUNT_PROFILE_FLOW_DEFINITION_REGISTRY));
             WebUtils.putPasswordManagementEnabled(context, casProperties.getAuthn().getPm().getCore().isEnabled());
+            WebUtils.putForgotUsernameEnabled(context, casProperties.getAuthn().getPm().getForgotUsername().isEnabled());
         });
         flow.getStartActionList().add(action);
     }

--- a/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/AccountProfilePreparePasswordManagementAction.java
+++ b/support/cas-server-support-pm-webflow/src/main/java/org/apereo/cas/pm/web/flow/actions/AccountProfilePreparePasswordManagementAction.java
@@ -31,6 +31,7 @@ public class AccountProfilePreparePasswordManagementAction extends BaseCasWebflo
     @Override
     protected Event doExecuteInternal(final RequestContext requestContext) throws Exception {
         WebUtils.putPasswordManagementEnabled(requestContext, casProperties.getAuthn().getPm().getCore().isEnabled());
+        WebUtils.putForgotUsernameEnabled(requestContext, casProperties.getAuthn().getPm().getForgotUsername().isEnabled());
         WebUtils.putAccountProfileManagementEnabled(requestContext, true);
         val secQuestionsEnabled = casProperties.getAuthn().getPm().getReset().isSecurityQuestionsEnabled()
                                   && casProperties.getAuthn().getPm().getCore().isEnabled();

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurerTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/PasswordManagementWebflowConfigurerTests.java
@@ -169,6 +169,7 @@ class PasswordManagementWebflowConfigurerTests {
                 .execute(context);
             assertNull(event);
             assertTrue(WebUtils.isPasswordManagementEnabled(context));
+            assertTrue(WebUtils.isForgotUsernameEnabled(context));
         }
     }
 }

--- a/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/AccountProfilePreparePasswordManagementActionTests.java
+++ b/support/cas-server-support-pm-webflow/src/test/java/org/apereo/cas/pm/web/flow/actions/AccountProfilePreparePasswordManagementActionTests.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.*;
 @TestPropertySource(properties = {
     "cas.authn.pm.groovy.location=classpath:PasswordManagementService.groovy",
     "cas.authn.pm.core.enabled=true",
+    "cas.authn.pm.forgot-username.enabled=false",
     "cas.authn.pm.reset.security-questions-enabled=true",
     "CasFeatureModule.AccountManagement.enabled=true"
 })
@@ -58,6 +59,7 @@ class AccountProfilePreparePasswordManagementActionTests extends BasePasswordMan
         val result = prepareAccountProfilePasswordMgmtAction.execute(context);
         assertNull(result);
         assertTrue(WebUtils.isPasswordManagementEnabled(context));
+        assertFalse(WebUtils.isForgotUsernameEnabled(context));
         assertNotNull(PasswordManagementWebflowUtils.getPasswordResetQuestions(context, Map.class));
 
         assertEquals(0, accountProfileServiceTicketGeneratorAuthority.getOrder());

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pmlinks.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pmlinks.html
@@ -28,7 +28,7 @@
                 onclick="document.getElementById('passwordManagementForm').submit();" />
             <br><br>
         </form>
-        <form th:if="${forgotUsernameEnabled}" method="post" id="forgotUsernameForm">
+        <form th:if="${passwordManagementEnabled && forgotUsernameEnabled}" method="post" id="forgotUsernameForm">
             <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
             <input type="hidden" name="_eventId" value="forgotUsername" />
             <span class="mdi mdi-account-question" aria-hidden="true"></span>

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pmlinks.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/pmlinks.html
@@ -28,12 +28,12 @@
                 onclick="document.getElementById('passwordManagementForm').submit();" />
             <br><br>
         </form>
-        <form th:if="${passwordManagementEnabled}" method="post" id="passwordManagementUserForm">
+        <form th:if="${forgotUsernameEnabled}" method="post" id="forgotUsernameForm">
             <input type="hidden" name="execution" th:value="${flowExecutionKey}" />
             <input type="hidden" name="_eventId" value="forgotUsername" />
             <span class="mdi mdi-account-question" aria-hidden="true"></span>
             <a id="forgotUsernameLink" th:utext="#{screen.pm.button.forgotUsername}" href="javascript:void(0)"
-                onclick="document.getElementById('passwordManagementUserForm').submit();" />
+                onclick="document.getElementById('forgotUsernameForm').submit();" />
             <br><br>
         </form>
         <div th:unless="${passwordManagementEnabled}" class="mt-2">


### PR DESCRIPTION
The display of the "Forgot username?" link should be tied to the `cas.authn.pm.forgot-username.enabled` property and not to the `cas.authn.pm.core.enabled` property.