### PR TITLE
Fix: TGC cookie should not be persistent when remember-me is unchecked

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.web.support.gen;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apereo.cas.authentication.CoreAuthenticationUtils;
 import org.apereo.cas.authentication.RememberMeCredential;
 import org.apereo.cas.util.LoggingUtils;
@@ -82,7 +83,7 @@ public class CookieRetrievingCookieGenerator extends CookieGenerator implements 
         val request = WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext);
         val value = request.getParameter(RememberMeCredential.REQUEST_PARAMETER_REMEMBER_ME);
         LOGGER.trace("Locating request parameter [{}] with value [{}]", RememberMeCredential.REQUEST_PARAMETER_REMEMBER_ME, value);
-        return StringUtils.isNotBlank(value) && WebUtils.isRememberMeAuthenticationEnabled(requestContext);
+        return StringUtils.isNotBlank(value) && BooleanUtils.toBoolean(value) && WebUtils.isRememberMeAuthenticationEnabled(requestContext);
     }
 
     @Override

--- a/core/cas-server-core-cookie/src/test/java/org/apereo/cas/web/support/CookieRetrievingCookieGeneratorTests.java
+++ b/core/cas-server-core-cookie/src/test/java/org/apereo/cas/web/support/CookieRetrievingCookieGeneratorTests.java
@@ -221,6 +221,25 @@ class CookieRetrievingCookieGeneratorTests {
     }
 
     @Test
+    void verifyTgcCookieForNoRememberMeByAuthnRequest() throws Throwable {
+        val ctx = getCookieGenerationContext();
+        // set the max age to -1 (session cookie) as ticketGrantingCookieBuilder
+        ctx.setMaxAge(-1);
+        val cookieValueManager = new NoOpCookieValueManager(tenantExtractor);
+        val gen = CookieUtils.buildCookieRetrievingGenerator(cookieValueManager, ctx);
+        val context = MockRequestContext.create(applicationContext);
+        context.setParameter(RememberMeCredential.REQUEST_PARAMETER_REMEMBER_ME, "false");
+        WebUtils.putRememberMeAuthenticationEnabled(context, Boolean.TRUE);
+
+        gen.addCookie(context.getHttpServletRequest(), context.getHttpServletResponse(),
+                CookieRetrievingCookieGenerator.isRememberMeAuthentication(context), "CAS-Cookie-Value");
+        val cookie = context.getHttpServletResponse().getCookie(ctx.getName());
+        assertNotNull(cookie);
+        Assertions.assertNotEquals(ctx.getRememberMeMaxAge(), cookie.getMaxAge());
+        Assertions.assertEquals(-1, cookie.getMaxAge());
+    }
+
+    @Test
     void verifyCookieForRememberMeByRequestContext() throws Throwable {
         val ctx = getCookieGenerationContext();
         val cookieValueManager = new NoOpCookieValueManager(tenantExtractor);


### PR DESCRIPTION
## Context

Since CAS version 7.1, the "remember me" UI element was changed from a `<input type="checkbox">` to a switch-style button that manipulates a hidden `<input type="hidden">`. This change causes the `rememberme` HTTP parameter to always be present in form submissions, even when the user does **not** explicitly request to be remembered.

However, in the current code, the decision to make the TGC (Ticket Granting Cookie) persistent is based solely on the **presence** of the `rememberme` parameter, not on its **value**.

As a result, CAS sets a long-lived TGC cookie even when the user did not intend to enable the "remember me" option. This breaks expected session behavior: closing the browser no longer logs the user out, which is problematic on shared devices.

## Proposed fix

This PR updates the condition so that a persistent TGC cookie is only issued when:
- the `rememberme` parameter is present **and**
- its value is explicitly truthy (e.g., `"true"`, `"on"`, `"yes"`), **and**
- remember-me functionality is enabled for the application context.

This restores the correct behavior for session cookies when the user does **not** opt into remember-me.

## Additional changes

- Added a unit test to cover scenario: when `rememberme=false`.

---

Thanks for reviewing!
