### PR TITLE
Dynamic discovery provider locator can't resolved principal

### DIFF
--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/pac4j/discovery/DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/pac4j/discovery/DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.pac4j.discovery;
 
-import lombok.val;
 import org.apereo.cas.authentication.PrincipalElectionStrategy;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
@@ -11,6 +10,8 @@ import org.apereo.cas.pac4j.client.DelegatedIdentityProviderFactory;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.support.pac4j.authentication.clients.RefreshableDelegatedIdentityProviders;
 import org.apereo.cas.web.flow.DelegatedClientIdentityProviderConfigurationProducer;
+
+import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
     }
 
     private DelegatedAuthenticationDynamicDiscoveryProviderLocator getLocator(final Principal principal, final List<PrincipalResolver> principalResolvers)
-            throws Throwable {
+        throws Throwable {
         val producer = mock(DelegatedClientIdentityProviderConfigurationProducer.class);
 
         val electionStrategy = mock(PrincipalElectionStrategy.class);
@@ -56,7 +57,7 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
 
         val client = new SAML2Client();
         val refreshableClients = new RefreshableDelegatedIdentityProviders("http://localhost:8080/cas",
-                DelegatedIdentityProviderFactory.withClients(List.of(client)));
+            DelegatedIdentityProviderFactory.withClients(List.of(client)));
         val locator = new DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocator(producer, refreshableClients, resolver, properties);
         assertNotNull(locator.getProviderProducer());
         assertNotNull(locator.getProperties());
@@ -70,9 +71,9 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
         val principal = RegisteredServiceTestUtils.getPrincipal("cas@example.org");
         val locator = getLocator(principal, List.of(new EchoingPrincipalResolver()));
         val request = DelegatedAuthenticationDynamicDiscoveryProviderLocator.DynamicDiscoveryProviderRequest
-                .builder()
-                .userId(principal.getId())
-                .build();
+            .builder()
+            .userId(principal.getId())
+            .build();
         val result = locator.locate(request);
         assertFalse(result.isPresent());
     }
@@ -85,9 +86,9 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
         val json = properties.getAuthn().getPac4j().getCore().getDiscoverySelection().getJson();
         json.setLocation(new ClassPathResource("delegated-discovery.json"));
         val request = DelegatedAuthenticationDynamicDiscoveryProviderLocator.DynamicDiscoveryProviderRequest
-                .builder()
-                .userId(principal.getId())
-                .build();
+            .builder()
+            .userId(principal.getId())
+            .build();
         val result = locator.locate(request);
         assertTrue(result.isPresent());
     }
@@ -100,9 +101,9 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
         json.setLocation(new ClassPathResource("delegated-discovery.json"));
         json.setPrincipalAttribute("email");
         val request = DelegatedAuthenticationDynamicDiscoveryProviderLocator.DynamicDiscoveryProviderRequest
-                .builder()
-                .userId(principal.getId())
-                .build();
+            .builder()
+            .userId(principal.getId())
+            .build();
         val result = locator.locate(request);
         assertTrue(result.isPresent());
     }

--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/pac4j/discovery/DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/pac4j/discovery/DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests.java
@@ -10,7 +10,6 @@ import org.apereo.cas.pac4j.client.DelegatedIdentityProviderFactory;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.support.pac4j.authentication.clients.RefreshableDelegatedIdentityProviders;
 import org.apereo.cas.web.flow.DelegatedClientIdentityProviderConfigurationProducer;
-
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -18,16 +17,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.pac4j.saml.client.SAML2Client;
 import org.springframework.core.io.ClassPathResource;
-
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * This is {@link DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests}.

--- a/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/pac4j/discovery/DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests.java
+++ b/support/cas-server-support-pac4j-core/src/test/java/org/apereo/cas/pac4j/discovery/DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests.java
@@ -1,21 +1,25 @@
 package org.apereo.cas.pac4j.discovery;
 
-import org.apereo.cas.authentication.Credential;
+import lombok.val;
+import org.apereo.cas.authentication.PrincipalElectionStrategy;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalResolver;
+import org.apereo.cas.authentication.principal.resolvers.ChainingPrincipalResolver;
+import org.apereo.cas.authentication.principal.resolvers.EchoingPrincipalResolver;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.pac4j.client.DelegatedIdentityProviderFactory;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.support.pac4j.authentication.clients.RefreshableDelegatedIdentityProviders;
 import org.apereo.cas.web.flow.DelegatedClientIdentityProviderConfigurationProducer;
-import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.pac4j.saml.client.SAML2Client;
 import org.springframework.core.io.ClassPathResource;
+
 import java.util.List;
 import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -27,6 +31,7 @@ import static org.mockito.Mockito.*;
  */
 @Tag("Delegation")
 class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
+
     private CasConfigurationProperties properties;
 
     @BeforeEach
@@ -34,10 +39,15 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
         this.properties = new CasConfigurationProperties();
     }
 
-    private DelegatedAuthenticationDynamicDiscoveryProviderLocator getLocator(final Principal principal) throws Throwable {
+    private DelegatedAuthenticationDynamicDiscoveryProviderLocator getLocator(final Principal principal, final List<PrincipalResolver> principalResolvers)
+        throws Throwable {
         val producer = mock(DelegatedClientIdentityProviderConfigurationProducer.class);
-        val resolver = mock(PrincipalResolver.class);
-        when(resolver.resolve(any(Credential.class))).thenReturn(principal);
+
+        val electionStrategy = mock(PrincipalElectionStrategy.class);
+        final List<Principal> ts = anyList();
+        when(electionStrategy.nominate(ts, any(Map.class))).thenReturn(principal);
+        val resolver = new ChainingPrincipalResolver(electionStrategy, properties);
+        resolver.setChain(principalResolvers);
 
         val client = new SAML2Client();
         val refreshableClients = new RefreshableDelegatedIdentityProviders("http://localhost:8080/cas",
@@ -53,7 +63,7 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
     @Test
     void verifyResourceIsUnavailable() throws Throwable {
         val principal = RegisteredServiceTestUtils.getPrincipal("cas@example.org");
-        val locator = getLocator(principal);
+        val locator = getLocator(principal, List.of(new EchoingPrincipalResolver()));
         val request = DelegatedAuthenticationDynamicDiscoveryProviderLocator.DynamicDiscoveryProviderRequest
             .builder()
             .userId(principal.getId())
@@ -65,7 +75,8 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
     @Test
     void verifyResourceFindUser() throws Throwable {
         val principal = RegisteredServiceTestUtils.getPrincipal("cas@example.org", Map.of("cn", List.of("cas", "casuser", "cas-user")));
-        val locator = getLocator(principal);
+        val locator = getLocator(principal, List.of(new EchoingPrincipalResolver()));
+
         val json = properties.getAuthn().getPac4j().getCore().getDiscoverySelection().getJson();
         json.setLocation(new ClassPathResource("delegated-discovery.json"));
         val request = DelegatedAuthenticationDynamicDiscoveryProviderLocator.DynamicDiscoveryProviderRequest
@@ -78,9 +89,9 @@ class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocatorTests {
 
     @Test
     void verifyPrincipalAttribute() throws Throwable {
-        val principal = RegisteredServiceTestUtils.getPrincipal("cas@example.org",
-            Map.of("email", List.of("cas@example.net", "casuser@example.org", "casuser@yahoo.com")));
-        val locator = getLocator(principal);
+        final Map<String, List<Object>> principalAttributes = Map.of("email", List.of("cas@example.net", "casuser@example.org", "casuser@yahoo.com"));
+        val principal = RegisteredServiceTestUtils.getPrincipal("cas@example.org", principalAttributes);
+        val locator = getLocator(principal, List.of(new EchoingPrincipalResolver()));
         val json = properties.getAuthn().getPac4j().getCore().getDiscoverySelection().getJson();
         json.setLocation(new ClassPathResource("delegated-discovery.json"));
         json.setPrincipalAttribute("email");


### PR DESCRIPTION
Hi, 

We use Dynamic Discovery Provider, to determine Client to authentication ( We have Office365 and soon OpenAM). We have about 150 auth request per minute. When I try upgrade library from 6.5 to 7.0 there is a problem to determine where forward client.

 I found that in class DefaultDelegatedAuthenticationDynamicDiscoveryProviderLocator was added Principal Resolver. Default Principal Resolver is EchoingPrincipalResolver called from ChainingPrincipalResolver, where EchoingPrincipalResolver always return NullPrincipal.

Result: It cannot find Client to redirect.