### PR TITLE
[fix-passwordless-sms-token] add the token value to the message

### DIFF
--- a/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/CreatePasswordlessAuthenticationTokenAction.java
+++ b/support/cas-server-support-passwordless-webflow/src/main/java/org/apereo/cas/web/flow/CreatePasswordlessAuthenticationTokenAction.java
@@ -71,7 +71,7 @@ public class CreatePasswordlessAuthenticationTokenAction extends BasePasswordles
             FunctionUtils.doUnchecked(u -> {
                 val smsProperties = passwordlessProperties.getTokens().getSms();
                 val text = SmsBodyBuilder.builder().properties(smsProperties)
-                    .parameters(Map.of("token", token)).build().get();
+                    .parameters(Map.of("token", token.getToken())).build().get();
                 val smsRequest = SmsRequest
                     .builder()
                     .from(smsProperties.getFrom())


### PR DESCRIPTION
Pass the token value into the SmsBodyBuilder so that is what is added to the sms message that is generated and not the toString() value of the PasswordlessAuthenticationToken
