### PR TITLE
fix proxy tickets

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/ProxyingPrincipalResolver.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/principal/resolvers/ProxyingPrincipalResolver.java
@@ -25,8 +25,7 @@ public class ProxyingPrincipalResolver implements PrincipalResolver {
     @Override
     public Principal resolve(final Credential credential, final Optional<Principal> currentPrincipal,
                              final Optional<AuthenticationHandler> handler, final Optional<Service> service) throws Throwable {
-        val id = currentPrincipal.map(Principal::getId).orElseGet(credential::getId);
-        return principalFactory.createPrincipal(id);
+        return this.principalFactory.createPrincipal(credential.getId());
     }
 
     @Override

--- a/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/ProxyingPrincipalResolverTests.java
+++ b/core/cas-server-core-authentication-api/src/test/java/org/apereo/cas/authentication/principal/resolvers/ProxyingPrincipalResolverTests.java
@@ -19,14 +19,9 @@ class ProxyingPrincipalResolverTests {
     @Test
     void verifyOperation() throws Throwable {
         val resolver = new ProxyingPrincipalResolver(PrincipalFactoryUtils.newPrincipalFactory());
-        var credential = CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword();
+        val credential = CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword();
         assertTrue(resolver.supports(credential));
         assertNull(resolver.getAttributeRepository());
-        var principal = resolver.resolve(credential);
-        assertEquals(credential.getId(), principal.getId());
-        principal = resolver.resolve(credential,
-            Optional.of(CoreAuthenticationTestUtils.getPrincipal("helloworld")),
-            Optional.empty(), Optional.empty());
-        assertEquals("helloworld", principal.getId());
+        assertNotNull(resolver.resolve(credential));
     }
 }


### PR DESCRIPTION
### Partial revert of changes made by commit 0e458eb

Hello,
Since 7.1.0-RC1, proxy tickets no longer work correctly.

Instead of containing the proxy, `cas:proxy` now contains the identifier of the user.
For example:
```xml
<cas:authenticationSuccess>
	<cas:user>username</cas:user>
	<cas:proxies>
		<cas:proxy>username</cas:proxy>
	</cas:proxies>
```
Indeed, this new behavior is even documented in the 7.1.0-RC1 changelog.
https://apereo.github.io/cas/7.1.x/release_notes/RC1.html#other-stuff
> Proxy ticket validation should now correctly resolve and determine the authenticated principal id.

However, the CAS protocol documentation clearly shows that this is not what is expected.
https://apereo.github.io/cas/development/protocol/CAS-Protocol-Specification.html#262-response
```xml
<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
	<cas:authenticationSuccess>
		<cas:user>username</cas:user>
		<cas:proxyGrantingTicket>PGTIOU-84678-8a9d...</cas:proxyGrantingTicket>
		<cas:proxies>
			<cas:proxy>https://proxy2/pgtUrl</cas:proxy>
			<cas:proxy>https://proxy1/pgtUrl</cas:proxy>
		</cas:proxies>
	</cas:authenticationSuccess>
</cas:serviceResponse>
```
This PR restores this behavior.