### PR TITLE
Since this commit : 15580dc we are not able to register a new device.…

### DIFF
--- a/support/cas-server-support-thymeleaf/src/test/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
+++ b/support/cas-server-support-thymeleaf/src/test/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+
+    <title th:text="#{cas.mfa.googleauth.pagetitle}">Google Authentication Registration Review View</title>
+    <link href="../../static/css/cas.css" rel="stylesheet" th:remove="tag"/>
+</head>
+
+<body id="cas">
+<main class="container mt-3 mb-3">
+    <div layout:fragment="content" id="login" class="mdc-card card p-4 m-auto w-lg-66">
+        <h2 th:text="#{screen.authentication.gauth.register}">Your account is not registered.</h2>
+
+        <!-- Confirmation Dialog -->
+        <div class="mdc-dialog" id="confirm-reg-dialog" role="alertdialog"
+             aria-modal="true" aria-labelledby="notif-dialog-title" aria-describedby="notif-dialog-content">
+             <form method="post" id="fm1" class="fm-v clearfix" th:action="@{/login}"> <!-- Test -->
+                <div class="mdc-dialog__container">
+                    <div class="mdc-dialog__surface">
+                        <h2 class="mdc-dialog__title mt-lg-2" id="notif-dialog-title"
+                            th:utext="#{screen.authentication.gauth.confirm.title}">
+                            Confirm Account Registration
+                        </h2>
+                        <div class="mdc-dialog__content" id="notif-dialog-content">
+                            <div class="mdc-typography--body1">
+                                <div class="banner banner-danger alert alert-danger banner-dismissible"
+                                     role="alert" style="display: none" id="errorPanel">
+                                    <a href="#" class="close" onclick="$(this).parent().hide();" th:aria-label="#{screen.pm.button.close}">
+                                        <span class="mdi mdi-close-box" aria-hidden="true"></span>
+                                    </a>
+                                    <h3>Failure</h3>
+                                    <p th:utext="#{screen.authentication.gauth.invalidtoken}">
+                                </div>
+
+                                <p th:utext="#{screen.authentication.gauth.confirm.desc}">Description</p>
+
+                                <input type="hidden" name="_eventId_submit" value="Confirm"/>
+                                <input type="hidden" name="execution" th:value="${flowExecutionKey}"/>
+                                <input type="hidden" name="geolocation"/>
+
+                                <section class="cas-field form-group my-3 mdc-input-group">
+                                    <div class="mdc-input-group-field mdc-input-group-field-append">
+                                        <div class="d-flex caps-check">
+                                            <label for="token"
+                                                   class="mdc-text-field mdc-text-field--outlined control-label mdc-text-field--with-trailing-icon">
+                                                <span class="mdc-notched-outline">
+                                                    <span class="mdc-notched-outline__leading"></span>
+                                                    <span class="mdc-notched-outline__notch">
+                                                        <span class="mdc-floating-label"
+                                                              th:utext="#{cas.mfa.googleauth.label.token}">Token</span>
+                                                    </span>
+                                                    <span class="mdc-notched-outline__trailing"></span>
+                                                </span>
+                                                <input class="mdc-text-field__input form-control pwd"
+                                                       type="password"
+                                                       name="token"
+                                                       id="token"
+                                                       size="25"
+                                                       oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                                                       required
+                                                       autocomplete="off"/>
+                                            </label>
+                                            <button class="reveal-password align-self-end mdc-button mdc-button--raised btn btn-primary mdc-input-group-append mdc-icon-button"
+                                                    tabindex="-1"
+                                                    type="button">
+                                                <i class="mdi mdi-eye fas fa-eye reveal-password-icon" aria-hidden="true"></i>
+                                                <span class="visually-hidden">Toggle Token</span>
+                                            </button>
+                                        </div>
+                                        <br>
+                                        <div class="d-flex">
+                                            <label for="accountName"
+                                                   class="mdc-text-field mdc-text-field--outlined control-label">
+                                                <span class="mdc-notched-outline">
+                                                    <span class="mdc-notched-outline__leading"></span>
+                                                    <span class="mdc-notched-outline__notch">
+                                                        <span class="mdc-floating-label" th:utext="#{screen.authentication.gauth.name}">Account Name</span>
+                                                    </span>
+                                                    <span class="mdc-notched-outline__trailing"></span>
+                                                </span>
+                                                <input class="mdc-text-field__input form-control"
+                                                       type="text"
+                                                       name="accountName"
+                                                       id="accountName"
+                                                       size="50"
+                                                       autocomplete="off"/>
+                                            </label>
+                                            <script>document.getElementById("accountName").value = randomWord();</script>
+                                        </div>
+                                    </div>
+                                </section>
+                            </div>
+                        </div>
+                        <footer class="mdc-dialog__actions">
+                            <button class="mdc-button mdc-button--raised btn btn-primary me-2" name="registerButton" id="registerButton">
+                                <span class="mdc-button__label" th:text="#{screen.welcome.button.register}">Register</span>
+                            </button>
+                            <button type="button" class="mdc-button mdc-button--outline btn btn-outline-secondary button-cancel"
+                                    data-mdc-dialog-action="accept" data-mdc-dialog-button-default>
+                                <span class="mdc-button__label">Cancel</span>
+                            </button>
+                        </footer>
+                    </div>
+                </div>
+                <div class="mdc-dialog__scrim"></div>
+            </form>
+
+            <script type="text/javascript">
+                let btn = document.getElementById('registerButton');
+                btn.addEventListener('click', event => {
+                    if (document.getElementById("fm1").reportValidity()) {
+                        let endpoint = $('#fm1').attr('action');
+                        event.preventDefault();
+                        $('#errorPanel').hide();
+
+                        let formData = $("#fm1").serializeArray();
+                        formData.push({
+                            name: "validate",
+                            value: true
+                        });
+                        $.post(endpoint, formData)
+                            .done((data, status, jqxhr) => {
+                                $('#errorPanel').hide();
+                                $("#fm1").submit();
+                            })
+                            .fail((data, status, jqxhr) => {
+                                $('#errorPanel').show("fast", "swing");
+                            });
+                    }
+                }, false);
+            </script>
+        </div>
+        <!-- Confirmation Dialog -->
+        
+        <!-- Account Information -->
+        <div class="row">
+            <div class="col-md-5 text-center">
+                <img id="imageQRCode" th:src="@{'data:image/jpeg;base64,' + ${QRcode}}"
+                     th:alt="#{screen.authentication.gauth.qrimage}"/>
+            </div>
+            <div class="col-md-7">
+                <div class="my-2" id="seckeypanel">
+                    <p th:utext="#{screen.authentication.gauth.key(${key.getSecretKey()})}">Secret key to register is...</p>
+                </div>
+                <hr>
+                <p th:text="#{screen.authentication.gauth.scratchcodes}">Scratch codes:</p>
+                <div class="d-flex align-items-start mb-4">
+                    <div class="mdc-chip-set" role="grid" id="scratchcodes">
+                        <div th:each="code : ${key.getScratchCodes()}" class="mdc-chip" role="row">
+                            <div class="mdc-chip__ripple"></div>
+                            <span role="gridcell">
+                              <span class="mdc-chip__text" th:text="${code}">Chip One</span>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="d-flex flex-column align-items-center">
+            <div class="d-flex justify-content-center">
+                <button class="mdc-button mdc-button--raised btn btn-primary me-2" name="confirm" id="confirm" accesskey="f"
+                        onclick="cas.openDialog('confirm-reg-dialog')" value="Confirm">
+                    <span class="mdc-button__label" th:text="#{screen.welcome.button.confirm}">Confirm</span>
+                </button>
+                <button class="mdc-button mdc-button--raised btn btn-primary me-2" id="print" name="print" accesskey="p" type="button"
+                        onclick="window.print();">
+                    <span class="mdc-button__label" th:text="#{screen.welcome.button.print}">Print</span>
+                </button>
+                <button class="mdc-button mdc-button--outline btn btn-outline-secondary button-cancel" name="back" accesskey="c" type="button"
+                        value="Cancel" id="cancel"
+                        onclick="location.href = location.href;"
+                        th:value="#{screen.pm.button.cancel}">
+                    <span class="mdc-button__label" th:text="#{screen.pm.button.cancel}">Cancel</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</main>
+</body>
+
+</html>


### PR DESCRIPTION
… Rolling back make it work again but I know this is not a solution as this commit announces a more global login strategy ...

Issue : I have a 401 error trying to acces /cas/mfa-gauth when trying to register new devices.

Docker engine is not available.
./gradlew testMFA  --tests "TestClass" -no-daemon --configure-on-demand --build-cache -x javadoc -x check -Dverbose=true --parallel To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.9-rc-2/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build
Configuration on demand is an incubating feature.
Calculating task graph as no cached configuration is available for tasks: testMFA --tests TestClass

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.9-rc-2/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 54s
264 actionable tasks: 183 executed, 81 from cache
Configuration cache entry stored.
***************************************************************************************
Gradle build finished at Tue  9 Jul 16:08:36 CEST 2024 with exit code 0 ***************************************************************************************
Gradle build finished successfully.


I flushed the db before
cloned a brand new cas-overlay-template version=7.1.0-SNAPSHOT and springBootVersion=3.3.1 (this morning master branch) First I gave it a try and I can confirm to you that I could not registered my device with this version. Then I edited https://github.com/apereo/cas/blob/master/support/cas-server-support-thymeleaf/src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html :

rolled back line 20 to th:action="@{/login}"
build and deployed again the .war into tomcat (gradlew then mv as you did) flushed my former cas entry in my device (google authenticator on my mobile phone)

Then I was able to register my mobile phone again and was able to log in.

After that, and because like gaming, I deleted the src/main/resources/templates/gauth/casGoogleAuthenticatorRegistrationView.html and regradlewed again all that stuff nut I did not flushed the db so my device is still registered : I'm able to log in but cannot register any other devices ...

There might side effects as I do not know about the global strategy in commit 15580dc Regards,


