### PR TITLE
Fix incompatibility with Sentry

### DIFF
--- a/ci/tests/puppeteer/scenarios/login-success/script.json
+++ b/ci/tests/puppeteer/scenarios/login-success/script.json
@@ -1,5 +1,5 @@
 {
-  "dependencies": "core,google-analytics",
+  "dependencies": "core,google-analytics,sentry",
   "conditions": {
     "docker": "true"
   },
@@ -17,7 +17,8 @@
 
     "--cas.monitor.endpoints.endpoint.defaults.access=ANONYMOUS",
     "--management.endpoints.web.exposure.include=*",
-    "--management.endpoints.enabled-by-default=true"
+    "--management.endpoints.enabled-by-default=true",
+    "--management.server.port=8081"
   ],
   "initScript": "${PWD}/ci/tests/httpbin/run-httpbin-server.sh"
 }

--- a/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
+++ b/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
@@ -90,9 +90,7 @@ public class SentryMonitoringAspect implements Serializable {
     @Pointcut("within(org.apereo.cas..*) "
         + "&& !within(org.apereo.cas..*config..*) "
         + "&& !within(org.apereo.cas..*Configuration) "
-        + "&& !within(org.apereo.cas.authentication.credential..*)"
-        + "&& !within(org.apereo.cas.support.saml.web.idp.profile.slo.SamlIdPLogoutResponseObjectBuilder)"
-        + "&& !within(org.apereo.cas.support.saml.web.idp.profile.HttpServletRequestXMLMessageDecodersMap)")
+        + "&& !within(org.apereo.cas.authentication.credential..*)")
     private void allSentryComponents() {
     }
 }

--- a/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
+++ b/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
@@ -90,7 +90,9 @@ public class SentryMonitoringAspect implements Serializable {
     @Pointcut("within(org.apereo.cas..*) "
         + "&& !within(org.apereo.cas..*config..*) "
         + "&& !within(org.apereo.cas..*Configuration) "
-        + "&& !within(org.apereo.cas.authentication.credential..*)")
+        + "&& !within(org.apereo.cas.authentication.credential..*)"
+        + "&& !within(org.apereo.cas.support.saml.web.idp.profile.slo.SamlIdPLogoutResponseObjectBuilder)"
+        + "&& !within(org.apereo.cas.support.saml.web.idp.profile.HttpServletRequestXMLMessageDecodersMap)")
     private void allSentryComponents() {
     }
 }

--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
@@ -12,8 +12,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.embedded.tomcat.ConfigurableTomcatWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
-import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -33,7 +33,7 @@ class CasEmbeddedContainerTomcatConfiguration {
 
     @ConditionalOnMissingBean(name = "casServletWebServerFactory")
     @Bean
-    public ConfigurableServletWebServerFactory casServletWebServerFactory(
+    public ConfigurableTomcatWebServerFactory casServletWebServerFactory(
         final ServerProperties serverProperties,
         final CasConfigurationProperties casProperties) {
         return new CasTomcatServletWebServerFactory(casProperties, serverProperties);


### PR DESCRIPTION
This PR fixes an incompatibility with Sentry and defining the property `management.server.port`.

The solution was to change the interface used for bean creation (like https://github.com/apereo/cas/commit/827ccd8585797fb3b36d987a7a461d97c2ef0f15).

The `login-success` Puppeteer has been updated to confirm the fix (`./ci/tests/puppeteer/run.sh --rebuild --scenario ./ci/tests/puppeteer/scenarios/login-success`).

Locally, I also successfully run:
- `./gradlew cleanTest testWebApp --no-configuration-cache -p webapp/cas-server-webapp-init-tomcat`
- `./gradlew clean build check javadoc -no-configuration-cache -p support/cas-server-support-sentry`
- `./gradlew clean build check javadoc -no-configuration-cache -p  webapp/cas-server-webapp-init-tomcat`
