### PR TITLE
Update casGoogleAuthenticatorRegistrationView.html

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
@@ -17,7 +17,7 @@
         <!-- Confirmation Dialog -->
         <div class="mdc-dialog" id="confirm-reg-dialog" role="alertdialog"
              aria-modal="true" aria-labelledby="notif-dialog-title" aria-describedby="notif-dialog-content">
-            <form method="post" id="fm1" class="fm-v clearfix" th:action="@{${'/' + activeFlowId} }">
+            <form method="post" id="fm1" class="fm-v clearfix" th:action="@{/login}">
                 <div class="mdc-dialog__container">
                     <div class="mdc-dialog__surface">
                         <h2 class="mdc-dialog__title mt-lg-2" id="notif-dialog-title"


### PR DESCRIPTION
Since this commit : https://github.com/apereo/cas/commit/15580dc we are not able to register a new device. Rolling back make it work again but I know this is not a solution as this commit announces a more global login strategy ...

Issue : I have a 401 error trying to acces /cas/mfa-gauth when trying to register new devices.

Test I did : 
- I flushed the db before
- cloned a brand new cas-overlay-template version=7.1.0-SNAPSHOT and springBootVersion=3.3.1 (this morning master branch)
- First I gave it a try and I can confirm to you that I could not registered my device with this version.
- Then I edited https://github.com/apereo/cas/blob/master/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html :
     nano src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
     changed line 20 from <form method="post" id="fm1" class="fm-v clearfix" th:action="@{${'/' + activeFlowId} }"> to  <form method="post" id="fm1" class="fm-v clearfix" th:action="@{/login}">
- build and deployed again the .war into tomcat (gradlew then mv as you did)
- flushed my former cas entry in my device (google authenticator on my mobile phone)

Then I was able to register my mobile phone again and was able to log in.

After that, and because like gaming, I deleted the src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html and regradlewed again all that stuff nut I did not flushed the db so my device is still registered : I'm able to log in but cannot register any other devices ...

There might side effects as I do not know about the global strategy in commit 15580dc
Regards,
