### PR TITLE
Fix S3 metadata support without crypto

### DIFF
--- a/ci/tests/puppeteer/scenarios/saml2-idp-login-metadata-aws-s3/script.json
+++ b/ci/tests/puppeteer/scenarios/saml2-idp-login-metadata-aws-s3/script.json
@@ -11,7 +11,7 @@
     "--cas.authn.saml-idp.metadata.amazon-s3.region=us-east-1",
     "--cas.authn.saml-idp.metadata.amazon-s3.credential-access-key=test",
     "--cas.authn.saml-idp.metadata.amazon-s3.credential-secret-key=test",
-    "--cas.authn.saml-idp.metadata.amazon-s3.crypto.enabled=true",
+    "--cas.authn.saml-idp.metadata.amazon-s3.crypto.enabled=false",
 
     "--cas.server.name=https://localhost:8443",
     "--cas.server.prefix=https://localhost:8443/cas",

--- a/support/cas-server-support-saml-idp-metadata-aws-s3/src/main/java/org/apereo/cas/support/saml/idp/metadata/AmazonS3SamlIdPMetadataLocator.java
+++ b/support/cas-server-support-saml-idp-metadata-aws-s3/src/main/java/org/apereo/cas/support/saml/idp/metadata/AmazonS3SamlIdPMetadataLocator.java
@@ -82,10 +82,10 @@ public class AmazonS3SamlIdPMetadataLocator extends AbstractSamlIdPMetadataLocat
         metadataDocument.setMetadata(FunctionUtils.doUnchecked(() -> IOUtils.toString(object, StandardCharsets.UTF_8)));
         val objectMetadata = object.response().metadata();
         LOGGER.debug("Located S3 object metadata [{}] from bucket [{}]", objectMetadata, bucketToUse);
-        metadataDocument.setEncryptionCertificate(getObjectMetadataEntry(objectMetadata, "encryptionCertificate"));
-        metadataDocument.setSigningCertificate(getObjectMetadataEntry(objectMetadata, "signingCertificate"));
-        metadataDocument.setEncryptionKey(getObjectMetadataEntry(objectMetadata, "encryptionKey"));
-        metadataDocument.setSigningKey(getObjectMetadataEntry(objectMetadata, "signingKey"));
+        metadataDocument.setEncryptionCertificate(restoreNewline(getObjectMetadataEntry(objectMetadata, "encryptionCertificate")));
+        metadataDocument.setSigningCertificate(restoreNewline(getObjectMetadataEntry(objectMetadata, "signingCertificate")));
+        metadataDocument.setEncryptionKey(restoreNewline(getObjectMetadataEntry(objectMetadata, "encryptionKey")));
+        metadataDocument.setSigningKey(restoreNewline(getObjectMetadataEntry(objectMetadata, "signingKey")));
         metadataDocument.setAppliesTo(bucketToUse);
         return metadataDocument;
     }
@@ -93,6 +93,12 @@ public class AmazonS3SamlIdPMetadataLocator extends AbstractSamlIdPMetadataLocat
     private static String getObjectMetadataEntry(final Map<String, String> objectMetadata,
                                                  final String key) {
         return StringUtils.defaultIfBlank(objectMetadata.get(key), objectMetadata.get(key.toLowerCase(Locale.ENGLISH)));
+    }
+
+    private static String restoreNewline(final String s) {
+        val r = s.replaceAll("<br/>", "\n");
+        LOGGER.trace("[{}] => [{}]", s, r);
+        return r;
     }
 }
 


### PR DESCRIPTION
When saving and retrieving IdP metadata in S3, new lines (`\n`) are lost.

This PR prevents this issue by turning new lines into the string `<br/>` and back to the original new lines.
