### PR TITLE
Handle URISyntaxException in setting of service fragment

### DIFF
--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractWebApplicationService.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractWebApplicationService.java
@@ -1,4 +1,4 @@
-package org.apereo.cas.authentication.principal;
+    package org.apereo.cas.authentication.principal;
 
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.jpa.MultivaluedMapToJsonAttributeConverter;
@@ -96,7 +96,7 @@ public abstract class AbstractWebApplicationService implements WebApplicationSer
     @Override
     @JsonIgnore
     public String getFragment() {
-        return FunctionUtils.doUnchecked(() -> new URIBuilder(this.id).getFragment());
+        return FunctionUtils.doAndHandle(() -> new URIBuilder(this.id).getFragment());
     }
 
     private static String collectFragmentFor(final String id, final String fragment) {

--- a/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractWebApplicationService.java
+++ b/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractWebApplicationService.java
@@ -1,4 +1,4 @@
-    package org.apereo.cas.authentication.principal;
+package org.apereo.cas.authentication.principal;
 
 import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.jpa.MultivaluedMapToJsonAttributeConverter;

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/DefaultCasDelegatingWebflowEventResolver.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/DefaultCasDelegatingWebflowEventResolver.java
@@ -207,10 +207,10 @@ public class DefaultCasDelegatingWebflowEventResolver extends AbstractCasWebflow
             return strategies.resolveService(serviceFromRequest);
         }
         if (serviceFromRequest != null) {
-            try {
-                serviceFromFlow.setFragment(serviceFromRequest.getFragment());
-            } catch (final Exception e) {
-                LOGGER.error("Unable to extract fragment from [{}]: [{}]", serviceFromRequest.getOriginalUrl(), e.getMessage());
+            val fragment = serviceFromRequest.getFragment();
+
+            if (fragment != null) {
+                serviceFromFlow.setFragment(fragment);
             }
         }
         return strategies.resolveService(serviceFromFlow);

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/DefaultCasDelegatingWebflowEventResolver.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/DefaultCasDelegatingWebflowEventResolver.java
@@ -207,7 +207,11 @@ public class DefaultCasDelegatingWebflowEventResolver extends AbstractCasWebflow
             return strategies.resolveService(serviceFromRequest);
         }
         if (serviceFromRequest != null) {
-            serviceFromFlow.setFragment(serviceFromRequest.getFragment());
+            try {
+                serviceFromFlow.setFragment(serviceFromRequest.getFragment());
+            } catch (final Exception e) {
+                LOGGER.error("Unable to extract fragment from [{}]: [{}]", serviceFromRequest.getOriginalUrl(), e.getMessage());
+            }
         }
         return strategies.resolveService(serviceFromFlow);
     }


### PR DESCRIPTION
Fixing a backwards incompatibility regression introduced in https://github.com/apereo/cas/commit/83a68848bf2a808ae149ce27e4c84fafd901a061 that was subsequently released as part of 7.1.1 patch release.

Given an example URL, where the service contains query string parameters with illegal characters, or any other means which generate an exception upon parsing into the UriBuilder object:

https://localhost:8443/cas/login?service=https%3A%2F%2Finit.cas.org%2F%3Fquery%3D%2FInvalid%20Format

Prior, CAS would process the request and log the following ERROR:

`ERROR [org.apereo.cas.authentication.principal.AbstractServiceFactory] - <Unable to extract query parameters from [https://init.cas.org/?query=/Invalid Format]: [java.net.URISyntaxException: Illegal character in query at index 36: https://init.cas.org/?query=/Invalid Format]>`

After the patch update, CAS is throwing a 500 Internal Server Error:

`Exception thrown executing org.apereo.cas.web.flow.actions.InitialAuthenticationAction@6b46ca59 in state 'realSubmit' of flow 'login' -- action execution attributes were 'map[[empty]]'`

This PR adds similar logic as the previously logged error defined [here](https://github.com/apereo/cas/blob/master/core/cas-server-core-services-authentication/src/main/java/org/apereo/cas/authentication/principal/AbstractServiceFactory.java#L95-L97).

A test has been included that verifies a service URL that throws URISyntaxException will be caught and processing will continue, thus fixing the regression.