### PR TITLE
New property for syncope authentication. This property define number of max retry attempts for login

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/syncope/SyncopeAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/syncope/SyncopeAuthenticationProperties.java
@@ -47,6 +47,11 @@ public class SyncopeAuthenticationProperties extends BaseSyncopeProperties {
     private int order = Integer.MAX_VALUE;
 
     /**
+     * Max retry attempts for the authentication
+     */
+    private int maxRetryAttempts;
+
+    /**
      * Password encoder settings for the authentication handler.
      */
     @NestedConfigurationProperty


### PR DESCRIPTION
**Use case**
When you try to log in on syncope console using CAS, when authentication fails, `loginFailed` attribute for syncope user increment by 3 beacuse variable `maxRetryAttempts` of `HttpExecutionRequest` class is set to 3 by default and it's not configurable.

**Brief description of changes applied**:
New property in class `SyncopeAuthenticationProperties`. This property will be used to define number of max retry login attempts. Value of this property will be used to set `maxRetryAttempts` value when  authentication will be done.
