### PR TITLE
Fix the SAML logout support (back channel) in authentication delegation

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlIdPProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/AbstractSamlIdPProfileHandlerController.java
@@ -301,14 +301,15 @@ public abstract class AbstractSamlIdPProfileHandlerController {
         val st = factory.create(ticketGrantingTicket, service, false, ServiceTicket.class);
         getConfigurationContext().getTicketRegistry().addTicket(st);
         getConfigurationContext().getTicketRegistry().updateTicket(ticketGrantingTicket);
-        buildSamlResponse(response, request, authenticationContext, Optional.of(assertion), binding);
+        buildSamlResponse(response, request, authenticationContext, Optional.of(assertion), binding, st.getId());
     }
 
     protected XMLObject buildSamlResponse(final HttpServletResponse response,
                                           final HttpServletRequest request,
                                           final Pair<? extends RequestAbstractType, MessageContext> authenticationContext,
                                           final Optional<AuthenticatedAssertionContext> casAssertion,
-                                          final String binding) throws Exception {
+                                          final String binding,
+                                          final String sessionIndex) throws Exception {
         val authnRequest = (AuthnRequest) authenticationContext.getKey();
         val pair = getRegisteredServiceAndFacade(authnRequest, request);
 
@@ -323,6 +324,7 @@ public abstract class AbstractSamlIdPProfileHandlerController {
             .adaptor(pair.getValue())
             .binding(binding)
             .messageContext(authenticationContext.getValue())
+            .sessionIndex(sessionIndex)
             .build();
         val samlResponse = configurationContext.getResponseBuilder().build(buildContext);
         LOGGER.info("Built the SAML2 response for [{}]", entityId);

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileBuilderContext.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/SamlProfileBuilderContext.java
@@ -48,6 +48,8 @@ public class SamlProfileBuilderContext {
     @Builder.Default
     private final MessageContext messageContext = new MessageContext();
 
+    private final String sessionIndex;
+
     /**
      * Transfer to a new context.
      *

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/authn/SamlProfileSamlAuthNStatementBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/authn/SamlProfileSamlAuthNStatementBuilder.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.support.saml.web.idp.profile.builders.authn;
 
-import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.support.Beans;
 import org.apereo.cas.support.saml.OpenSamlConfigBean;
@@ -87,10 +86,7 @@ public class SamlProfileSamlAuthNStatementBuilder extends AbstractSaml20ObjectBu
     }
 
     private static String buildAuthnStatementSessionIdex(final SamlProfileBuilderContext context) {
-        var id = Optional.ofNullable(context.getHttpRequest())
-            .map(request -> request.getParameter(CasProtocolConstants.PARAMETER_TICKET))
-            .filter(StringUtils::isNotBlank)
-            .orElse(StringUtils.EMPTY);
+        var id = context.getSessionIndex();
         if (StringUtils.isBlank(id)) {
             LOGGER.info("Unable to locate service ticket as the session index; Generating random identifier instead...");
             id = '_' + String.valueOf(RandomUtils.nextLong());

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/ecp/ECPSamlIdPProfileHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/ecp/ECPSamlIdPProfileHandlerController.java
@@ -99,7 +99,7 @@ public class ECPSamlIdPProfileHandlerController extends AbstractSamlIdPProfileHa
 
             LOGGER.trace("CAS assertion to use for building ECP SAML2 response is [{}]", casAssertion);
             buildSamlResponse(context.getHttpResponse(), context.getHttpRequest(),
-                authenticationContext, Optional.of(casAssertion), context.getBinding());
+                authenticationContext, Optional.of(casAssertion), context.getBinding(), null);
         } catch (final AuthenticationException e) {
             LoggingUtils.error(LOGGER, e);
             val error = e.getHandlerErrors().values()

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPProfileCallbackHandlerController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/sso/SSOSamlIdPProfileCallbackHandlerController.java
@@ -103,7 +103,7 @@ public class SSOSamlIdPProfileCallbackHandlerController extends AbstractSamlIdPP
             LOGGER.error("Unable to determine profile binding");
             return WebUtils.produceErrorView(new IllegalArgumentException("Unable to determine profile binding"));
         }
-        val resultObject = buildSamlResponse(response, request, authenticationContext, assertion, binding);
+        val resultObject = buildSamlResponse(response, request, authenticationContext, assertion, binding, ticket);
         request.setAttribute(Response.class.getName(), resultObject);
         return null;
     }


### PR DESCRIPTION
After fixing the SAML (front channel) logout support (https://github.com/apereo/cas/pull/6205), I'm focusing my efforts on the back channel way.

It partially works. I still have a CAS server delegating via SAML to another CAS server and after a successful login, I perform a logout on the second CAS server expecting it to send a logout call to the first CAS server.
The logout propagation works if I log in during the authn delegation, but not if I'm already authenticated on the second CAS server before the authn delegation.

This comes from the way we compute the session index at the authentication stage. Getting the "ticket" parameter only works half of the time, it looks and is fragile.

This PR proposes to **explicitly** pass the service ticket as the session index in the `SamlProfileBuilderContext` and other components that need it.

Side note: I don't have a service ticket in the `ECPSamlIdPProfileHandlerController` so I pass `null` here.
