### PR TITLE
Handle languages for Friendly Captcha

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/recaptcha.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/fragments/recaptcha.html
@@ -59,7 +59,7 @@
                 <script src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.16/widget.min.js" async defer></script>
 
                 <section id="friendlyCaptchaSection" class="form-group">
-                    <div class="frc-captcha" th:attr="data-sitekey=${recaptchaSiteKey}"></div>
+                    <div class="frc-captcha" th:attr="data-sitekey=${recaptchaSiteKey},data-lang=${#locale.language}"></div>
                 </section>
             </span>
 


### PR DESCRIPTION
Friendly Captcha ships at the moment with 29 different languages. English, French, German and many more are available.

This PR supports this language feature.

See: https://support.friendlycaptcha.com/en/article/can-i-translate-the-friendly-captcha-widget-1eeyiwu/
