### PR TITLE
fix actuator endpoints

### DIFF
--- a/core/cas-server-core-web/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
+++ b/core/cas-server-core-web/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
@@ -1,0 +1,1 @@
+org.apereo.cas.config.CasCoreWebConfiguration.CasCoreWebEndpointsConfiguration


### PR DESCRIPTION
Description:
Since v7.1.0, the actuator endpoints can no longer be called if the actuator is running on its own port.

All calls end in status 404 with the message "problemDetail.org.springframework.web.servlet.resource.NoResourceFoundException".

The reason is that the "WebMvcEndpointHandlerMapping" bean is initialized too early for the management context.

This PR registers the configuration "CasCoreWebConfiguration.CasCoreWebEndpointsConfiguration" in "/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports" and thereby fixes the problem.

