### PR TITLE
add class to identify impersonation principle

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/ImpersonatedPrincipal.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/ImpersonatedPrincipal.java
@@ -1,0 +1,93 @@
+package org.apereo.cas.authentication.principal;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.Serial;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Implementation of {@link Principal} to identify
+ * the impersonated principle of a surrogate authentication.
+ *
+ * @author Ray Bon
+ * @since 7.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ToString
+@Getter
+@NoArgsConstructor
+public class ImpersonatedPrincipal implements Principal {
+
+	@Serial
+	private static final long serialVersionUID = 4439906474953664064L;
+
+	/**
+	 * The unique identifier for the principal.
+	 */
+	@JsonProperty
+	private String id;
+
+	/**
+	 * Principal attributes.
+	 **/
+	@JsonSetter(nulls = Nulls.AS_EMPTY)
+	private Map<String, List<Object>> attributes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+	/**
+	 * Instantiates a new simple principal.
+	 *
+	 * @param id         the id
+	 * @param attributes the attributes
+	 */
+	@JsonCreator
+	protected ImpersonatedPrincipal(@JsonProperty("id") final @NonNull String id,
+									@JsonProperty("attributes") final Map<String, List<Object>> attributes) {
+		this.id = id;
+		this.attributes = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+		this.attributes.putAll(attributes);
+	}
+
+	/**
+	 * Copy a principal as impersonated.
+	 *
+	 * @param principal the Principal to copy
+	 */
+	public ImpersonatedPrincipal(Principal principal) {
+		this(principal.getId(), principal.getAttributes());
+	}
+
+	@Override
+	public int hashCode() {
+		val builder = new HashCodeBuilder(83, 31);
+		builder.append(id.toLowerCase(Locale.ENGLISH));
+		return builder.toHashCode();
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (obj == null) {
+			return false;
+		}
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof final SimplePrincipal rhs)) {
+			return false;
+		}
+		return StringUtils.equalsIgnoreCase(id, rhs.getId());
+	}
+}

--- a/support/cas-server-support-surrogate-authentication/src/test/java/org/apereo/cas/authentication/SurrogatePrincipalElectionStrategyTests.java
+++ b/support/cas-server-support-surrogate-authentication/src/test/java/org/apereo/cas/authentication/SurrogatePrincipalElectionStrategyTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.authentication;
 
+import org.apereo.cas.authentication.principal.ImpersonatedPrincipal;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalFactoryUtils;
 import org.apereo.cas.authentication.surrogate.SimpleSurrogateAuthenticationService;
@@ -9,6 +10,7 @@ import org.apereo.cas.util.CollectionUtils;
 
 import lombok.val;
 import org.apereo.services.persondir.IPersonAttributeDao;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +30,21 @@ import static org.mockito.Mockito.*;
  */
 @Tag("Impersonation")
 class SurrogatePrincipalElectionStrategyTests {
+
+    private Map<String, List<Object>> attributes = new HashMap<>(0);
+
+    @BeforeEach
+    public void initialize() {
+        attributes = CollectionUtils.wrap(
+                "formalName", CollectionUtils.wrapSet("cas"),
+                "theName", CollectionUtils.wrapSet("user"),
+                "sysuser", CollectionUtils.wrapSet("casuser"),
+                "firstName", CollectionUtils.wrapSet("cas-first"),
+                "lastName", CollectionUtils.wrapSet("cas-last"),
+                "someOther", CollectionUtils.wrapSet("so that"),
+                "count", CollectionUtils.wrapSet("is different from test utils"));
+    }
+
     private static Principal buildSurrogatePrincipal(final String surrogateId,
                                                      final Authentication primaryAuth,
                                                      final IPersonAttributeDao attributeRepository) throws Throwable {
@@ -54,12 +71,6 @@ class SurrogatePrincipalElectionStrategyTests {
     @Test
     void verifyOperation() throws Throwable {
         val strategy = new SurrogatePrincipalElectionStrategy();
-        val attributes = CollectionUtils.wrap(
-            "formalName", CollectionUtils.wrapSet("cas"),
-            "theName", CollectionUtils.wrapSet("user"),
-            "sysuser", CollectionUtils.wrapSet("casuser"),
-            "firstName", CollectionUtils.wrapSet("cas-first"),
-            "lastName", CollectionUtils.wrapSet("cas-last"));
 
         val authentications = new ArrayList<Authentication>();
         val primaryAuth = CoreAuthenticationTestUtils.getAuthentication("casuser");
@@ -79,6 +90,118 @@ class SurrogatePrincipalElectionStrategyTests {
             .filter(key -> !principal.getAttributes().containsKey(key))
             .findAny();
         if (result.isPresent()) {
+            fail();
+        }
+    }
+
+    @Test
+    void verifyAttributes() throws Throwable {
+        val strategy = new SurrogatePrincipalElectionStrategy();
+
+        val principal = CoreAuthenticationTestUtils.getPrincipal("casuser1");
+        val attributesCalculated = strategy
+                .getPrincipalAttributesForPrincipal(principal, attributes);
+        assertNotNull(attributesCalculated);
+        assertEquals(attributes.size(), attributesCalculated.size());
+
+        val surrogate = new ImpersonatedPrincipal(CoreAuthenticationTestUtils.getPrincipal("casuser2"));
+        val attributesFromSurrogate = strategy
+                .getPrincipalAttributesForPrincipal(surrogate, attributes);
+        assertNotNull(attributesFromSurrogate);
+        assertEquals(CoreAuthenticationTestUtils.getAttributeRepository().getBackingMap().size(), attributesFromSurrogate.size());
+    }
+
+    @Test
+    void verifyOperationMultipleAuthnNoSurrogate() throws Throwable {
+        val strategy = new SurrogatePrincipalElectionStrategy();
+
+        val authentication1 = CoreAuthenticationTestUtils.
+                getAuthentication(CoreAuthenticationTestUtils.getPrincipal("casuser1"));
+        val authentication2 = CoreAuthenticationTestUtils.
+                getAuthentication(CoreAuthenticationTestUtils.getPrincipal("casuser2"));
+        val principal = strategy.nominate(List.of(authentication1, authentication2), attributes);
+        assertNotNull(principal);
+        assertEquals("casuser2", principal.getId());
+        assertEquals(attributes.size(), principal.getAttributes().size());
+    }
+
+    @Test
+    void verifyOperationAuthnSurrogate() throws Throwable {
+        val strategy = new SurrogatePrincipalElectionStrategy();
+
+        val attributeRepository = CoreAuthenticationTestUtils.getAttributeRepository();
+        val primaryAuth = CoreAuthenticationTestUtils.
+                getAuthentication(CoreAuthenticationTestUtils.getPrincipal("casuser1"));
+        val surrogatePrincipal = buildSurrogatePrincipal("cas-surrogate", primaryAuth, attributeRepository);
+
+        val authentications = new ArrayList<Authentication>();
+        authentications.add(CoreAuthenticationTestUtils.getAuthentication(surrogatePrincipal));
+        val principal = strategy.nominate(authentications, attributes);
+        assertNotNull(principal);
+        assertEquals("cas-surrogate", principal.getId());
+        assertEquals(attributeRepository.getBackingMap().size(), principal.getAttributes().size());
+    }
+
+    @Test
+    void verifyOperationPrincipalsNoSurrogate() throws Throwable {
+        val strategy = new SurrogatePrincipalElectionStrategy();
+
+        val attributeRepositoryType0 = CoreAuthenticationTestUtils.getAttributeRepository();
+        attributeRepositoryType0.getBackingMap().put("some", CollectionUtils.wrapList("authentication zero"));
+        val attributeRepositoryType1 = CoreAuthenticationTestUtils.getAttributeRepository();
+        attributeRepositoryType1.getBackingMap().put("another", CollectionUtils.wrapList("authentication one"));
+
+        val authentications = new ArrayList<Authentication>();
+        val authnFromType0 = CoreAuthenticationTestUtils.getAuthentication("casuser", attributeRepositoryType0.getBackingMap());
+        val authnFromType1 = CoreAuthenticationTestUtils.getAuthentication("casuser", attributeRepositoryType1.getBackingMap());
+        authentications.add(authnFromType0);
+        authentications.add(authnFromType1);
+
+        val principal = strategy.nominate(authentications, (Map) attributes);
+        assertNotNull(principal);
+        assertEquals("casuser", principal.getId());
+        assertEquals(attributes.size(), principal.getAttributes().size());
+
+        val result = attributes.keySet()
+                .stream()
+                .filter(key -> !principal.getAttributes().containsKey(key))
+                .findAny();
+        if (result.isPresent()) {
+            fail();
+        }
+    }
+
+    @Test
+    void verifyOperationPrincipalsSurrogate() throws Throwable {
+        val strategy = new SurrogatePrincipalElectionStrategy();
+
+        val attributeRepository = CoreAuthenticationTestUtils.getAttributeRepository();
+
+        val attributeRepositoryType0 = CoreAuthenticationTestUtils.getAttributeRepository();
+        attributeRepositoryType0.getBackingMap().put("some", CollectionUtils.wrapList("authentication zero"));
+        val attributeRepositoryType1 = CoreAuthenticationTestUtils.getAttributeRepository();
+        attributeRepositoryType1.getBackingMap().put("another", CollectionUtils.wrapList("authentication one"));
+
+        val principals = new ArrayList<Principal>();
+
+        val primaryAuth = CoreAuthenticationTestUtils.getAuthentication("casuser", attributeRepository.getBackingMap());
+        principals.add(primaryAuth.getPrincipal());
+
+        val surrogatePrincipal = buildSurrogatePrincipal("cas-surrogate", primaryAuth, attributeRepository);
+        principals.add(surrogatePrincipal);
+        assertEquals(2, principals.size());
+
+        val principal1 = strategy.nominate(principals, (Map) attributes);
+        assertEquals(1, principals.size());
+        assertNotNull(principal1);
+        assertEquals("cas-surrogate", principal1.getId());
+        assertEquals(attributeRepository.getBackingMap().size(), principal1.getAttributes().size());
+
+        val result1 = attributeRepository.getBackingMap().keySet()
+                .stream()
+                .filter(key -> !principal1.getAttributes().containsKey(key))
+                .findAny();
+        if (result1.isPresent()) {
             fail();
         }
     }

--- a/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/SurrogatePrincipal.java
+++ b/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/SurrogatePrincipal.java
@@ -1,11 +1,10 @@
 package org.apereo.cas.authentication;
 
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.authentication.principal.ImpersonatedPrincipal;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 import java.io.Serial;
@@ -21,14 +20,18 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ToString
 @Getter
-@NoArgsConstructor(force = true)
-@RequiredArgsConstructor
 public class SurrogatePrincipal implements Principal {
     @Serial
     private static final long serialVersionUID = 5672386093026290631L;
 
     private final Principal primary;
     private final Principal surrogate;
+
+    public SurrogatePrincipal(Principal primary, Principal surrogate) {
+        this.primary = primary;
+        this.surrogate = new ImpersonatedPrincipal(surrogate);
+//        this.surrogate = surrogate;
+    }
 
     @Override
     public String getId() {

--- a/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/SurrogatePrincipalElectionStrategy.java
+++ b/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/SurrogatePrincipalElectionStrategy.java
@@ -2,6 +2,7 @@ package org.apereo.cas.authentication;
 
 import org.apereo.cas.authentication.principal.DefaultPrincipalElectionStrategy;
 import org.apereo.cas.authentication.principal.Principal;
+import org.apereo.cas.authentication.principal.ImpersonatedPrincipal;
 
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -26,8 +27,18 @@ public class SurrogatePrincipalElectionStrategy extends DefaultPrincipalElection
 
     @Override
     protected Map<String, List<Object>> getPrincipalAttributesForPrincipal(final Principal principal, final Map<String, List<Object>> principalAttributes) {
-        return principal.getAttributes();
+        if (principal instanceof ImpersonatedPrincipal) {
+            return principal.getAttributes();
+        }
+        return super.getPrincipalAttributesForPrincipal(principal, principalAttributes);
+//        return principal.getAttributes();
     }
+    /*
+    if (principal instanceof ImpersonatedPrincipal) {
+            return principal.getAttributes();
+        }
+        return super.getPrincipalAttributesForPrincipal(principal, principalAttributes);
+     */
 
     @Override
     protected Principal getPrincipalFromAuthentication(final Collection<Authentication> authentications) {


### PR DESCRIPTION
When the surrogate feature is enabled, the SurrogatePrincipalElectionStrategy is used instead of DefaultPrincipalElectionStrategy.
SPES selects attributes that are 'attached' to the principal, in comparison to DPES, which selects the merged collection of attributes from all principals.
When authentication flow involves more than one authentication method, with resulting multiple principals each having different attribute sets, SPES will select an attribute set from only one of the principals.
e.g., ldap authn with ldap attributes, duo MFA with duo attributes; only the duo attributes are included in the nominated principal.

This change adds a surrogate specific principal which is checked by SPES when selecting attributes. Only if the principal is a surrogate will the surrogate's attributes be returned. Otherwise behaviour is as in DPES.


- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [NA] Any documentation on how to configure, test
- [nil] Any possible limitations, side effects, etc
- [none] Reference any other pull requests that might be related
