### PR TITLE
Small refactoring for the WebAuthn support

### DIFF
--- a/support/cas-server-support-webauthn-core/src/main/java/com/yubico/core/DefaultSessionManager.java
+++ b/support/cas-server-support-webauthn-core/src/main/java/com/yubico/core/DefaultSessionManager.java
@@ -1,24 +1,17 @@
 package com.yubico.core;
 
-
 import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.yubico.webauthn.data.ByteArray;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
+@RequiredArgsConstructor
 public class DefaultSessionManager implements SessionManager {
-    private final Cache<ByteArray, ByteArray> sessionIdsToUsers = newCache();
+    private final Cache<ByteArray, ByteArray> sessionIdsToUsers;
 
-    private final Cache<ByteArray, ByteArray> usersToSessionIds = newCache();
-
-    private static Cache<ByteArray, ByteArray> newCache() {
-        return Caffeine.newBuilder()
-            .maximumSize(100L)
-            .expireAfterAccess(5L, TimeUnit.MINUTES)
-            .build();
-    }
+    private final Cache<ByteArray, ByteArray> usersToSessionIds;
 
     @Override
     public ByteArray createSession(@NonNull final ByteArray userHandle) {


### PR DESCRIPTION
The idea of this PR is to allow customisations by replacing the current local Caffeine `Cache` by a clustered one (based on the ticket registry for example).

No new test is needed. 