### PR TITLE
Fix MFA simple bypass rest headers not included

### DIFF
--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/bypass/RestMultifactorAuthenticationProviderBypassEvaluator.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/bypass/RestMultifactorAuthenticationProviderBypassEvaluator.java
@@ -59,6 +59,7 @@ public class RestMultifactorAuthenticationProviderBypassEvaluator extends BaseMu
                 .basicAuthPassword(rest.getBasicAuthPassword())
                 .basicAuthUsername(rest.getBasicAuthUsername())
                 .method(HttpMethod.valueOf(rest.getMethod().toUpperCase(Locale.ENGLISH).trim()))
+                .headers(rest.getHeaders())
                 .url(rest.getUrl())
                 .parameters(parameters)
                 .build();


### PR DESCRIPTION
Hi,

As documented in the [MFA section](https://apereo.github.io/cas/7.0.x/mfa/Simple-Multifactor-Authentication.html), headers should be configurable using the following property:

`cas.authn.mfa.simple.bypass.rest.headers=`

This change ensures that the headers defined in the YAML configuration are included in REST requests when using Simple MFA Bypass via REST.

In my company, we use this property because we need to delegate the bypass logic to another service protected by an API key. As a result, we had to override...

Thanks!