### PR TITLE
Fix the Redis ticket registry

### DIFF
--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -38,7 +38,6 @@ import org.springframework.data.redis.core.convert.KeyspaceConfiguration;
 import org.springframework.data.redis.core.convert.MappingConfiguration;
 import org.springframework.data.redis.core.index.IndexConfiguration;
 import org.springframework.data.redis.core.mapping.RedisMappingContext;
-import org.springframework.util.Assert;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -427,7 +426,6 @@ public class RedisTicketRegistry extends AbstractTicketRegistry implements Clean
                 val ops = casRedisTemplates.getSessionsRedisTemplate().boundSetOps(redisPrincipalPattern);
                 if (onlyTrackMostRecentSession) {
                     ops.expireAt(Instant.now(Clock.systemUTC()));
-                    Assert.isTrue(ops.members().isEmpty(), "Member count must be zero");
                 }
                 ops.add(digestedId);
                 ops.expire(timeout, TimeUnit.SECONDS);


### PR DESCRIPTION
One of my customers has reported me a random issue with the Redis ticket registry although it happens rarely.

The error is: "Member count must be zero".

I have been able to reproduce it when performing multiple logins concurrently with the same user.

After removing the check on the size, it no longer occurs.

A unit test confirms the fix.
