### PR TITLE
feat: add cloudflare turnstile captcha recaptcha v2 compatible integration

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/captcha/GoogleRecaptchaProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/captcha/GoogleRecaptchaProperties.java
@@ -40,7 +40,11 @@ public class GoogleRecaptchaProperties implements Serializable {
         /**
          * hCaptcha.
          */
-        HCAPTCHA
+        HCAPTCHA,
+        /**
+         * Cloudflare turnstyle(google recaptcha v2 compatibility mode).
+         */
+        CLOUDFLARE_TURNSTILE
     }
 
     /**

--- a/support/cas-server-support-captcha-core/src/main/java/org/apereo/cas/web/CaptchaValidator.java
+++ b/support/cas-server-support-captcha-core/src/main/java/org/apereo/cas/web/CaptchaValidator.java
@@ -25,6 +25,9 @@ public interface CaptchaValidator {
         if (googleRecaptcha.getVersion() == RecaptchaVersions.GOOGLE_RECAPTCHA_V3) {
             return new GoogleCaptchaV3Validator(googleRecaptcha);
         }
+        if(googleRecaptcha.getVersion() == RecaptchaVersions.CLOUDFLARE_TURNSTILE){
+            return new TurnstileCaptchaV2CompatibleValidator(googleRecaptcha);
+        }
         return new HCaptchaValidator(googleRecaptcha);
     }
 

--- a/support/cas-server-support-captcha-core/src/main/java/org/apereo/cas/web/TurnstileCaptchaV2CompatibleValidator.java
+++ b/support/cas-server-support-captcha-core/src/main/java/org/apereo/cas/web/TurnstileCaptchaV2CompatibleValidator.java
@@ -1,0 +1,85 @@
+package org.apereo.cas.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apereo.cas.configuration.model.support.captcha.GoogleRecaptchaProperties;
+import org.apereo.cas.util.CollectionUtils;
+import org.apereo.cas.util.HttpUtils;
+import org.apereo.cas.util.LoggingUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+/**
+ * This is {@link TurnstileCaptchaV2CompatibleValidator}.
+ * Cloudflare Turnstile ReCAPTCHA v2 Compatible validator.
+ * This version is the compatibility mode from Google ReCaptcha V2 with some differences.
+ * <a href="https://developers.cloudflare.com/turnstile/migration/migrating-from-recaptcha/">migrating-from-recaptcha</a>
+ * <a href="https://developers.cloudflare.com/turnstile/get-started/server-side-validation/">server-side-validation</a>
+ *
+ * @author KambaAbi
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class TurnstileCaptchaV2CompatibleValidator implements CaptchaValidator {
+    private static final ObjectReader READER = new ObjectMapper().findAndRegisterModules().reader();
+
+    @Getter
+    private final GoogleRecaptchaProperties recaptchaProperties;
+
+    @Override
+    public boolean validate(final String recaptchaResponse, final String userAgent) {
+        HttpResponse response = null;
+        try {
+            val exec = HttpUtils.HttpExecutionRequest.builder()
+                .method(HttpMethod.POST)
+                .url(recaptchaProperties.getVerifyUrl())
+                .headers(CollectionUtils.wrap("User-Agent", userAgent, "Accept-Language", "en-US,en;q=0.5","Content-Type", "application/x-www-form-urlencoded"))
+                // Sending query parameters like recaptcha doesn't work with turnstile. Needs content type header with entity generation below.
+                // https://developers.cloudflare.com/turnstile/migration/migrating-from-recaptcha/#server-side-integration
+                .entity("secret=" + recaptchaProperties.getSecret() + "&response" + recaptchaResponse)
+                .build();
+
+            response = HttpUtils.execute(exec);
+            if (response != null && response.getStatusLine().getStatusCode() == HttpStatus.OK.value()) {
+                try (val content = response.getEntity().getContent()) {
+                    val result = IOUtils.toString(content, StandardCharsets.UTF_8);
+                    if (StringUtils.isBlank(result)) {
+                        throw new IllegalArgumentException("Unable to parse empty entity response from " + recaptchaProperties.getVerifyUrl());
+                    }
+                    LOGGER.debug("Recaptcha verification response received: [{}]", result);
+                    val node = READER.readTree(result);
+                    if (node.has("score") && node.get("score").doubleValue() <= recaptchaProperties.getScore()) {
+                        LOGGER.warn("Recaptcha score received is less than the threshold score defined for CAS");
+                        return false;
+                    }
+                    if (node.has("success") && node.get("success").booleanValue()) {
+                        LOGGER.trace("Recaptcha has successfully verified the request");
+                        return true;
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            LoggingUtils.error(LOGGER, e);
+        } finally {
+            HttpUtils.close(response);
+        }
+        return false;
+    }
+
+    /**
+     * Turnstile recaptcha v2 compatibility mode uses the same name as recaptcha v2's.
+     */
+    @Override
+    public String getRecaptchaResponse(HttpServletRequest request) {
+        return request.getParameter(GoogleCaptchaV2Validator.REQUEST_PARAM_RECAPTCHA_RESPONSE);
+    }
+}

--- a/support/cas-server-support-captcha-core/src/test/java/org/apereo/cas/AllTestsSuite.java
+++ b/support/cas-server-support-captcha-core/src/test/java/org/apereo/cas/AllTestsSuite.java
@@ -1,6 +1,7 @@
 package org.apereo.cas;
 
 import org.apereo.cas.web.CaptchaValidatorTests;
+import org.apereo.cas.web.CloudFlareTurnstileCaptchaValidatorTests;
 import org.apereo.cas.web.DefaultCaptchaActivationStrategyTests;
 import org.apereo.cas.web.GoogleCaptchaV2ValidatorTests;
 import org.apereo.cas.web.GoogleCaptchaV3ValidatorTests;
@@ -20,7 +21,8 @@ import org.junit.platform.suite.api.Suite;
     CaptchaValidatorTests.class,
     HCaptchaValidatorTests.class,
     GoogleCaptchaV2ValidatorTests.class,
-    GoogleCaptchaV3ValidatorTests.class
+    GoogleCaptchaV3ValidatorTests.class,
+    CloudFlareTurnstileCaptchaValidatorTests.class
 })
 @Suite
 public class AllTestsSuite {

--- a/support/cas-server-support-captcha-core/src/test/java/org/apereo/cas/web/CaptchaValidatorTests.java
+++ b/support/cas-server-support-captcha-core/src/test/java/org/apereo/cas/web/CaptchaValidatorTests.java
@@ -87,5 +87,9 @@ public class CaptchaValidatorTests {
         assertNotNull(CaptchaValidator.getInstance(new GoogleRecaptchaProperties()
             .setVersion(GoogleRecaptchaProperties.RecaptchaVersions.HCAPTCHA)
             .setVerifyUrl("http://localhost:8812")));
+
+        assertNotNull(CaptchaValidator.getInstance(new GoogleRecaptchaProperties()
+            .setVersion(GoogleRecaptchaProperties.RecaptchaVersions.CLOUDFLARE_TURNSTILE)
+            .setVerifyUrl("http://localhost:8812")));
     }
 }

--- a/support/cas-server-support-captcha-core/src/test/java/org/apereo/cas/web/CloudFlareTurnstileCaptchaValidatorTests.java
+++ b/support/cas-server-support-captcha-core/src/test/java/org/apereo/cas/web/CloudFlareTurnstileCaptchaValidatorTests.java
@@ -1,0 +1,30 @@
+package org.apereo.cas.web;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.UUID;
+import lombok.val;
+import org.apereo.cas.configuration.model.support.captcha.GoogleRecaptchaProperties;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * This is {@link CloudFlareTurnstileCaptchaValidatorTests}.
+ *
+ * @author KambaAbi
+ */
+@Tag("Simple")
+public class CloudFlareTurnstileCaptchaValidatorTests {
+    @Test
+    public void verifyOperation() {
+        val props = new GoogleRecaptchaProperties()
+            .setScore(.1)
+            .setSecret(UUID.randomUUID().toString())
+            .setVerifyUrl("http://localhost:8812");
+        val validator = new TurnstileCaptchaV2CompatibleValidator(props);
+        val request = new MockHttpServletRequest();
+        request.addParameter(GoogleCaptchaV2Validator.REQUEST_PARAM_RECAPTCHA_RESPONSE, UUID.randomUUID().toString());
+        assertNotNull(validator.getRecaptchaResponse(request));
+    }
+}

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/recaptcha.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/recaptcha.html
@@ -13,8 +13,8 @@
 <body>
     <main role="main" class="container mt-3 mb-3">
         <div th:fragment="recaptchaToken">
-            <span th:if="${recaptchaSiteKey != null AND #strings.equalsIgnoreCase(recaptchaVersion, 'GOOGLE_RECAPTCHA_V2')}" th:remove="tag">
-                <script src="https://www.google.com/recaptcha/api.js"></script>
+            <span th:if="${recaptchaSiteKey != null AND (#strings.equalsIgnoreCase(recaptchaVersion, 'GOOGLE_RECAPTCHA_V2') || #strings.equalsIgnoreCase(recaptchaVersion, 'CLOUDFLARE_TURNSTILE'))}" th:remove="tag">
+                <script th:attr="src=${#strings.equalsIgnoreCase(recaptchaVersion, 'CLOUDFLARE_TURNSTILE') ? 'https://challenges.cloudflare.com/turnstile/v0/api.js?compat=recaptcha' : 'https://www.google.com/recaptcha/api.js'}"></script>
                 <script type="text/javascript"
                         th:if="${recaptchaInvisible != null AND recaptchaInvisible}"
                         th:inline="javascript">


### PR DESCRIPTION

After reading up on the Cloudflare's Turnstile Recaptcha and its compatibility mode with recaptcha v2, i decided to do a POC and do a pull request on this functionality. 

https://developers.cloudflare.com/turnstile/migration/migrating-from-recaptcha/
https://developers.cloudflare.com/turnstile/migration/migrating-from-recaptcha/#server-side-integration

### Brief description of changes applied

- Added a new type `CLOUDFLARE_TURNSTILE` on enum `GoogleRecaptchaProperties.RecaptchaVersions`
- Added a new `CaptchaValidator` implementation named `TurnstileCaptchaV2CompatibleValidator` a, modified a clone of `BaseCaptchaValidator`, with some request changes(not using query params, using request entity/body), using the same name as the google's recaptcha V2 field name
- Added necessary instantiation of `TurnstileCaptchaV2CompatibleValidator` in `CaptchaValidator.getInstance` 
- On the frontend side, updated `recaptchaToken` fragment in template `recaptcha.html`, used Google recaptcha v2's template, with addition recaptcha type `version` checked and js file imported accordingly.
- Test case codes derived from hCaptcha



