### PR TITLE
Fix throttling endpoint deleteByKey

### DIFF
--- a/support/cas-server-support-throttle/src/test/java/org/apereo/cas/web/support/ThrottledSubmissionHandlerEndpointTests.java
+++ b/support/cas-server-support-throttle/src/test/java/org/apereo/cas/web/support/ThrottledSubmissionHandlerEndpointTests.java
@@ -50,8 +50,8 @@ class ThrottledSubmissionHandlerEndpointTests extends AbstractCasEndpointTests {
         throttle.recordSubmissionFailure(request);
         val records = throttledSubmissionHandlerEndpoint.getRecords();
         assertFalse(records.isEmpty());
-        throttledSubmissionHandlerEndpoint.deleteByKey(records.getFirst().getKey());
-        assertDoesNotThrow(() -> throttledSubmissionHandlerEndpoint.release(false));
-        assertDoesNotThrow(() -> throttledSubmissionHandlerEndpoint.release(true));
+        throttledSubmissionHandlerEndpoint.deleteByKeyOrRelease(false, records.getFirst().getKey());
+        assertDoesNotThrow(() -> throttledSubmissionHandlerEndpoint.deleteByKeyOrRelease(false, null));
+        assertDoesNotThrow(() -> throttledSubmissionHandlerEndpoint.deleteByKeyOrRelease(true, null));
     }
 }

--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir.js
@@ -3074,7 +3074,7 @@ async function initializeThrottlesOperations() {
                     .then((result) => {
                         if (result.isConfirmed) {
                             $.ajax({
-                                url: `${actuatorEndpoints.throttles}/${key}`,
+                                url: `${actuatorEndpoints.throttles}?key=` + encodeURIComponent(key),
                                 type: "DELETE",
                                 contentType: "application/x-www-form-urlencoded",
                                 success: (response, status, xhr) => {


### PR DESCRIPTION
When using Palantir, I'm unable to remove a specific throttled record when the key is the IP and the username.

This happens because the key is directly used in the path.

This PR changes this behavior to receive the key as an URL parameter.
