### PR TITLE
Use POST instead of GET for calls with entities

### DIFF
--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/validation/RestfulCasSimpleMultifactorAuthenticationService.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/validation/RestfulCasSimpleMultifactorAuthenticationService.java
@@ -57,7 +57,7 @@ public class RestfulCasSimpleMultifactorAuthenticationService implements CasSimp
             Optional.ofNullable(service).ifPresent(s -> parameters.put("service", s.getId()));
 
             val exec = HttpExecutionRequest.builder()
-                .method(HttpMethod.GET)
+                .method(HttpMethod.POST)
                 .headers(properties.getHeaders())
                 .url(StringUtils.appendIfMissing(properties.getUrl(), "/").concat("new"))
                 .entity(writer.toString())
@@ -115,7 +115,7 @@ public class RestfulCasSimpleMultifactorAuthenticationService implements CasSimp
         try (val writer = new StringWriter()) {
             MAPPER.writer(new MinimalPrettyPrinter()).writeValue(writer, resolvedPrincipal);
             val exec = HttpExecutionRequest.builder()
-                .method(HttpMethod.GET)
+                .method(HttpMethod.POST)
                 .headers(properties.getHeaders())
                 .url(StringUtils.appendIfMissing(properties.getUrl(), "/").concat(credential.getToken()))
                 .entity(writer.toString())
@@ -142,7 +142,7 @@ public class RestfulCasSimpleMultifactorAuthenticationService implements CasSimp
         HttpResponse response = null;
         try {
             val exec = HttpExecutionRequest.builder()
-                .method(HttpMethod.GET)
+                .method(HttpMethod.POST)
                 .headers(properties.getHeaders())
                 .url(StringUtils.appendIfMissing(properties.getUrl(), "/").concat(tokenCredential.getToken()))
                 .basicAuthPassword(properties.getBasicAuthPassword())

--- a/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/validation/RestfulCasSimpleMultifactorAuthenticationService.java
+++ b/support/cas-server-support-simple-mfa-core/src/main/java/org/apereo/cas/mfa/simple/validation/RestfulCasSimpleMultifactorAuthenticationService.java
@@ -142,7 +142,7 @@ public class RestfulCasSimpleMultifactorAuthenticationService implements CasSimp
         HttpResponse response = null;
         try {
             val exec = HttpExecutionRequest.builder()
-                .method(HttpMethod.POST)
+                .method(HttpMethod.GET)
                 .headers(properties.getHeaders())
                 .url(StringUtils.appendIfMissing(properties.getUrl(), "/").concat(tokenCredential.getToken()))
                 .basicAuthPassword(properties.getBasicAuthPassword())


### PR DESCRIPTION
Currently, the `RestfulCasSimpleMultifactorAuthenticationService` component performs GET calls with entities.

This is inconsistent: bodies should be POSTed.

This PR changes the HTTP method from GET to POST wherever a body is used.
