### PR TITLE
use IDX_PRINCIPAL not text index in getSessionsFor()

### DIFF
--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -222,7 +222,7 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
             .flatMap(map -> {
                 val query = isCipherExecutorEnabled()
                     ? new Query(Criteria.where(MongoDbTicketDocument.FIELD_NAME_PRINCIPAL).is(digestIdentifier(principalId)))
-                    : TextQuery.queryText(TextCriteria.forDefaultLanguage().matchingAny(principalId)).sortByScore().with(PageRequest.of(0, PAGE_SIZE));
+                    : new Query(Criteria.where(MongoDbTicketDocument.FIELD_NAME_PRINCIPAL).regex(principalId, "i"));
                 return mongoTemplate.stream(query, MongoDbTicketDocument.class, map);
             })
             .map(ticket -> decodeTicket(deserializeTicket(ticket.getJson(), ticket.getType())))


### PR DESCRIPTION
Currently, MongoDbTicketRegistry.getSessionsFor() does a TextQuery of the ticket document to find the principalId. This pull request changes it to query the principal_id directly (which already has its own index).

Using the TextQuery _requires_ CAS to maintain an full-text index of the 'json' attribute to support this search (otherwise, mongo throws an exception). This index is seldom useful in routine CAS operation - apparently the only time the getSessionsFor() method is used is by operations like `DELETE actuator/ssoSessions?username=`.  Even though it is rarely used, the index becomes very large and expensive to maintain -- load testing shows a 50% reduction in tickets-generated-per-second throughput when the index is present.

This pull request _allows_ you to remove the index, but perhaps CAS should never create it in the first place? 