### PR TITLE
Avoid starting Redis connection if not needed

### DIFF
--- a/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/CasRedisTicketRegistryAutoConfiguration.java
+++ b/support/cas-server-support-redis-ticket-registry/src/main/java/org/apereo/cas/config/CasRedisTicketRegistryAutoConfiguration.java
@@ -78,6 +78,7 @@ public class CasRedisTicketRegistryAutoConfiguration {
     @Configuration(value = "RedisTicketRegistryCachingConfiguration", proxyBeanMethods = false)
     @EnableConfigurationProperties(CasConfigurationProperties.class)
     @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.TicketRegistry, module = "redis-messaging")
+    @ConditionalOnProperty(value="cas.ticket.registry.redis.enabled", havingValue = "true", matchIfMissing = true)
     @Lazy(false)
     static class RedisTicketRegistryCachingConfiguration {
         @Bean


### PR DESCRIPTION
When setting cas.ticket.registry.redis.enabled=false, CAS will still attempt to create a Redis connection, which may fail if Redis is not configured. This poses a problem for environments that wish to rollout a Redis backed ticket registry in a step wise manor. E.g. enable the ticket registry on a set of staging hosts, but rollout the same deployment to production, or where you have multiple production hosts, and wish to first migrate a standby host and do a switch-over, but again ensure that the same release is running on both hosts.

The current situation, when building a deployment package, using CAS Initializr, is that you will end up with a deployment, containing Redis Ticket Registry support, which will fail to boot if no Redis server is found, regardless of the state of cas.ticket.registry.redis.enabled.

Because I normally build using CAS Initializr I don't really know how to build a .war file that I can test in our environment. Any points as to how to go about that would be appreciated.

This patch is currently not test, and I understand that it MUST be, so it may be completely the wrong way to go about this.

The documentation should not need to be updated, as the documentation appears correct, but the behavior of the code doesn't match the expectations set in the documentation. 