### PR TITLE
Fix: CAS Interrupt Thymeleaf View – Sanitize link ID to handle special characters

### DIFF
--- a/ci/tests/puppeteer/scenarios/interrupt-afterauthn-groovy/interrupt.groovy
+++ b/ci/tests/puppeteer/scenarios/interrupt-afterauthn-groovy/interrupt.groovy
@@ -11,7 +11,7 @@ def run(final Object... args) {
     logger.info("Constructing interrupt response for [{}]", principal)
     if (principal.id == "blockuser") {
         logger.warn("Blocking user [{}]", principal)
-        return new InterruptResponse("Blocked!", [link1:"https://localhost:9859/anything/cas"], true, false)
+        return new InterruptResponse("Blocked!", [link1:"https://localhost:9859/anything/cas", "Test link with special symbols: é & @":"https://localhost:9859/anything/cas"], true, false)
     }
     return new InterruptResponse("Hello World!", [link1:"https://google.com", link2:"https://yahoo.com"], false, true)
 }

--- a/ci/tests/puppeteer/scenarios/interrupt-afterauthn-groovy/script.js
+++ b/ci/tests/puppeteer/scenarios/interrupt-afterauthn-groovy/script.js
@@ -29,6 +29,17 @@ const assert = require("assert");
     const url = await page.url();
     assert(url.includes("https://localhost:9859/anything/cas"));
     await cas.gotoLogout(page);
+
+    await cas.gotoLogin(page);
+    await cas.loginWith(page, "blockuser", "blockuser");
+    await cas.sleep(1000);
+    await cas.assertInvisibility(page, "#proceed");
+    await page.locator("div ::-p-text(Test link with special symbols: é & @)").click();
+    await cas.sleep(2000);
+    await cas.logPage(page);
+    const url2 = await page.url();
+    assert(url2.includes("https://localhost:9859/anything/cas"));
+    await cas.gotoLogout(page);
     
     await browser.close();
 })();

--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/interrupt/casInterruptView.html
@@ -46,7 +46,7 @@
                         <input type="hidden" id="linkToRedirect" name="link"/>
                     </form>
 
-                    <span th:with="linkid=${#strings.toLowerCase(#strings.replace(link.key, ' ', ''))}"
+                    <span th:with="linkid=${#strings.toLowerCase(link.key.replaceAll('[^A-Za-z0-9]', ''))}"
                           th:each="link : ${interrupt.links}">
                         <a class="mdc-button mdc-button--outline btn btn-primary me-2"
                            th:text="${link.key}"


### PR DESCRIPTION
This PR improves the robustness of the casInterruptView.html Thymeleaf view by sanitizing the generated HTML id for each interrupt link.

Previously, the linkid was derived from the link text using only a .replace(' ', '') operation. As a result, special characters such as colon, accented letters (é), ampersand, or at signs were preserved in the computed id, leading to invalid selectors and client-side issues ; the link would not work properly.

For example, a link labeled "Test link with special symbols: é & @" would previously generate the id testlinkwithspecialsymbols:é&@, which is problematic when referenced by a selector or script.
With this fix, the id is now generated as testlinkwithspecialsymbols.

A Puppeteer scenario has been updated accordingly to assert this behavior, ensuring that links with special characters in their labels can be clickable and lead to the correct target page as expected.