### PR TITLE
improve performance of MongoDb/GoogleCloudFirestore ticket registry

### DIFF
--- a/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudFirestoreTicketRegistry.java
+++ b/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudFirestoreTicketRegistry.java
@@ -272,8 +272,10 @@ public class GoogleCloudFirestoreTicketRegistry extends AbstractTicketRegistry {
     protected GoogleCloudFirestoreTicketDocument buildTicketAsDocument(final Ticket ticket) throws Exception {
         val encTicket = encodeTicket(ticket);
         val json = serializeTicket(encTicket);
-        LOGGER.trace("Serialized ticket into a JSON document as\n [{}]",
-            JsonValue.readJSON(json).toString(Stringify.FORMATTED));
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Serialized ticket into a JSON document as\n [{}]",
+                JsonValue.readJSON(json).toString(Stringify.FORMATTED));
+        }
         val principal = getPrincipalIdFrom(ticket);
 
         val expireAt = getExpireAt(ticket);

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -331,8 +331,10 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
         val json = serializeTicket(encTicket);
         FunctionUtils.throwIf(StringUtils.isBlank(json),
             () -> new IllegalArgumentException("Ticket " + ticket.getId() + " cannot be serialized to JSON"));
-        LOGGER.trace("Serialized ticket into a JSON document as\n [{}]",
-            JsonValue.readJSON(json).toString(Stringify.FORMATTED));
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Serialized ticket into a JSON document as\n [{}]",
+                JsonValue.readJSON(json).toString(Stringify.FORMATTED));
+        }
 
         val expireAt = getExpireAt(ticket);
         LOGGER.trace("Calculated expiration date for ticket ttl as [{}]", expireAt);


### PR DESCRIPTION
NB: org.hjson can be quite costly. This change increases >10% CAS ST generation throughput
