### PR TITLE
Use CookieCsrfTokenRepository

### DIFF
--- a/support/cas-server-support-webauthn/src/main/java/org/apereo/cas/config/WebAuthnConfiguration.java
+++ b/support/cas-server-support-webauthn/src/main/java/org/apereo/cas/config/WebAuthnConfiguration.java
@@ -72,8 +72,8 @@ import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.access.expression.WebExpressionAuthorizationManager;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
-import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import java.net.URI;
@@ -462,7 +462,7 @@ class WebAuthnConfiguration {
             @ConditionalOnMissingBean(name = "webAuthnCsrfTokenRepository")
             @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
             public CsrfTokenRepository webAuthnCsrfTokenRepository() {
-                return new HttpSessionCsrfTokenRepository();
+                return new CookieCsrfTokenRepository();
             }
 
             @Bean

--- a/support/cas-server-support-webauthn/src/test/java/org/apereo/cas/webauthn/web/flow/WebAuthnPopulateCsrfTokenActionTests.java
+++ b/support/cas-server-support-webauthn/src/test/java/org/apereo/cas/webauthn/web/flow/WebAuthnPopulateCsrfTokenActionTests.java
@@ -1,6 +1,8 @@
 package org.apereo.cas.webauthn.web.flow;
 
 import org.apereo.cas.util.MockRequestContext;
+import org.apereo.cas.web.support.WebUtils;
+
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -8,8 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.webflow.execution.Action;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -31,13 +36,20 @@ public class WebAuthnPopulateCsrfTokenActionTests {
     @Test
     void verifyOperation() throws Exception {
         val context = MockRequestContext.create(applicationContext);
+        val request = (MockHttpServletRequest) WebUtils.getHttpServletRequestFromExternalWebflowContext(context);
+        val response = (MockHttpServletResponse) WebUtils.getHttpServletResponseFromExternalWebflowContext(context);
+
         webAuthnPopulateCsrfTokenAction.execute(context);
         val csrf1 = context.getFlowScope().get("_csrf", CsrfToken.class);
         assertNotNull(csrf1);
-        assertEquals("X-CSRF-TOKEN", csrf1.getHeaderName());
+        assertEquals("X-XSRF-TOKEN", csrf1.getHeaderName());
+
+        request.setCookies(response.getCookie("XSRF-TOKEN"));
 
         webAuthnPopulateCsrfTokenAction.execute(context);
         val csrf2 = context.getFlowScope().get("_csrf", CsrfToken.class);
-        assertEquals(csrf1, csrf2);
+        assertEquals(csrf1.getToken(), csrf2.getToken());
+        assertEquals(csrf1.getParameterName(), csrf2.getParameterName());
+        assertEquals(csrf1.getHeaderName(), csrf2.getHeaderName());
     }
 }


### PR DESCRIPTION
In the latest CAS server versions, we always prefer the distributed approach and enable the distributed configuration.

So we should do the same for the CSRF tokens of Spring Security by using the `CookieCsrfTokenRepository` instead of the `HttpSessionCsrfTokenRepository`.