### PR TITLE
Fix OAuth attributes

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/CASOAuth20TicketValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/CASOAuth20TicketValidator.java
@@ -1,7 +1,6 @@
 package org.apereo.cas.support.oauth.validator;
 
 import org.apereo.cas.authentication.Authentication;
-import org.apereo.cas.authentication.CoreAuthenticationUtils;
 import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.client.authentication.AttributePrincipalImpl;
 import org.apereo.cas.client.validation.Assertion;
@@ -42,8 +41,9 @@ public class CASOAuth20TicketValidator implements org.apereo.cas.client.validati
             .map(Authentication::getPrincipal)
             .map(Principal::getAttributes)
             .orElseGet(HashMap::new);
-        val finalAttributes = CoreAuthenticationUtils.mergeAttributes(originalAttributes, principalAttributes);
-        val attrPrincipal = new AttributePrincipalImpl(validationResult.getPrincipal().getId(), finalAttributes);
+
+        principalAttributes.putAll(originalAttributes);
+        val attrPrincipal = new AttributePrincipalImpl(validationResult.getPrincipal().getId(), principalAttributes);
         val registeredService = validationResult.getRegisteredService();
 
         val authenticationAttributes = authenticationAttributeReleasePolicy.getAuthenticationAttributesForRelease(

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -8,7 +8,6 @@ import org.apereo.cas.audit.AuditTrailRecordResolutionPlanConfigurer;
 import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.authentication.CasSSLContext;
-import org.apereo.cas.authentication.CoreAuthenticationUtils;
 import org.apereo.cas.authentication.adaptive.geo.GeoLocationService;
 import org.apereo.cas.authentication.attribute.AttributeDefinitionStore;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
@@ -168,7 +167,6 @@ import org.apereo.inspektr.audit.spi.AuditResourceResolver;
 import org.apereo.inspektr.audit.spi.support.DefaultAuditActionResolver;
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.cas.config.CasConfiguration;
-import org.pac4j.cas.profile.CasProfile;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.context.session.SessionStore;
@@ -178,7 +176,6 @@ import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.matching.matcher.Matcher;
 import org.pac4j.core.matching.matcher.csrf.CsrfTokenGeneratorMatcher;
 import org.pac4j.core.matching.matcher.csrf.DefaultCsrfTokenGenerator;
-import org.pac4j.core.profile.BasicUserProfile;
 import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.http.client.direct.DirectBasicAuthClient;
 import org.pac4j.http.client.direct.DirectFormClient;
@@ -490,14 +487,6 @@ class CasOAuth20Configuration {
             oauthCasClient.setUrlResolver(casCallbackUrlResolver);
             oauthCasClient.setCallbackUrl(OAuth20Utils.casOAuthCallbackUrl(server.getPrefix()));
             oauthCasClient.setCheckAuthenticationAttempt(false);
-            oauthCasClient.setProfileCreator((callContext, credentials) -> {
-                val initialUserProfile = (CasProfile) credentials.getUserProfile();
-                val userProfile = new BasicUserProfile();
-                userProfile.build(initialUserProfile.getId(),
-                    CoreAuthenticationUtils.convertAttributeValuesToObjects(initialUserProfile.getAttributes()),
-                    CoreAuthenticationUtils.convertAttributeValuesToObjects(initialUserProfile.getAuthenticationAttributes()));
-                return Optional.of(userProfile);
-            });
             oauthCasClient.init();
             return oauthCasClient;
         }


### PR DESCRIPTION
A CAS principal consists of data coming from CAS (like the `stateless` flag) and data coming from attribute repositories.

1. Data coming from attribute repositories should not be altered by the CAS server. If I call a REST attribute repository, I want to retrieve my JSON as is.

So the profile creator is removed from the `CasClient` in the `CasOAuth20Configuration`, which was flattening lists of single value.

2. Data coming from CAS should be in the intended format (like a boolean for the `stateless` flag).

So the `CoreAuthenticationUtils.mergeAttributes` method is no longer called in the `CASOAuth20TicketValidator` as it was creating lists with single-value.
