### PR TITLE
Save webauthn device pb

### DIFF
--- a/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/account/WebAuthnMultifactorAccountProfileWebflowConfigurer.java
+++ b/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/account/WebAuthnMultifactorAccountProfileWebflowConfigurer.java
@@ -40,8 +40,8 @@ public class WebAuthnMultifactorAccountProfileWebflowConfigurer extends Multifac
             createEvaluateAction(CasWebflowConstants.ACTION_ID_WEBAUTHN_POPULATE_CSRF_TOKEN),
             createEvaluateAction(CasWebflowConstants.ACTION_ID_ACCOUNT_PROFILE_WEBAUTHN_REGISTRATION),
             createEvaluateAction(CasWebflowConstants.ACTION_ID_WEB_AUTHN_START_REGISTRATION));
-        createTransitionForState(regViewState, CasWebflowConstants.TRANSITION_ID_SUBMIT, CasWebflowConstants.STATE_ID_SAVE_REGISTRATION);
-
+        createTransitionForState(regViewState, CasWebflowConstants.TRANSITION_ID_SUBMIT, CasWebflowConstants.STATE_ID_MY_ACCOUNT_PROFILE_VIEW);
+	
         val accountProfileView = (ViewState) accountFlow.getState(CasWebflowConstants.STATE_ID_MY_ACCOUNT_PROFILE_VIEW);
         createTransitionForState(accountProfileView, CasWebflowConstants.TRANSITION_ID_REGISTER, regViewState.getId());
     }


### PR DESCRIPTION
On branch 7.1.x: correction of a (webflow) problem when registering a new fido2/webauthn authenticator ("device") in the account management mini portal (see thread https://groups.google.com/a/apereo.org/g/cas-user/c/bYz_05OmPbI).

This pull request against 7.1.x branch  *should* allow an user to add a webauthn device without triggering a (spurious) error message. 

No test added, as it seems there is no test initially against fido2/webauthn device registration.

