### PR TITLE
Improve logs and fix bug in WebAuthn support

### DIFF
--- a/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/WebAuthnMultifactorWebflowConfigurer.java
+++ b/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/WebAuthnMultifactorWebflowConfigurer.java
@@ -54,6 +54,7 @@ public class WebAuthnMultifactorWebflowConfigurer extends AbstractCasMultifactor
 
             val acctRegCheckState = createActionState(flow, CasWebflowConstants.STATE_ID_CHECK_ACCOUNT_REGISTRATION,
                 createEvaluateAction(CasWebflowConstants.ACTION_ID_WEBAUTHN_CHECK_ACCOUNT_REGISTRATION));
+            acctRegCheckState.getEntryActionList().add(createEvaluateAction(CasWebflowConstants.ACTION_ID_POPULATE_SECURITY_CONTEXT));
             createTransitionForState(acctRegCheckState, CasWebflowConstants.TRANSITION_ID_REGISTER,
                 CasWebflowConstants.STATE_ID_WEBAUTHN_VIEW_REGISTRATION);
             createTransitionForState(acctRegCheckState, CasWebflowConstants.TRANSITION_ID_SUCCESS,

--- a/support/cas-server-support-webauthn-core/src/main/java/org/apereo/cas/webauthn/web/WebAuthnController.java
+++ b/support/cas-server-support-webauthn-core/src/main/java/org/apereo/cas/webauthn/web/WebAuthnController.java
@@ -54,15 +54,18 @@ public class WebAuthnController extends BaseWebAuthnController {
     private final WebAuthnServer server;
 
     private static ResponseEntity<Object> startResponse(final Object request) throws Exception {
-        LOGGER.trace("Response: [{}]", request);
-        return ResponseEntity.ok(writeJson(request));
+        val json = writeJson(request);
+        LOGGER.trace("Start: [{}]", json);
+        return ResponseEntity.ok(json);
     }
 
     private static ResponseEntity<Object> finishResponse(final Either<List<String>, ?> result,
                                                          final String responseJson) throws Exception {
         if (result.isRight()) {
-            LOGGER.trace("Response: [{}]", responseJson);
-            return ResponseEntity.ok(writeJson(result.right().orElseThrow()));
+            LOGGER.trace("Received: [{}]", responseJson);
+            val json = writeJson(result.right().orElseThrow());
+            LOGGER.trace("Returned: [{}]", json);
+            return ResponseEntity.ok(json);
         }
         return messagesJson(ResponseEntity.badRequest(), result.left().orElseThrow());
     }


### PR DESCRIPTION
This PR does two things:

1) Improve logs in the `WebAuthnController`: the changes are quite obvious here

2) Fix a bug in the WebAuthn support:

The `authenticatedPrincipal` in the `startAuthentication` method of the `WebAuthnController` was only populated during the registration and not for a regular MFA authentication. Thanks to the change in the `WebAuthnMultifactorWebflowConfigurer`, the `authenticatedPrincipal` in the `startAuthentication` method of the `WebAuthnController` is also now populated in any regular MFA authentication (much later after the registration).
