### PR TITLE
Missing state 'saveRegistration' in flow 'account' for WebAuthn

### DIFF
--- a/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/account/WebAuthnMultifactorAccountProfileWebflowConfigurer.java
+++ b/support/cas-server-support-webauthn-core-webflow/src/main/java/org/apereo/cas/webauthn/web/flow/account/WebAuthnMultifactorAccountProfileWebflowConfigurer.java
@@ -42,6 +42,9 @@ public class WebAuthnMultifactorAccountProfileWebflowConfigurer extends Multifac
             createEvaluateAction(CasWebflowConstants.ACTION_ID_WEB_AUTHN_START_REGISTRATION));
         createTransitionForState(regViewState, CasWebflowConstants.TRANSITION_ID_SUBMIT, CasWebflowConstants.STATE_ID_SAVE_REGISTRATION);
 
+        val saveState = createActionState(accountFlow, CasWebflowConstants.STATE_ID_SAVE_REGISTRATION, CasWebflowConstants.ACTION_ID_WEBAUTHN_SAVE_ACCOUNT_REGISTRATION);
+        createTransitionForState(saveState, CasWebflowConstants.TRANSITION_ID_SUCCESS, CasWebflowConstants.STATE_ID_MY_ACCOUNT_PROFILE_VIEW);
+
         val accountProfileView = (ViewState) accountFlow.getState(CasWebflowConstants.STATE_ID_MY_ACCOUNT_PROFILE_VIEW);
         createTransitionForState(accountProfileView, "registerWebAuthn", regViewState.getId());
     }

--- a/support/cas-server-support-webauthn/src/test/java/org/apereo/cas/webauthn/web/flow/WebAuthnMultifactorAccountProfileWebflowConfigurerTests.java
+++ b/support/cas-server-support-webauthn/src/test/java/org/apereo/cas/webauthn/web/flow/WebAuthnMultifactorAccountProfileWebflowConfigurerTests.java
@@ -33,6 +33,6 @@ class WebAuthnMultifactorAccountProfileWebflowConfigurerTests extends BaseWebflo
         val registrationState = (ViewState) flow.getState(CasWebflowConstants.STATE_ID_WEBAUTHN_VIEW_REGISTRATION);
         assertNotNull(registrationState);
         assertEquals(5, registrationState.getEntryActionList().size());
+        assertNotNull(flow.getState(CasWebflowConstants.STATE_ID_SAVE_REGISTRATION));
     }
 }
-


### PR DESCRIPTION
After successfully registering security key the following error is thrown when
CasFeatureModule.AccountManagement.enabled=true

Caused by: java.lang.IllegalArgumentException: Cannot find state with id 'saveRegistration' in flow 'account' -- Known state ids are 'array<String>['myAccountProfile', 'updateSecurityQuestions', 'passwordChangeRequest', 'redirectToPasswordReset', 'ticketGrantingTicketCheck', 'redirectToLogin', 'removeSingleSignOnSession', 'casBrowserStorageReadView', 'oidcRevokeAccessToken', 'deleteMfaDevice', 'deleteMultifactorTrustedDevice', 'viewRegistrationWebAuthn']'