### PR TITLE
Multi-hosts support

### DIFF
--- a/api/cas-server-core-api-audit/src/main/java/org/apereo/cas/multihost/MultiHostClientInfo.java
+++ b/api/cas-server-core-api-audit/src/main/java/org/apereo/cas/multihost/MultiHostClientInfo.java
@@ -1,0 +1,43 @@
+package org.apereo.cas.multihost;
+
+import org.apereo.cas.configuration.model.core.multihost.SimpleHostProperties;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apereo.inspektr.common.web.ClientInfo;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+/**
+ * The {@link ClientInfo} supplemented with the current host.
+ *
+ * @author Jerome LELEU
+ * @since 7.2.0
+ */
+@Slf4j
+@Getter
+public class MultiHostClientInfo extends ClientInfo {
+
+    private SimpleHostProperties currentHost;
+
+    public MultiHostClientInfo(final ClientInfo clientInfo, final SimpleHostProperties currentHost) {
+        super(clientInfo.getClientIpAddress(), clientInfo.getServerIpAddress(), clientInfo.getUserAgent(), clientInfo.getGeoLocation());
+
+        setDeviceFingerprint(clientInfo.getDeviceFingerprint());
+        val extraInfo = new HashMap<String, Serializable>();
+        for (val entry : clientInfo.getExtraInfo().entrySet()) {
+            extraInfo.put(entry.getKey(), entry.getValue());
+        }
+        setExtraInfo(extraInfo);
+        val headers = new HashMap<String, String>();
+        for (val entry : clientInfo.getHeaders().entrySet()) {
+            headers.put(entry.getKey(), (String) entry.getValue());
+        }
+        setHeaders(headers);
+        setLocale(clientInfo.getLocale());
+
+        this.currentHost = currentHost;
+    }
+}

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/CasConfigurationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/CasConfigurationProperties.java
@@ -14,6 +14,7 @@ import org.apereo.cas.configuration.model.core.events.EventsProperties;
 import org.apereo.cas.configuration.model.core.logging.LoggingProperties;
 import org.apereo.cas.configuration.model.core.logout.LogoutProperties;
 import org.apereo.cas.configuration.model.core.monitor.MonitorProperties;
+import org.apereo.cas.configuration.model.core.multihost.SimpleHostProperties;
 import org.apereo.cas.configuration.model.core.rest.RestProperties;
 import org.apereo.cas.configuration.model.core.services.ServiceRegistryProperties;
 import org.apereo.cas.configuration.model.core.slo.SingleLogoutProperties;
@@ -65,6 +66,8 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -392,6 +395,12 @@ public class CasConfigurationProperties implements Serializable {
      */
     @NestedConfigurationProperty
     private MultitenancyProperties multitenancy = new MultitenancyProperties();
+
+    /**
+     * Multi-hosts settings.
+     */
+    @NestedConfigurationProperty
+    private List<SimpleHostProperties> multiHosts = new ArrayList<>();
 
     /**
      * Bind from map.

--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/multihost/SimpleHostProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/core/multihost/SimpleHostProperties.java
@@ -1,0 +1,41 @@
+package org.apereo.cas.configuration.model.core.multihost;
+
+import org.apereo.cas.configuration.support.RequiredProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * A (multi-)host definition.
+ *
+ * @author Jerome LELEU
+ * @since 7.2.0
+ */
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class SimpleHostProperties {
+
+    /**
+     * A custom server name.
+     */
+    @RequiredProperty
+    private String serverName;
+
+    /**
+     * A custom server prefix.
+     */
+    @RequiredProperty
+    private String serverPrefix;
+
+    /**
+     * A custom OIDC issuer.
+     */
+    @RequiredProperty
+    private String oidcIssuer;
+}

--- a/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/multihost/MultiHostClientInfoThreadLocalFilter.java
+++ b/core/cas-server-core-audit-api/src/main/java/org/apereo/cas/multihost/MultiHostClientInfoThreadLocalFilter.java
@@ -1,0 +1,70 @@
+package org.apereo.cas.multihost;
+
+import org.apereo.cas.configuration.model.core.multihost.SimpleHostProperties;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.inspektr.common.web.ClientInfo;
+import org.apereo.inspektr.common.web.ClientInfoExtractionOptions;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
+import org.apereo.inspektr.common.web.ClientInfoThreadLocalFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * The {@link ClientInfoThreadLocalFilter} supplemented with the current host.
+ *
+ * @author Jerome LELEU
+ * @since 7.2.0
+ */
+@Slf4j
+public class MultiHostClientInfoThreadLocalFilter extends ClientInfoThreadLocalFilter {
+    private final ClientInfoExtractionOptions options;
+    private final SimpleHostProperties primaryHost;
+    private final List<SimpleHostProperties> secondariesHosts;
+
+    public MultiHostClientInfoThreadLocalFilter(final ClientInfoExtractionOptions options,
+                                                final SimpleHostProperties primaryHost,
+                                                final List<SimpleHostProperties> secondariesHosts) {
+        super(options);
+        this.options = options;
+        this.primaryHost = primaryHost;
+        this.secondariesHosts = secondariesHosts;
+    }
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response,
+                         final FilterChain filterChain) throws IOException, ServletException {
+        try {
+            if (request instanceof final HttpServletRequest httpServletRequest) {
+                val clientInfo = ClientInfo.from(httpServletRequest, options);
+
+                var currentHost = primaryHost;
+                val url = request != null ? httpServletRequest.getRequestURL().toString() : null;
+                LOGGER.trace("Request URL: [{}]", url);
+                if (StringUtils.isNotBlank(url)) {
+                    for (val secondaryHost : secondariesHosts) {
+                        if (url.startsWith(secondaryHost.getServerPrefix())) {
+                            currentHost = secondaryHost;
+                            break;
+                        }
+                    }
+                }
+                LOGGER.trace("Current host: [{}]", currentHost);
+
+                ClientInfoHolder.setClientInfo(new MultiHostClientInfo(clientInfo, currentHost));
+            }
+            filterChain.doFilter(request, response);
+        } finally {
+            ClientInfoHolder.clear();
+        }
+    }
+}

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/multihost/MultiHostUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/multihost/MultiHostUtils.java
@@ -1,0 +1,64 @@
+package org.apereo.cas.util.multihost;
+
+import org.apereo.cas.CasProtocolConstants;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.model.support.oidc.OidcProperties;
+import org.apereo.cas.multihost.MultiHostClientInfo;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apereo.inspektr.common.web.ClientInfoHolder;
+
+/**
+ * Helper for the multi-hosts feature.
+ *
+ * @author Jerome LELEU
+ * @since 7.2.0
+ */
+@UtilityClass
+@Slf4j
+public class MultiHostUtils {
+
+    /**
+     * Compute the login URL in a multi-hosts environment.
+     *
+     * @param casProperties the CAS configuration properties
+     * @return the login URL
+     */
+    public static String computeLoginUrl(final CasConfigurationProperties casProperties) {
+        return computeServerPrefix(casProperties).concat(CasProtocolConstants.ENDPOINT_LOGIN);
+    }
+
+    /**
+     * Compute the prefix URL in a multi-hosts environment.
+     *
+     * @param casProperties the CAS configuration properties
+     * @return the prefix URL
+     */
+    public static String computeServerPrefix(final CasConfigurationProperties casProperties) {
+        val clientInfo = ClientInfoHolder.getClientInfo();
+        if (clientInfo instanceof final MultiHostClientInfo mhClientInfo) {
+            LOGGER.trace("Using current host server prefix: [{}]", mhClientInfo.getCurrentHost().getServerPrefix());
+            return mhClientInfo.getCurrentHost().getServerPrefix();
+        }
+        LOGGER.trace("Using default (primary) server prefix: [{}]", casProperties.getServer().getPrefix());
+        return casProperties.getServer().getPrefix();
+    }
+
+    /**
+     * Compute the OIDC issuer in a multi-hosts environment.
+     *
+     * @param oidcProperties the OIDC configuration properties
+     * @return the OIDC issuer
+     */
+    public static String computeOidcIssuer(final OidcProperties oidcProperties) {
+        val clientInfo = ClientInfoHolder.getClientInfo();
+        if (clientInfo instanceof final MultiHostClientInfo mhClientInfo) {
+            LOGGER.trace("Using current host OIDC issuer: [{}]", mhClientInfo.getCurrentHost().getOidcIssuer());
+            return mhClientInfo.getCurrentHost().getOidcIssuer();
+        }
+        LOGGER.trace("Using default (primary) OIDC issuer: [{}]", oidcProperties.getCore().getIssuer());
+        return oidcProperties.getCore().getIssuer();
+    }
+}

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/services/OAuth20ServicesManagerRegisteredServiceLocator.java
@@ -68,8 +68,16 @@ public class OAuth20ServicesManagerRegisteredServiceLocator extends DefaultServi
                 .map(String.class::cast)
                 .orElse(StringUtils.EMPTY);
             val callbackService = OAuth20Utils.casOAuthCallbackUrl(casProperties.getServer().getPrefix());
-            return StringUtils.isBlank(source) || StringUtils.startsWith(source, callbackService)
-                || OAuth20Utils.checkCallbackValid(registeredService, source);
+            if (StringUtils.startsWith(source, callbackService)) {
+                return true;
+            }
+            for (val host : casProperties.getMultiHosts()) {
+                val currentCallbackService = OAuth20Utils.casOAuthCallbackUrl(host.getServerPrefix());
+                if (StringUtils.startsWith(source, currentCallbackService)) {
+                    return true;
+                }
+            }
+            return StringUtils.isBlank(source) || OAuth20Utils.checkCallbackValid(registeredService, source);
         }
         return false;
     }

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/MultiHostSecurityClientFinder.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/MultiHostSecurityClientFinder.java
@@ -1,0 +1,40 @@
+package org.apereo.cas.support.oauth.web;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.support.oauth.authenticator.Authenticators;
+import org.apereo.cas.util.EncodingUtils;
+import org.apereo.cas.util.multihost.MultiHostUtils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.client.finder.DefaultSecurityClientFinder;
+import org.pac4j.core.context.WebContext;
+
+import java.util.List;
+
+/**
+ * Custom {@link DefaultSecurityClientFinder} to rename the CAS OAuth client in case of multi-hosts.
+ *
+ * @author Jerome LELEU
+ * @since 7.2.0
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class MultiHostSecurityClientFinder extends DefaultSecurityClientFinder {
+
+    private final CasConfigurationProperties casProperties;
+
+    @Override
+    public List<Client> find(final Clients clients, final WebContext context, final String clientNames) {
+        var mhClientNames = clientNames;
+        if (Authenticators.CAS_OAUTH_CLIENT.equals(mhClientNames)) {
+            val currentPrefix = MultiHostUtils.computeServerPrefix(casProperties);
+            mhClientNames = Authenticators.CAS_OAUTH_CLIENT + EncodingUtils.hexEncode(currentPrefix);
+            LOGGER.debug("Translating requested clientNames to: [{}] for multi-hosts", mhClientNames);
+        }
+        return super.find(clients, context, mhClientNames);
+    }
+}

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/OAuth20CasCallbackUrlResolver.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/OAuth20CasCallbackUrlResolver.java
@@ -28,9 +28,19 @@ import java.util.Optional;
 @Slf4j
 @RequiredArgsConstructor
 public class OAuth20CasCallbackUrlResolver implements UrlResolver {
-    private final String callbackUrl;
+    protected final String callbackUrl;
 
-    private final OAuth20RequestParameterResolver requestParameterResolver;
+    protected final OAuth20RequestParameterResolver requestParameterResolver;
+
+    /**
+     * Duplicate the current URL resolver with a new callback URL.
+     *
+     * @param callbackUrl the new callback URL
+     * @return the new URL resolver
+     */
+    public OAuth20CasCallbackUrlResolver duplicateWithNewCallbackUrl(final String callbackUrl) {
+        return new OAuth20CasCallbackUrlResolver(callbackUrl, requestParameterResolver);
+    }
 
     @Override
     public String compute(final String url, final WebContext context) {

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20ThrottleConfiguration.java
@@ -19,6 +19,7 @@ import org.apereo.cas.web.cookie.CasCookieBuilder;
 import lombok.val;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.DirectClient;
+import org.pac4j.core.client.finder.ClientFinder;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.engine.DefaultSecurityLogic;
@@ -131,8 +132,10 @@ class CasOAuth20ThrottleConfiguration {
             @Qualifier("oauthSecConfig") final Config oauthSecConfig,
             @Qualifier(CasCookieBuilder.BEAN_NAME_TICKET_GRANTING_COOKIE_BUILDER)
             final CasCookieBuilder ticketGrantingTicketCookieGenerator,
-            @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry) {
+            @Qualifier(TicketRegistry.BEAN_NAME) final TicketRegistry ticketRegistry,
+            @Qualifier("multiHostSecurityClientFinder") final ClientFinder multiHostSecurityClientFinder) {
             val logic = new OAuth20TicketGrantingTicketAwareSecurityLogic(ticketGrantingTicketCookieGenerator, ticketRegistry);
+            logic.setClientFinder(multiHostSecurityClientFinder);
             return new SecurityLogicInterceptor(oauthSecConfig.withSecurityLogic(logic), Authenticators.CAS_OAUTH_CLIENT);
         }
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/authn/OidcCasCallbackUrlResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/authn/OidcCasCallbackUrlResolver.java
@@ -1,8 +1,6 @@
 package org.apereo.cas.oidc.authn;
 
-import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.oidc.OidcConstants;
-import org.apereo.cas.support.oauth.util.OAuth20Utils;
 import org.apereo.cas.support.oauth.web.OAuth20CasCallbackUrlResolver;
 import org.apereo.cas.support.oauth.web.OAuth20RequestParameterResolver;
 
@@ -17,9 +15,13 @@ import java.util.List;
  * @since 6.4.0
  */
 public class OidcCasCallbackUrlResolver extends OAuth20CasCallbackUrlResolver {
-    public OidcCasCallbackUrlResolver(final CasConfigurationProperties casProperties,
-                                      final OAuth20RequestParameterResolver oauthRequestParameterResolver) {
-        super(OAuth20Utils.casOAuthCallbackUrl(casProperties.getServer().getPrefix()), oauthRequestParameterResolver);
+    public OidcCasCallbackUrlResolver(final String callbackUrl, final OAuth20RequestParameterResolver oauthRequestParameterResolver) {
+        super(callbackUrl, oauthRequestParameterResolver);
+    }
+
+    @Override
+    public OidcCasCallbackUrlResolver duplicateWithNewCallbackUrl(final String callbackUrl) {
+        return new OidcCasCallbackUrlResolver(callbackUrl, requestParameterResolver);
     }
 
     @Override

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/webfinger/OidcDefaultWebFingerDiscoveryService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/discovery/webfinger/OidcDefaultWebFingerDiscoveryService.java
@@ -2,6 +2,7 @@ package org.apereo.cas.oidc.discovery.webfinger;
 
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettings;
+import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettingsFactory;
 import org.apereo.cas.util.CollectionUtils;
 
 import lombok.Getter;
@@ -59,7 +60,12 @@ public class OidcDefaultWebFingerDiscoveryService implements OidcWebFingerDiscov
 
     private final OidcWebFingerUserInfoRepository userInfoRepository;
 
-    private final OidcServerDiscoverySettings discovery;
+    private final OidcServerDiscoverySettingsFactory serverDiscoverySettingsFactory;
+
+    @Override
+    public OidcServerDiscoverySettings getDiscovery() {
+        return serverDiscoverySettingsFactory.getObject();
+    }
 
     @Override
     public ResponseEntity<Map> handleRequest(final String resource, final String rel) throws Throwable {
@@ -67,7 +73,7 @@ public class OidcDefaultWebFingerDiscoveryService implements OidcWebFingerDiscov
             LOGGER.warn("Handling discovery request for a non-standard OIDC relation [{}]", rel);
         }
 
-        val issuer = discovery.getIssuer();
+        val issuer = getDiscovery().getIssuer();
         if (!StringUtils.equalsIgnoreCase(resource, issuer)) {
             val resourceUri = normalize(resource);
             if (resourceUri == null) {

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/issuer/OidcDefaultIssuerService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/issuer/OidcDefaultIssuerService.java
@@ -5,6 +5,7 @@ import org.apereo.cas.services.OidcRegisteredService;
 import org.apereo.cas.services.RegisteredService;
 import org.apereo.cas.util.RegexUtils;
 import org.apereo.cas.util.function.FunctionUtils;
+import org.apereo.cas.util.multihost.MultiHostUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,10 +31,11 @@ public class OidcDefaultIssuerService implements OidcIssuerService {
 
     @Override
     public String determineIssuer(final Optional<OidcRegisteredService> registeredService) {
+        val currentOidcIssuer = MultiHostUtils.computeOidcIssuer(properties);
         val issuer = registeredService
             .filter(svc -> StringUtils.isNotBlank(svc.getIdTokenIssuer()))
             .map(OidcRegisteredService::getIdTokenIssuer)
-            .orElseGet(() -> properties.getCore().getIssuer());
+            .orElseGet(() -> currentOidcIssuer);
         LOGGER.trace("Determined issuer as [{}] for [{}]", issuer,
             registeredService.map(RegisteredService::getName).orElse("CAS"));
         return StringUtils.removeEnd(issuer, "/");

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcEndpointsConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcEndpointsConfiguration.java
@@ -38,6 +38,7 @@ import org.apereo.cas.support.oauth.validator.authorization.OAuth20Authorization
 import org.apereo.cas.support.oauth.web.OAuth20RequestParameterResolver;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenGrantRequestExtractor;
 import org.apereo.cas.util.RandomUtils;
+import org.apereo.cas.util.multihost.MultiHostUtils;
 import org.apereo.cas.util.spring.RefreshableHandlerInterceptor;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 import org.apereo.cas.validation.CasProtocolViewFactory;
@@ -188,7 +189,7 @@ class OidcEndpointsConfiguration {
         private static String getOidcBaseEndpoint(final OidcIssuerService issuerService,
                                                   final CasConfigurationProperties casProperties) {
             val issuer = issuerService.determineIssuer(Optional.empty());
-            val endpoint = StringUtils.remove(issuer, casProperties.getServer().getPrefix());
+            val endpoint = StringUtils.remove(issuer, MultiHostUtils.computeServerPrefix(casProperties));
             return StringUtils.prependIfMissing(endpoint, "/");
         }
 

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/discovery/webfinger/OidcDefaultWebFingerDiscoveryServiceTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/discovery/webfinger/OidcDefaultWebFingerDiscoveryServiceTests.java
@@ -3,6 +3,7 @@ package org.apereo.cas.oidc.discovery.webfinger;
 import org.apereo.cas.oidc.AbstractOidcTests;
 import org.apereo.cas.oidc.OidcConstants;
 import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettings;
+import org.apereo.cas.oidc.discovery.OidcServerDiscoverySettingsFactory;
 
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -50,7 +51,7 @@ class OidcDefaultWebFingerDiscoveryServiceTests extends AbstractOidcTests {
         when(repository.findByEmailAddress(anyString())).thenReturn(Map.of());
         when(repository.findByUsername(anyString())).thenReturn(Map.of());
         val service = new OidcDefaultWebFingerDiscoveryService(repository,
-            new OidcServerDiscoverySettings("https://apereo.org/cas"));
+                new MockOidcServerDiscoverySettingsFactory(new OidcServerDiscoverySettings("https://apereo.org/cas")));
         val entity = service.handleRequest(
             "okta:acct:joe.stormtrooper@sso.example.org", OidcConstants.WEBFINGER_REL);
         assertEquals(HttpStatus.SC_NOT_FOUND, entity.getStatusCode().value());
@@ -61,5 +62,20 @@ class OidcDefaultWebFingerDiscoveryServiceTests extends AbstractOidcTests {
         val entity = oidcWebFingerDiscoveryService.handleRequest(
             StringUtils.EMPTY, OidcConstants.WEBFINGER_REL);
         assertEquals(HttpStatus.SC_NOT_FOUND, entity.getStatusCode().value());
+    }
+
+    private static final class MockOidcServerDiscoverySettingsFactory extends OidcServerDiscoverySettingsFactory {
+
+        private final OidcServerDiscoverySettings oidcServerDiscoverySettings;
+
+        private MockOidcServerDiscoverySettingsFactory(final OidcServerDiscoverySettings oidcServerDiscoverySettings) {
+            super(null, null, null);
+            this.oidcServerDiscoverySettings = oidcServerDiscoverySettings;
+        }
+
+        @Override
+        public OidcServerDiscoverySettings getObject() {
+            return oidcServerDiscoverySettings;
+        }
     }
 }

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/BaseDelegatedIdentityProviderFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/BaseDelegatedIdentityProviderFactory.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.support.pac4j.authentication.clients;
 
+import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.CasSSLContext;
 import org.apereo.cas.authentication.principal.ClientCustomPropertyConstants;
 import org.apereo.cas.configuration.CasConfigurationProperties;
@@ -8,6 +9,7 @@ import org.apereo.cas.pac4j.client.DelegatedIdentityProviderFactory;
 import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.util.concurrent.CasReentrantLock;
 import org.apereo.cas.util.function.FunctionUtils;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,8 +99,9 @@ public abstract class BaseDelegatedIdentityProviderFactory implements DelegatedI
             FunctionUtils.doIfNotBlank(clientProperties.getDisplayName(),
                 __ -> customProperties.put(ClientCustomPropertyConstants.CLIENT_CUSTOM_PROPERTY_DISPLAY_NAME, clientProperties.getDisplayName()));
             if (client instanceof final IndirectClient indirectClient) {
-                val callbackUrl = StringUtils.defaultIfBlank(clientProperties.getCallbackUrl(), casProperties.getServer().getLoginUrl());
+                val callbackUrl = StringUtils.defaultIfBlank(clientProperties.getCallbackUrl(), CasProtocolConstants.ENDPOINT_LOGIN);
                 indirectClient.setCallbackUrl(callbackUrl);
+                indirectClient.setUrlResolver(new MultiHostUrlResolver(casProperties));
                 LOGGER.trace("Client [{}] will use the callback URL [{}]", client.getName(), callbackUrl);
                 val resolver = switch (clientProperties.getCallbackUrlType()) {
                     case PATH_PARAMETER -> new PathParameterCallbackUrlResolver();

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/MultiHostUrlResolver.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/MultiHostUrlResolver.java
@@ -1,0 +1,28 @@
+package org.apereo.cas.support.pac4j.authentication.clients;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.util.multihost.MultiHostUtils;
+
+import lombok.RequiredArgsConstructor;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.http.url.UrlResolver;
+
+/**
+ * Specific {@link UrlResolver} handling multi-hosts configuration.
+ *
+ * @author Jerome LELEU
+ * @since 7.2.0
+ */
+@RequiredArgsConstructor
+public class MultiHostUrlResolver implements UrlResolver {
+
+    private final CasConfigurationProperties casProperties;
+
+    @Override
+    public String compute(final String url, final WebContext context) {
+        if (url.startsWith("http://") || url.startsWith("https://")) {
+            return url;
+        }
+        return MultiHostUtils.computeServerPrefix(casProperties) + url;
+    }
+}

--- a/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/controller/DefaultDelegatedAuthenticationNavigationController.java
+++ b/support/cas-server-support-pac4j-webflow/src/main/java/org/apereo/cas/web/flow/controller/DefaultDelegatedAuthenticationNavigationController.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.web.flow.controller;
 
+import org.apereo.cas.util.multihost.MultiHostUtils;
 import org.apereo.cas.web.flow.DelegatedClientAuthenticationConfigurationContext;
 
 import lombok.Getter;
@@ -83,7 +84,7 @@ public class DefaultDelegatedAuthenticationNavigationController {
      * @throws Exception the exception
      */
     protected View buildRedirectViewBackToFlow(final String clientName, final HttpServletRequest request) throws Exception {
-        val urlBuilder = new URIBuilder(configurationContext.getCasProperties().getServer().getLoginUrl());
+        val urlBuilder = new URIBuilder(MultiHostUtils.computeLoginUrl(configurationContext.getCasProperties()));
         request.getParameterMap().forEach((name, v) -> {
             val value = request.getParameter(name);
             urlBuilder.addParameter(name, value);

--- a/support/cas-server-support-webconfig/src/main/java/org/apereo/cas/config/CasWebSecurityConfiguration.java
+++ b/support/cas-server-support-webconfig/src/main/java/org/apereo/cas/config/CasWebSecurityConfiguration.java
@@ -3,7 +3,9 @@ package org.apereo.cas.config;
 import org.apereo.cas.authentication.support.password.PasswordEncoderUtils;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
+import org.apereo.cas.configuration.model.core.multihost.SimpleHostProperties;
 import org.apereo.cas.configuration.support.JpaBeans;
+import org.apereo.cas.multihost.MultiHostClientInfoThreadLocalFilter;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.crypto.DefaultPasswordEncoder;
 import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
@@ -144,7 +146,9 @@ class CasWebSecurityConfiguration {
                 .useServerHostAddress(audit.isUseServerHostAddress())
                 .httpRequestHeaders(audit.getHttpRequestHeaders())
                 .build();
-            bean.setFilter(new ClientInfoThreadLocalFilter(options));
+            val server = casProperties.getServer();
+            val primaryHost = new SimpleHostProperties(server.getName(), server.getPrefix(), casProperties.getAuthn().getOidc().getCore().getIssuer());
+            bean.setFilter(new MultiHostClientInfoThreadLocalFilter(options, primaryHost, casProperties.getMultiHosts()));
             bean.setUrlPatterns(CollectionUtils.wrap("/*"));
             bean.setName("CAS Client Info Logging Filter");
             bean.setAsyncSupported(true);


### PR DESCRIPTION
This PR adds the multi-hosts support for the CAS server. This is only a **partial** implementation targeting the OIDC authorization code flow and the authn delegation. This is a first step which can be supplemented later on.

A configuration example:

```yml
cas.server.name: http://localhost:8080
cas.server.prefix: http://localhost:8080/cas
cas.host.name: castest

cas.multi-hosts:
  - server-name: http://cas-server:8080
    server-prefix: http://cas-server:8080/cas
    oidc-issuer: http://cas-server:8080/cas/oidc
```

With that configuration, the CAS server would be an OIDC OP on the `http://localhost:8080/cas/oidc` and  `http://cas-server:8080/cas/oidc` URLs.

**Currently, no new tests have been added until the design is validated.**
