### PR TITLE
Remove text index from mongo ticket repository

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mongo/ticketregistry/MongoDbTicketRegistryProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mongo/ticketregistry/MongoDbTicketRegistryProperties.java
@@ -51,7 +51,6 @@ public class MongoDbTicketRegistryProperties extends BaseMongoDbProperties {
      * Supported indexes are:
      * <ul>
      *     <li>{@code IDX_ID}: index created for ticket identifiers.</li>
-     *     <li>{@code IDX_JSON_TYPE_ID}: compound index for ticket body, type and id used for text queries.</li>
      *     <li>{@code IDX_PRINCIPAL}: index created for principal attached to the ticket.</li>
      *     <li>{@code IDX_EXPIRATION}: index created for ticket expiration date.</li>
      *</ul>

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -222,7 +222,7 @@ public class MongoDbTicketRegistry extends AbstractTicketRegistry {
             .flatMap(map -> {
                 val query = isCipherExecutorEnabled()
                     ? new Query(Criteria.where(MongoDbTicketDocument.FIELD_NAME_PRINCIPAL).is(digestIdentifier(principalId)))
-                    : TextQuery.queryText(TextCriteria.forDefaultLanguage().matchingAny(principalId)).sortByScore().with(PageRequest.of(0, PAGE_SIZE));
+                    : new Query(Criteria.where(MongoDbTicketDocument.FIELD_NAME_PRINCIPAL).regex(principalId, "i"));
                 return mongoTemplate.stream(query, MongoDbTicketDocument.class, map);
             })
             .map(ticket -> decodeTicket(deserializeTicket(ticket.getJson(), ticket.getType())))

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/ticket/registry/MongoDbTicketRegistry.java
@@ -21,12 +21,9 @@ import org.hjson.JsonValue;
 import org.hjson.Stringify;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.domain.Limit;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.TextCriteria;
-import org.springframework.data.mongodb.core.query.TextQuery;
 import org.springframework.data.mongodb.core.query.Update;
 import java.io.Serializable;
 import java.time.Instant;
@@ -49,7 +46,6 @@ import java.util.stream.Stream;
 @Slf4j
 @Monitorable
 public class MongoDbTicketRegistry extends AbstractTicketRegistry {
-    private static final int PAGE_SIZE = 500;
 
     private final MongoOperations mongoTemplate;
 

--- a/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/util/MongoDbTicketRegistryFacilitator.java
+++ b/support/cas-server-support-mongo-ticket-registry/src/main/java/org/apereo/cas/util/MongoDbTicketRegistryFacilitator.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
-import org.springframework.data.mongodb.core.index.TextIndexDefinition;
 import java.time.Duration;
 import java.util.ArrayList;
 
@@ -34,10 +33,6 @@ public class MongoDbTicketRegistryFacilitator {
      * documentation that lists all supported indexes.
      */
     private static final String INDEX_NAME_ID = "IDX_ID";
-    /**
-     * Index name for ticket json body, type and id as a compound index.
-     */
-    private static final String INDEX_NAME_JSON_TYPE_ID = "IDX_JSON_TYPE_ID";
     private static final String INDEX_NAME_PRINCIPAL = "IDX_PRINCIPAL";
     private static final String INDEX_NAME_EXPIRATION = "IDX_EXPIRATION";
 
@@ -85,15 +80,6 @@ public class MongoDbTicketRegistryFacilitator {
                         .on(MongoDbTicketDocument.FIELD_NAME_PRINCIPAL, Sort.Direction.ASC)
                         .named(INDEX_NAME_PRINCIPAL);
                     expectedIndexes.add(principalIdIndex);
-                }
-                if (properties.getIndexes().isEmpty() || properties.getIndexes().contains(INDEX_NAME_JSON_TYPE_ID)){
-                    val columnsIndex = new TextIndexDefinition.TextIndexDefinitionBuilder()
-                        .onField(MongoDbTicketDocument.FIELD_NAME_JSON)
-                        .onField(MongoDbTicketDocument.FIELD_NAME_TYPE)
-                        .onField(MongoDbTicketDocument.FIELD_NAME_ID)
-                        .named(INDEX_NAME_JSON_TYPE_ID)
-                        .build();
-                    expectedIndexes.add(columnsIndex);
                 }
             }
 


### PR DESCRIPTION
### Issue to solve
Currently, the MongoDbTicketRegistry creates a "text" mongo index on the full json contents of the ticket. That index is large and expensive to maintain: it our environment the index is larger than the ticket storage itself, and load testing shows a 50% reduction in tickets-generated-per-second throughput when the index is present. (Updating this index is the bottleneck in how many authentication transactions CAS can perform).

The only use of the text index is in `MongoDbTicketRegistry.getSessionsFor()`, which does a TextQuery of the ticket document to search by`principal`. Since `principal` is already an field in the ticket document in mongo (with its own index!) there is no need to do a full-text search to find it.

### Summary of changes

- in `getSessionsFor`, query the `principal` directly instead of a text search of the `json`
- remove code that creates the json text index (`IDX_JSON_TYPE_ID`)
- remove `IDX_JSON_TYPE_ID` from list of supported indexes
- integration tests

