### PR TITLE
Improve TGT deletion behavior

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
@@ -244,4 +244,11 @@ public interface TicketRegistry {
     default long countTickets() {
         return stream().count();
     }
+
+    /**
+     * Define if the cleaner is enabled.
+     *
+     * @param cleanerEnabled whether the cleaner is enabled
+     */
+    void setCleanerEnabled(boolean cleanerEnabled);
 }

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/NoOpTicketRegistryCleaner.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/NoOpTicketRegistryCleaner.java
@@ -16,9 +16,11 @@ public class NoOpTicketRegistryCleaner implements TicketRegistryCleaner {
     /**
      * Gets instance.
      *
+     * @param ticketRegistry the ticket registry
      * @return the instance
      */
-    public static TicketRegistryCleaner getInstance() {
+    public static TicketRegistryCleaner getInstance(final TicketRegistry ticketRegistry) {
+        ticketRegistry.setCleanerEnabled(false);
         if (INSTANCE == null) {
             INSTANCE = new NoOpTicketRegistryCleaner();
         }

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
@@ -49,7 +49,6 @@ class CasCoreTicketsSchedulingConfiguration {
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
     @Lazy(false)
     public TicketRegistryCleaner ticketRegistryCleaner(
-        final CasConfigurationProperties casProperties,
         @Qualifier(LockRepository.BEAN_NAME) final LockRepository lockRepository,
         @Qualifier(LogoutManager.DEFAULT_BEAN_NAME) final LogoutManager logoutManager,
         @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry) {
@@ -63,12 +62,14 @@ class CasCoreTicketsSchedulingConfiguration {
     @Lazy(false)
     public Runnable ticketRegistryCleanerScheduler(
         final ConfigurableApplicationContext applicationContext,
-        @Qualifier(TicketRegistryCleaner.BEAN_NAME) final TicketRegistryCleaner ticketRegistryCleaner) {
+        @Qualifier(TicketRegistryCleaner.BEAN_NAME) final TicketRegistryCleaner ticketRegistryCleaner,
+        @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry) {
         return BeanSupplier.of(Runnable.class)
             .when(BeanCondition.on("cas.ticket.registry.cleaner.schedule.enabled").isTrue()
                 .evenIfMissing().given(applicationContext.getEnvironment()))
             .supply(() -> {
                 LOGGER.debug("Ticket registry cleaner is enabled to run on schedule.");
+                ticketRegistry.setCleanerEnabled(true);
                 return new TicketRegistryCleanerScheduler(ticketRegistryCleaner);
             })
             .otherwiseProxy(__ -> LOGGER.info("Ticket registry cleaner is not enabled to run on schedule. "

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryTests.java
@@ -1,11 +1,14 @@
 package org.apereo.cas.ticket.registry;
 
+import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.mock.MockServiceTicket;
 import org.apereo.cas.mock.MockTicketGrantingTicket;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.ticket.DefaultTicketCatalog;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
+import org.apereo.cas.ticket.TicketGrantingTicketImpl;
+import org.apereo.cas.ticket.expiration.HardTimeoutExpirationPolicy;
 import org.apereo.cas.ticket.serialization.TicketSerializationManager;
 import org.apereo.cas.ticket.tracking.TicketTrackingPolicy;
 import org.apereo.cas.util.cipher.DefaultTicketCipherExecutor;
@@ -13,6 +16,7 @@ import lombok.val;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -80,5 +84,36 @@ class DefaultTicketRegistryTests extends BaseTicketRegistryTests {
         val reg = new DefaultTicketRegistry(cipher, mock(TicketSerializationManager.class), new DefaultTicketCatalog());
         assertNull(reg.encodeTicket(null));
         assertNotNull(reg.decodeTicket(mock(Ticket.class)));
+    }
+
+    @RepeatedTest(1)
+    void verifyGetExpiredTicketWithoutCleaner() throws Throwable {
+        val registry = getNewTicketRegistry();
+        val originalAuthn = CoreAuthenticationTestUtils.getAuthentication();
+        val ticketGrantingTicket = new TicketGrantingTicketImpl(TestTicketIdentifiers.generate().ticketGrantingTicketId(),
+                originalAuthn, new HardTimeoutExpirationPolicy(1));
+        registry.addTicket(ticketGrantingTicket);
+        Thread.sleep(1500);
+        val tgtId = ticketGrantingTicket.getId();
+        val tgt = registry.getTicket(tgtId);
+        assertNull(tgt);
+        val internalTgt = ((DefaultTicketRegistry) registry).getMapInstance().get(tgtId);
+        assertNull(internalTgt);
+    }
+
+    @RepeatedTest(1)
+    void verifyGetExpiredTicketWithCleaner() throws Throwable {
+        val registry = getNewTicketRegistry();
+        registry.setCleanerEnabled(true);
+        val originalAuthn = CoreAuthenticationTestUtils.getAuthentication();
+        val ticketGrantingTicket = new TicketGrantingTicketImpl(TestTicketIdentifiers.generate().ticketGrantingTicketId(),
+                originalAuthn, new HardTimeoutExpirationPolicy(1));
+        registry.addTicket(ticketGrantingTicket);
+        Thread.sleep(1500);
+        val tgtId = ticketGrantingTicket.getId();
+        val tgt = registry.getTicket(tgtId);
+        assertNull(tgt);
+        val internalTgt = ((DefaultTicketRegistry) registry).getMapInstance().get(tgtId);
+        assertNotNull(internalTgt);
     }
 }

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/CasHazelcastTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/CasHazelcastTicketRegistryAutoConfiguration.java
@@ -140,7 +140,9 @@ public class CasHazelcastTicketRegistryAutoConfiguration {
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
     @Lazy(false)
-    public TicketRegistryCleaner ticketRegistryCleaner() {
-        return NoOpTicketRegistryCleaner.getInstance();
+    public TicketRegistryCleaner ticketRegistryCleaner(
+        @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry
+    ) {
+        return NoOpTicketRegistryCleaner.getInstance(ticketRegistry);
     }
 }

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/config/CasMemcachedTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/config/CasMemcachedTicketRegistryAutoConfiguration.java
@@ -83,7 +83,9 @@ public class CasMemcachedTicketRegistryAutoConfiguration {
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
     @Lazy(false)
-    public TicketRegistryCleaner ticketRegistryCleaner() {
-        return NoOpTicketRegistryCleaner.getInstance();
+    public TicketRegistryCleaner ticketRegistryCleaner(
+        @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry
+    ) {
+        return NoOpTicketRegistryCleaner.getInstance(ticketRegistry);
     }
 }

--- a/support/cas-server-support-stateless-ticket-registry/src/main/java/org/apereo/cas/config/CasStatelessTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-stateless-ticket-registry/src/main/java/org/apereo/cas/config/CasStatelessTicketRegistryAutoConfiguration.java
@@ -57,8 +57,10 @@ public class CasStatelessTicketRegistryAutoConfiguration {
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
     @Lazy(false)
-    public TicketRegistryCleaner ticketRegistryCleaner() {
-        return NoOpTicketRegistryCleaner.getInstance();
+    public TicketRegistryCleaner ticketRegistryCleaner(
+        @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry
+    ) {
+        return NoOpTicketRegistryCleaner.getInstance(ticketRegistry);
     }
     
     @Bean


### PR DESCRIPTION
Currently, there is a flaw in the current deletion behavior of the expired TGT: depending on the settings and the user browsing, the expired TGT can be removed by the ticket registry during a "get" operation or by the ticket registry cleaner.
Both cases are not the same: in the first case, the TGT only is deleted while in the second case, a whole single logout is performed.

So I propose that the ticket registry does not delete an expired TGT on a "get" operation if the cleaner is enabled, letting the cleaner eventually removes the TGT and performs a full SLO.
