### PR TITLE
Palantir: Initialize the services buttons each time the table is re-drawn

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir.js
@@ -133,6 +133,10 @@ function fetchServices(callback) {
                 $("#saml2metadataproviders").toggle(metadataSourcesCount > 0);
             }
 
+            applicationsTable.on("draw", function () {
+                initializeServiceButtons();
+            });
+            
             applicationsTable.search("").draw();
             saml2MetadataProvidersTable.search("").draw();
 
@@ -142,8 +146,6 @@ function fetchServices(callback) {
             if (callback !== undefined) {
                 callback(applicationsTable);
             }
-
-            initializeServiceButtons();
         }).fail((xhr, status, error) => {
             console.error("Error fetching data:", error);
             displayBanner(xhr);


### PR DESCRIPTION
When there are more rows in the `applicationsTable` (service entries) than DataTables will render on it's first draw, those non-rendered rows are not actually in the DOM, so `initializeServiceButtons()` does not apply the click event handlers to them. 

Those event handlers should be re-applied to the rows rendered in the DOM after the table is re-drawn at any point (due to filtering or pagination).