### PR TITLE
avoid logging missing scope warning message

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticator.java
@@ -37,8 +37,10 @@ import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.profile.CommonProfile;
 import org.springframework.context.ConfigurableApplicationContext;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Authenticator for client credentials authentication.
@@ -136,7 +138,7 @@ public class OAuth20ClientIdClientSecretAuthenticator implements Authenticator {
     protected Principal buildAuthenticatedPrincipal(final Principal resolvedPrincipal, final OAuthRegisteredService registeredService,
                                                     final WebApplicationService service, final CallContext callContext) throws Throwable {
         val accessTokenFactory = (OAuth20AccessTokenFactory) ticketFactory.get(OAuth20AccessToken.class);
-        val scopes = requestParameterResolver.resolveRequestedScopes(callContext.webContext());
+        val scopes = getScopes(callContext);
         val responseType = requestParameterResolver.resolveResponseType(callContext.webContext());
         val grantType = requestParameterResolver.resolveGrantType(callContext.webContext());
 
@@ -146,6 +148,11 @@ public class OAuth20ClientIdClientSecretAuthenticator implements Authenticator {
         val finalPrincipal = profileScopeToAttributesFilter.filter(service, resolvedPrincipal, registeredService, accessToken);
         LOGGER.debug("Built final principal [{}]", finalPrincipal);
         return finalPrincipal;
+    }
+
+    protected Collection<String> getScopes(final CallContext callContext) {
+        val requestScopes = requestParameterResolver.resolveRequestedScopes(callContext.webContext());
+        return requestScopes.isEmpty() ? Set.of("openid") : requestScopes;
     }
 
     protected void validateCredentials(final UsernamePasswordCredentials credentials,

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/authenticator/OAuth20ClientIdClientSecretAuthenticatorTests.java
@@ -159,6 +159,16 @@ class OAuth20ClientIdClientSecretAuthenticatorTests {
             oauthClientAuthenticator.validate(new CallContext(ctx, new JEESessionStore()), credentials);
             assertNotNull(credentials.getUserProfile());
         }
+
+        @Test
+        void verifyGetScopes() {
+            val authenticator = (OAuth20ClientIdClientSecretAuthenticator) oauthClientAuthenticator;
+            val request = new MockHttpServletRequest();
+            val ctx = new JEEContext(request, new MockHttpServletResponse());
+            val scopes = authenticator.getScopes(new CallContext(ctx, new JEESessionStore()));
+            assertNotNull(scopes);
+            assertFalse(scopes.isEmpty());
+        }
     }
 
     @Import(NullPrincipalTestConfiguration.class)


### PR DESCRIPTION
This change avoids a warn logging statement [here](https://github.com/apereo/cas/blob/d03752c7c951d9257f8b32031509bbe730af59bb/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/profile/OidcProfileScopeToAttributesFilter.java#L69
).

If you set a breakpoint on the `OidcProfileScopeToAttributesFilter` logging in a puppeteer scenario such as `oidc-authn-claims-freeform`, the filter is called three times but when it is called from `OAuth20ClientIdClientSecretAuthenticator` it is called without the openid scope and you see a warning message logged. I don't think scope matters for `OAuth20ClientIdClientSecretAuthenticator` so this passes in "openid" when no other scopes are set (I don't think they usually are) and the warning log doesn't happen. 
