### PR TITLE
Fix the OIDC logout support (back channel) in authentication delegation

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/slo/OidcSingleLogoutMessageCreator.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/slo/OidcSingleLogoutMessageCreator.java
@@ -62,11 +62,12 @@ public class OidcSingleLogoutMessageCreator implements SingleLogoutMessageCreato
         claims.setAudience(((OAuthRegisteredService) request.getRegisteredService()).getClientId());
         claims.setIssuedAtToNow();
         claims.setJwtId(UUID.randomUUID().toString());
+        claims.setExpirationTimeMinutesInTheFuture(1);
         val events = new HashMap<String, Object>();
         events.put("http://schemas.openid.net/event/backchannel-logout", new HashMap<>());
         claims.setClaim("events", events);
         claims.setClaim(OidcConstants.CLAIM_SESSION_ID,
-            DigestUtils.sha(request.getExecutionRequest().getTicketGrantingTicket().getId()));
+                DigestUtils.sha(DigestUtils.sha512(request.getExecutionRequest().getTicketGrantingTicket().getId())));
 
         return claims;
     }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/slo/OidcSingleLogoutMessageCreatorTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/slo/OidcSingleLogoutMessageCreatorTests.java
@@ -61,9 +61,10 @@ class OidcSingleLogoutMessageCreatorTests extends AbstractOidcTests {
         assertEquals(service.getClientId(), claims.getAudience().getFirst());
         assertNotNull(claims.getClaim("iat"));
         assertNotNull(claims.getClaim("jti"));
+        assertNotNull(claims.getClaim("exp"));
         val events = (Map<String, Object>) claims.getClaim("events");
         assertNotNull(events.get("http://schemas.openid.net/event/backchannel-logout"));
-        assertEquals(DigestUtils.sha(TGT_ID), claims.getClaim(OidcConstants.CLAIM_SESSION_ID));
+        assertEquals(DigestUtils.sha(DigestUtils.sha512(TGT_ID)), claims.getClaim(OidcConstants.CLAIM_SESSION_ID));
     }
 
     @Test


### PR DESCRIPTION
After fixing the SAML back channel logout support (https://github.com/apereo/cas/pull/6213), I'm now focusing on the OIDC back channel logout support.

I always perform the same test: one CAS server acting as the OIDC client and another CAS server acting as the OIDC server. After an authentication delegation, the logout is not transmitted from the OIDC server to the OIDC client because of two inconsistencies in the OIDC logout request:
1) the "exp" claim is missing (mandatory in the spec: https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken)
2) the "sid" claim is not properly computed for the logout: it should be a SHA of the "jwtId" which is itself a SHA512 of the TGT identifier (like in the `OidcIdTokenGeneratorService`).

This PR fixes these two issues in the `OidcSingleLogoutMessageCreator`. Unit tests have been updated accordingly.


