### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@
 #################################################
 group=org.apereo.cas
 version=7.1.0-SNAPSHOT
+# CAS server version
+cas.version=7.1.0-SNAPSHOT
 projectUrl=https://www.apereo.org/projects/cas
 projectInceptionYear=2004
 projectScmUrl=scm:git@github.com:apereo/cas.git


### PR DESCRIPTION
cas.version is checked by 

implementation enforcedPlatform("org.apereo.cas:cas-server-support-bom:${project.'cas.version'}")

https://apereo.github.io/cas/development/installation/BOM-Dependency-Management.html

I saw this definition was on the 6.6 branch, but not in 7.0.x and 7.1.0-SNAPSHOT branches.

I get an error after './gradlew clean' if I include 'implementation enforcedPlatform("org.apereo...' in build.gradle but 'cas.version=7.1.0-SNAPSHOT' is not defined gradle.properties.