### PR TITLE
Fix RequestParameterPolicyEnforcementFilter configuration logic for 7.0.x branch

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/security/HttpRequestProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/web/security/HttpRequestProperties.java
@@ -43,7 +43,7 @@ public class HttpRequestProperties implements Serializable {
     private String onlyPostParams = "username,password";
 
     /**
-     * Parameters to sanitize and cross-check in incoming requests.
+     * Parameters to sanitize and cross-check in incoming requests.  Separate parameter names by a comma.
      * The special value * instructs the Filter to check all parameters.
      */
     private String paramsToCheck = "ticket,service,renew,gateway,warn,method,target,SAMLart," + "pgtUrl,pgt,pgtId,pgtIou,targetService,entityId,token";

--- a/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/RequestParameterPolicyEnforcementFilter.java
+++ b/core/cas-server-core-web-api/src/main/java/org/apereo/cas/web/support/filters/RequestParameterPolicyEnforcementFilter.java
@@ -206,13 +206,13 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
         if (initParamValue.trim().isEmpty()) {
             throwException(new IllegalArgumentException('[' + initParamValue + "] had no tokens but should have had at least one token."));
         }
-        val tokens = Splitter.onPattern("\\s+").splitToList(initParamValue.trim());
+        val tokens = Splitter.onPattern("\\,\\s*").splitToList(initParamValue.trim());
         if (allowWildcard && 1 == tokens.size() && "*".equals(tokens.getFirst())) {
             return new HashSet<>(0);
         }
         val parameterNames = new HashSet<String>();
         for (val parameterName : tokens) {
-            if ("*".equals(parameterName)) {
+            if (parameterName.contains("*")) {
                 throwException(new IllegalArgumentException("Star token encountered among other tokens in parsing [" + initParamValue + ']'));
             }
             parameterNames.add(parameterName);
@@ -221,10 +221,12 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
     }
 
     /**
-     * Parse a whitespace delimited set of Characters from a String.
+     * Parse a space delimited set of Characters from a String.
      * <p>
      * If the String is "none" parse to empty set meaning block no characters.
      * If the String is empty throw, to avoid configurer accidentally configuring not to block any characters.
+     * <p>
+     * Note that only the space charater should be used as a delimiter, not tabs or newlines.
      *
      * @param value value of the init param to parse
      * @return non-null Set of zero or more Characters to block
@@ -243,7 +245,7 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
             return charactersToForbid;
         }
 
-        val tokens = Splitter.onPattern("\\s+").splitToList(paramValue);
+        val tokens = Splitter.onPattern("\\ +").splitToList(paramValue);
         for (val token : tokens) {
             if (token.length() > 1) {
                 throwException(new IllegalArgumentException("Expected tokens of length 1 but found [" + token + "] when parsing [" + paramValue + ']'));

--- a/core/cas-server-core-web-api/src/test/java/org/apereo/cas/web/support/filters/RequestParameterPolicyEnforcementFilterTests.java
+++ b/core/cas-server-core-web-api/src/test/java/org/apereo/cas/web/support/filters/RequestParameterPolicyEnforcementFilterTests.java
@@ -197,8 +197,8 @@ class RequestParameterPolicyEnforcementFilterTests {
     }
 
     @Test
-    void verifyParsesWhiteSpaceDelimitedStringToSet() throws Throwable {
-        val parameterValue = "service renew gateway";
+    void verifyParsesCommaDelimitedStringToSet() throws Throwable {
+        val parameterValue = "service,renew, gateway";
         val expectedSet = new HashSet<String>();
         expectedSet.add("service");
         expectedSet.add("renew");
@@ -262,8 +262,11 @@ class RequestParameterPolicyEnforcementFilterTests {
         expected.add('*');
         expected.add('#');
         expected.add('@');
+        expected.add('\u0000');
+        expected.add('\u0010');
+        expected.add('\u0001');
 
-        val actual = RequestParameterPolicyEnforcementFilter.parseCharactersToForbid("& % * # @");
+        val actual = RequestParameterPolicyEnforcementFilter.parseCharactersToForbid("& % * # @ \u0000 \u0010 \u0001");
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
master: https://github.com/apereo/cas/pull/5938

- Fix "parameters-to-check" property parsing to be comma-delimited so the default property value will work as expected
- Allow characters below 0x20 to be blocked by the filter by parsing the "characters-to-forbid" property as delimited only by the space character, rather than by any whitespace character
- Update unit tests as needed.
