### PR TITLE
Clean up/simplify delegated logout flow

### DIFF
--- a/support/cas-server-support-pac4j-webflow/build.gradle
+++ b/support/cas-server-support-pac4j-webflow/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compileOnly project(":support:cas-server-support-discovery-profile-core")
     compileOnly project(":support:cas-server-support-scim-core")
     compileOnly project(":support:cas-server-support-ldap-core")
+	compileOnly project(":support:cas-server-support-actions-core")
 
     testImplementation libraries.pac4jcas
     testImplementation libraries.springboottomcat

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationWebflowConfiguration.java
@@ -30,6 +30,7 @@ import org.apereo.cas.support.pac4j.authentication.clients.DelegatedClientsEndpo
 import org.apereo.cas.support.pac4j.authentication.clients.DelegatedClientsEndpointContributor;
 import org.apereo.cas.ticket.TicketFactory;
 import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.crypto.CipherExecutor;
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.nativex.CasRuntimeHintsRegistrar;
@@ -488,14 +489,17 @@ class DelegatedAuthenticationWebflowConfiguration {
             @Qualifier(DelegatedIdentityProviders.BEAN_NAME)
             final DelegatedIdentityProviders identityProviders,
             @Qualifier("delegatedClientDistributedSessionStore")
-            final SessionStore delegatedClientDistributedSessionStore) {
+            final SessionStore delegatedClientDistributedSessionStore,
+            @Qualifier(TicketRegistrySupport.BEAN_NAME)
+            final TicketRegistrySupport ticketRegistrySupport) {
             return BeanSupplier.of(Action.class)
                 .when(BeanCondition.on("cas.slo.disabled").isFalse().evenIfMissing()
                     .given(applicationContext.getEnvironment()))
                 .supply(() -> WebflowActionBeanSupplier.builder()
                     .withApplicationContext(applicationContext)
                     .withProperties(casProperties)
-                    .withAction(() -> new DelegatedAuthenticationClientLogoutAction(identityProviders, delegatedClientDistributedSessionStore, casProperties.getLogout().isConfirmLogout()))
+                    .withAction(() -> new DelegatedAuthenticationClientLogoutAction(identityProviders,
+                            delegatedClientDistributedSessionStore, ticketRegistrySupport, casProperties.getLogout().isConfirmLogout()))
                     .withId(CasWebflowConstants.ACTION_ID_DELEGATED_AUTHENTICATION_CLIENT_LOGOUT)
                     .build()
                     .get())

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationWebflowConfiguration.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/config/DelegatedAuthenticationWebflowConfiguration.java
@@ -495,7 +495,7 @@ class DelegatedAuthenticationWebflowConfiguration {
                 .supply(() -> WebflowActionBeanSupplier.builder()
                     .withApplicationContext(applicationContext)
                     .withProperties(casProperties)
-                    .withAction(() -> new DelegatedAuthenticationClientLogoutAction(identityProviders, delegatedClientDistributedSessionStore))
+                    .withAction(() -> new DelegatedAuthenticationClientLogoutAction(identityProviders, delegatedClientDistributedSessionStore, casProperties.getLogout().isConfirmLogout()))
                     .withId(CasWebflowConstants.ACTION_ID_DELEGATED_AUTHENTICATION_CLIENT_LOGOUT)
                     .build()
                     .get())

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/logout/DelegatedAuthenticationClientLogoutAction.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/actions/logout/DelegatedAuthenticationClientLogoutAction.java
@@ -5,6 +5,7 @@ import org.apereo.cas.pac4j.client.DelegatedIdentityProviders;
 import org.apereo.cas.support.pac4j.authentication.DelegatedAuthenticationClientLogoutRequest;
 import org.apereo.cas.web.flow.DelegationWebflowUtils;
 import org.apereo.cas.web.flow.actions.BaseCasWebflowAction;
+import org.apereo.cas.web.flow.logout.TerminateSessionAction;
 import org.apereo.cas.web.support.WebUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +42,8 @@ public class DelegatedAuthenticationClientLogoutAction extends BaseCasWebflowAct
 
     protected final SessionStore sessionStore;
 
+    protected final boolean confirmLogout;
+
     @Override
     protected Event doPreExecute(final RequestContext requestContext) {
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
@@ -59,6 +62,17 @@ public class DelegatedAuthenticationClientLogoutAction extends BaseCasWebflowAct
 
     @Override
     protected Event doExecuteInternal(final RequestContext requestContext) {
+        val terminate = confirmLogout
+            ? WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext)
+                .getParameterMap().containsKey(TerminateSessionAction.REQUEST_PARAM_LOGOUT_REQUEST_CONFIRMED)
+            : true;
+        if (terminate) {
+            return terminateSessions(requestContext);
+        }
+        return null;
+    }
+
+    protected Event terminateSessions(final RequestContext requestContext) {
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
         val response = WebUtils.getHttpServletResponseFromExternalWebflowContext(requestContext);
         val context = new JEEContext(request, response);


### PR DESCRIPTION
This PR includes two changes we've had to make locally:

## Prevent delegated logout from firing before logout has been confirmed
This is a bugfix: because `delegatedAuthenticationClientLogoutAction` is attached to `terminateSession` as an entry action, it will fire before any checks have even happened for logout confirmation. This PR patches this behavior by implementing the same check as is used in `TerminateSessionAction`, but this may not be the ideal approach - for example, it might be more appropriate to attach the delegated logout action to `finishLogout`, or one of the end states of the logout flow.

One interesting avenue to consider would be trying to get a delegated IdP to send the user back to CAS, allowing jumping off in the middle of the logout flow, and then picking it back up. This would not automatically solve the problem of skipping the logout confirmation page, but it might make it easier to choose a new webflow state to attach the delegated logout action to. In OIDC, this could be done with `post_logout_redirect_uri ` and related settings.

### Tests
This should be easy to test, but I do not know how to modify the CAS properties within a test.

## Bypass Pac4j SessionStore when locating a UserProfile during logout
This may be somewhat more contentious. We have encountered issues where the Pac4j SessionStore eventually becomes inaccessible, likely due to a cookie misconfiguration, leading to a failure to log users out of delegated clients. While debugging this behavior, it struck me that the method of locating the relevant UserProfile in `DelegatedAuthenticationClientLogoutAction` need not be dependent on the Pac4j SessionStore at all - the UserProfile is tracked in the Authentication bundle. Retrieving the profile from the authentication, rather than from the JEEContext, is the change made by my second commit.

### Possible interactions with Pac4j APIs
Due to Pac4j's approach of bundling all possible information into a `CallContext` object, it's a little hard to evaluate what is or is not needed to generate the logout action. I have inspected the following LogoutActionBuilders:
* [CasLogoutActionBuilder](https://github.com/pac4j/pac4j/blob/17e7b5ca454357a815329fd91be8fb80f2088fab/pac4j-core/src/main/java/org/pac4j/core/logout/CasLogoutActionBuilder.java#L46-L56) uses only the WebContext part of the CallContext
* [GoogleLogoutActionBuilder](https://github.com/pac4j/pac4j/blob/17e7b5ca454357a815329fd91be8fb80f2088fab/pac4j-core/src/main/java/org/pac4j/core/logout/GoogleLogoutActionBuilder.java#L23-L27) also uses only the WebContext
* [OidcLogoutActionBuilder](https://github.com/pac4j/pac4j/blob/17e7b5ca454357a815329fd91be8fb80f2088fab/pac4j-oidc/src/main/java/org/pac4j/oidc/logout/OidcLogoutActionBuilder.java#L65C71-L65C84) only interacts with the SessionStore to unset a requested URL, and only in an error state
* [SAML2LogoutActionBuilder](https://github.com/pac4j/pac4j/blob/17e7b5ca454357a815329fd91be8fb80f2088fab/pac4j-saml/src/main/java/org/pac4j/saml/logout/SAML2LogoutActionBuilder.java#L58-L84) is substantially harder to evaluate but I am fairly certain that it does not interact with the SessionStore

### Tests
This also seems like it should be easy to test, but so far I am not sure what to provide RegisteredServiceTestUtils::getAuthentication for an AuthenticationHandler, is required in order to be able to set an appropriate Credential.


Let me know what you think of these changes. Happy to pursue some tests but I would appreciate some guidance, e.g. existing tests that make use of some of the same APIs.