### PR TITLE
Don't retry failed login attempts in order to avoid premature account locking

### DIFF
--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
@@ -31,6 +31,7 @@ import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -259,6 +260,10 @@ public class MockWebServer implements Closeable {
         this.worker.setResourceSupplier(sup);
     }
 
+    public int getRequestCount() {
+        return this.worker.getRequestCounter().get();
+    }
+
     /**
      * Starts the Web server so it can accept requests on the listening port.
      */
@@ -328,6 +333,9 @@ public class MockWebServer implements Closeable {
         @Setter
         private Supplier<Resource> resourceSupplier;
 
+        @Getter
+        private final AtomicInteger requestCounter = new AtomicInteger(0);
+
         private boolean running;
 
         Worker(final ServerSocket sock, final String contentType) {
@@ -388,7 +396,10 @@ public class MockWebServer implements Closeable {
                         }
                     }
                     LOGGER.debug("Headers are [{}]", givenHeaders);
-                    if (this.functionToExecute != null) {
+
+                    requestCounter.incrementAndGet();
+
+                    if (functionToExecute != null) {
                         LOGGER.trace("Executed function with result [{}]", functionToExecute.apply(socket));
                     } else {
                         writeResponse(socket);

--- a/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
+++ b/support/cas-server-support-rest-authentication/src/main/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandler.java
@@ -91,6 +91,7 @@ public class RestAuthenticationHandler extends AbstractUsernamePasswordAuthentic
                 .method(HttpMethod.valueOf(properties.getMethod().toUpperCase(Locale.ENGLISH)))
                 .url(properties.getUri())
                 .httpClient(httpClient)
+                .maximumRetryAttempts(1)
                 .build();
             response = HttpUtils.execute(exec);
             val status = HttpStatus.resolve(Objects.requireNonNull(response).getCode());

--- a/support/cas-server-support-rest-authentication/src/test/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandlerTests.java
+++ b/support/cas-server-support-rest-authentication/src/test/java/org/apereo/cas/adaptors/rest/RestAuthenticationHandlerTests.java
@@ -101,14 +101,17 @@ class RestAuthenticationHandlerTests {
 
             val res = getFirstHandler().authenticate(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword(), mock(Service.class));
             assertEquals("casuser", res.getPrincipal().getId());
+            assertEquals(1, webServer.getRequestCount());
 
             webServer.responseBody("{}");
             assertThrows(FailedLoginException.class,
                 () -> getFirstHandler().authenticate(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword(), mock(Service.class)));
+            assertEquals(2, webServer.getRequestCount());
 
             webServer.responseStatus(HttpStatus.FORBIDDEN);
             assertThrows(AccountDisabledException.class,
                 () -> getFirstHandler().authenticate(CoreAuthenticationTestUtils.getCredentialsWithSameUsernameAndPassword(), mock(Service.class)));
+            assertEquals(3, webServer.getRequestCount());
 
 
             webServer.responseStatus(HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
Currently a (failed) login is attempted 3 times, which causes one failed login attempt on cas to be 3 failed login attempts in the backend. This is a problem when the backend uses rate-limiting or locks accounts after too many failed attempts.

Backport of #6637 and #6638 

```
master: https://github.com/apereo/cas/pull/6638
7.2.x: https://github.com/apereo/cas/pull/6637
7.1.x: https://github.com/apereo/cas/pull/6636
```

Recreated PR as requested in https://github.com/apereo/cas/pull/6636#issuecomment-2760344213