### PR TITLE
Remove the old Guava fork from ben-manes

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -611,11 +611,6 @@ ext.libraries = [
                 dependencies.create("com.github.ben-manes.caffeine:caffeine:$caffeineVersion") {
                     exclude(group: "org.slf4j", module: "slf4j-api")
                     exclude(group: "com.fasterxml.jackson.module", module: "jackson-module-jaxb-annotations")
-                },
-                dependencies.create("com.github.ben-manes.caffeine:guava:$caffeineVersion") {
-                    exclude(group: "com.google.guava", module: "guava")
-                    exclude(group: "org.slf4j", module: "slf4j-api")
-                    exclude(group: "com.fasterxml.jackson.module", module: "jackson-module-jaxb-annotations")
                 }
         ],
         websockets                 : [


### PR DESCRIPTION
I think this "old Guava fork or so" dependency is no longer necessary.