### PR TITLE
Don't retry failed login attempts in order to avoid premature account locking.

### DIFF
--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -91,6 +91,7 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
                 .method(HttpMethod.valueOf(properties.getMethod().toUpperCase(Locale.ENGLISH)))
                 .url(properties.getUri())
                 .httpClient(httpClient)
+                .maximumRetryAttempts(1)
                 .build();
             response = HttpUtils.execute(exec);
             val status = HttpStatus.resolve(Objects.requireNonNull(response).getCode());


### PR DESCRIPTION
Currently a (failed) login is attempted 3 times, which causes one failed login attempt on cas to be 3 failed login attempts in the backend. This is a problem when the backend uses rate-limiting or locks accounts after too many failed attempts.
