### PR TITLE
Fix Redis tickets registry when cas.ticket.crypto.enabled

### DIFF
--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -138,7 +138,7 @@ public abstract class BaseTicketRegistryTests {
     }
 
     @BeforeEach
-    public void initialize(final TestInfo info, final RepetitionInfo repetitionInfo) {
+    public void initialize(final TestInfo info, final RepetitionInfo repetitionInfo) throws Throwable {
         this.ticketGrantingTicketId = TICKET_GRANTING_TICKET_ID_GENERATOR.getNewTicketId(TicketGrantingTicket.PREFIX);
         this.serviceTicketId = new ServiceTicketIdGenerator(10, StringUtils.EMPTY)
             .getNewTicketId(ServiceTicket.PREFIX);
@@ -501,7 +501,7 @@ public abstract class BaseTicketRegistryTests {
     @RepeatedTest(2)
     void verifyDeleteTicketWithChildren() throws Throwable {
         assumeTrue(canTicketRegistryDelete());
-        val addedTicket = ticketRegistry.addTicket(new TicketGrantingTicketImpl(ticketGrantingTicketId + '1', CoreAuthenticationTestUtils.getAuthentication(),
+        val addedTicket = ticketRegistry.addTicket(new TicketGrantingTicketImpl(ticketGrantingTicketId, CoreAuthenticationTestUtils.getAuthentication(),
             NeverExpiresExpirationPolicy.INSTANCE));
         val tgt = ticketRegistry.getTicket(addedTicket.getId(), TicketGrantingTicket.class);
 
@@ -518,7 +518,7 @@ public abstract class BaseTicketRegistryTests {
         ticketRegistry.addTicket(st2);
         ticketRegistry.addTicket(st3);
 
-        assertNotNull(ticketRegistry.getTicket(ticketGrantingTicketId + '1', TicketGrantingTicket.class));
+        assertNotNull(ticketRegistry.getTicket(ticketGrantingTicketId, TicketGrantingTicket.class));
         assertNotNull(ticketRegistry.getTicket("ST-11", ServiceTicket.class));
         assertNotNull(ticketRegistry.getTicket("ST-21", ServiceTicket.class));
         assertNotNull(ticketRegistry.getTicket("ST-31", ServiceTicket.class));
@@ -527,7 +527,7 @@ public abstract class BaseTicketRegistryTests {
 
         assertSame(4, ticketRegistry.deleteTicket(tgt.getId()));
 
-        assertThrows(InvalidTicketException.class, () -> ticketRegistry.getTicket(ticketGrantingTicketId + '1', TicketGrantingTicket.class));
+        assertThrows(InvalidTicketException.class, () -> ticketRegistry.getTicket(ticketGrantingTicketId, TicketGrantingTicket.class));
         assertThrows(InvalidTicketException.class, () -> ticketRegistry.getTicket("ST-11", ServiceTicket.class));
         assertThrows(InvalidTicketException.class, () -> ticketRegistry.getTicket("ST-21", ServiceTicket.class));
         assertThrows(InvalidTicketException.class, () -> ticketRegistry.getTicket("ST-31", ServiceTicket.class));

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/CasRedisTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/CasRedisTicketRegistryAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.apereo.cas.ticket.registry.sub.DefaultRedisTicketRegistryMessageListe
 import org.apereo.cas.ticket.serialization.TicketSerializationManager;
 import org.apereo.cas.util.CoreTicketUtils;
 import org.apereo.cas.util.PublisherIdentifier;
+import org.apereo.cas.util.crypto.CipherExecutor;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.lock.DefaultLockRepository;
 import org.apereo.cas.util.lock.LockRepository;
@@ -235,7 +236,9 @@ public class CasRedisTicketRegistryAutoConfiguration {
             @Qualifier("redisTicketRegistryMessagePublisher")
             final RedisTicketRegistryMessagePublisher redisTicketRegistryMessagePublisher,
             final ConfigurableApplicationContext applicationContext,
-            final CasConfigurationProperties casProperties) {
+            final CasConfigurationProperties casProperties,
+            @Qualifier("protocolTicketCipherExecutor")
+            final CipherExecutor protocolTicketCipherExecutor) {
             return BeanSupplier.of(TicketRegistry.class)
                 .when(CONDITION.given(applicationContext.getEnvironment()))
                 .supply(Unchecked.supplier(() -> {
@@ -246,7 +249,7 @@ public class CasRedisTicketRegistryAutoConfiguration {
                         : Optional.<RedisModulesCommands>empty();
                     return new RedisTicketRegistry(cipher, ticketSerializationManager, ticketCatalog,
                         casRedisTemplates, redisTicketRegistryCache, redisTicketRegistryMessagePublisher,
-                        searchCommands, redisKeyGeneratorFactory, casProperties);
+                        searchCommands, redisKeyGeneratorFactory, casProperties, protocolTicketCipherExecutor);
                 }))
                 .otherwise(() -> new DefaultTicketRegistry(ticketSerializationManager, ticketCatalog))
                 .get();

--- a/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisServerTicketRegistryTests.java
+++ b/support/cas-server-support-redis-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/RedisServerTicketRegistryTests.java
@@ -7,7 +7,10 @@ import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.TicketGrantingTicketFactory;
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
+import org.apereo.cas.ticket.TransientSessionTicket;
+import org.apereo.cas.ticket.TransientSessionTicketFactory;
 import org.apereo.cas.ticket.expiration.NeverExpiresExpirationPolicy;
 import org.apereo.cas.util.ServiceTicketIdGenerator;
 import org.apereo.cas.util.TicketGrantingTicketIdGenerator;
@@ -20,10 +23,13 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.jooq.lambda.Unchecked;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -132,6 +138,32 @@ class RedisServerTicketRegistryTests {
         "cas.ticket.registry.redis.crypto.signing.key=cAPyoHMrOMWrwydOXzBA-ufZQM-TilnLjbRgMQWlUlwFmy07bOtAgCIdNBma3c5P4ae_JV6n1OpOAYqSh2NkmQ"
     })
     class WithoutRedisModulesTests extends BaseRedisSentinelTicketRegistryTests {
+
+    }
+
+    @Nested
+    @TestPropertySource(properties = {
+            "cas.ticket.registry.redis.queue-identifier=cas-node-100",
+            "cas.ticket.registry.redis.host=localhost",
+            "cas.ticket.registry.redis.port=6379",
+            "cas.ticket.registry.redis.enable-redis-search=false",
+            "cas.ticket.registry.redis.crypto.enabled=false",
+            "cas.ticket.crypto.enabled=true"
+    })
+    class WithEncryptedIdentifiersTests extends BaseRedisSentinelTicketRegistryTests {
+
+        @Override
+        @BeforeEach
+        public void initialize(final TestInfo info, final RepetitionInfo repetitionInfo) throws Throwable {
+            super.initialize(info, repetitionInfo);
+
+            val tgtFactory = (TicketGrantingTicketFactory) ticketFactory.get(TicketGrantingTicket.class);
+            this.ticketGrantingTicketId = tgtFactory.create(CoreAuthenticationTestUtils.getAuthentication(), null,
+                    TicketGrantingTicket.class).getId();
+
+            val transientFactory = (TransientSessionTicketFactory) ticketFactory.get(TransientSessionTicket.class);
+            this.transientSessionTicketId = transientFactory.create(null).getId();
+        }
 
     }
 


### PR DESCRIPTION
As soon as we enable `cas.ticket.crypto.enabled` in the Redis ticket registry, the retrieval of the tickets no longer work.

Indeed, the tickets are saved as `CAS_TICKET:TGT:eyxxx` but retrieved as `CAS_TICKET:eyxxx`.

This perfectly works without the `cas.ticket.crypto.enabled`.

This PR fixes the problem by decrypting the ticket identifier before the `getTicket` if need be.
