### PR TITLE
Fixes an issue where the Twilio API requires the verification channel to be lowercase value

### DIFF
--- a/support/cas-server-support-twilio-mfa/src/main/java/org/apereo/cas/mfa/twilio/CasDefaultTwilioMultifactorAuthenticationService.java
+++ b/support/cas-server-support-twilio-mfa/src/main/java/org/apereo/cas/mfa/twilio/CasDefaultTwilioMultifactorAuthenticationService.java
@@ -40,7 +40,7 @@ public class CasDefaultTwilioMultifactorAuthenticationService implements CasTwil
         return channels
             .stream()
             .anyMatch(channel -> FunctionUtils.doAndHandle(() -> {
-                val verification = Verification.creator(serviceSid, recipient, channel.name()).create();
+                val verification = Verification.creator(serviceSid, recipient, channel.toString()).create();
                 LOGGER.debug("Generated token for [{}] with SID: [{}]", principal.getId(), verification);
                 return StringUtils.isNotBlank(verification.getSid());
             }, e -> false).get());


### PR DESCRIPTION
Brief description of changes applied:

Sends the Twilio verification channel value in lowercase to the Twilio API (using the enum value instead of the enum name).
The Twilio API throws an "Invalid parameter: Channel" error when the request contains an uppercase channel value (e.g., "Channel=SMS"). It requires the value to be lowercase (e.g., "Channel=sms"), so the com.twilio.rest.verify.v2.service.Verification.Channel enum value should be used instead of the enum name.
