### PR TITLE
remove email from saml attr definition b/c mail maps to urn

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/resources/samlidp-attribute-definitions.json
+++ b/support/cas-server-support-saml-idp-web/src/main/resources/samlidp-attribute-definitions.json
@@ -73,12 +73,6 @@
     "friendlyName" : "eduPersonUniqueId",
     "urn" : "urn:oid:1.3.6.1.4.1.5923.1.1.1.13"
   },
-  "email" : {
-    "@class" : "org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlIdPAttributeDefinition",
-    "key" : "email",
-    "friendlyName" : "email",
-    "urn" : "urn:oid:0.9.2342.19200300.100.1.3"
-  },
   "givenName" : {
     "@class" : "org.apereo.cas.support.saml.web.idp.profile.builders.attr.SamlIdPAttributeDefinition",
     "key" : "givenName",


### PR DESCRIPTION
Having an official mapping to the urn for both mail and email was causing problems with SAML authentication for gitlab.com (SaaS) since they only look for email under those two attribute names and both were coming back with the urn as the name (and gitlab wasn't looking for friendly name). Since the official mapping of the urn for e-mail is "mail", e-mail shouldn't be in the mapping file and this has already been changed on master branch. 

- [x] Brief description of changes applied
- [n/a] Test cases for all modified changes, where applicable
- [n/a] The same pull request targeted at the master branch, if applicable

[Shows oid mapped to mail, not e-mail](https://oid-rep.orange-labs.fr/get/0.9.2342.19200300.100.1.3)
