### PR TITLE
Problem with person directory when passwordless MFA only

### DIFF
--- a/ci/tests/puppeteer/scenarios/passwordless-login-with-simplemfa/accounts.json
+++ b/ci/tests/puppeteer/scenarios/passwordless-login-with-simplemfa/accounts.json
@@ -1,0 +1,17 @@
+{
+  "@class" : "java.util.LinkedHashMap",
+  "casuser" : {
+    "@class" : "org.apereo.cas.api.PasswordlessUserAccount",
+    "username": "casuser",
+    "email": "casuser@example.org",
+    "phone": "1234567890",
+    "name": "CAS",
+    "requestPassword": false,
+    "multifactorAuthenticationEligible": "TRUE",
+    "attributes" : {
+      "@class" : "java.util.TreeMap",
+      "memberOf" : [ "java.util.ArrayList", [ "mfa" ] ],
+      "email": [ "java.util.ArrayList", [ "casuser@example.org" ] ]
+    }
+  }
+}

--- a/ci/tests/puppeteer/scenarios/passwordless-login-with-simplemfa/script.js
+++ b/ci/tests/puppeteer/scenarios/passwordless-login-with-simplemfa/script.js
@@ -1,0 +1,40 @@
+const puppeteer = require("puppeteer");
+const assert = require("assert");
+
+const cas = require("../../cas.js");
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+
+    await cas.gotoLogin(page);
+
+    const pswd = await page.$("#password");
+    assert(pswd === null);
+
+    await cas.type(page,"#username", "casuser");
+    await cas.pressEnter(page);
+    await page.waitForNavigation();
+
+    await page.waitForTimeout(1000);
+
+    await cas.assertVisibility(page, "#token");
+    await page.waitForTimeout(1000);
+
+    const page2 = await browser.newPage();
+    await page2.goto("http://localhost:8282");
+    await page2.waitForTimeout(1000);
+    await cas.click(page2, "table tbody td a");
+    await page2.waitForTimeout(1000);
+    const code =  await cas.textContent(page2, "div[name=bodyPlainText] .well");
+    await page2.close();
+
+    await cas.type(page, "#token", code);
+    await cas.submitForm(page, "#fm1");
+    await page.waitForTimeout(1000);
+
+    await cas.assertInnerTextContains(page, "#attribute-tab-0 table#attributesTable tbody", "firstname");
+    await page.waitForTimeout(2000);
+
+    await browser.close();
+})();

--- a/ci/tests/puppeteer/scenarios/passwordless-login-with-simplemfa/script.json
+++ b/ci/tests/puppeteer/scenarios/passwordless-login-with-simplemfa/script.json
@@ -1,0 +1,35 @@
+{
+  "dependencies": "passwordless-webflow,simple-mfa",
+  "conditions": {
+    "docker": "true"
+  },
+  "properties": [
+    "--cas.audit.engine.enabled=true",
+    "--cas.audit.slf4j.use-single-line=true",
+
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=https://localhost:8443/cas",
+    "--cas.server.scope=example.net",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.authn.passwordless.accounts.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/accounts.json",
+    "--cas.authn.passwordless.accounts.ldap.email-attribute=email",
+    "--cas.authn.passwordless.core.delegated-authentication-activated=false",
+    "--cas.authn.passwordless.core.multifactor-authentication-activated=true",
+
+    "--cas.authn.mfa.triggers.principal.global-principal-attribute-name-triggers=memberOf",
+    "--cas.authn.mfa.triggers.principal.global-principal-attribute-value-regex=mfa",
+
+    "--cas.authn.mfa.simple.mail.from=cas@apereo.org",
+    "--cas.authn.mfa.simple.mail.text=${token}",
+    "--cas.authn.mfa.simple.mail.subject=MFA code",
+    "--cas.authn.mfa.simple.mail.attribute-name=email",
+
+    "--spring.mail.host=localhost",
+    "--spring.mail.port=25000",
+
+    "--cas.authn.attribute-repository.stub.attributes.firstname=jerome"
+  ],
+  "jvmArgs": "-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true",
+  "initScript": "${PWD}/ci/tests/mail/run-mail-server.sh"
+}

--- a/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationEventExecutionPlanConfiguration.java
@@ -11,6 +11,7 @@ import org.apereo.cas.authentication.metadata.AuthenticationContextAttributeMeta
 import org.apereo.cas.authentication.metadata.MultifactorAuthenticationProviderMetadataPopulator;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
+import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
 import org.apereo.cas.mfa.simple.CasSimpleMultifactorAuthenticationHandler;
@@ -150,8 +151,11 @@ class CasSimpleMultifactorAuthenticationEventExecutionPlanConfiguration {
         @Qualifier("casSimpleMultifactorAuthenticationHandler")
         final AuthenticationHandler casSimpleMultifactorAuthenticationHandler,
         @Qualifier("casSimpleMultifactorAuthenticationMetaDataPopulator")
-        final AuthenticationMetaDataPopulator casSimpleMultifactorAuthenticationMetaDataPopulator) {
+        final AuthenticationMetaDataPopulator casSimpleMultifactorAuthenticationMetaDataPopulator,
+        @Qualifier(PrincipalResolver.BEAN_NAME_PRINCIPAL_RESOLVER)
+        final PrincipalResolver principalResolver) {
         return plan -> {
+            //plan.registerAuthenticationHandlerWithPrincipalResolver(casSimpleMultifactorAuthenticationHandler, principalResolver);
             plan.registerAuthenticationHandler(casSimpleMultifactorAuthenticationHandler);
             plan.registerAuthenticationMetadataPopulator(casSimpleMultifactorAuthenticationMetaDataPopulator);
             plan.registerAuthenticationMetadataPopulator(casSimpleMultifactorProviderAuthenticationMetadataPopulator);

--- a/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationEventExecutionPlanConfiguration.java
+++ b/support/cas-server-support-simple-mfa/src/main/java/org/apereo/cas/config/CasSimpleMultifactorAuthenticationEventExecutionPlanConfiguration.java
@@ -11,7 +11,6 @@ import org.apereo.cas.authentication.metadata.AuthenticationContextAttributeMeta
 import org.apereo.cas.authentication.metadata.MultifactorAuthenticationProviderMetadataPopulator;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
-import org.apereo.cas.authentication.principal.PrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
 import org.apereo.cas.mfa.simple.CasSimpleMultifactorAuthenticationHandler;
@@ -151,11 +150,8 @@ class CasSimpleMultifactorAuthenticationEventExecutionPlanConfiguration {
         @Qualifier("casSimpleMultifactorAuthenticationHandler")
         final AuthenticationHandler casSimpleMultifactorAuthenticationHandler,
         @Qualifier("casSimpleMultifactorAuthenticationMetaDataPopulator")
-        final AuthenticationMetaDataPopulator casSimpleMultifactorAuthenticationMetaDataPopulator,
-        @Qualifier(PrincipalResolver.BEAN_NAME_PRINCIPAL_RESOLVER)
-        final PrincipalResolver principalResolver) {
+        final AuthenticationMetaDataPopulator casSimpleMultifactorAuthenticationMetaDataPopulator) {
         return plan -> {
-            //plan.registerAuthenticationHandlerWithPrincipalResolver(casSimpleMultifactorAuthenticationHandler, principalResolver);
             plan.registerAuthenticationHandler(casSimpleMultifactorAuthenticationHandler);
             plan.registerAuthenticationMetadataPopulator(casSimpleMultifactorAuthenticationMetaDataPopulator);
             plan.registerAuthenticationMetadataPopulator(casSimpleMultifactorProviderAuthenticationMetadataPopulator);


### PR DESCRIPTION
In the specific use case of passwordless with MFA only, person directory is not called (in the Puppeteer test, it's a static attribute repository).
