### PR TITLE
Reset maxPostSize to Tomcat default to not fail SAML responses

### DIFF
--- a/webapp/cas-server-webapp-resources/src/main/resources/application.properties
+++ b/webapp/cas-server-webapp-resources/src/main/resources/application.properties
@@ -28,7 +28,7 @@ server.http2.enabled=false
 ##
 # CAS Web Application Embedded Tomcat Configuration
 #
-server.tomcat.max-http-form-post-size=40KB
+server.tomcat.max-http-form-post-size=2MB
 server.tomcat.max-http-response-header-size=60KB
 server.tomcat.basedir=build/tomcat
 server.tomcat.connection-timeout=PT20S


### PR DESCRIPTION
With CAS 7.1.0 RC1 (https://github.com/apereo/cas/commit/3e84b9d22f7d23da4195bfd08d3d377257822179), `server.tomcat.max-http-form-post-size` was reduced from Tomcat's default of 2MiB to 40KiB. As a result of this change, SAMLResponses from one of our identity providers were no longer parsed, resulting in failed logins.

This PR reverts the change to fix the regression.