### PR TITLE
Fix Sentry incompatibility

### DIFF
--- a/api/cas-server-core-api-monitor/src/main/java/org/apereo/cas/monitor/NotMonitorable.java
+++ b/api/cas-server-core-api-monitor/src/main/java/org/apereo/cas/monitor/NotMonitorable.java
@@ -1,0 +1,19 @@
+package org.apereo.cas.monitor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * For components that should not be monitored.
+ *
+ * @author Jerome LELEU
+ * @since 7.1.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+public @interface NotMonitorable {
+}

--- a/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
+++ b/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
@@ -91,7 +91,8 @@ public class SentryMonitoringAspect implements Serializable {
         + "&& !within(org.apereo.cas..*config..*) "
         + "&& !within(org.apereo.cas..*Configuration) "
         + "&& !within(org.apereo.cas.authentication.credential..*)"
-        + "&& !within(org.apereo.cas.tomcat..*)")
+        + "&& !@within(org.apereo.cas.monitor.NotMonitorable)"
+        + "&& !@target(org.apereo.cas.monitor.NotMonitorable)")
     private void allSentryComponents() {
     }
 }

--- a/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
+++ b/support/cas-server-support-sentry/src/main/java/org/apereo/cas/sentry/SentryMonitoringAspect.java
@@ -90,7 +90,8 @@ public class SentryMonitoringAspect implements Serializable {
     @Pointcut("within(org.apereo.cas..*) "
         + "&& !within(org.apereo.cas..*config..*) "
         + "&& !within(org.apereo.cas..*Configuration) "
-        + "&& !within(org.apereo.cas.authentication.credential..*)")
+        + "&& !within(org.apereo.cas.authentication.credential..*)"
+        + "&& !within(org.apereo.cas.tomcat..*)")
     private void allSentryComponents() {
     }
 }

--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/config/CasEmbeddedContainerTomcatConfiguration.java
@@ -12,8 +12,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.embedded.tomcat.ConfigurableTomcatWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -33,7 +33,7 @@ class CasEmbeddedContainerTomcatConfiguration {
 
     @ConditionalOnMissingBean(name = "casServletWebServerFactory")
     @Bean
-    public ConfigurableTomcatWebServerFactory casServletWebServerFactory(
+    public ConfigurableServletWebServerFactory casServletWebServerFactory(
         final ServerProperties serverProperties,
         final CasConfigurationProperties casProperties) {
         return new CasTomcatServletWebServerFactory(casProperties, serverProperties);

--- a/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/tomcat/CasTomcatServletWebServerFactory.java
+++ b/webapp/cas-server-webapp-init-tomcat/src/main/java/org/apereo/cas/tomcat/CasTomcatServletWebServerFactory.java
@@ -2,6 +2,7 @@ package org.apereo.cas.tomcat;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.core.web.tomcat.CasEmbeddedApacheTomcatClusteringProperties;
+import org.apereo.cas.monitor.NotMonitorable;
 
 import lombok.Getter;
 import lombok.ToString;
@@ -46,6 +47,7 @@ import java.util.Locale;
  * @author sbearcsiro
  * @since 5.3.0
  */
+@NotMonitorable
 @Slf4j
 public class CasTomcatServletWebServerFactory extends TomcatServletWebServerFactory {
 


### PR DESCRIPTION
https://github.com/apereo/cas/pull/6044 has broken the `tomcat-port-redirect` scenario.

This PR reverts the change in `CasEmbeddedContainerTomcatConfiguration` and marks the `CasTomcatServletWebServerFactory` class as `NotMonitorable`.

Both scenarios: `login-success` and `tomcat-port-redirect` now pass.