### PR TITLE
Improve TGT deletion behavior (new attempt)

### DIFF
--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/logout/CasRequestSingleLogoutEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/logout/CasRequestSingleLogoutEvent.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 import org.apereo.inspektr.common.web.ClientInfo;
 
 /**
- * Concrete subclass of {@code AbstractCasEvent} representing a request for SLO.
+ * Concrete subclass of {@link AbstractCasEvent} representing a request for SLO.
  *
  * @author Jerome LELEU
  * @since 7.2

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/logout/CasRequestSingleLogoutEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/logout/CasRequestSingleLogoutEvent.java
@@ -1,0 +1,34 @@
+package org.apereo.cas.support.events.logout;
+
+import org.apereo.cas.support.events.AbstractCasEvent;
+import org.apereo.cas.ticket.TicketGrantingTicket;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.apereo.inspektr.common.web.ClientInfo;
+
+/**
+ * Concrete subclass of {@code AbstractCasEvent} representing a request for SLO.
+ *
+ * @author Jerome LELEU
+ * @since 7.2
+ */
+@ToString(callSuper = true)
+@Getter
+public class CasRequestSingleLogoutEvent extends AbstractCasEvent {
+
+    private final TicketGrantingTicket ticketGrantingTicket;
+
+    /**
+     * Instantiates a new CAS request single logout event.
+     *
+     * @param source               the source
+     * @param ticketGrantingTicket the ticket granting ticket
+     * @param clientInfo           the client info
+     */
+    public CasRequestSingleLogoutEvent(final Object source, final TicketGrantingTicket ticketGrantingTicket,
+                                       final ClientInfo clientInfo) {
+        super(source, clientInfo);
+        this.ticketGrantingTicket = ticketGrantingTicket;
+    }
+}

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasProxyTicketGrantedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasProxyTicketGrantedEvent.java
@@ -9,7 +9,7 @@ import org.apereo.inspektr.common.web.ClientInfo;
 import java.io.Serial;
 
 /**
- * Concrete subclass of {@code AbstractCasEvent} representing granting of a
+ * Concrete subclass of {@link AbstractCasEvent} representing granting of a
  * proxy ticket by a CAS server.
  *
  * @author Misagh Moayyed

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasServiceTicketGrantedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasServiceTicketGrantedEvent.java
@@ -11,7 +11,7 @@ import org.apereo.inspektr.common.web.ClientInfo;
 import java.io.Serial;
 
 /**
- * Concrete subclass of {@code AbstractCasEvent} representing granting of a
+ * Concrete subclass of {@link AbstractCasEvent} representing granting of a
  * service ticket by a CAS server.
  *
  * @author Dmitriy Kopylenko

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasServiceTicketValidatedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasServiceTicketValidatedEvent.java
@@ -11,7 +11,7 @@ import org.apereo.inspektr.common.web.ClientInfo;
 import java.io.Serial;
 
 /**
- * Concrete subclass of {@code AbstractCasEvent} representing validation of a
+ * Concrete subclass of {@link AbstractCasEvent} representing validation of a
  * service ticket by a CAS server.
  *
  * @author Dmitriy Kopylenko

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketCreatedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketCreatedEvent.java
@@ -7,9 +7,8 @@ import org.apereo.inspektr.common.web.ClientInfo;
 
 import java.io.Serial;
 
-
 /**
- * Concrete subclass of {@code AbstractCasEvent} representing single sign on session establishment
+ * Concrete subclass of {@link org.apereo.cas.support.events.AbstractCasEvent} representing single sign on session establishment
  * event e.g. user logged in
  * and <i>TicketGrantingTicket</i> has been vended by a CAS server.
  *

--- a/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketDestroyedEvent.java
+++ b/api/cas-server-core-api-events/src/main/java/org/apereo/cas/support/events/ticket/CasTicketGrantingTicketDestroyedEvent.java
@@ -9,7 +9,7 @@ import org.apereo.inspektr.common.web.ClientInfo;
 import java.io.Serial;
 
 /**
- * Concrete subclass of {@code AbstractCasEvent} representing single sign on session
+ * Concrete subclass of {@link org.apereo.cas.support.events.AbstractCasEvent} representing single sign on session
  * destruction event e.g. user logged out
  * and <i>TicketGrantingTicket</i> has been destroyed by a CAS server.
  *

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
@@ -3,6 +3,7 @@ package org.apereo.cas.support.events.listener;
 import org.apereo.cas.authentication.adaptive.geo.GeoLocationRequest;
 import org.apereo.cas.authentication.adaptive.geo.GeoLocationService;
 import org.apereo.cas.logout.LogoutManager;
+import org.apereo.cas.logout.LogoutRequestStatus;
 import org.apereo.cas.logout.slo.SingleLogoutExecutionRequest;
 import org.apereo.cas.support.events.AbstractCasEvent;
 import org.apereo.cas.support.events.CasEventRepository;
@@ -127,7 +128,9 @@ public class CasAuthenticationAuthenticationEventListener implements CasAuthenti
             val request = SingleLogoutExecutionRequest.builder()
                 .ticketGrantingTicket(ticket)
                 .build();
-            logoutManager.performLogout(request);
+            val results = logoutManager.performLogout(request);
+            results.stream().filter(r -> r.getStatus() == LogoutRequestStatus.FAILURE)
+                .forEach(r -> LOGGER.warn("Logout request for [{}] and [{}] has failed", r.getTicketId(), r.getLogoutUrl()));
         } catch (final Throwable e) {
             LoggingUtils.error(LOGGER, e);
         }

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
@@ -19,9 +19,8 @@ import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.http.HttpRequestUtils;
 import org.apereo.cas.util.text.MessageSanitizer;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.common.web.ClientInfo;
@@ -36,7 +35,7 @@ import java.time.Instant;
  * @author Misagh Moayyed
  * @since 5.0.0
  */
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Getter
 @Slf4j
 public class CasAuthenticationAuthenticationEventListener implements CasAuthenticationEventListener {
@@ -47,8 +46,7 @@ public class CasAuthenticationAuthenticationEventListener implements CasAuthenti
 
     private final GeoLocationService geoLocationService;
 
-    @Setter
-    private LogoutManager logoutManager;
+    private final LogoutManager logoutManager;
 
     private CasEvent prepareCasEvent(final AbstractCasEvent event) {
         val dto = new CasEvent();

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
@@ -14,11 +14,14 @@ import org.apereo.cas.support.events.logout.CasRequestSingleLogoutEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEvent;
 import org.apereo.cas.util.DateTimeUtils;
+import org.apereo.cas.util.LoggingUtils;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.http.HttpRequestUtils;
 import org.apereo.cas.util.text.MessageSanitizer;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.common.web.ClientInfo;
@@ -33,7 +36,7 @@ import java.time.Instant;
  * @author Misagh Moayyed
  * @since 5.0.0
  */
-@RequiredArgsConstructor
+@AllArgsConstructor
 @Getter
 @Slf4j
 public class CasAuthenticationAuthenticationEventListener implements CasAuthenticationEventListener {
@@ -44,7 +47,8 @@ public class CasAuthenticationAuthenticationEventListener implements CasAuthenti
 
     private final GeoLocationService geoLocationService;
 
-    private final LogoutManager logoutManager;
+    @Setter
+    private LogoutManager logoutManager;
 
     private CasEvent prepareCasEvent(final AbstractCasEvent event) {
         val dto = new CasEvent();
@@ -119,11 +123,15 @@ public class CasAuthenticationAuthenticationEventListener implements CasAuthenti
 
     @Override
     public void handleCasRequestSingleLogoutEvent(final CasRequestSingleLogoutEvent event) throws Throwable {
-        val ticket = event.getTicketGrantingTicket();
-        LOGGER.debug("Performing single logout for expired ticket-granting ticket [{}]", ticket.getId());
-        val request = SingleLogoutExecutionRequest.builder()
-            .ticketGrantingTicket(ticket)
-            .build();
-        logoutManager.performLogout(request);
+        try {
+            val ticket = event.getTicketGrantingTicket();
+            LOGGER.debug("Performing single logout for expired ticket-granting ticket [{}]", ticket.getId());
+            val request = SingleLogoutExecutionRequest.builder()
+                .ticketGrantingTicket(ticket)
+                .build();
+            logoutManager.performLogout(request);
+        } catch (final Throwable e) {
+            LoggingUtils.error(LOGGER, e);
+        }
     }
 }

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationAuthenticationEventListener.java
@@ -2,12 +2,15 @@ package org.apereo.cas.support.events.listener;
 
 import org.apereo.cas.authentication.adaptive.geo.GeoLocationRequest;
 import org.apereo.cas.authentication.adaptive.geo.GeoLocationService;
+import org.apereo.cas.logout.LogoutManager;
+import org.apereo.cas.logout.slo.SingleLogoutExecutionRequest;
 import org.apereo.cas.support.events.AbstractCasEvent;
 import org.apereo.cas.support.events.CasEventRepository;
 import org.apereo.cas.support.events.authentication.CasAuthenticationPolicyFailureEvent;
 import org.apereo.cas.support.events.authentication.CasAuthenticationTransactionFailureEvent;
 import org.apereo.cas.support.events.authentication.adaptive.CasRiskyAuthenticationDetectedEvent;
 import org.apereo.cas.support.events.dao.CasEvent;
+import org.apereo.cas.support.events.logout.CasRequestSingleLogoutEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEvent;
 import org.apereo.cas.util.DateTimeUtils;
@@ -19,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.common.web.ClientInfo;
+
 import java.time.Instant;
 
 /**
@@ -39,6 +43,8 @@ public class CasAuthenticationAuthenticationEventListener implements CasAuthenti
     private final MessageSanitizer messageSanitizer;
 
     private final GeoLocationService geoLocationService;
+
+    private final LogoutManager logoutManager;
 
     private CasEvent prepareCasEvent(final AbstractCasEvent event) {
         val dto = new CasEvent();
@@ -109,5 +115,15 @@ public class CasAuthenticationAuthenticationEventListener implements CasAuthenti
         dto.putEventId(event.getService().getName());
         dto.setPrincipalId(event.getAuthentication().getPrincipal().getId());
         this.casEventRepository.save(dto);
+    }
+
+    @Override
+    public void handleCasRequestSingleLogoutEvent(final CasRequestSingleLogoutEvent event) throws Throwable {
+        val ticket = event.getTicketGrantingTicket();
+        LOGGER.debug("Performing single logout for expired ticket-granting ticket [{}]", ticket.getId());
+        val request = SingleLogoutExecutionRequest.builder()
+            .ticketGrantingTicket(ticket)
+            .build();
+        logoutManager.performLogout(request);
     }
 }

--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationEventListener.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/listener/CasAuthenticationEventListener.java
@@ -3,6 +3,7 @@ package org.apereo.cas.support.events.listener;
 import org.apereo.cas.support.events.authentication.CasAuthenticationPolicyFailureEvent;
 import org.apereo.cas.support.events.authentication.CasAuthenticationTransactionFailureEvent;
 import org.apereo.cas.support.events.authentication.adaptive.CasRiskyAuthenticationDetectedEvent;
+import org.apereo.cas.support.events.logout.CasRequestSingleLogoutEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEvent;
 import org.apereo.cas.util.spring.CasEventListener;
@@ -67,4 +68,14 @@ public interface CasAuthenticationEventListener extends CasEventListener {
     @EventListener
     @Async
     void handleCasRiskyAuthenticationDetectedEvent(CasRiskyAuthenticationDetectedEvent event) throws Throwable;
+
+    /**
+     * Handle CAS request SLO event.
+     *
+     * @param event the event
+     * @throws Throwable the throwable
+     */
+    @EventListener
+    @Async
+    void handleCasRequestSingleLogoutEvent(CasRequestSingleLogoutEvent event) throws Throwable;
 }

--- a/core/cas-server-core-events/src/main/java/org/apereo/cas/config/CasCoreEventsAutoConfiguration.java
+++ b/core/cas-server-core-events/src/main/java/org/apereo/cas/config/CasCoreEventsAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.apereo.cas.config;
 import org.apereo.cas.authentication.adaptive.geo.GeoLocationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
+import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.support.events.CasEventRepository;
 import org.apereo.cas.support.events.dao.NoOpCasEventRepository;
 import org.apereo.cas.support.events.listener.CasAuthenticationAuthenticationEventListener;
@@ -50,11 +51,12 @@ public class CasCoreEventsAutoConfiguration {
             @Qualifier(GeoLocationService.BEAN_NAME) final ObjectProvider<GeoLocationService> geoLocationService,
             @Qualifier(MessageSanitizer.BEAN_NAME) final MessageSanitizer messageSanitizer,
             final ConfigurableApplicationContext applicationContext,
-            @Qualifier(CasEventRepository.BEAN_NAME) final CasEventRepository casEventRepository) {
+            @Qualifier(CasEventRepository.BEAN_NAME) final CasEventRepository casEventRepository,
+            @Qualifier(LogoutManager.DEFAULT_BEAN_NAME) final LogoutManager logoutManager) {
             return BeanSupplier.of(CasAuthenticationEventListener.class)
                 .when(CONDITION.given(applicationContext.getEnvironment()))
                 .supply(() -> new CasAuthenticationAuthenticationEventListener(casEventRepository,
-                    messageSanitizer, geoLocationService.getIfAvailable()))
+                    messageSanitizer, geoLocationService.getIfAvailable(), logoutManager))
                 .otherwiseProxy()
                 .get();
         }

--- a/core/cas-server-core-monitor/src/test/java/org/apereo/cas/monitor/SessionHealthIndicatorTests.java
+++ b/core/cas-server-core-monitor/src/test/java/org/apereo/cas/monitor/SessionHealthIndicatorTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import java.util.stream.IntStream;
 import static org.junit.jupiter.api.Assertions.*;
@@ -77,7 +78,8 @@ class SessionHealthIndicatorTests {
 
     @BeforeEach
     public void initialize() {
-        this.defaultRegistry = new DefaultTicketRegistry(mock(TicketSerializationManager.class), new DefaultTicketCatalog());
+        this.defaultRegistry = new DefaultTicketRegistry(mock(TicketSerializationManager.class), new DefaultTicketCatalog(),
+                mock(ConfigurableApplicationContext.class));
     }
 
     @Test

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractMapBasedTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractMapBasedTicketRegistry.java
@@ -15,6 +15,8 @@ import org.apereo.cas.util.crypto.CipherExecutor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.ApplicationContext;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
@@ -38,9 +40,10 @@ public abstract class AbstractMapBasedTicketRegistry extends AbstractTicketRegis
     public AbstractMapBasedTicketRegistry(final CipherExecutor cipherExecutor,
                                           final TicketSerializationManager ticketSerializationManager,
                                           final TicketCatalog ticketCatalog,
+                                          final ApplicationContext applicationContext,
                                           final QueueableTicketRegistryMessagePublisher ticketPublisher,
                                           final PublisherIdentifier publisherIdentifier) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.ticketPublisher = ticketPublisher;
         this.publisherIdentifier = publisherIdentifier;
     }

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -114,7 +114,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
                 try {
                     deleteTicket(ticket);
                 } catch (final Exception e) {
-                    LOGGER.warn("Deletion failed for ticket [{}]", ticket.getId());
+                    LOGGER.warn("Deletion failed for expired ticket [{}]", ticket.getId());
                 }
                 return false;
             }

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/AbstractTicketRegistry.java
@@ -16,6 +16,7 @@ import org.apereo.cas.ticket.proxy.ProxyGrantingTicket;
 import org.apereo.cas.ticket.serialization.TicketSerializationManager;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.DigestUtils;
+import org.apereo.cas.util.LoggingUtils;
 import org.apereo.cas.util.crypto.CipherExecutor;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.serialization.SerializationUtils;
@@ -114,7 +115,7 @@ public abstract class AbstractTicketRegistry implements TicketRegistry {
                 try {
                     deleteTicket(ticket);
                 } catch (final Exception e) {
-                    LOGGER.warn("Deletion failed for expired ticket [{}]", ticket.getId());
+                    LoggingUtils.warn(LOGGER, e);
                 }
                 return false;
             }

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistry.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistry.java
@@ -9,6 +9,7 @@ import org.apereo.cas.util.PublisherIdentifier;
 import org.apereo.cas.util.crypto.CipherExecutor;
 
 import lombok.Getter;
+import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,24 +27,26 @@ public class DefaultTicketRegistry extends AbstractMapBasedTicketRegistry {
     private final Map<String, Ticket> mapInstance;
 
     public DefaultTicketRegistry(final TicketSerializationManager ticketSerializationManager,
-                                 final TicketCatalog ticketCatalog) {
-        this(CipherExecutor.noOp(), ticketSerializationManager, ticketCatalog);
+                                 final TicketCatalog ticketCatalog, final ConfigurableApplicationContext applicationContext) {
+        this(CipherExecutor.noOp(), ticketSerializationManager, ticketCatalog, applicationContext);
     }
 
     public DefaultTicketRegistry(final CipherExecutor cipherExecutor,
                                  final TicketSerializationManager ticketSerializationManager,
-                                 final TicketCatalog ticketCatalog) {
-        this(cipherExecutor, ticketSerializationManager, ticketCatalog,
+                                 final TicketCatalog ticketCatalog,
+                                 final ConfigurableApplicationContext applicationContext) {
+        this(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext,
             new ConcurrentHashMap<>(), QueueableTicketRegistryMessagePublisher.noOp(), new PublisherIdentifier());
     }
 
     public DefaultTicketRegistry(final CipherExecutor cipherExecutor,
                                  final TicketSerializationManager ticketSerializationManager,
                                  final TicketCatalog ticketCatalog,
+                                 final ConfigurableApplicationContext applicationContext,
                                  final Map<String, Ticket> storageMap,
                                  final QueueableTicketRegistryMessagePublisher ticketPublisher,
                                  final PublisherIdentifier publisherIdentifier) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog, ticketPublisher, publisherIdentifier);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext, ticketPublisher, publisherIdentifier);
         this.mapInstance = storageMap;
     }
 }

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
@@ -9,6 +9,7 @@ import org.apereo.cas.util.lock.LockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.Objects;
@@ -47,8 +48,9 @@ public class DefaultTicketRegistryCleaner implements TicketRegistryCleaner {
     public int cleanTicket(final Ticket ticket) {
         return lockRepository.execute(ticket.getId(), () -> {
             if (ticket instanceof final TicketGrantingTicket tgt) {
-                applicationContext.publishEvent(new CasRequestSingleLogoutEvent(this, tgt, null));
-                applicationContext.publishEvent(new CasTicketGrantingTicketDestroyedEvent(this, tgt, null));
+                val clientInfo = ClientInfoHolder.getClientInfo();
+                applicationContext.publishEvent(new CasRequestSingleLogoutEvent(this, tgt, clientInfo));
+                applicationContext.publishEvent(new CasTicketGrantingTicketDestroyedEvent(this, tgt, clientInfo));
             }
 
             try {

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
@@ -1,7 +1,7 @@
 package org.apereo.cas.ticket.registry;
 
-import org.apereo.cas.logout.LogoutManager;
-import org.apereo.cas.logout.slo.SingleLogoutExecutionRequest;
+import org.apereo.cas.support.events.logout.CasRequestSingleLogoutEvent;
+import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketDestroyedEvent;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.util.LoggingUtils;
@@ -9,6 +9,7 @@ import org.apereo.cas.util.lock.LockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.Objects;
 
@@ -24,7 +25,7 @@ import java.util.Objects;
 public class DefaultTicketRegistryCleaner implements TicketRegistryCleaner {
     private final LockRepository lockRepository;
 
-    private final LogoutManager logoutManager;
+    private final ConfigurableApplicationContext applicationContext;
 
     private final TicketRegistry ticketRegistry;
 
@@ -45,16 +46,9 @@ public class DefaultTicketRegistryCleaner implements TicketRegistryCleaner {
     @Override
     public int cleanTicket(final Ticket ticket) {
         return lockRepository.execute(ticket.getId(), () -> {
-            try {
-                if (ticket instanceof final TicketGrantingTicket tgt) {
-                    LOGGER.debug("Cleaning up expired ticket-granting ticket [{}]", ticket.getId());
-                    val request = SingleLogoutExecutionRequest.builder()
-                        .ticketGrantingTicket(tgt)
-                        .build();
-                    logoutManager.performLogout(request);
-                }
-            } catch (final Throwable e) {
-                LoggingUtils.error(LOGGER, e);
+            if (ticket instanceof final TicketGrantingTicket tgt) {
+                applicationContext.publishEvent(new CasRequestSingleLogoutEvent(this, tgt, null));
+                applicationContext.publishEvent(new CasTicketGrantingTicketDestroyedEvent(this, tgt, null));
             }
 
             try {

--- a/core/cas-server-core-tickets/build.gradle
+++ b/core/cas-server-core-tickets/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     implementation project(":core:cas-server-core-services-authentication")
     implementation project(":core:cas-server-core-configuration-api")
     implementation project(":core:cas-server-core-util")
+    implementation project(":core:cas-server-core-events-api")
+    implementation project(":core:cas-server-core-events")
 
     compileOnly project(":core:cas-server-core-services")
 

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsConfiguration.java
@@ -5,7 +5,6 @@ import org.apereo.cas.authentication.AuthenticationPolicy;
 import org.apereo.cas.authentication.policy.UniquePrincipalAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
-import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.DefaultTicketCatalog;
 import org.apereo.cas.ticket.ExpirationPolicyBuilder;
@@ -185,17 +184,16 @@ class CasCoreTicketsConfiguration {
             final PublisherIdentifier messageQueueTicketRegistryIdentifier,
             @Qualifier(TicketCatalog.BEAN_NAME)
             final TicketCatalog ticketCatalog,
+            final ConfigurableApplicationContext applicationContext,
             @Qualifier(TicketSerializationManager.BEAN_NAME)
             final TicketSerializationManager ticketSerializationManager,
-            @Qualifier(LogoutManager.DEFAULT_BEAN_NAME)
-            final ObjectProvider<LogoutManager> logoutManager,
             final CasConfigurationProperties casProperties) {
             LOGGER.info("Runtime memory is used as the persistence storage for retrieving and managing tickets. "
                         + "Tickets that are issued during runtime will be LOST when the web server is restarted. This MAY impact SSO functionality.");
             val mem = casProperties.getTicket().getRegistry().getInMemory();
             val storageMap = new ConcurrentHashMap<String, Ticket>(mem.getInitialCapacity(), mem.getLoadFactor(), mem.getConcurrency());
             return new DefaultTicketRegistry(defaultTicketRegistryCipherExecutor, ticketSerializationManager, ticketCatalog,
-                storageMap, messageQueueTicketRegistryPublisher, messageQueueTicketRegistryIdentifier);
+                    applicationContext, storageMap, messageQueueTicketRegistryPublisher, messageQueueTicketRegistryIdentifier);
         }
 
         @Bean

--- a/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
+++ b/core/cas-server-core-tickets/src/main/java/org/apereo/cas/config/CasCoreTicketsSchedulingConfiguration.java
@@ -2,7 +2,6 @@ package org.apereo.cas.config;
 
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
-import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.ticket.registry.DefaultTicketRegistryCleaner;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.ticket.registry.TicketRegistryCleaner;
@@ -51,9 +50,9 @@ class CasCoreTicketsSchedulingConfiguration {
     public TicketRegistryCleaner ticketRegistryCleaner(
         final CasConfigurationProperties casProperties,
         @Qualifier(LockRepository.BEAN_NAME) final LockRepository lockRepository,
-        @Qualifier(LogoutManager.DEFAULT_BEAN_NAME) final LogoutManager logoutManager,
+        final ConfigurableApplicationContext applicationContext,
         @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry) {
-        return new DefaultTicketRegistryCleaner(lockRepository, logoutManager, ticketRegistry);
+        return new DefaultTicketRegistryCleaner(lockRepository, applicationContext, ticketRegistry);
     }
 
     @ConditionalOnMissingBean(name = "ticketRegistryCleanerScheduler")

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistrySupportTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistrySupportTests.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+
 import java.util.List;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,7 +31,8 @@ class DefaultTicketRegistrySupportTests {
 
     @Test
     void verifyOperation() throws Throwable {
-        val registry = new DefaultTicketRegistry(mock(TicketSerializationManager.class), new DefaultTicketCatalog());
+        val registry = new DefaultTicketRegistry(mock(TicketSerializationManager.class), new DefaultTicketCatalog(),
+                mock(ConfigurableApplicationContext.class));
         val tgt = new MockTicketGrantingTicket("casuser", Map.of("name", List.of("CAS")));
         registry.addTicket(tgt);
         val support = new DefaultTicketRegistrySupport(registry);

--- a/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/config/CassandraTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/config/CassandraTicketRegistryAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ScopedProxyMode;
 import java.util.function.Function;
@@ -71,6 +72,7 @@ public class CassandraTicketRegistryAutoConfiguration {
     public TicketRegistry ticketRegistry(
         @Qualifier(TicketCatalog.BEAN_NAME)
         final TicketCatalog ticketCatalog,
+        final ConfigurableApplicationContext applicationContext,
         final CasConfigurationProperties casProperties,
         @Qualifier("cassandraTicketRegistrySessionFactory")
         final CassandraSessionFactory cassandraTicketRegistrySessionFactory,
@@ -78,7 +80,7 @@ public class CassandraTicketRegistryAutoConfiguration {
         final TicketSerializationManager ticketSerializationManager) {
         val cassandra = casProperties.getTicket().getRegistry().getCassandra();
         val cipher = CoreTicketUtils.newTicketRegistryCipherExecutor(cassandra.getCrypto(), "cassandra");
-        return new CassandraTicketRegistry(cipher, ticketSerializationManager, ticketCatalog,
+        return new CassandraTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, applicationContext,
             cassandraTicketRegistrySessionFactory, cassandra);
     }
 

--- a/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CassandraTicketRegistry.java
+++ b/support/cas-server-support-cassandra-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/CassandraTicketRegistry.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.cassandra.core.cql.BeanPropertyRowMapper;
 
 import java.util.ArrayList;
@@ -53,9 +54,10 @@ public class CassandraTicketRegistry extends AbstractTicketRegistry implements D
     public CassandraTicketRegistry(final CipherExecutor cipherExecutor,
                                    final TicketSerializationManager ticketSerializationManager,
                                    final TicketCatalog ticketCatalog,
+                                   final ConfigurableApplicationContext applicationContext,
                                    final CassandraSessionFactory cassandraSessionFactory,
                                    final CassandraTicketRegistryProperties properties) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.cassandraSessionFactory = cassandraSessionFactory;
         this.properties = properties;
     }

--- a/support/cas-server-support-cosmosdb-ticket-registry/src/main/java/org/apereo/cas/config/CasCosmosDbTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-cosmosdb-ticket-registry/src/main/java/org/apereo/cas/config/CasCosmosDbTicketRegistryAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ScopedProxyMode;
 
@@ -61,6 +62,7 @@ public class CasCosmosDbTicketRegistryAutoConfiguration {
         final TicketSerializationManager ticketSerializationManager,
         @Qualifier(TicketCatalog.BEAN_NAME)
         final TicketCatalog ticketCatalog,
+        final ConfigurableApplicationContext applicationContext,
         @Qualifier("cosmosDbTicketRegistryObjectFactory")
         final CosmosDbObjectFactory cosmosDbTicketRegistryObjectFactory) {
 
@@ -78,6 +80,6 @@ public class CasCosmosDbTicketRegistryAutoConfiguration {
 
         val cipher = CoreTicketUtils.newTicketRegistryCipherExecutor(
             casProperties.getTicket().getRegistry().getCosmosDb().getCrypto(), "cosmos-db");
-        return new CosmosDbTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, containers);
+        return new CosmosDbTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, applicationContext, containers);
     }
 }

--- a/support/cas-server-support-cosmosdb-ticket-registry/src/main/java/org/apereo/cas/ticket/CosmosDbTicketRegistry.java
+++ b/support/cas-server-support-cosmosdb-ticket-registry/src/main/java/org/apereo/cas/ticket/CosmosDbTicketRegistry.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
 
 import java.util.ArrayList;
@@ -47,8 +48,9 @@ public class CosmosDbTicketRegistry extends AbstractTicketRegistry {
     public CosmosDbTicketRegistry(final CipherExecutor cipherExecutor,
                                   final TicketSerializationManager ticketSerializationManager,
                                   final TicketCatalog ticketCatalog,
+                                  final ConfigurableApplicationContext applicationContext,
                                   final List<CosmosContainer> cosmosContainers) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.cosmosContainers = cosmosContainers;
     }
 

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/config/CasDynamoDbTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/config/CasDynamoDbTicketRegistryAutoConfiguration.java
@@ -17,6 +17,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -76,13 +77,15 @@ public class CasDynamoDbTicketRegistryAutoConfiguration {
             final TicketCatalog ticketCatalog,
             @Qualifier(TicketSerializationManager.BEAN_NAME)
             final TicketSerializationManager ticketSerializationManager,
+            final ConfigurableApplicationContext applicationContext,
             @Qualifier("dynamoDbTicketRegistryFacilitator")
             final DynamoDbTicketRegistryFacilitator dynamoDbTicketRegistryFacilitator,
             final CasConfigurationProperties casProperties) {
             val db = casProperties.getTicket().getRegistry().getDynamoDb();
             val crypto = db.getCrypto();
             val cipherExecutor = CoreTicketUtils.newTicketRegistryCipherExecutor(crypto, "dynamo-db");
-            return new DynamoDbTicketRegistry(cipherExecutor, ticketSerializationManager, ticketCatalog, dynamoDbTicketRegistryFacilitator);
+            return new DynamoDbTicketRegistry(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext,
+                dynamoDbTicketRegistryFacilitator);
         }
     }
 

--- a/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
+++ b/support/cas-server-support-dynamodb-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/DynamoDbTicketRegistry.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.jooq.lambda.Unchecked;
+import org.springframework.context.ConfigurableApplicationContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -42,8 +43,9 @@ public class DynamoDbTicketRegistry extends AbstractTicketRegistry {
     public DynamoDbTicketRegistry(final CipherExecutor cipherExecutor,
                                   final TicketSerializationManager ticketSerializationManager,
                                   final TicketCatalog ticketCatalog,
+                                  final ConfigurableApplicationContext applicationContext,
                                   final DynamoDbTicketRegistryFacilitator dbTableService) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.dbTableService = dbTableService;
     }
 

--- a/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/config/CasGoogleCloudFirestoreTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/config/CasGoogleCloudFirestoreTicketRegistryAutoConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -44,10 +45,11 @@ public class CasGoogleCloudFirestoreTicketRegistryAutoConfiguration {
         @Qualifier("firestore")
         final Firestore firestore,
         @Qualifier(TicketSerializationManager.BEAN_NAME)
-        final TicketSerializationManager ticketSerializationManager) {
+        final TicketSerializationManager ticketSerializationManager,
+        final ConfigurableApplicationContext applicationContext) {
         val firestoreProps = casProperties.getTicket().getRegistry().getGoogleCloudFirestore();
         val cipher = CoreTicketUtils.newTicketRegistryCipherExecutor(firestoreProps.getCrypto(), "firestore");
-        return new GoogleCloudFirestoreTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, firestore);
+        return new GoogleCloudFirestoreTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, applicationContext, firestore);
     }
 
 

--- a/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudFirestoreTicketRegistry.java
+++ b/support/cas-server-support-gcp-firestore-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/GoogleCloudFirestoreTicketRegistry.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hjson.JsonValue;
 import org.hjson.Stringify;
 import org.jooq.lambda.Unchecked;
+import org.springframework.context.ConfigurableApplicationContext;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -46,8 +47,9 @@ public class GoogleCloudFirestoreTicketRegistry extends AbstractTicketRegistry {
     private final Firestore firestore;
 
     public GoogleCloudFirestoreTicketRegistry(final CipherExecutor cipherExecutor, final TicketSerializationManager ticketSerializationManager,
-                                              final TicketCatalog ticketCatalog, final Firestore firestore) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+                                              final TicketCatalog ticketCatalog, final ConfigurableApplicationContext applicationContext,
+                                              final Firestore firestore) {
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.firestore = firestore;
     }
 

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/CasHazelcastTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/config/CasHazelcastTicketRegistryAutoConfiguration.java
@@ -69,10 +69,11 @@ public class CasHazelcastTicketRegistryAutoConfiguration {
         @Qualifier(TicketSerializationManager.BEAN_NAME) final TicketSerializationManager ticketSerializationManager,
         @Qualifier("casTicketRegistryHazelcastInstance") final HazelcastInstance casTicketRegistryHazelcastInstance,
         @Qualifier(TicketCatalog.BEAN_NAME) final TicketCatalog ticketCatalog,
-        final CasConfigurationProperties casProperties) {
+        final CasConfigurationProperties casProperties,
+        final ConfigurableApplicationContext applicationContext) {
         val hz = casProperties.getTicket().getRegistry().getHazelcast();
         val cipher = CoreTicketUtils.newTicketRegistryCipherExecutor(hz.getCrypto(), "hazelcast");
-        return new HazelcastTicketRegistry(cipher, ticketSerializationManager, ticketCatalog,
+        return new HazelcastTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, applicationContext,
             casTicketRegistryHazelcastInstance, hz);
     }
 

--- a/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistry.java
@@ -20,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.ConfigurableApplicationContext;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -52,9 +54,10 @@ public class HazelcastTicketRegistry extends AbstractTicketRegistry implements A
     public HazelcastTicketRegistry(final CipherExecutor cipherExecutor,
                                    final TicketSerializationManager ticketSerializationManager,
                                    final TicketCatalog ticketCatalog,
+                                   final ConfigurableApplicationContext applicationContext,
                                    final HazelcastInstance hazelcastInstance,
                                    final HazelcastTicketRegistryProperties properties) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.hazelcastInstance = hazelcastInstance;
         this.properties = properties;
     }

--- a/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
+++ b/support/cas-server-support-hazelcast-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/HazelcastTicketRegistryTests.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import java.util.UUID;
@@ -80,6 +81,9 @@ class HazelcastTicketRegistryTests {
         @Autowired
         private CasConfigurationProperties casProperties;
 
+        @Autowired
+        private ConfigurableApplicationContext applicationContext;
+
         @RepeatedTest(1)
         void verifyBadExpPolicyValue() throws Throwable {
             val ticket = new MockTicketGrantingTicket("casuser");
@@ -88,7 +92,7 @@ class HazelcastTicketRegistryTests {
             val myMap = mock(IMap.class);
             when(instance.getMap(anyString())).thenReturn(myMap);
             try (val registry = new HazelcastTicketRegistry(CipherExecutor.noOp(), ticketSerializationManager, ticketCatalog,
-                instance, casProperties.getTicket().getRegistry().getHazelcast())) {
+                    applicationContext, instance, casProperties.getTicket().getRegistry().getHazelcast())) {
                 ticket.setExpirationPolicy(new HardTimeoutExpirationPolicy(-1));
                 assertDoesNotThrow(() -> registry.addTicket(ticket));
                 assertDoesNotThrow(registry::shutdown);
@@ -107,7 +111,7 @@ class HazelcastTicketRegistryTests {
             defn.getProperties().setStorageName("Tickets");
             when(catalog.find(any(Ticket.class))).thenReturn(defn);
             try (val registry = new HazelcastTicketRegistry(CipherExecutor.noOp(), ticketSerializationManager, catalog,
-                instance, casProperties.getTicket().getRegistry().getHazelcast())) {
+                    applicationContext, instance, casProperties.getTicket().getRegistry().getHazelcast())) {
                 assertDoesNotThrow(() -> registry.addTicket(ticket));
                 assertNull(registry.getTicket(ticket.getId()));
             }

--- a/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/config/CasIgniteTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/config/CasIgniteTicketRegistryAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.util.StringUtils;
@@ -179,13 +180,14 @@ public class CasIgniteTicketRegistryAutoConfiguration {
         final TicketCatalog ticketCatalog,
         @Qualifier(TicketSerializationManager.BEAN_NAME)
         final TicketSerializationManager ticketSerializationManager,
+        final ConfigurableApplicationContext applicationContext,
         final CasConfigurationProperties casProperties,
         @Qualifier("igniteConfiguration")
         final IgniteConfiguration igniteConfiguration) {
         val igniteProperties = casProperties.getTicket().getRegistry().getIgnite();
         val cipher = CoreTicketUtils.newTicketRegistryCipherExecutor(igniteProperties.getCrypto(), "ignite");
         val registry = new IgniteTicketRegistry(cipher, ticketSerializationManager,
-            ticketCatalog, igniteConfiguration, igniteProperties);
+            ticketCatalog, applicationContext, igniteConfiguration, igniteProperties);
         registry.initialize();
         return registry;
     }

--- a/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/IgniteTicketRegistry.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/IgniteTicketRegistry.java
@@ -23,6 +23,8 @@ import org.apache.ignite.cache.query.SqlFieldsQuery;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.ConfigurableApplicationContext;
+
 import javax.cache.Cache;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
@@ -61,9 +63,9 @@ public class IgniteTicketRegistry extends AbstractTicketRegistry implements Disp
     private Ignite ignite;
 
     public IgniteTicketRegistry(final CipherExecutor cipherExecutor, final TicketSerializationManager ticketSerializationManager,
-                                final TicketCatalog ticketCatalog, final IgniteConfiguration igniteConfiguration,
-                                final IgniteProperties properties) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+                                final TicketCatalog ticketCatalog, final ConfigurableApplicationContext applicationContext,
+                                final IgniteConfiguration igniteConfiguration, final IgniteProperties properties) {
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.igniteConfiguration = igniteConfiguration;
         this.properties = properties;
     }

--- a/support/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
+++ b/support/cas-server-support-ignite-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/IgniteTicketRegistryTests.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.TestPropertySource;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -61,6 +62,9 @@ class IgniteTicketRegistryTests extends BaseTicketRegistryTests {
     @Qualifier("igniteConfiguration")
     private IgniteConfiguration igniteConfiguration;
 
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
+
     @BeforeAll
     public static void beforeAll() throws Exception {
         val ks = KeyStore.getInstance("pkcs12");
@@ -74,8 +78,8 @@ class IgniteTicketRegistryTests extends BaseTicketRegistryTests {
     @RepeatedTest(1)
     void verifyDeleteUnknown() throws Throwable {
         val catalog = mock(TicketCatalog.class);
-        val registry = new IgniteTicketRegistry(CipherExecutor.noOp(), ticketSerializationManager, catalog, igniteConfiguration,
-            casProperties.getTicket().getRegistry().getIgnite());
+        val registry = new IgniteTicketRegistry(CipherExecutor.noOp(), ticketSerializationManager, catalog, applicationContext,
+            igniteConfiguration, casProperties.getTicket().getRegistry().getIgnite());
         registry.initialize();
         assertTrue(registry.deleteSingleTicket(new MockTicketGrantingTicket(RegisteredServiceTestUtils.getAuthentication())) > 0);
         registry.destroy();

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/CasJpaTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/config/CasJpaTicketRegistryAutoConfiguration.java
@@ -202,7 +202,7 @@ public class CasJpaTicketRegistryAutoConfiguration {
                 .supply(() -> {
                     val jpa = casProperties.getTicket().getRegistry().getJpa();
                     val cipher = CoreTicketUtils.newTicketRegistryCipherExecutor(jpa.getCrypto(), "jpa");
-                    return new JpaTicketRegistry(cipher, ticketSerializationManager, ticketCatalog,
+                    return new JpaTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, applicationContext,
                         jpaBeanFactory, jpaTicketRegistryTransactionTemplate, casProperties);
                 })
                 .otherwiseProxy()

--- a/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
+++ b/support/cas-server-support-jpa-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/JpaTicketRegistry.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.jooq.lambda.Unchecked;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.transaction.support.TransactionOperations;
 
 import jakarta.persistence.EntityManager;
@@ -60,10 +61,12 @@ public class JpaTicketRegistry extends AbstractTicketRegistry {
 
     public JpaTicketRegistry(final CipherExecutor cipherExecutor,
                              final TicketSerializationManager ticketSerializationManager,
-                             final TicketCatalog ticketCatalog, final JpaBeanFactory jpaBeanFactory,
+                             final TicketCatalog ticketCatalog,
+                             final ConfigurableApplicationContext applicationContext,
+                             final JpaBeanFactory jpaBeanFactory,
                              final TransactionOperations transactionTemplate,
                              final CasConfigurationProperties casProperties) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.jpaBeanFactory = jpaBeanFactory;
         this.transactionTemplate = transactionTemplate;
         this.casProperties = casProperties;

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/config/CasMemcachedTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/config/CasMemcachedTicketRegistryAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -70,6 +71,7 @@ public class CasMemcachedTicketRegistryAutoConfiguration {
                                          final TicketCatalog ticketCatalog,
                                          @Qualifier(TicketSerializationManager.BEAN_NAME)
                                          final TicketSerializationManager ticketSerializationManager,
+                                         final ConfigurableApplicationContext applicationContext,
                                          @Qualifier("memcachedTicketRegistryTranscoder")
                                          final Transcoder memcachedTicketRegistryTranscoder) {
         val memcached = casProperties.getTicket()
@@ -77,7 +79,7 @@ public class CasMemcachedTicketRegistryAutoConfiguration {
             .getMemcached();
         val factory = new MemcachedPooledClientConnectionFactory(memcached, memcachedTicketRegistryTranscoder);
         val cipherExecutor = CoreTicketUtils.newTicketRegistryCipherExecutor(memcached.getCrypto(), "memcached");
-        return new MemcachedTicketRegistry(cipherExecutor, ticketSerializationManager, ticketCatalog, factory.getObjectPool());
+        return new MemcachedTicketRegistry(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext, factory.getObjectPool());
     }
 
     @Bean

--- a/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemcachedTicketRegistry.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MemcachedTicketRegistry.java
@@ -12,6 +12,7 @@ import lombok.val;
 import net.spy.memcached.MemcachedClientIF;
 import org.apache.commons.pool2.ObjectPool;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,8 +41,9 @@ public class MemcachedTicketRegistry extends AbstractTicketRegistry implements D
     private final ObjectPool<MemcachedClientIF> connectionPool;
 
     public MemcachedTicketRegistry(final CipherExecutor cipherExecutor, final TicketSerializationManager ticketSerializationManager,
-                                   final TicketCatalog ticketCatalog, final ObjectPool<MemcachedClientIF> connectionPool) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+                                   final TicketCatalog ticketCatalog, final ConfigurableApplicationContext applicationContext,
+                                   final ObjectPool<MemcachedClientIF> connectionPool) {
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.connectionPool = connectionPool;
     }
 

--- a/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MemcachedTicketRegistryTests.java
+++ b/support/cas-server-support-memcached-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MemcachedTicketRegistryTests.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import java.util.HashMap;
@@ -91,6 +92,9 @@ class MemcachedTicketRegistryTests extends BaseTicketRegistryTests {
     @Qualifier(AuthenticationSystemSupport.BEAN_NAME)
     private AuthenticationSystemSupport authenticationSystemSupport;
 
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
+
     @Override
     protected boolean canTicketRegistryIterate() {
         return false;
@@ -134,7 +138,7 @@ class MemcachedTicketRegistryTests extends BaseTicketRegistryTests {
     @RepeatedTest(1)
     void verifyFailures() throws Throwable {
         val pool = mock(ObjectPool.class);
-        val registry = new MemcachedTicketRegistry(CipherExecutor.noOp(), ticketSerializationManager, ticketCatalog, pool);
+        val registry = new MemcachedTicketRegistry(CipherExecutor.noOp(), ticketSerializationManager, ticketCatalog, applicationContext, pool);
         assertNotNull(registry.updateTicket(new MockTicketGrantingTicket("casuser")));
         assertTrue(registry.deleteSingleTicket(new MockTicketGrantingTicket("casuser")) > 0);
         assertDoesNotThrow(() -> {

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/config/MongoDbTicketRegistryConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -41,13 +42,14 @@ class MongoDbTicketRegistryConfiguration {
         @Qualifier("mongoDbTicketRegistryTemplate")
         final MongoOperations mongoDbTicketRegistryTemplate,
         @Qualifier(TicketSerializationManager.BEAN_NAME)
-        final TicketSerializationManager ticketSerializationManager) {
+        final TicketSerializationManager ticketSerializationManager,
+        final ConfigurableApplicationContext applicationContext) {
 
         val mongo = casProperties.getTicket().getRegistry().getMongo();
         new MongoDbTicketRegistryFacilitator(ticketCatalog, mongoDbTicketRegistryTemplate, mongo).createTicketCollections();
 
         val cipher = CoreTicketUtils.newTicketRegistryCipherExecutor(mongo.getCrypto(), "mongo");
-        return new MongoDbTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, mongoDbTicketRegistryTemplate);
+        return new MongoDbTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, applicationContext, mongoDbTicketRegistryTemplate);
     }
 
     @ConditionalOnMissingBean(name = "mongoDbTicketRegistryTemplate")

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -19,6 +19,7 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.hjson.JsonValue;
 import org.hjson.Stringify;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -53,8 +54,9 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
     private final MongoOperations mongoTemplate;
 
     public MongoDbTicketRegistry(final CipherExecutor cipherExecutor, final TicketSerializationManager ticketSerializationManager,
-                                 final TicketCatalog ticketCatalog, final MongoOperations mongoTemplate) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+                                 final TicketCatalog ticketCatalog, final ConfigurableApplicationContext applicationContext,
+                                 final MongoOperations mongoTemplate) {
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.mongoTemplate = mongoTemplate;
     }
 

--- a/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/test/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistryTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.test.context.TestPropertySource;
@@ -61,6 +62,9 @@ class MongoDbTicketRegistryTests extends BaseTicketRegistryTests {
     @Autowired
     @Qualifier("mongoDbTicketRegistryTemplate")
     private MongoOperations mongoDbTicketRegistryTemplate;
+
+    @Autowired
+    private ConfigurableApplicationContext applicationContext;
 
     @BeforeEach
     public void before() {
@@ -124,7 +128,7 @@ class MongoDbTicketRegistryTests extends BaseTicketRegistryTests {
         when(catalog.find(any(Ticket.class))).thenReturn(null);
         val mgr = mock(TicketSerializationManager.class);
         when(mgr.serializeTicket(any())).thenReturn("{}");
-        val registry = new MongoDbTicketRegistry(CipherExecutor.noOp(), mgr, catalog, mongoDbTicketRegistryTemplate);
+        val registry = new MongoDbTicketRegistry(CipherExecutor.noOp(), mgr, catalog, applicationContext, mongoDbTicketRegistryTemplate);
         registry.addTicket(ticket);
         assertNull(registry.updateTicket(ticket));
 

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/CasRedisTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/CasRedisTicketRegistryAutoConfiguration.java
@@ -276,11 +276,11 @@ public class CasRedisTicketRegistryAutoConfiguration {
                         keySpaceConfig.addKeyspaceSettings(keyspaceSettings);
                     }
                     val adapter = new RedisKeyValueAdapter(casRedisTemplates.getTicketsRedisTemplate(), redisMappingContext);
-                    return new RedisTicketRegistry(cipher, ticketSerializationManager, ticketCatalog,
+                    return new RedisTicketRegistry(cipher, ticketSerializationManager, ticketCatalog, applicationContext,
                         casRedisTemplates, redisTicketRegistryCache, redisTicketRegistryMessagePublisher,
                         searchCommands, redisKeyGeneratorFactory, adapter, casProperties);
                 }))
-                .otherwise(() -> new DefaultTicketRegistry(ticketSerializationManager, ticketCatalog))
+                .otherwise(() -> new DefaultTicketRegistry(ticketSerializationManager, ticketCatalog, applicationContext))
                 .get();
         }
     }

--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/RedisTicketRegistry.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hjson.JsonValue;
 import org.hjson.Stringify;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.ScanOptions;
@@ -90,6 +91,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry implements Clean
     public RedisTicketRegistry(final CipherExecutor cipherExecutor,
                                final TicketSerializationManager ticketSerializationManager,
                                final TicketCatalog ticketCatalog,
+                               final ConfigurableApplicationContext applicationContext,
                                final CasRedisTemplates casRedisTemplates,
                                final ObjectProvider<Cache<String, Ticket>> ticketCache,
                                final ObjectProvider<RedisTicketRegistryMessagePublisher> messagePublisher,
@@ -97,7 +99,7 @@ public class RedisTicketRegistry extends AbstractTicketRegistry implements Clean
                                final RedisKeyGeneratorFactory redisKeyGeneratorFactory,
                                final RedisKeyValueAdapter redisKeyValueAdapter,
                                final CasConfigurationProperties casProperties) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.casRedisTemplates = casRedisTemplates;
         this.ticketCache = ticketCache;
         this.messagePublisher = messagePublisher;

--- a/support/cas-server-support-stateless-ticket-registry/src/main/java/org/apereo/cas/config/CasStatelessTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-stateless-ticket-registry/src/main/java/org/apereo/cas/config/CasStatelessTicketRegistryAutoConfiguration.java
@@ -6,7 +6,6 @@ import org.apereo.cas.authentication.principal.ServiceMatchingStrategy;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
-import org.apereo.cas.logout.LogoutManager;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketCatalog;
@@ -80,10 +79,9 @@ public class CasStatelessTicketRegistryAutoConfiguration {
         final TicketCatalog ticketCatalog,
         @Qualifier(TicketSerializationManager.BEAN_NAME)
         final TicketSerializationManager ticketSerializationManager,
-        @Qualifier(LogoutManager.DEFAULT_BEAN_NAME)
-        final ObjectProvider<LogoutManager> logoutManager,
-        final CasConfigurationProperties casProperties) {
-        return new StatelessTicketRegistry(statelessTicketRegistryCipherExecutor, ticketSerializationManager, ticketCatalog, ticketCompactors);
+        final ConfigurableApplicationContext applicationContext) {
+        return new StatelessTicketRegistry(statelessTicketRegistryCipherExecutor, ticketSerializationManager, ticketCatalog,
+            applicationContext, ticketCompactors);
     }
 
     @Bean

--- a/support/cas-server-support-stateless-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/StatelessTicketRegistry.java
+++ b/support/cas-server-support-stateless-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/StatelessTicketRegistry.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import java.time.Clock;
 import java.time.Instant;
@@ -38,8 +39,9 @@ public class StatelessTicketRegistry extends AbstractTicketRegistry {
     public StatelessTicketRegistry(final CipherExecutor<byte[], byte[]> cipherExecutor,
                                    final TicketSerializationManager ticketSerializationManager,
                                    final TicketCatalog ticketCatalog,
+                                   final ConfigurableApplicationContext applicationContext,
                                    final List<TicketCompactor<? extends Ticket>> compactors) {
-        super(cipherExecutor, ticketSerializationManager, ticketCatalog);
+        super(cipherExecutor, ticketSerializationManager, ticketCatalog, applicationContext);
         this.ticketCompactors = List.copyOf(compactors);
     }
 


### PR DESCRIPTION
As a follow-up of: https://github.com/apereo/cas/pull/6156

The main changes are in the:
- `DefaultTicketRegistryCleaner`:  in case of a TGT, the `logoutManager` is no longer called, only two events: `CasRequestSingleLogoutEvent` + `CasTicketGrantingTicketDestroyedEvent` are published
- `AbstractTicketRegistry`: in case of an expired TGT, two events: `CasRequestSingleLogoutEvent` + `CasTicketGrantingTicketDestroyedEvent` are published. The single deletion of a ticket: `deleteSingletTicket` is replaced by the more global `deleteTicket` method (which destroys all tickets related to a TGT)
- `CasAuthenticationAuthenticationEventListener`: the `CasRequestSingleLogoutEvent` is handled, perfoming a SLO thanks to the `logoutManager`.
