### PR TITLE
Core webauthn device registration flow: remove reference to unneeded STATE_ID_SAVE_REGISTRATION.

### DIFF
--- a/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/account/WebAuthnMultifactorAccountProfileWebflowConfigurer.java
+++ b/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/account/WebAuthnMultifactorAccountProfileWebflowConfigurer.java
@@ -40,8 +40,8 @@ public class WebAuthnMultifactorAccountProfileWebflowConfigurer extends Multifac
             createEvaluateAction(CasWebflowConstants.ACTION_ID_WEBAUTHN_POPULATE_CSRF_TOKEN),
             createEvaluateAction(CasWebflowConstants.ACTION_ID_ACCOUNT_PROFILE_WEBAUTHN_REGISTRATION),
             createEvaluateAction(CasWebflowConstants.ACTION_ID_WEB_AUTHN_START_REGISTRATION));
-        createTransitionForState(regViewState, CasWebflowConstants.TRANSITION_ID_SUBMIT, CasWebflowConstants.STATE_ID_SAVE_REGISTRATION);
-
+        createTransitionForState(regViewState, CasWebflowConstants.TRANSITION_ID_SUBMIT, CasWebflowConstants.STATE_ID_MY_ACCOUNT_PROFILE_VIEW);
+	
         val accountProfileView = (ViewState) accountFlow.getState(CasWebflowConstants.STATE_ID_MY_ACCOUNT_PROFILE_VIEW);
         createTransitionForState(accountProfileView, CasWebflowConstants.TRANSITION_ID_REGISTER, regViewState.getId());
     }


### PR DESCRIPTION
A FLow error occurs on adding a new webauthn authenticator : an error occurs at the GUI  while the new authenticator is added to the repository  (see thread https://groups.google.com/a/apereo.org/g/cas-user/c/bYz_05OmPbI). This PR should correct the problem.

