### PR TITLE
update: replace 'therefor' with 'therefore'

### DIFF
--- a/docs/cas-server-documentation/planning/Getting-Started.md
+++ b/docs/cas-server-documentation/planning/Getting-Started.md
@@ -25,7 +25,7 @@ how changes are managed and released, what the project expects from you and what
 
 A CAS deployment is often seen as mission critical. Its deployment success, health status and general upkeep is vital to an organization's
 daily routine and business. Furthermore, as an identity provider that operates in the domain of access management, it plays an important
-and sensitive role in the overall security architecture of one's deployment. Therefor, you may need *extra expert* help
+and sensitive role in the overall security architecture of one's deployment. Therefore, you may need *extra expert* help
 from specialists and experts that know the software in and out and can help you with gotchas, deployment best practices and practical upgrade guidelines.
 Free support only works up to a certain degree, and generally is best for personal use and/or hobbyists.
 

--- a/docs/cas-server-documentation/release_notes/RC2.md
+++ b/docs/cas-server-documentation/release_notes/RC2.md
@@ -83,7 +83,7 @@ avoid accidents and mistakes made when a test run is incorrectly skipped. As the
 we expect the model to improve and learn more efficiently.
 
 This capability is provided by [Develocity](https://gradle.com/develocity/) to the Apereo CAS project for free and is proving
-to be extremely valuable in cutting down test execution time and therefor resulting in a quicker feedback loop. 
+to be extremely valuable in cutting down test execution time and therefore resulting in a quicker feedback loop. 
 
 ### Startup Time Improvements
 

--- a/support/cas-server-support-thymeleaf/src/main/resources/messages.properties
+++ b/support/cas-server-support-thymeleaf/src/main/resources/messages.properties
@@ -399,7 +399,7 @@ screen.surrogates.button.cancel=Cancel
 screen.surrogates.account.selection.error=You are not authorized to impersonate the indicated user at this time.
 screen.surrogates.wildcard.title=Impersonation Account Selection 
 screen.surrogates.wildcard.description=Your account is internally recognized by CAS as one with special permissions, \
-  authorized to impersonate all users and accounts. Therefor, impersonation account selection is not allowed for your \
+  authorized to impersonate all users and accounts. Therefore, impersonation account selection is not allowed for your \
   account. Instead, you may directly proceed to log in and impersonate any other account using its username.
 
 # Password policy


### PR DESCRIPTION
According to the Grammarist [1],"therefor is an archaic form meaning for that object or purpose, in exchange for this or that or it".

These example sentences by content writer Gina Rancaño [2] illustrate the distinction:

A - I returned the damaged item and received store credit therefor. B - I returned the damaged item and received store credit (in return) for that.

[1] https://grammarist.com/usage/therefore-vs-therefor/
[2] https://languagetool.org/insights/post/word-choice-therefore-or-therefor/
