### PR TITLE
Improve sessions counting by using Jet for the Hazelcast ticket registry

### DIFF
--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -78,6 +78,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import static org.awaitility.Awaitility.*;
@@ -515,7 +516,7 @@ public abstract class BaseTicketRegistryTests {
                 val addedServiceTicket = ticketRegistry.addTicket(st);
                 await().untilAsserted(() -> assertNotNull(ticketRegistry.getTicket(addedServiceTicket.getId())));
             }
-            await().untilAsserted(() -> {
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
                 val sessionCount = ticketRegistry.sessionCount();
                 assertEquals(tgts.size(), ticketRegistry.sessionCount(),
                     () -> "The sessionCount " + sessionCount + " is not the same as the collection " + tgts.size());

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/BaseTicketRegistryTests.java
@@ -78,7 +78,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import static org.awaitility.Awaitility.*;
@@ -516,9 +515,9 @@ public abstract class BaseTicketRegistryTests {
                 val addedServiceTicket = ticketRegistry.addTicket(st);
                 await().untilAsserted(() -> assertNotNull(ticketRegistry.getTicket(addedServiceTicket.getId())));
             }
-            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            await().untilAsserted(() -> {
                 val sessionCount = ticketRegistry.sessionCount();
-                assertEquals(tgts.size(), ticketRegistry.sessionCount(),
+                assertEquals(tgts.size(), sessionCount,
                     () -> "The sessionCount " + sessionCount + " is not the same as the collection " + tgts.size());
             });
 

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -4,6 +4,7 @@ import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.configuration.model.support.hazelcast.HazelcastTicketRegistryProperties;
 import org.apereo.cas.monitor.Monitorable;
 import org.apereo.cas.ticket.ServiceAwareTicket;
+import org.apereo.cas.ticket.ServiceTicket;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketCatalog;
 import org.apereo.cas.ticket.TicketDefinition;
@@ -199,6 +200,19 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements A
             }
         }
         return super.sessionCount();
+    }
+
+    @Override
+    public long serviceTicketCount() {
+        if (properties.getCore().isEnableJet()) {
+            val md = ticketCatalog.find(ServiceTicket.PREFIX);
+            val sql = String.format("SELECT COUNT(*) FROM %s", md.getProperties().getStorageName());
+            LOGGER.debug("Executing SQL query [{}]", sql);
+            try (val results = hazelcastInstance.getSql().execute(sql)) {
+                return results.stream().findFirst().get().getObject(0);
+            }
+        }
+        return super.serviceTicketCount();
     }
 
     @Override

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -189,6 +189,19 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements A
     }
 
     @Override
+    public long sessionCount() {
+        if (properties.getCore().isEnableJet()) {
+            val md = ticketCatalog.find(TicketGrantingTicket.PREFIX);
+            val sql = String.format("SELECT COUNT(*) FROM %s", md.getProperties().getStorageName());
+            LOGGER.debug("Executing SQL query [{}]", sql);
+            try (val results = hazelcastInstance.getSql().execute(sql)) {
+                return results.stream().findFirst().get().getObject(0);
+            }
+        }
+        return super.sessionCount();
+    }
+
+    @Override
     public Stream<? extends Ticket> getSessionsWithAttributes(final Map<String, List<Object>> queryAttributes) {
         if (properties.getCore().isEnableJet()) {
             val md = ticketCatalog.find(TicketGrantingTicket.PREFIX);

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -196,7 +196,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements A
             val sql = String.format("SELECT COUNT(*) FROM %s", md.getProperties().getStorageName());
             LOGGER.debug("Executing SQL query [{}]", sql);
             try (val results = hazelcastInstance.getSql().execute(sql)) {
-                return results.stream().findFirst().get().getObject(0);
+                return results.iterator().next().getObject(0);
             }
         }
         return super.sessionCount();
@@ -209,7 +209,7 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements A
             val sql = String.format("SELECT COUNT(*) FROM %s", md.getProperties().getStorageName());
             LOGGER.debug("Executing SQL query [{}]", sql);
             try (val results = hazelcastInstance.getSql().execute(sql)) {
-                return results.stream().findFirst().get().getObject(0);
+                return results.iterator().next().getObject(0);
             }
         }
         return super.serviceTicketCount();


### PR DESCRIPTION
The performance of the sessions counting can be greatly improved by using Jet for the Hazelcast ticket registry.

The `HazelcastTicketRegistryTests` already covered this use case.