### PR TITLE
Don't retry failed login attempts in order to avoid premature account locking.

### DIFF
--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
@@ -32,6 +32,7 @@ import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -273,6 +274,10 @@ public class MockWebServer implements Closeable {
         this.worker.setHeadersConsumer(consumer);
     }
 
+    public int getRequestCount() {
+        return this.worker.getRequestCounter().get();
+    }
+
     /**
      * Starts the Web server so it can accept requests on the listening port.
      */
@@ -345,6 +350,9 @@ public class MockWebServer implements Closeable {
         @Setter
         private Consumer<Map<String, String>> headersConsumer;
 
+        @Getter
+        private final AtomicInteger requestCounter = new AtomicInteger(0);
+
         private boolean running;
 
         Worker(final ServerSocket sock, final String contentType) {
@@ -408,7 +416,9 @@ public class MockWebServer implements Closeable {
                     if (headersConsumer != null) {
                         headersConsumer.accept(givenHeaders);
                     }
-                    
+
+                    requestCounter.incrementAndGet();
+
                     if (functionToExecute != null) {
                         LOGGER.trace("Executed function with result [{}]", functionToExecute.apply(socket));
                     } else {

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -91,6 +91,7 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
                 .method(HttpMethod.valueOf(properties.getMethod().toUpperCase(Locale.ENGLISH)))
                 .url(properties.getUri())
                 .httpClient(httpClient)
+                .maximumRetryAttempts(1)
                 .build();
             response = HttpUtils.execute(exec);
             val status = HttpStatus.resolve(Objects.requireNonNull(response).getCode());

--- a/support/cas-server-support-rest-authentication/src/test/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandlerTests.java
+++ b/support/cas-server-support-rest-authentication/src/test/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandlerTests.java
@@ -101,14 +101,17 @@ class RestAuthenticationHandlerTests {
 
             val res = getFirstHandler().authenticate(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword(), mock(Service.class));
             assertEquals("casuser", res.getPrincipal().getId());
+            assertEquals(1, webServer.getRequestCount());
 
             webServer.responseBody("{}");
             assertThrows(FailedLoginException.class,
                 () -> getFirstHandler().authenticate(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword(), mock(Service.class)));
+            assertEquals(2, webServer.getRequestCount());
 
             webServer.responseStatus(HttpStatus.FORBIDDEN);
             assertThrows(AccountDisabledException.class,
                 () -> getFirstHandler().authenticate(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword(), mock(Service.class)));
+            assertEquals(3, webServer.getRequestCount());
 
 
             webServer.responseStatus(HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
Currently a (failed) login is attempted 3 times, which causes one failed login attempt on cas to be 3 failed login attempts in the backend. This is a problem when the backend uses rate-limiting or locks accounts after too many failed attempts.

```
master: https://github.com/apereo/cas/pull/6638
7.2.x: https://github.com/apereo/cas/pull/6637
7.1.x: https://github.com/apereo/cas/pull/6636
```