### PR TITLE
fix(typo): replace 2 comma's with 1

### DIFF
--- a/ci/tests/puppeteer/scenarios/delegated-login-cas-idp-scim/script.json
+++ b/ci/tests/puppeteer/scenarios/delegated-login-cas-idp-scim/script.json
@@ -1,5 +1,5 @@
 {
-  "dependencies": "oidc,pac4j-webflow,scim,,pac4j-cas",
+  "dependencies": "oidc,pac4j-webflow,scim,pac4j-cas",
   "conditions": {
     "docker": "true"
   },


### PR DESCRIPTION
I was going through the commit's, and just saw this small mistake.