### PR TITLE
Stop webflow when pac4j client getCredentials() fails (7.0.x)

### DIFF
--- a/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/authentication/clients/DelegatedAuthenticationClientsTestConfiguration.java
+++ b/support/cas-server-support-pac4j-core-clients/src/test/java/org/apereo/cas/support/pac4j/authentication/clients/DelegatedAuthenticationClientsTestConfiguration.java
@@ -16,6 +16,7 @@ import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.CallContext;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.credentials.SessionKeyCredentials;
+import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.exception.http.AutomaticFormPostAction;
 import org.pac4j.core.exception.http.OkAction;
 import org.pac4j.core.logout.LogoutType;
@@ -133,8 +134,12 @@ public class DelegatedAuthenticationClientsTestConfiguration {
         doThrow(new IllegalArgumentException("Unable to init")).when(failingClient).init();
         customizers.forEach(customizer -> customizer.customize(failingClient));
 
+        val badCredentialsClient = mock(IndirectClient.class);
+        when(badCredentialsClient.getName()).thenReturn("BadCredentialsClient");
+        when(badCredentialsClient.getCredentials(any())).thenThrow(new TechnicalException("Client failed to validate credentials"));
+
         val clients = List.of(saml2Client, casClient, facebookClient,
-            oidcClient, logoutClient, logoutPostClient, failingClient, saml2PostClient);
+            oidcClient, logoutClient, logoutPostClient, failingClient, saml2PostClient, badCredentialsClient);
         return new RefreshableDelegatedIdentityProviders("https://cas.login.com", DelegatedIdentityProviderFactory.withClients(clients));
     }
 

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/DelegatedClientAuthenticationAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/DelegatedClientAuthenticationAction.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.web.flow.actions;
 
 import org.apereo.cas.CasProtocolConstants;
+import org.apereo.cas.authentication.AuthenticationException;
 import org.apereo.cas.authentication.principal.ClientCredential;
 import org.apereo.cas.authentication.principal.DelegatedAuthenticationCandidateProfile;
 import org.apereo.cas.authentication.principal.DelegatedClientAuthenticationCredentialResolver;
@@ -134,6 +135,10 @@ public class DelegatedClientAuthenticationAction extends AbstractAuthenticationA
                     throw client.processLogout(callContext, clientCredential.get().getCredentials());
                 }
                 return finalizeDelegatedClientAuthentication(context, clientCredential.get());
+            } else if (StringUtils.isNotBlank(clientName)) {
+                val msg = "Client %s failed to validate credentials".formatted(clientName);
+                LoggingUtils.error(LOGGER, msg);
+                return stopWebflow(new AuthenticationException(msg), context);
             }
         } catch (final HttpAction e) {
             FunctionUtils.doIf(LOGGER.isDebugEnabled(),


### PR DESCRIPTION
master: https://github.com/apereo/cas/pull/5987

In 6.6.x, when a pac4j client failed to validate its credentials (e.g. after receiving a SAML error response from the IdP, failing to verify the signature on a SAML response, etc.), the ``DelegatedClientAuthenticationAction`` handled the error by returning a ``stop`` event, causing the webflow to move to the ``stopWebflow`` state.  In 7.0.x and 7.1.x, it will return a ``generate`` event, which does not indicate an error, and the webflow continues on to ``viewLoginForm`` with no error messages, which would be terribly confusing to my users.

This PR restores the 6.6.x behavior.   A test has been added to verify (which fails without the change to ``DelegatedClientAuthenticationAction``).

