### PR TITLE
Provide the ability to retrieve NameId from the service during SLO

### DIFF
--- a/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/logout/SamlIdPProfileSingleLogoutMessageCreatorTests.java
+++ b/support/cas-server-support-saml-idp/src/test/java/org/apereo/cas/support/saml/services/logout/SamlIdPProfileSingleLogoutMessageCreatorTests.java
@@ -3,10 +3,12 @@ package org.apereo.cas.support.saml.services.logout;
 import org.apereo.cas.logout.DefaultSingleLogoutRequestContext;
 import org.apereo.cas.logout.slo.SingleLogoutExecutionRequest;
 import org.apereo.cas.mock.MockTicketGrantingTicket;
+import org.apereo.cas.services.PrincipalAttributeRegisteredServiceUsernameProvider;
 import org.apereo.cas.services.RegisteredServiceLogoutType;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.support.saml.BaseSamlIdPConfigurationTests;
 import org.apereo.cas.support.saml.SamlIdPTestUtils;
+import org.apereo.cas.support.saml.SamlIdPUtils;
 import org.apereo.cas.support.saml.web.idp.profile.slo.SamlIdPProfileSingleLogoutMessageCreator;
 import org.apereo.cas.support.saml.web.idp.profile.slo.SamlIdPSingleLogoutServiceLogoutUrlBuilder;
 import org.apereo.cas.util.CollectionUtils;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.springframework.test.context.TestPropertySource;
 import java.net.URI;
+import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -134,5 +137,71 @@ class SamlIdPProfileSingleLogoutMessageCreatorTests extends BaseSamlIdPConfigura
             .build();
 
         assertThrows(IllegalArgumentException.class, () -> creator.create(logoutRequest));
+    }
+
+    @Test
+    void verifyNameIdOperation() throws Throwable {
+        val creator = new SamlIdPProfileSingleLogoutMessageCreator(openSamlConfigBean, servicesManager,
+                defaultSamlRegisteredServiceCachingMetadataResolver,
+                casProperties.getAuthn().getSamlIdp(),
+                samlIdPObjectSigner);
+
+        val samlRegisteredService = SamlIdPTestUtils.getSamlRegisteredService();
+        samlRegisteredService.setWhiteListBlackListPrecedence("INCLUDE");
+        samlRegisteredService.setSigningKeyAlgorithm("RSA");
+        samlRegisteredService.setSigningSignatureCanonicalizationAlgorithm("http://www.w3.org/2001/10/xml-exc-c14n#");
+        samlRegisteredService.setUsernameAttributeProvider(
+                new PrincipalAttributeRegisteredServiceUsernameProvider("email"));
+
+        val logoutRequest = DefaultSingleLogoutRequestContext.builder()
+                .logoutUrl(new URI("https://sp.example.org/slo").toURL())
+                .registeredService(samlRegisteredService)
+                .service(RegisteredServiceTestUtils.getService("https://sp.testshib.org/shibboleth-sp"))
+                .ticketId("ST-123456789")
+                .executionRequest(SingleLogoutExecutionRequest.builder()
+                        .ticketGrantingTicket(
+                                new MockTicketGrantingTicket("casuser",
+                                        Map.of("email", "casuser@example.org"))).build())
+                .logoutType(RegisteredServiceLogoutType.BACK_CHANNEL)
+                .properties(CollectionUtils.wrap(
+                        SamlIdPSingleLogoutServiceLogoutUrlBuilder.PROPERTY_NAME_SINGLE_LOGOUT_BINDING,
+                        SAMLConstants.SAML2_POST_BINDING_URI))
+                .build();
+
+        val result = creator.create(logoutRequest);
+        assertNotNull(result);
+        assertTrue(result.getPayload().contains("casuser@example.org"));
+    }
+
+    @Test
+    void verifyPrincipalIdIfNotAttrOperation() throws Throwable {
+        val creator = new SamlIdPProfileSingleLogoutMessageCreator(openSamlConfigBean, servicesManager,
+                defaultSamlRegisteredServiceCachingMetadataResolver,
+                casProperties.getAuthn().getSamlIdp(),
+                samlIdPObjectSigner);
+
+        val samlRegisteredService = SamlIdPTestUtils.getSamlRegisteredService();
+        samlRegisteredService.setWhiteListBlackListPrecedence("INCLUDE");
+        samlRegisteredService.setSigningKeyAlgorithm("RSA");
+        samlRegisteredService.setSigningSignatureCanonicalizationAlgorithm("http://www.w3.org/2001/10/xml-exc-c14n#");
+        samlRegisteredService.setUsernameAttributeProvider(
+                new PrincipalAttributeRegisteredServiceUsernameProvider("email"));
+
+        val logoutRequest = DefaultSingleLogoutRequestContext.builder()
+                .logoutUrl(new URI("https://sp.example.org/slo").toURL())
+                .registeredService(samlRegisteredService)
+                .service(RegisteredServiceTestUtils.getService("https://sp.testshib.org/shibboleth-sp"))
+                .ticketId("ST-123456789")
+                .executionRequest(SingleLogoutExecutionRequest.builder()
+                        .ticketGrantingTicket(new MockTicketGrantingTicket("casuser")).build())
+                .logoutType(RegisteredServiceLogoutType.BACK_CHANNEL)
+                .properties(CollectionUtils.wrap(
+                        SamlIdPSingleLogoutServiceLogoutUrlBuilder.PROPERTY_NAME_SINGLE_LOGOUT_BINDING,
+                        SAMLConstants.SAML2_POST_BINDING_URI))
+                .build();
+
+        val result = creator.create(logoutRequest);
+        assertNotNull(result);
+        assertFalse(result.getPayload().contains("casuser@example.org"));
     }
 }


### PR DESCRIPTION
The NameID value in the logout request is always the value of the "Principal" that CAS builds during authentication. 

It can happen that in a service, the NameID doesn't match the principal, which means that during logout flow the service provider cannot identify the user.

In my PR, during the construction of the response, I retrieve the attribute from the service definition to include in the logout response. If the NameID has not been defined in the service, CAS will insert the principal.

Here are the steps to reproduce my issue:

1. The user authenticates with the "uid" on CAS.
2. The user accesses the webapp (SP) via SAML2, where the NameID is the email.
3. The user logs out, but in the logoutRequest CAS includes the "uid".
4. The SP is unable to identify the user and doesn't terminate the session.