### PR TITLE
Avoid using both theme-id and theme_name

### DIFF
--- a/docs/cas-server-documentation/ux/User-Interface-Customization-ThemedViews.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization-ThemedViews.md
@@ -13,7 +13,7 @@ the standard views (`login/casLoginView.html`, etc). This is specially useful in
 for a different type of audience are entirely different structurally that using a simple theme is not practical 
 to augment the default views. In such cases, new view pages may be required.
 
-Views associated with a particular theme by default are expected to be found at: `src/main/resources/templates/<theme-id>`. Note that CAS 
+Views associated with a particular theme by default are expected to be found at: `src/main/resources/templates/<theme-name>`. Note that CAS
 views and theme-based views may both be externalized out of the web application context. When externalized, themed 
 views are expected to be found at the specified path via CAS properties under a 
 directory named after the theme. For instance, if the external path for CAS views is `/etc/cas/templates`, view template files for 
@@ -30,5 +30,5 @@ cas.standard.css.file=/themes/[theme_name]/css/cas.css
 cas.standard.js.file=/themes/[theme_name]/js/cas.js
 ```
 
-- Clone the default set of view pages into a new directory based on the theme id (i.e. `src/main/resources/templates/<theme-id>`).
+- Clone the default set of view pages into a new directory based on the theme name (i.e. `src/main/resources/templates/<theme_name>`).
 - Specify the name of your theme for the service definition under the `theme` property.

--- a/docs/cas-server-documentation/ux/User-Interface-Customization-ThemedViews.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization-ThemedViews.md
@@ -13,7 +13,7 @@ the standard views (`login/casLoginView.html`, etc). This is specially useful in
 for a different type of audience are entirely different structurally that using a simple theme is not practical 
 to augment the default views. In such cases, new view pages may be required.
 
-Views associated with a particular theme by default are expected to be found at: `src/main/resources/templates/<theme-name>`. Note that CAS
+Views associated with a particular theme by default are expected to be found at: `src/main/resources/templates/<theme_name>`. Note that CAS
 views and theme-based views may both be externalized out of the web application context. When externalized, themed 
 views are expected to be found at the specified path via CAS properties under a 
 directory named after the theme. For instance, if the external path for CAS views is `/etc/cas/templates`, view template files for 


### PR DESCRIPTION
When reading the documentation themes are almost exclusively described using the term theme_name. Having a single part of the documentation using "theme-id" instead confuses the reader.

Update the documentation for "User Interface Customization" to also use "theme_name".
