### PR TITLE
Fix parameter name for SAML authn delegation logout call

### DIFF
--- a/api/cas-server-core-api-protocol/src/main/java/org/apereo/cas/CasProtocolConstants.java
+++ b/api/cas-server-core-api-protocol/src/main/java/org/apereo/cas/CasProtocolConstants.java
@@ -120,6 +120,11 @@ public interface CasProtocolConstants {
      */
     String PARAMETER_PROXY_GRANTING_TICKET_URL = "pgtUrl";
 
+    /**
+     * Constant representing the logout parameter in the request.
+     */
+    String PARAMETER_LOGOUT_REQUEST = "logoutRequest";
+
     /* CAS Protocol Error Codes. **/
 
     /**

--- a/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/LogoutHttpMessage.java
+++ b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/LogoutHttpMessage.java
@@ -18,19 +18,15 @@ import java.net.URL;
 @Getter
 public class LogoutHttpMessage extends HttpMessage {
 
-    /**
-     * The parameter name that contains the logout request.
-     */
-    public static final String LOGOUT_REQUEST_PARAMETER = "logoutRequest";
-
     @Serial
     private static final long serialVersionUID = 399581521957873727L;
 
-    private String logoutRequestParameter = LOGOUT_REQUEST_PARAMETER;
+    private final String logoutRequestParameter;
 
-    public LogoutHttpMessage(final URL url, final String message, final boolean asynchronous) {
+    public LogoutHttpMessage(final String logoutRequestParameter, final URL url, final String message, final boolean asynchronous) {
         super(url, message, asynchronous);
         setContentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        this.logoutRequestParameter = logoutRequestParameter;
     }
 
     @Override

--- a/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/slo/BaseSingleLogoutServiceMessageHandler.java
+++ b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/slo/BaseSingleLogoutServiceMessageHandler.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.logout.slo;
 
+import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.principal.WebApplicationService;
 import org.apereo.cas.logout.DefaultSingleLogoutRequestContext;
@@ -205,6 +206,6 @@ public abstract class BaseSingleLogoutServiceMessageHandler implements SingleLog
     
     @Override
     public HttpMessage prepareLogoutHttpMessageToSend(final SingleLogoutRequestContext request, final SingleLogoutMessage logoutMessage) {
-        return new LogoutHttpMessage(request.getLogoutUrl(), logoutMessage.getPayload(), this.asynchronous);
+        return new LogoutHttpMessage(CasProtocolConstants.PARAMETER_LOGOUT_REQUEST, request.getLogoutUrl(), logoutMessage.getPayload(), this.asynchronous);
     }
 }

--- a/core/cas-server-core-logout/src/test/java/org/apereo/cas/logout/LogoutHttpMessageTests.java
+++ b/core/cas-server-core-logout/src/test/java/org/apereo/cas/logout/LogoutHttpMessageTests.java
@@ -1,5 +1,7 @@
 package org.apereo.cas.logout;
 
+import org.apereo.cas.CasProtocolConstants;
+
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -18,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class LogoutHttpMessageTests {
     @Test
     void verifyOperation() throws Throwable {
-        val message = new LogoutHttpMessage(new URI("https://github.com").toURL(), "LogoutMessage", false);
-        assertTrue(message.getMessage().startsWith(LogoutHttpMessage.LOGOUT_REQUEST_PARAMETER));
+        val message = new LogoutHttpMessage(CasProtocolConstants.PARAMETER_LOGOUT_REQUEST, new URI("https://github.com").toURL(), "LogoutMessage", false);
+        assertTrue(message.getMessage().startsWith(CasProtocolConstants.PARAMETER_LOGOUT_REQUEST));
     }
 }

--- a/support/cas-server-support-pac4j-saml/src/main/java/org/apereo/cas/web/flow/actions/logout/DelegatedSaml2ClientLogoutAction.java
+++ b/support/cas-server-support-pac4j-saml/src/main/java/org/apereo/cas/web/flow/actions/logout/DelegatedSaml2ClientLogoutAction.java
@@ -1,9 +1,10 @@
 package org.apereo.cas.web.flow.actions.logout;
 
+import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.principal.ClientCredential;
-import org.apereo.cas.logout.LogoutHttpMessage;
 import org.apereo.cas.logout.slo.SingleLogoutRequestExecutor;
 import org.apereo.cas.support.pac4j.authentication.DelegatedAuthenticationClientLogoutRequest;
+import org.apereo.cas.support.saml.SamlProtocolConstants;
 import org.apereo.cas.ticket.InvalidTicketException;
 import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.ticket.TransientSessionTicket;
@@ -91,6 +92,8 @@ public class DelegatedSaml2ClientLogoutAction extends BaseCasWebflowAction {
     }
 
     protected boolean isDirectLogoutRequest(final HttpServletRequest request) {
-        return HttpMethod.POST.matches(request.getMethod()) || request.getParameter(LogoutHttpMessage.LOGOUT_REQUEST_PARAMETER) != null;
+        return HttpMethod.POST.matches(request.getMethod())
+            || request.getParameter(CasProtocolConstants.PARAMETER_LOGOUT_REQUEST) != null
+            || request.getParameter(SamlProtocolConstants.PARAMETER_SAML_REQUEST) != null;
     }
 }

--- a/support/cas-server-support-pac4j-saml/src/test/java/org/apereo/cas/web/saml2/DelegatedSaml2ClientLogoutActionTests.java
+++ b/support/cas-server-support-pac4j-saml/src/test/java/org/apereo/cas/web/saml2/DelegatedSaml2ClientLogoutActionTests.java
@@ -1,8 +1,8 @@
 package org.apereo.cas.web.saml2;
 
+import org.apereo.cas.CasProtocolConstants;
 import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.authentication.principal.ClientCredential;
-import org.apereo.cas.logout.LogoutHttpMessage;
 import org.apereo.cas.support.pac4j.authentication.DelegatedAuthenticationClientLogoutRequest;
 import org.apereo.cas.test.CasTestExtension;
 import org.apereo.cas.ticket.TicketFactory;
@@ -116,7 +116,7 @@ class DelegatedSaml2ClientLogoutActionTests {
 
         val context = MockRequestContext.create(applicationContext);
         context.setMethod(HttpMethod.GET);
-        context.setParameter(LogoutHttpMessage.LOGOUT_REQUEST_PARAMETER, "adirectlogoutrequesttotreat");
+        context.setParameter(CasProtocolConstants.PARAMETER_LOGOUT_REQUEST, "adirectlogoutrequesttotreat");
         val webContext = new JEEContext(context.getHttpServletRequest(), context.getHttpServletResponse());
         val manager = new ProfileManager(webContext, delegatedClientDistributedSessionStore);
         val profile = new CommonProfile();

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceMessageHandler.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/slo/SamlIdPSingleLogoutServiceMessageHandler.java
@@ -2,6 +2,7 @@ package org.apereo.cas.support.saml.web.idp.profile.slo;
 
 import org.apereo.cas.authentication.AuthenticationServiceSelectionPlan;
 import org.apereo.cas.authentication.principal.WebApplicationService;
+import org.apereo.cas.logout.LogoutHttpMessage;
 import org.apereo.cas.logout.slo.BaseSingleLogoutServiceMessageHandler;
 import org.apereo.cas.logout.slo.SingleLogoutExecutionRequest;
 import org.apereo.cas.logout.slo.SingleLogoutMessage;
@@ -158,5 +159,10 @@ public class SamlIdPSingleLogoutServiceMessageHandler extends BaseSingleLogoutSe
         }
         LOGGER.warn("No (successful) logout response received from the url [{}]", msg.getUrl().toExternalForm());
         return false;
+    }
+
+    @Override
+    public HttpMessage prepareLogoutHttpMessageToSend(final SingleLogoutRequestContext request, final SingleLogoutMessage logoutMessage) {
+        return new LogoutHttpMessage(SamlProtocolConstants.PARAMETER_SAML_REQUEST, request.getLogoutUrl(), logoutMessage.getPayload(), isAsynchronous());
     }
 }


### PR DESCRIPTION
To follow up my previous PR on this topic: https://github.com/apereo/cas/pull/6206, I realized that the logout parameter used to send the SAML request in the front-channel way was incorrect: it is "logoutRequest" instead of "SAMLRequest" (pac4j being versatile enough to accept both parameters).

This PR fixes this issue and takes it into account to consider it's a direct logout call.
