### PR TITLE
Add ConditionalOnMissingBean to SamlValidateController

### DIFF
--- a/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
+++ b/support/cas-server-support-saml/src/main/java/org/apereo/cas/config/SamlConfiguration.java
@@ -235,6 +235,7 @@ class SamlConfiguration {
         }
 
         @Bean
+        @ConditionalOnMissingBean(name = "samlValidateController")
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public SamlValidateController samlValidateController(
             @Qualifier("casValidationConfigurationContext")

--- a/support/cas-server-support-validation-core/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
+++ b/support/cas-server-support-validation-core/src/main/java/org/apereo/cas/web/AbstractServiceValidateController.java
@@ -229,6 +229,9 @@ public abstract class AbstractServiceValidateController extends AbstractDelegate
     protected void onSuccessfulValidation(final String serviceTicketId, final Assertion assertion) {
     }
 
+    protected void beforeErrorResponse(final String code, final String description, final HttpServletRequest request, final WebApplicationService service) {
+    }
+
     /**
      * Enforce ticket validation authorization for.
      *
@@ -275,6 +278,8 @@ public abstract class AbstractServiceValidateController extends AbstractDelegate
                                            final String description,
                                            final HttpServletRequest request,
                                            final WebApplicationService service) {
+        beforeErrorResponse(code, description, request, service);
+
         val modelAndView = serviceValidateConfigurationContext.getValidationViewFactory()
             .getModelAndView(request, false, service, getClass());
         modelAndView.addObject(CasViewConstants.MODEL_ATTRIBUTE_NAME_ERROR_CODE, StringEscapeUtils.escapeHtml4(code));


### PR DESCRIPTION
Adding `@ConditionalOnMissingBean` on `SamlValidateController` to allow usage of customized controller.

The intended purpose of the change is to allow SamlValidateController to be extended to include additional logging on when Service Ticket Validation requests fail.

I believe this to be considered a trivial change in regards to no unit tests, and follows the pattern of no implementation / tests  similar to `prepareForTicketValidation` and `onSuccessfulValidation`