### PR TITLE
For passwordless LDAP, allow to choose the final username

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/account/PasswordlessAuthenticationLdapAccountsProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/account/PasswordlessAuthenticationLdapAccountsProperties.java
@@ -40,7 +40,10 @@ public class PasswordlessAuthenticationLdapAccountsProperties extends AbstractLd
     /**
      * Name of the LDAP attribute that
      * indicates the user's name.
+     *
+     * @deprecated This property will likely be removed in v8.
      */
+    @Deprecated
     private String nameAttribute = "cn";
 
     /**

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/account/PasswordlessAuthenticationLdapAccountsProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/passwordless/account/PasswordlessAuthenticationLdapAccountsProperties.java
@@ -45,6 +45,12 @@ public class PasswordlessAuthenticationLdapAccountsProperties extends AbstractLd
 
     /**
      * Name of the LDAP attribute that
+     * indicates the username.
+     */
+    private String usernameAttribute;
+
+    /**
+     * Name of the LDAP attribute that
      * is the passwordless flow to request a password prompt from user.
      * The attribute value must be a boolean. Acceoted values
      * are {@code true}, {@code false}, {@code on}, {@code off}, {@code yes}, {@code no},

--- a/support/cas-server-support-passwordless-ldap/src/main/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStore.java
+++ b/support/cas-server-support-passwordless-ldap/src/main/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStore.java
@@ -48,6 +48,9 @@ public class LdapPasswordlessUserAccountStore implements PasswordlessUserAccount
                 val entry = response.getEntry();
                 val acctBuilder = PasswordlessUserAccount.builder().username(username).name(username);
 
+                if (entry.getAttribute(ldapProperties.getUsernameAttribute()) != null) {
+                    acctBuilder.username(entry.getAttribute(ldapProperties.getUsernameAttribute()).getStringValue());
+                }
                 if (entry.getAttribute(ldapProperties.getNameAttribute()) != null) {
                     acctBuilder.name(entry.getAttribute(ldapProperties.getNameAttribute()).getStringValue());
                 }

--- a/support/cas-server-support-passwordless-ldap/src/test/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStoreTests.java
+++ b/support/cas-server-support-passwordless-ldap/src/test/java/org/apereo/cas/impl/account/LdapPasswordlessUserAccountStoreTests.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
     "cas.authn.passwordless.accounts.ldap.bind-credential=password",
     "cas.authn.passwordless.accounts.ldap.email-attribute=mail",
     "cas.authn.passwordless.accounts.ldap.phone-attribute=telephoneNumber",
+    "cas.authn.passwordless.accounts.ldap.username-attribute=mail",
     "cas.authn.passwordless.accounts.ldap.request-password-attribute=description"
 })
 @Slf4j
@@ -54,6 +55,7 @@ class LdapPasswordlessUserAccountStoreTests extends BasePasswordlessUserAccountS
         assertTrue(user.isPresent());
         assertEquals("passwordlessuser@example.org", user.get().getEmail());
         assertEquals("123456789", user.get().getPhone());
+        assertEquals("passwordlessuser@example.org", user.get().getUsername());
         assertTrue(user.get().isRequestPassword());
     }
 }


### PR DESCRIPTION
This PR adds a configuration to be able to choose the final username for the passwordless LDAP support.

The integration test has been updated accordingly.
