### PR TITLE
Deadlock Caused by Changes in Commit 999c8ce (05.09.2024)

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseStringCipherExecutor.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/cipher/BaseStringCipherExecutor.java
@@ -213,6 +213,8 @@ public abstract class BaseStringCipherExecutor extends AbstractCipherExecutor<Se
         configureSigningKey(signingKeyToUse);
     }
 
+// Deadlock detected
+        
     private void configureEncryptionParameters(final String secretKeyEncryption, final String contentEncryptionAlgorithmIdentifier) {
         var secretKeyToUse = secretKeyEncryption;
         if (StringUtils.isBlank(secretKeyToUse)) {


### PR DESCRIPTION
### Description:  

**Issue:**  
Following the implementation of changes introduced in commit `999c8ce` (dated 05.09.2024), a deadlock issue has been identified under high system load. Load testing of CAS revealed that the application hangs when processing **16 messages per second**. The issue occurs on machines with the following configuration:  
- **4 GB of RAM**  
- **4 CPU cores**  

**Steps to Reproduce:**  
1. Launch the system with the specified configuration.  
2. Apply a load of 16 messages per second.  
3. The system hangs before the application fully starts.  

**Last Logs Before the Deadlock (BaseStringCipherExecutor.java):**  
```java  
LOGGER.trace("Unable to recognize encryption key [{}] as a JSON web key: [{}].", getEncryptionKeySetting(), e.getMessage());  
LOGGER.debug("Using pre-defined encryption key to use for [{}]", getEncryptionKeySetting());  
```  