### PR TITLE
Stop parsing tickets as HJSON

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/EncodedTicketStringSerializer.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/EncodedTicketStringSerializer.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.ticket.serialization.serializers;
 
 import org.apereo.cas.ticket.registry.DefaultEncodedTicket;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import java.io.Serial;
@@ -12,7 +12,7 @@ import java.io.Serial;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-public class EncodedTicketStringSerializer extends AbstractJacksonBackedStringSerializer<DefaultEncodedTicket> {
+public class EncodedTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<DefaultEncodedTicket> {
     @Serial
     private static final long serialVersionUID = 8959835299162115085L;
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/ProxyGrantingTicketStringSerializer.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/ProxyGrantingTicketStringSerializer.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.ticket.serialization.serializers;
 
 import org.apereo.cas.ticket.ProxyGrantingTicketImpl;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import java.io.Serial;
@@ -12,7 +12,7 @@ import java.io.Serial;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-public class ProxyGrantingTicketStringSerializer extends AbstractJacksonBackedStringSerializer<ProxyGrantingTicketImpl> {
+public class ProxyGrantingTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<ProxyGrantingTicketImpl> {
     @Serial
     private static final long serialVersionUID = 7089208351327601379L;
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/ProxyTicketStringSerializer.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/ProxyTicketStringSerializer.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.ticket.serialization.serializers;
 
 import org.apereo.cas.ticket.ProxyTicketImpl;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import java.io.Serial;
@@ -12,7 +12,7 @@ import java.io.Serial;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-public class ProxyTicketStringSerializer extends AbstractJacksonBackedStringSerializer<ProxyTicketImpl> {
+public class ProxyTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<ProxyTicketImpl> {
     @Serial
     private static final long serialVersionUID = -6343596853082798477L;
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/ServiceTicketStringSerializer.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/ServiceTicketStringSerializer.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.ticket.serialization.serializers;
 
 import org.apereo.cas.ticket.ServiceTicketImpl;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import java.io.Serial;
@@ -12,7 +12,7 @@ import java.io.Serial;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-public class ServiceTicketStringSerializer extends AbstractJacksonBackedStringSerializer<ServiceTicketImpl> {
+public class ServiceTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<ServiceTicketImpl> {
     @Serial
     private static final long serialVersionUID = 8959617299162115085L;
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/TicketGrantingTicketStringSerializer.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/TicketGrantingTicketStringSerializer.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.ticket.serialization.serializers;
 
 import org.apereo.cas.ticket.TicketGrantingTicketImpl;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import java.io.Serial;
@@ -12,7 +12,7 @@ import java.io.Serial;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-public class TicketGrantingTicketStringSerializer extends AbstractJacksonBackedStringSerializer<TicketGrantingTicketImpl> {
+public class TicketGrantingTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<TicketGrantingTicketImpl> {
     @Serial
     private static final long serialVersionUID = 1527874389457723545L;
 

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/TransientSessionTicketStringSerializer.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/serialization/serializers/TransientSessionTicketStringSerializer.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.ticket.serialization.serializers;
 
 import org.apereo.cas.ticket.TransientSessionTicketImpl;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import java.io.Serial;
@@ -12,7 +12,7 @@ import java.io.Serial;
  * @author Misagh Moayyed
  * @since 6.1.0
  */
-public class TransientSessionTicketStringSerializer extends AbstractJacksonBackedStringSerializer<TransientSessionTicketImpl> {
+public class TransientSessionTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<TransientSessionTicketImpl> {
     @Serial
     private static final long serialVersionUID = 8959617299162115085L;
 

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/AbstractJacksonBackedNonHjsonStringSerializer.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/AbstractJacksonBackedNonHjsonStringSerializer.java
@@ -1,0 +1,23 @@
+package org.apereo.cas.util.serialization;
+
+import com.fasterxml.jackson.core.PrettyPrinter;
+import org.springframework.context.ConfigurableApplicationContext;
+import java.io.Serial;
+
+public abstract class AbstractJacksonBackedNonHjsonStringSerializer<T> extends AbstractJacksonBackedStringSerializer<T> {
+    @Serial
+    private static final long serialVersionUID = 2247573730512441790L;
+
+    protected AbstractJacksonBackedNonHjsonStringSerializer(final PrettyPrinter prettyPrinter, final ConfigurableApplicationContext applicationContext) {
+        super(prettyPrinter, applicationContext);
+    }
+
+    protected AbstractJacksonBackedNonHjsonStringSerializer(final ConfigurableApplicationContext applicationContext) {
+        super(applicationContext);
+    }
+
+    @Override
+    protected boolean mayBeHjson() {
+        return false;
+    }
+}

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20TicketSerializationConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20TicketSerializationConfiguration.java
@@ -13,7 +13,7 @@ import org.apereo.cas.ticket.device.OAuth20DeviceUserCode;
 import org.apereo.cas.ticket.refreshtoken.OAuth20DefaultRefreshToken;
 import org.apereo.cas.ticket.refreshtoken.OAuth20RefreshToken;
 import org.apereo.cas.ticket.serialization.TicketSerializationExecutionPlanConfigurer;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -60,7 +60,7 @@ class CasOAuth20TicketSerializationConfiguration {
         };
     }
 
-    private static final class OAuthCodeTicketStringSerializer extends AbstractJacksonBackedStringSerializer<OAuth20DefaultCode> {
+    private static final class OAuthCodeTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<OAuth20DefaultCode> {
         @Serial
         private static final long serialVersionUID = -2198623586274810263L;
 
@@ -74,7 +74,7 @@ class CasOAuth20TicketSerializationConfiguration {
         }
     }
 
-    private static final class AccessTokenTicketStringSerializer extends AbstractJacksonBackedStringSerializer<OAuth20DefaultAccessToken> {
+    private static final class AccessTokenTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<OAuth20DefaultAccessToken> {
         @Serial
         private static final long serialVersionUID = -2198623586274810263L;
 
@@ -88,7 +88,7 @@ class CasOAuth20TicketSerializationConfiguration {
         }
     }
 
-    private static final class RefreshTokenTicketStringSerializer extends AbstractJacksonBackedStringSerializer<OAuth20DefaultRefreshToken> {
+    private static final class RefreshTokenTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<OAuth20DefaultRefreshToken> {
         @Serial
         private static final long serialVersionUID = -2198623586274810263L;
 
@@ -102,7 +102,7 @@ class CasOAuth20TicketSerializationConfiguration {
         }
     }
 
-    private static final class DeviceTokenTicketStringSerializer extends AbstractJacksonBackedStringSerializer<OAuth20DefaultDeviceToken> {
+    private static final class DeviceTokenTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<OAuth20DefaultDeviceToken> {
         @Serial
         private static final long serialVersionUID = -2198623586274810263L;
 
@@ -117,7 +117,7 @@ class CasOAuth20TicketSerializationConfiguration {
         }
     }
 
-    private static final class DeviceUserCodeTicketStringSerializer extends AbstractJacksonBackedStringSerializer<OAuth20DefaultDeviceUserCode> {
+    private static final class DeviceUserCodeTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<OAuth20DefaultDeviceUserCode> {
         @Serial
         private static final long serialVersionUID = -2198623586274810263L;
 

--- a/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPTicketSerializationConfiguration.java
+++ b/support/cas-server-support-saml-idp/src/main/java/org/apereo/cas/config/SamlIdPTicketSerializationConfiguration.java
@@ -7,7 +7,7 @@ import org.apereo.cas.ticket.artifact.SamlArtifactTicketImpl;
 import org.apereo.cas.ticket.query.SamlAttributeQueryTicket;
 import org.apereo.cas.ticket.query.SamlAttributeQueryTicketImpl;
 import org.apereo.cas.ticket.serialization.TicketSerializationExecutionPlanConfigurer;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -46,7 +46,7 @@ class SamlIdPTicketSerializationConfiguration {
         };
     }
 
-    private static final class SamlArtifactTicketStringSerializer extends AbstractJacksonBackedStringSerializer<SamlArtifactTicketImpl> {
+    private static final class SamlArtifactTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<SamlArtifactTicketImpl> {
         @Serial
         private static final long serialVersionUID = -2198623586274810263L;
 
@@ -60,7 +60,7 @@ class SamlIdPTicketSerializationConfiguration {
         }
     }
 
-    private static final class SamlAttributeQueryTicketStringSerializer extends AbstractJacksonBackedStringSerializer<SamlAttributeQueryTicketImpl> {
+    private static final class SamlAttributeQueryTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<SamlAttributeQueryTicketImpl> {
         @Serial
         private static final long serialVersionUID = -2198623586274810263L;
 

--- a/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CasWsSecurityTokenTicketComponentSerializationConfiguration.java
+++ b/support/cas-server-support-ws-sts/src/main/java/org/apereo/cas/config/CasWsSecurityTokenTicketComponentSerializationConfiguration.java
@@ -5,7 +5,7 @@ import org.apereo.cas.configuration.features.CasFeatureModule;
 import org.apereo.cas.ticket.DefaultSecurityTokenTicket;
 import org.apereo.cas.ticket.SecurityTokenTicket;
 import org.apereo.cas.ticket.serialization.TicketSerializationExecutionPlanConfigurer;
-import org.apereo.cas.util.serialization.AbstractJacksonBackedStringSerializer;
+import org.apereo.cas.util.serialization.AbstractJacksonBackedNonHjsonStringSerializer;
 import org.apereo.cas.util.serialization.ComponentSerializationPlanConfigurer;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 
@@ -46,7 +46,7 @@ class CasWsSecurityTokenTicketComponentSerializationConfiguration {
         return plan -> plan.registerSerializableClass(DefaultSecurityTokenTicket.class);
     }
 
-    private static final class SecurityTokenTicketStringSerializer extends AbstractJacksonBackedStringSerializer<DefaultSecurityTokenTicket> {
+    private static final class SecurityTokenTicketStringSerializer extends AbstractJacksonBackedNonHjsonStringSerializer<DefaultSecurityTokenTicket> {
         @Serial
         private static final long serialVersionUID = -3198623586274810263L;
 


### PR DESCRIPTION
We noticed that Apereo CAS spent a lot of time (de)serializing HJSON into JSON and vice versa.
![image](https://github.com/user-attachments/assets/3f7a4f65-6c13-4555-9aac-5accf4de8a75)


Indeed, whenever we want to read a JSON, AbstractJacksonBackedStringSerializer calls org.hjson.JsonValue.readHjson(String).toString() to convert the String from HJSON to JSON.
Unfortunately this is very costly in terms of performance, whereas in most cases the String is already a JSON string.

This commit aims to stop converting from HJSON to JSON for Strings that may not have been written in HJSON (tickets, for example).