### PR TITLE
Remove duplicated tag from accountprofilemfadevices.html

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/accountprofilemfadevices.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/accountprofilemfadevices.html
@@ -144,7 +144,6 @@
                                 </li>
                             </ul>
                         </div>
-                        </div>
                         <input type="hidden" name="type" value=""/>
                         <input type="hidden" name="_eventId_register" value="Register"/>
                         <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>


### PR DESCRIPTION
The duplicated div closing tag causes form to teminate prematurely.
