### PR TITLE
URL encode parameters in frgament

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilder.java
@@ -21,6 +21,9 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.apereo.inspektr.audit.annotation.Audit;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -88,7 +91,7 @@ public class OAuth20TokenAuthorizationResponseBuilder<T extends OAuth20Configura
 
         val parameterList = builder.getQueryParams()
             .stream()
-            .map(parameter -> String.format("%s=%s", parameter.getName(), parameter.getValue()))
+            .map(parameter -> String.format("%s=%s", parameter.getName(), URLEncoder.encode(parameter.getValue(), StandardCharsets.UTF_8)))
             .collect(Collectors.joining("&"));
 
         val url = UriComponentsBuilder.fromUriString(tokenRequestContext.getRedirectUri())

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilderTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/response/callback/OAuth20TokenAuthorizationResponseBuilderTests.java
@@ -16,6 +16,8 @@ import org.springframework.core.Ordered;
 import org.springframework.web.servlet.view.AbstractUrlBasedView;
 import org.springframework.web.servlet.view.RedirectView;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @Tag("OAuth")
 class OAuth20TokenAuthorizationResponseBuilderTests extends AbstractOAuth20Tests {
-    private static final String STATE = "%123=";
+    private static final String STATE = "{\"d\":\"value\"}";
 
     private static final String NONCE = "%123=";
 
@@ -104,7 +106,7 @@ class OAuth20TokenAuthorizationResponseBuilderTests extends AbstractOAuth20Tests
         val redirectUrl = ((AbstractUrlBasedView) modelAndView.getView()).getUrl();
         val params = splitQuery(redirectUrl.substring(redirectUrl.indexOf('#') + 1));
 
-        verifyParam(params, OAuth20Constants.STATE, STATE);
-        verifyParam(params, OAuth20Constants.NONCE, NONCE);
+        verifyParam(params, OAuth20Constants.STATE, URLEncoder.encode(STATE, StandardCharsets.UTF_8));
+        verifyParam(params, OAuth20Constants.NONCE, URLEncoder.encode(NONCE, StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
I have this very simple OAuth service:

```json
{
  "@class" : "org.apereo.cas.support.oauth.services.OAuthRegisteredService",
  "clientId": "myclient",
  "clientSecret": "clientSecret",
  "serviceId" : "^http?://.*",
  "name" : "OAuthService",
  "id" : 1,
  "bypassApprovalPrompt": true
}
```

I call: `http://localhost:8080/cas/oauth2.0/authorize?response_type=token&client_id=myclient&redirect_uri=http%3A%2F%2Ftest&scope=openid+profile+email+phone&state=%7B%22d%22%3A%22value%22%7D`

I get the following error:

```java
ERROR [org.apereo.cas.web.support.filters.AbstractSecurityFilter] - <Request processing failed: java.lang.IllegalArgumentException: Model has no value for key '"d":"value"'
	FrameworkServlet.java:processRequest:1022
	FrameworkServlet.java:doGet:903
	HttpServlet.java:service:564
>
```

The parameters in the fragment should be URL-encoded. A unit test (and a manual test) confirms the fix.
