### PR TITLE
Fix authn delegation + throttling

### DIFF
--- a/ci/tests/puppeteer/scenarios/authn-throttle-with-username-authndelegation-enabled/script.js
+++ b/ci/tests/puppeteer/scenarios/authn-throttle-with-username-authndelegation-enabled/script.js
@@ -1,0 +1,20 @@
+const puppeteer = require("puppeteer");
+const cas = require("../../cas.js");
+
+(async () => {
+    const browser = await puppeteer.launch(cas.browserOptions());
+    const page = await cas.newPage(browser);
+    await submitLoginFailure(page);
+    await cas.assertInnerTextStartsWith(page, "#content div.banner p", "Authentication attempt has failed");
+    await submitLoginFailure(page);
+    await cas.assertInnerText(page, "#content h2", "Access Denied");
+    await cas.assertInnerText(page, "#content p", "You've entered the wrong password for the user too many times. You've been throttled.");
+    await page.waitForTimeout(2000);
+
+    await browser.close();
+})();
+
+async function submitLoginFailure(page) {
+    await cas.gotoLoginWithLocale(page, undefined, "en");
+    await cas.loginWith(page, "casuser", "BadPassword");
+}

--- a/ci/tests/puppeteer/scenarios/authn-throttle-with-username-authndelegation-enabled/script.json
+++ b/ci/tests/puppeteer/scenarios/authn-throttle-with-username-authndelegation-enabled/script.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": "throttle,pac4j-webflow",
+
+  "properties": [
+    "--cas.authn.throttle.core.username-parameter=username",
+    "--cas.authn.throttle.failure.threshold=1",
+    "--cas.authn.throttle.failure.range-seconds=10",
+    "--cas.authn.throttle.failure.code=AUTHENTICATION_FAILED",
+
+    "--logging.level.org.apereo.cas=info"
+  ]
+}

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluator.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluator.java
@@ -34,6 +34,9 @@ public class DefaultDelegatedClientAuthenticationFailureEvaluator implements Del
 
     @Override
     public Optional<ModelAndView> evaluate(final HttpServletRequest request, final int status) {
+        if (status == HttpStatus.LOCKED.value()) {
+            return Optional.of(new ModelAndView("error/423", new HashMap<>()));
+        }
         val params = request.getParameterMap();
         val foundError = Stream.of("error", "error_code", "error_description", "error_message")
                              .anyMatch(params::containsKey) || HttpStatus.resolve(status).isError();

--- a/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluator.java
+++ b/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluator.java
@@ -35,7 +35,7 @@ public class DefaultDelegatedClientAuthenticationFailureEvaluator implements Del
     @Override
     public Optional<ModelAndView> evaluate(final HttpServletRequest request, final int status) {
         if (status == HttpStatus.LOCKED.value()) {
-            return Optional.of(new ModelAndView("error/423", new HashMap<>()));
+            return Optional.of(new ModelAndView("error/%s".formatted(status), new HashMap<>()));
         }
         val params = request.getParameterMap();
         val foundError = Stream.of("error", "error_code", "error_description", "error_message")

--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluatorTests.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluatorTests.java
@@ -5,6 +5,7 @@ import org.apereo.cas.web.flow.DelegatedClientAuthenticationConfigurationContext
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,7 +24,7 @@ public class DefaultDelegatedClientAuthenticationFailureEvaluatorTests {
     public void verifyThrottling() {
         val evaluator = new DefaultDelegatedClientAuthenticationFailureEvaluator(
                 mock(DelegatedClientAuthenticationConfigurationContext.class));
-        val optModelAndView = evaluator.evaluate(new MockHttpServletRequest(), 423);
-        assertEquals("error/423", optModelAndView.get().getViewName());
+        val optModelAndView = evaluator.evaluate(new MockHttpServletRequest(), HttpStatus.LOCKED.value());
+        assertEquals("error/%s".formatted(HttpStatus.LOCKED.value()), optModelAndView.get().getViewName());
     }
 }

--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluatorTests.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/web/flow/error/DefaultDelegatedClientAuthenticationFailureEvaluatorTests.java
@@ -1,0 +1,29 @@
+package org.apereo.cas.web.flow.error;
+
+import org.apereo.cas.web.flow.DelegatedClientAuthenticationConfigurationContext;
+
+import lombok.val;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * This is {@link DefaultDelegatedClientAuthenticationFailureEvaluatorTests}.
+ *
+ * @author Jerome LELEU
+ * @since 7.1.0
+ */
+@Tag("Delegation")
+public class DefaultDelegatedClientAuthenticationFailureEvaluatorTests {
+
+    @Test
+    public void verifyThrottling() {
+        val evaluator = new DefaultDelegatedClientAuthenticationFailureEvaluator(
+                mock(DelegatedClientAuthenticationConfigurationContext.class));
+        val optModelAndView = evaluator.evaluate(new MockHttpServletRequest(), 423);
+        assertEquals("error/423", optModelAndView.get().getViewName());
+    }
+}


### PR DESCRIPTION
When using authn delegation, if a login is throtlled, the 423 error is returned and the `delegated-authn/casDelegatedAuthnStopWebflow.html` page is displayed instead of the `error/423.html` page.

This PR fixes the issue.
