### PR TITLE
Introducing CAS Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Slack](https://img.shields.io/badge/Slack-join%20chat-blue.svg?style=for-the-badge&logo=slack)][casslack]
 [![Stack Overflow](http://img.shields.io/:stack%20overflow-cas-brightgreen.svg?style=for-the-badge&logo=stackoverflow)](http://stackoverflow.com/questions/tagged/cas)
 [![Support](https://img.shields.io/badge/Support-Mailing%20Lists-green.svg?colorB=ff69b4&style=for-the-badge)][cassupport]
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20CAS%20Guru-006BFF?style=for-the-badge)](https://gurubase.io/g/cas)
 
 ## Introduction
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [CAS Guru](https://gurubase.io/g/cas) has been manually added to Gurubase. CAS Guru uses the data from this repo and data from the [docs](https://apereo.github.io/cas/7.1.x) to answer questions by leveraging the LLM.

This PR introduces the "CAS Guru", showcasing that CAS now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "CAS Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the CAS documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable CAS Guru in Gurubase, just let us know that's totally fine.
