### PR TITLE
Fixing OpenFGA check call

### DIFF
--- a/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/OpenFGARegisteredServiceAccessStrategy.java
+++ b/core/cas-server-core-services-api/src/main/java/org/apereo/cas/services/OpenFGARegisteredServiceAccessStrategy.java
@@ -67,6 +67,8 @@ public class OpenFGARegisteredServiceAccessStrategy extends BaseRegisteredServic
     @ExpressionLanguageCapable
     private String token;
 
+    private String userType;
+
     @Override
     public boolean authorizeRequest(final RegisteredServiceAccessStrategyRequest request) {
         HttpResponse response = null;
@@ -83,7 +85,7 @@ public class OpenFGARegisteredServiceAccessStrategy extends BaseRegisteredServic
             val checkEntity = AuthorizationRequestEntity.builder()
                 .object(StringUtils.defaultIfBlank(this.object, request.getService().getId()))
                 .relation(StringUtils.defaultIfBlank(this.relation, "owner"))
-                .user(request.getPrincipalId())
+                .user(StringUtils.defaultIfBlank(this.userType, "user") + ":" + request.getPrincipalId())
                 .build()
                 .toJson();
             val exec = HttpExecutionRequest.builder()

--- a/docs/cas-server-documentation/services/Service-Access-Strategy-OpenFGA.md
+++ b/docs/cas-server-documentation/services/Service-Access-Strategy-OpenFGA.md
@@ -35,6 +35,7 @@ The following fields are available to this access strategy:
 
 | Field      | Purpose                                                                                            |
 |------------|----------------------------------------------------------------------------------------------------|
+| `userType` | <sup>[1]</sup> The user type in the authorization tuple; defaults to `user`. |
 | `relation` | <sup>[1]</sup> The relation or the type of access in the authorization tuple; defaults to `owner`. |
 | `object`   | <sup>[1]</sup> The *object* of the authorization tuple; defaults to the service URL if undefined.  |
 | `storeId`  | <sup>[1]</sup> The authorization store identifier.                                                 |


### PR DESCRIPTION
With the current code, the following `check` request to OpenFGA is sent:

```json
{
  "tuple_key": {
    "user": "bellini",
    "relation": "member",
    "object": "GROUP:managingDirector"
  }
}
```

This returns the error:

```json
{
  "code": "validation_error",
  "message": "the 'user' field must be an object (e.g. document:1) or an 'object#relation' or a typed wildcard (e.g. group:*)"
}
```

So, the request payload should be changed to something like:

```json
{
  "tuple_key": {
    "user": "USER:bellini",
    "relation": "member",
    "object": "GROUP:managingDirector"
  }
}
```

where `USER` is the type of `bellini` as specified by https://openfga.dev/docs/concepts#what-is-a-user

This change will allow to specify the user type, or fallback to `user` if none is specified.