### PR TITLE
7.1.x MongoDB trusted MFA Id -1 Fix

### DIFF
--- a/support/cas-server-support-trusted-mfa-mongo/src/main/java/org/apereo/cas/trusted/authentication/storage/MongoDbMultifactorAuthenticationTrustStorage.java
+++ b/support/cas-server-support-trusted-mfa-mongo/src/main/java/org/apereo/cas/trusted/authentication/storage/MongoDbMultifactorAuthenticationTrustStorage.java
@@ -101,6 +101,7 @@ public class MongoDbMultifactorAuthenticationTrustStorage extends BaseMultifacto
 
     @Override
     protected MultifactorAuthenticationTrustRecord saveInternal(final MultifactorAuthenticationTrustRecord record) {
+    	FunctionUtils.doIf(record.getId() < 0, __ -> record.setId(System.nanoTime())).accept(record);
         this.mongoTemplate.save(record, getTrustedDevicesMultifactorProperties().getMongo().getCollection());
         return record;
     }

--- a/support/cas-server-support-trusted-mfa-mongo/src/main/java/org/apereo/cas/trusted/authentication/storage/MongoDbMultifactorAuthenticationTrustStorage.java
+++ b/support/cas-server-support-trusted-mfa-mongo/src/main/java/org/apereo/cas/trusted/authentication/storage/MongoDbMultifactorAuthenticationTrustStorage.java
@@ -3,6 +3,7 @@ package org.apereo.cas.trusted.authentication.storage;
 import org.apereo.cas.configuration.model.support.mfa.trusteddevice.TrustedDevicesMultifactorProperties;
 import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustRecord;
 import org.apereo.cas.trusted.authentication.api.MultifactorAuthenticationTrustRecordKeyGenerator;
+import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.LoggingUtils;
 import org.apereo.cas.util.crypto.CipherExecutor;
 


### PR DESCRIPTION
Added code to set a unique ID for trusted MFA devices when stored to MongoDB. MongoDB is not assigning an auto incrementing ID.

 