### PR TITLE
Remove the apache-snapshots repository

### DIFF
--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -182,12 +182,6 @@ ext.createPomRepositories = { node ->
     repository.appendNode("releases").appendNode("enabled", "false")
 
     repository = repositories.appendNode("repository")
-    repository.appendNode("id", "apache-snapshot")
-    repository.appendNode("url", "https://repository.apache.org/content/repositories/snapshots")
-    repository.appendNode("snapshots").appendNode("enabled", "true")
-    repository.appendNode("releases").appendNode("enabled", "false")
-
-    repository = repositories.appendNode("repository")
     repository.appendNode("id", "spring-milestone")
     repository.appendNode("url", "https://repo.spring.io/milestone")
     repository.appendNode("snapshots").appendNode("enabled", "false")


### PR DESCRIPTION
The Apache Snapshots repository is quite unstable and I sometimes have such errors:

```
Downloading from apache-snapshot: https://repository.apache.org/content/repositories/snapshots/org/bouncycastle/bcutil-jdk18on/maven-metadata.xml
[WARNING] Could not transfer metadata org.bouncycastle:bcutil-jdk18on/maven-metadata.xml from/to apache-snapshot (https://repository.apache.org/content/repositories/snapshots): Connect to repository.apache.org:443 [repository.apache.org/65.109.119.155] failed: Connection refused
```

I'm not sure it is really used for the build. This PR removes it.
