### PR TITLE
Clean dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -618,6 +618,7 @@ ext.libraries = [
                 dependencies.create(libs.cqengine.get()) {
                     exclude(group: 'org.xerial', module: "sqlite-jdbc")
                     exclude(group: "org.javassist", module: "javassist")
+                    exclude(group: "org.antlr", module: "antlr4-runtime")
                 }
         ],
         maxmind                    : [


### PR DESCRIPTION
This PR excludes an old version of `antlr4` (v4.7.2) pulled by `cqengine` while other pulled `antlr4` versions are generally around `4.13.x`.