### PR TITLE
Populate sessionId in MDC

### DIFF
--- a/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
+++ b/core/cas-server-core-logging/src/main/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilter.java
@@ -77,6 +77,12 @@ public class ThreadContextMDCServletFilter implements Filter {
             request.setAttribute("requestId", requestId);
             response.setHeader("requestId", requestId);
 
+            val sessionId = request.getSession().getId();
+            addContextAttribute("sessionId", sessionId);
+            request.setAttribute("sessionId", sessionId);
+            response.setHeader("sessionId", sessionId);
+
+
             val params = request.getParameterMap();
             val mdc = casProperties.getLogging().getMdc();
             params.keySet()

--- a/core/cas-server-core-logging/src/test/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilterTests.java
+++ b/core/cas-server-core-logging/src/test/java/org/apereo/cas/logging/web/ThreadContextMDCServletFilterTests.java
@@ -86,5 +86,7 @@ class ThreadContextMDCServletFilterTests {
         assertFalse(mdcElements.containsKey("password"));
         assertFalse(mdcElements.containsKey("confirmedPassword"));
         assertFalse(mdcElements.containsKey("cookie"));
+
+        assertNotNull(request.getAttribute("sessionId"));
     }
 }


### PR DESCRIPTION
Being able to correlate log events across not just a single request but across a session is invaluable for quickly drilling down on errors when users encounter them. To that end, this PR adds automatic population of session ID, using the built-in HttpServletRequest API. A minimal test is included.

In use, this allows for configuring a log4j2 pattern (for example) as follows:
```xml
<PatternLayout pattern=".... %X{sessionId} ...." />
```

We at Bard have been running a filter that accomplishes the same thing for several years, and it's been immensely helpful.
