### PR TITLE
allowing syncope to handle password management operations for CAS 7.2.x

### DIFF
--- a/ci/tests/syncope/run-syncope-server.sh
+++ b/ci/tests/syncope/run-syncope-server.sh
@@ -487,6 +487,21 @@ curl -X 'POST' \
 
 echo -e "\n-----------------\n"
 
+echo "Creating phoneNumber plain schema..."
+curl -X 'POST' \
+  'http://localhost:18080/syncope/rest/schemas/PLAIN' \
+  -H 'accept: */*' \
+  -H 'X-Syncope-Domain: Master' \
+  -H 'Authorization: Basic YWRtaW46cGFzc3dvcmQ=' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "_class": "org.apache.syncope.common.lib.to.PlainSchemaTO",
+    "key": "phoneNumber",
+    "anyTypeClass": "BaseUser"
+}'
+
+echo -e "\n-----------------\n"
+
 echo "Creating sample user: syncopecas..."
 curl -X 'POST' \
   'http://localhost:18080/syncope/rest/users?storePassword=true' \
@@ -505,6 +520,12 @@ curl -X 'POST' \
               "schema": "email",
               "values": [
                 "syncopecas@syncope.org"
+              ]
+            },
+            {
+              "schema": "phoneNumber",
+              "values": [
+                "1234567890"
               ]
             }
         ],
@@ -540,6 +561,54 @@ curl -X 'POST' \
       "schema": "email",
       "values": [
         "casuser@syncope.org"
+      ]
+    },
+    {
+      "schema": "phoneNumber",
+      "values": [
+        "3477464523"
+      ]
+    }
+  ],
+  "derAttrs": [
+    {
+      "schema": "description"
+    }
+  ],
+  "virAttrs": [
+    {
+      "schema": "toBeVirtualized"
+    }
+  ]
+}'
+
+echo -e "\n-----------------\n"
+
+echo "Creating sample user: mustChangePasswordUser..."
+curl -X 'POST' \
+  'http://localhost:18080/syncope/rest/users?storePassword=true' \
+  -H 'accept: application/json' \
+  -H 'Prefer: return-content' \
+  -H 'X-Syncope-Null-Priority-Async: false' \
+  -H 'Authorization: Basic YWRtaW46cGFzc3dvcmQ=' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "_class": "org.apache.syncope.common.lib.request.UserCR",
+  "realm": "/",
+  "username": "mustChangePasswordUser",
+  "password": "ChangePassword",
+  "mustChangePassword": true,
+  "plainAttrs": [
+    {
+      "schema": "email",
+      "values": [
+        "mustChangePasswordUser@syncope.org"
+      ]
+    },
+    {
+      "schema": "phoneNumber",
+      "values": [
+        "2345678901"
       ]
     }
   ],

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/http/HttpUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/http/HttpUtils.java
@@ -98,7 +98,13 @@ public class HttpUtils {
         return null;
     }
 
-    private static CloseableHttpClient getHttpClient(final HttpExecutionRequest execution) throws Exception {
+    /**
+     * Create http client.
+     *
+     * @param execution http execution request
+     * @return http execution request
+     */
+    public static CloseableHttpClient getHttpClient(final HttpExecutionRequest execution) throws Exception {
         val builder = getHttpClientBuilder(execution);
         if (StringUtils.isNotBlank(execution.getProxyUrl())) {
             val proxyEndpoint = new URI(execution.getProxyUrl()).toURL();
@@ -152,7 +158,15 @@ public class HttpUtils {
         return acceptHeaders;
     }
 
-    private HttpUriRequest getHttpRequestByMethod(final String method, final String entity, final URI uri) {
+    /**
+     * Create http request.
+     *
+     * @param method http request method
+     * @param entity http request body
+     * @param uri http request uri
+     * @return http request with get method
+     */
+    public static HttpUriRequest getHttpRequestByMethod(final String method, final String entity, final URI uri) {
         if ("post".equalsIgnoreCase(method)) {
             val request = new HttpPost(uri);
             if (StringUtils.isNotBlank(entity)) {
@@ -176,7 +190,7 @@ public class HttpUtils {
      * @param request   the request
      * @param execution the execution request
      */
-    private void prepareHttpRequest(final HttpUriRequest request,
+    public static void prepareHttpRequest(final HttpUriRequest request,
                                     final HttpExecutionRequest execution) {
         if (execution.isBasicAuthentication()) {
             val auth = EncodingUtils.encodeBase64(execution.getBasicAuthUsername() + ':' + execution.getBasicAuthPassword());
@@ -187,7 +201,14 @@ public class HttpUtils {
         }
     }
 
-    private URI buildHttpUri(final String url, final Map<String, String> parameters) {
+    /**
+     * Build URI for http request
+     *
+     * @param url used for URI
+     * @param parameters for URI
+     * @return URI for http request
+     */
+    public static URI buildHttpUri(final String url, final Map<String, String> parameters) {
         return FunctionUtils.doUnchecked(() -> {
             val uriBuilder = new URIBuilder(url);
             parameters.forEach(uriBuilder::addParameter);

--- a/support/cas-server-support-openrewrite/recipes/META-INF/rewrite/cas725.yml
+++ b/support/cas-server-support-openrewrite/recipes/META-INF/rewrite/cas725.yml
@@ -33,7 +33,7 @@ recipeList:
       addIfMissing: true
   - org.openrewrite.gradle.AddProperty:
       key: tomcatVersion
-      value: 10.1.42
+      value: 10.1.43
       overwrite: false
       filePattern: 'gradle.properties'
   - org.openrewrite.gradle.AddProperty:

--- a/support/cas-server-support-syncope-authentication/build.gradle
+++ b/support/cas-server-support-syncope-authentication/build.gradle
@@ -17,7 +17,8 @@ dependencies {
     implementation project(":core:cas-server-core-util-api")
     implementation project(":core:cas-server-core-configuration-api")
     implementation project(":core:cas-server-core-webflow-api")
-    
+
+    implementation project(":support:cas-server-support-pm-core")
     implementation project(":support:cas-server-support-person-directory-core")
     implementation project(":support:cas-server-support-actions-core")
     
@@ -30,6 +31,8 @@ dependencies {
     testImplementation project(path: ":core:cas-server-core-authentication-api", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-util-api", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-webflow", configuration: "tests")
+
+    testImplementation libraries.springboottomcat
     
     testImplementation project(":core:cas-server-core-web")
     testImplementation project(":core:cas-server-core-webflow")
@@ -47,7 +50,13 @@ dependencies {
     testImplementation project(":core:cas-server-core-cookie-api")
     testImplementation project(":core:cas-server-core-scripting")
 
+    testImplementation project(":support:cas-server-support-passwordless-api")
+    testImplementation project(":support:cas-server-support-passwordless-authentication")
+    testImplementation project(":support:cas-server-support-passwordless-webflow")
     testImplementation project(":support:cas-server-support-account-mgmt-api")
     testImplementation project(":support:cas-server-support-account-mgmt")
     testImplementation project(":support:cas-server-support-person-directory")
+    testImplementation project(":support:cas-server-support-pm")
+    testImplementation project(":support:cas-server-support-pm-webflow")
+    testImplementation project(":support:cas-server-support-webconfig")
 }

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/CasSyncopeAutoConfiguration.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/CasSyncopeAutoConfiguration.java
@@ -7,20 +7,15 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
-/**
- * This is {@link CasSyncopeAutoConfiguration}.
- *
- * @author Misagh Moayyed
- * @since 7.1.0
- */
 @EnableConfigurationProperties(CasConfigurationProperties.class)
 @ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.Authentication, module = "syncope")
 @AutoConfiguration
 @Import({
-    SyncopeAuthenticationConfiguration.class,
-    SyncopeAccountManagementConfiguration.class,
-    SyncopePersonDirectoryConfiguration.class,
-    SyncopeWebflowConfiguration.class
+        SyncopeAuthenticationConfiguration.class,
+        SyncopeAccountManagementConfiguration.class,
+        SyncopePersonDirectoryConfiguration.class,
+        SyncopeWebflowConfiguration.class,
+        SyncopePasswordManagementConfiguration.class
 })
 public class CasSyncopeAutoConfiguration {
 }

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/SyncopePasswordManagementConfiguration.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/config/SyncopePasswordManagementConfiguration.java
@@ -1,0 +1,47 @@
+package org.apereo.cas.config;
+
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.configuration.features.CasFeatureModule;
+import org.apereo.cas.configuration.model.support.pm.PasswordManagementProperties;
+import org.apereo.cas.pm.PasswordHistoryService;
+import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.pm.impl.NoOpPasswordManagementService;
+import org.apereo.cas.syncope.pm.SyncopePasswordManagementService;
+import org.apereo.cas.util.crypto.CipherExecutor;
+import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ScopedProxyMode;
+
+/**
+ * This is {@link SyncopePasswordManagementConfiguration}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.4.0
+ */
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+@ConditionalOnFeatureEnabled(feature = CasFeatureModule.FeatureCatalog.PasswordManagement, module = "syncope")
+@ConditionalOnClass(PasswordManagementService.class)
+@Configuration(value = "SyncopePasswordManagementConfiguration", proxyBeanMethods = false)
+class SyncopePasswordManagementConfiguration {
+    @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+    @Bean
+    @ConditionalOnMissingBean(name = "syncopePasswordChangeService")
+    public PasswordManagementService passwordChangeService(
+            final CasConfigurationProperties casProperties,
+            @Qualifier("passwordManagementCipherExecutor")
+            final CipherExecutor passwordManagementCipherExecutor,
+            @Qualifier(PasswordHistoryService.BEAN_NAME)
+            final PasswordHistoryService passwordHistoryService) {
+        PasswordManagementProperties pm = casProperties.getAuthn().getPm();
+        if (pm.getCore().isEnabled() && pm.getSyncope().getDomain() != null && pm.getSyncope().getUrl() != null) {
+            return new SyncopePasswordManagementService(passwordManagementCipherExecutor, casProperties, passwordHistoryService);
+        }
+        return new NoOpPasswordManagementService(passwordManagementCipherExecutor, casProperties);
+    }
+}

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/configuration/model/support/pm/PasswordManagementProperties.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/configuration/model/support/pm/PasswordManagementProperties.java
@@ -1,0 +1,193 @@
+package org.apereo.cas.configuration.model.support.pm;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import org.apereo.cas.configuration.features.CasFeatureModule;
+import org.apereo.cas.configuration.model.core.web.flow.WebflowAutoConfigurationProperties;
+import org.apereo.cas.configuration.model.support.captcha.GoogleRecaptchaProperties;
+import org.apereo.cas.configuration.support.RequiresModule;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * This is {@link PasswordManagementProperties}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+@RequiresModule(name = "cas-server-support-pm-webflow")
+public class PasswordManagementProperties implements CasFeatureModule, Serializable {
+
+    @Serial
+    private static final long serialVersionUID = -260644582798411176L;
+
+    /**
+     * Password management core settings.
+     */
+    @NestedConfigurationProperty
+    private PasswordManagementCoreProperties core = new PasswordManagementCoreProperties();
+
+    /**
+     * Google reCAPTCHA settings.
+     */
+    @NestedConfigurationProperty
+    private GoogleRecaptchaProperties googleRecaptcha = new GoogleRecaptchaProperties();
+
+    /**
+     * Manage account passwords in LDAP.
+     */
+    private List<LdapPasswordManagementProperties> ldap = new ArrayList<>();
+
+    /**
+     * Manage account passwords in database.
+     */
+    @NestedConfigurationProperty
+    private JdbcPasswordManagementProperties jdbc = new JdbcPasswordManagementProperties();
+
+    /**
+     * Manage account passwords via REST.
+     */
+    @NestedConfigurationProperty
+    private RestfulPasswordManagementProperties rest = new RestfulPasswordManagementProperties();
+
+    /**
+     * Manage account passwords in JSON resources.
+     */
+    @NestedConfigurationProperty
+    private JsonPasswordManagementProperties json = new JsonPasswordManagementProperties();
+
+    /**
+     * Manage account passwords in Syncope.
+     */
+    @NestedConfigurationProperty
+    private SyncopePasswordManagementProperties syncope = new SyncopePasswordManagementProperties();
+
+    /**
+     * Settings related to resetting password.
+     */
+    @NestedConfigurationProperty
+    private ResetPasswordManagementProperties reset = new ResetPasswordManagementProperties();
+
+    /**
+     * Settings related to fetching usernames.
+     */
+    @NestedConfigurationProperty
+    private ForgotUsernamePasswordManagementProperties forgotUsername =
+            new ForgotUsernamePasswordManagementProperties();
+
+    /**
+     * Settings related to password history management.
+     */
+    @NestedConfigurationProperty
+    private PasswordHistoryProperties history = new PasswordHistoryProperties();
+
+    /**
+     * Handle password policy via Groovy script.
+     */
+    @NestedConfigurationProperty
+    private GroovyPasswordManagementProperties groovy = new GroovyPasswordManagementProperties();
+
+    /**
+     * The webflow configuration.
+     */
+    @NestedConfigurationProperty
+    private WebflowAutoConfigurationProperties webflow = new WebflowAutoConfigurationProperties().setOrder(200);
+
+    public PasswordManagementCoreProperties getCore() {
+        return core;
+    }
+
+    public void setCore(PasswordManagementCoreProperties core) {
+        this.core = core;
+    }
+
+    public GoogleRecaptchaProperties getGoogleRecaptcha() {
+        return googleRecaptcha;
+    }
+
+    public void setGoogleRecaptcha(GoogleRecaptchaProperties googleRecaptcha) {
+        this.googleRecaptcha = googleRecaptcha;
+    }
+
+    public List<LdapPasswordManagementProperties> getLdap() {
+        return ldap;
+    }
+
+    public void setLdap(List<LdapPasswordManagementProperties> ldap) {
+        this.ldap = ldap;
+    }
+
+    public JdbcPasswordManagementProperties getJdbc() {
+        return jdbc;
+    }
+
+    public void setJdbc(JdbcPasswordManagementProperties jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    public RestfulPasswordManagementProperties getRest() {
+        return rest;
+    }
+
+    public void setRest(RestfulPasswordManagementProperties rest) {
+        this.rest = rest;
+    }
+
+    public SyncopePasswordManagementProperties getSyncope() {
+        return syncope;
+    }
+
+    public void setSyncope(SyncopePasswordManagementProperties syncope) {
+        this.syncope = syncope;
+    }
+
+    public JsonPasswordManagementProperties getJson() {
+        return json;
+    }
+
+    public void setJson(JsonPasswordManagementProperties json) {
+        this.json = json;
+    }
+
+    public ResetPasswordManagementProperties getReset() {
+        return reset;
+    }
+
+    public void setReset(ResetPasswordManagementProperties reset) {
+        this.reset = reset;
+    }
+
+    public ForgotUsernamePasswordManagementProperties getForgotUsername() {
+        return forgotUsername;
+    }
+
+    public void setForgotUsername(
+            ForgotUsernamePasswordManagementProperties forgotUsername) {
+        this.forgotUsername = forgotUsername;
+    }
+
+    public PasswordHistoryProperties getHistory() {
+        return history;
+    }
+
+    public void setHistory(PasswordHistoryProperties history) {
+        this.history = history;
+    }
+
+    public GroovyPasswordManagementProperties getGroovy() {
+        return groovy;
+    }
+
+    public void setGroovy(GroovyPasswordManagementProperties groovy) {
+        this.groovy = groovy;
+    }
+
+    public WebflowAutoConfigurationProperties getWebflow() {
+        return webflow;
+    }
+
+    public void setWebflow(WebflowAutoConfigurationProperties webflow) {
+        this.webflow = webflow;
+    }
+}

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/configuration/model/support/pm/SyncopePasswordManagementProperties.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/configuration/model/support/pm/SyncopePasswordManagementProperties.java
@@ -1,0 +1,11 @@
+package org.apereo.cas.configuration.model.support.pm;
+
+import org.apereo.cas.configuration.model.support.syncope.BaseSyncopeSearchProperties;
+import org.apereo.cas.configuration.support.RequiresModule;
+
+@RequiresModule(name = "cas-server-support-syncope-authentication")
+public class SyncopePasswordManagementProperties extends BaseSyncopeSearchProperties {
+
+    private static final long serialVersionUID = -3772274510347618493L;
+
+}

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/syncope/SyncopeAuthenticationHandler.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/syncope/SyncopeAuthenticationHandler.java
@@ -1,10 +1,12 @@
 package org.apereo.cas.syncope;
 
+import org.apache.hc.core5.http.ProtocolException;
 import org.apereo.cas.authentication.AuthenticationHandlerExecutionResult;
 import org.apereo.cas.authentication.credential.UsernamePasswordCredential;
 import org.apereo.cas.authentication.exceptions.AccountDisabledException;
 import org.apereo.cas.authentication.exceptions.AccountPasswordMustChangeException;
 import org.apereo.cas.authentication.handler.support.AbstractUsernamePasswordAuthenticationHandler;
+import org.apereo.cas.authentication.principal.Principal;
 import org.apereo.cas.authentication.principal.PrincipalFactory;
 import org.apereo.cas.configuration.model.support.syncope.SyncopeAuthenticationProperties;
 import org.apereo.cas.monitor.Monitorable;
@@ -62,30 +64,23 @@ public class SyncopeAuthenticationHandler extends AbstractUsernamePasswordAuthen
             final UsernamePasswordCredential credential, final String originalPassword) throws Throwable {
         val result = authenticateSyncopeUser(credential);
         if (result.isPresent()) {
-            val user = result.get();
+            JsonNode user = result.get();
             LOGGER.debug("Received user object as [{}]", user);
-            if (user.has("suspended") && user.get("suspended").asBoolean()) {
-                throw new AccountDisabledException(
-                        "Could not authenticate forbidden account for " + credential.getUsername());
-            }
-            if (user.has("mustChangePassword") && user.get("mustChangePassword").asBoolean()) {
-                throw new AccountPasswordMustChangeException(
-                        "Account password must change for " + credential.getUsername());
-            }
-            val principal = principalFactory.createPrincipal(user.get("username").asText(),
+            Principal principal = principalFactory.createPrincipal(user.get("username").asText(),
                     SyncopeUtils.convertFromUserEntity(user, properties.getAttributeMappings()));
             return createHandlerResult(credential, principal, new ArrayList<>());
         }
         throw new FailedLoginException("Could not authenticate account for " + credential.getUsername());
     }
 
-    protected Optional<JsonNode> authenticateSyncopeUser(final UsernamePasswordCredential credential) {
+    protected Optional<JsonNode> authenticateSyncopeUser(final UsernamePasswordCredential credential)
+            throws AccountPasswordMustChangeException, AccountDisabledException {
         HttpResponse response = null;
         try {
-            val syncopeRestUrl = StringUtils.appendIfMissing(
+            String syncopeRestUrl = StringUtils.appendIfMissing(
                     SpringExpressionLanguageValueResolver.getInstance().resolve(properties.getUrl()),
                     "/rest/users/self");
-            val exec = HttpExecutionRequest.builder()
+            HttpExecutionRequest exec = HttpExecutionRequest.builder()
                     .method(HttpMethod.GET)
                     .url(syncopeRestUrl)
                     .basicAuthUsername(credential.getUsername())
@@ -93,11 +88,21 @@ public class SyncopeAuthenticationHandler extends AbstractUsernamePasswordAuthen
                     .headers(CollectionUtils.wrap("X-Syncope-Domain", syncopeDomain))
                     .maximumRetryAttempts(properties.getMaxRetryAttempts())
                     .build();
-            response = Objects.requireNonNull(HttpUtils.execute(exec));
+            response = Objects.requireNonNull(SyncopeUtils.execute(exec));
             LOGGER.debug("Received http response status as [{}]", response.getReasonPhrase());
             if (response.getCode() == HttpStatus.SC_OK) {
                 return parseResponseResults((HttpEntityContainer) response);
             }
+            val header = response.getHeader("x-application-error-info");
+            if (header.getValue().contains("change your password")) {
+                throw new AccountPasswordMustChangeException(
+                        "Account password must change for " + credential.getUsername());
+            } else if (header.getValue().contains("suspended")) {
+                throw new AccountDisabledException(
+                        "Could not authenticate forbidden account for " + credential.getUsername());
+            }
+        } catch (ProtocolException e) {
+            throw new RuntimeException(e);
         } finally {
             HttpUtils.close(response);
         }

--- a/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/syncope/pm/SyncopePasswordManagementService.java
+++ b/support/cas-server-support-syncope-authentication/src/main/java/org/apereo/cas/syncope/pm/SyncopePasswordManagementService.java
@@ -1,0 +1,135 @@
+package org.apereo.cas.syncope.pm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apereo.cas.authentication.Credential;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.pm.PasswordChangeRequest;
+import org.apereo.cas.pm.PasswordHistoryService;
+import org.apereo.cas.pm.PasswordManagementQuery;
+import org.apereo.cas.pm.impl.BasePasswordManagementService;
+import org.apereo.cas.syncope.SyncopeUtils;
+import org.apereo.cas.util.crypto.CipherExecutor;
+import org.apereo.cas.util.function.FunctionUtils;
+import org.apereo.cas.util.http.HttpExecutionRequest;
+import org.apereo.cas.util.http.HttpUtils;
+import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
+import org.apereo.cas.util.spring.SpringExpressionLanguageValueResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+public class SyncopePasswordManagementService extends BasePasswordManagementService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SyncopePasswordManagementService.class);
+
+    private static final ObjectMapper MAPPER = JacksonObjectMapperFactory.builder()
+            .defaultTypingEnabled(false).build().toObjectMapper();
+
+    public SyncopePasswordManagementService(final CipherExecutor<Serializable, String> cipherExecutor,
+                                            final CasConfigurationProperties casProperties,
+                                            final PasswordHistoryService passwordHistoryService) {
+        super(casProperties, cipherExecutor, passwordHistoryService);
+    }
+
+    @Override
+    public boolean changeInternal(final PasswordChangeRequest bean) {
+        return FunctionUtils.doAndHandle(() -> {
+            String syncopeRestPasswordResetUrl = StringUtils.appendIfMissing(
+                    SpringExpressionLanguageValueResolver.getInstance().resolve(
+                            casProperties.getAuthn().getPm().getSyncope().getUrl()),
+                    "/rest/users/self/mustChangePassword");
+            LOGGER.debug("Updating account password on syncope for user [{}]", bean.getUsername());
+            HttpExecutionRequest exec = HttpExecutionRequest.builder()
+                    .method(HttpMethod.POST)
+                    .url(syncopeRestPasswordResetUrl)
+                    .basicAuthUsername(bean.getUsername())
+                    .basicAuthPassword(bean.toCurrentPassword())
+                    .headers(Map.of("X-Syncope-Domain", casProperties.getAuthn().getSyncope().getDomain(),
+                            HttpHeaders.ACCEPT, "application/json",
+                            HttpHeaders.CONTENT_TYPE, "application/json"))
+                    .entity(MAPPER.writeValueAsString(getPasswordPatch(bean)))
+                    .maximumRetryAttempts(1)
+                    .build();
+            HttpResponse response = Objects.requireNonNull(HttpUtils.execute(exec));
+            if (response.getCode() == HttpStatus.SC_OK) {
+                LOGGER.debug("Successfully updated the account password on Syncope for [{}]", bean.getUsername());
+                return true;
+            }
+            return false;
+        }, e -> {
+            LOGGER.error("Error while update password on Syncope for user [{}]", bean.getUsername());
+            return false;
+        }).get();
+    }
+
+    @Override
+    public String findEmail(final PasswordManagementQuery query) {
+        return getUserAttribute(query, "email").orElseGet(query::getEmail);
+    }
+
+    @Override
+    public String findPhone(final PasswordManagementQuery query) {
+        return getUserAttribute(query, "phoneNumber").orElseGet(query::getPhoneNumber);
+    }
+
+    @Override
+    public String findUsername(final PasswordManagementQuery query) {
+        return getUserAttribute(query, "username").orElseGet(query::getUsername);
+    }
+
+    @Override
+    public Map<String, String> getSecurityQuestions(final PasswordManagementQuery query) {
+        throw new UnsupportedOperationException("Password Management Service does not support security questions");
+    }
+
+    @Override
+    public void updateSecurityQuestions(final PasswordManagementQuery query) {
+        throw new UnsupportedOperationException("Password Management Service does not support updating security questions");
+    }
+
+    @Override
+    public boolean unlockAccount(final Credential credential) {
+        throw new UnsupportedOperationException("Password Management Service does not support unlocking of accounts");
+    }
+
+    protected Optional<String> getUserAttribute(final PasswordManagementQuery query, final String attributeName) {
+        return searchUser(query)
+                .stream()
+                .findFirst()
+                .map(syncopeUser -> {
+                    String prefix = "%s_%s".formatted("syncopeUserAttr", attributeName);
+                    return syncopeUser.getOrDefault(attributeName, syncopeUser.get(prefix));
+                })
+                .filter(Objects::nonNull)
+                .filter(values -> !values.isEmpty())
+                .map(values -> values.getFirst().toString());
+    }
+
+    private List<Map<String, List<Object>>> searchUser(final PasswordManagementQuery query) {
+        return SyncopeUtils.syncopeUserSearch(casProperties.getAuthn().getPm().getSyncope(), query.getUsername());
+    }
+
+    private JsonNode getPasswordPatch(final PasswordChangeRequest bean) {
+        ObjectNode passwordPatch = MAPPER.createObjectNode();
+        passwordPatch.put("operation", "ADD_REPLACE");
+        passwordPatch.put("value", bean.toConfirmedPassword());
+        passwordPatch.put("onSyncope", true);
+
+        ArrayNode resources = MAPPER.createArrayNode();
+        passwordPatch.set("resources", resources);
+
+        return passwordPatch;
+    }
+}

--- a/support/cas-server-support-syncope-authentication/src/test/java/org/apereo/cas/syncope/BaseSyncopeTests.java
+++ b/support/cas-server-support-syncope-authentication/src/test/java/org/apereo/cas/syncope/BaseSyncopeTests.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.syncope;
 
+import org.apereo.cas.config.CasAccountManagementWebflowAutoConfiguration;
 import org.apereo.cas.config.CasAuthenticationEventExecutionPlanTestConfiguration;
 import org.apereo.cas.config.CasCoreAuditAutoConfiguration;
 import org.apereo.cas.config.CasCoreAuthenticationAutoConfiguration;
@@ -15,6 +16,8 @@ import org.apereo.cas.config.CasCoreTicketsAutoConfiguration;
 import org.apereo.cas.config.CasCoreUtilAutoConfiguration;
 import org.apereo.cas.config.CasCoreWebAutoConfiguration;
 import org.apereo.cas.config.CasCoreWebflowAutoConfiguration;
+import org.apereo.cas.config.CasPasswordManagementAutoConfiguration;
+import org.apereo.cas.config.CasPasswordlessAuthenticationAutoConfiguration;
 import org.apereo.cas.config.CasPersonDirectoryAutoConfiguration;
 import org.apereo.cas.config.CasRegisteredServicesTestConfiguration;
 import org.apereo.cas.config.CasSyncopeAutoConfiguration;
@@ -45,14 +48,14 @@ import java.util.UUID;
  */
 public abstract class BaseSyncopeTests {
     protected static final ObjectMapper MAPPER =
-        JacksonObjectMapperFactory.builder().defaultTypingEnabled(true).build().toObjectMapper();
+            JacksonObjectMapperFactory.builder().defaultTypingEnabled(true).build().toObjectMapper();
 
     protected static MockWebServer startMockSever(final JsonNode json, final HttpStatus status,
                                                   final int port) throws Exception {
         val data = MAPPER.writeValueAsString(json);
         val webServer = new MockWebServer(port,
-            new ByteArrayResource(data.getBytes(StandardCharsets.UTF_8), "REST Output"),
-            MediaType.APPLICATION_JSON_VALUE, status);
+                new ByteArrayResource(data.getBytes(StandardCharsets.UTF_8), "REST Output"),
+                MediaType.APPLICATION_JSON_VALUE, status);
         webServer.start();
         return webServer;
     }
@@ -65,11 +68,11 @@ public abstract class BaseSyncopeTests {
         user.putArray("dynRoles").add("DynRole1");
         user.putArray("dynRealms").add("Realm1");
         user.putArray("memberships").add(MAPPER.createObjectNode()
-            .put("groupName", "G1"));
+                .put("groupName", "G1"));
         user.putArray("dynMemberships").add(MAPPER.createObjectNode()
-            .put("groupName", "G1"));
+                .put("groupName", "G1"));
         user.putArray("relationships").add(MAPPER.createObjectNode()
-            .put("type", "T1").put("otherEndName", "Other1"));
+                .put("type", "T1").put("otherEndName", "Other1"));
 
         val plainAttrs = MAPPER.createObjectNode();
         plainAttrs.put("schema", "S1");
@@ -96,8 +99,8 @@ public abstract class BaseSyncopeTests {
 
         return user;
     }
-    
-    protected static ObjectNode userForMembershipsTypeExtension(){
+
+    protected static ObjectNode userForMembershipsTypeExtension() {
         val user = MAPPER.createObjectNode();
         user.put("key", UUID.randomUUID().toString());
         user.put("username", "casuser");
@@ -108,7 +111,7 @@ public abstract class BaseSyncopeTests {
                 .put("groupName", "G1"));
         user.putArray("relationships").add(MAPPER.createObjectNode()
                 .put("type", "T1").put("otherEndName", "Other1"));
-        
+
         val memberships = user.putArray("memberships");
         val membershipsInfo = MAPPER.createObjectNode().put("groupName", "G1");
         val membershipPlainAttrs = membershipsInfo.putArray("plainAttrs");
@@ -124,9 +127,9 @@ public abstract class BaseSyncopeTests {
         val values2 = plainAttrNode2.putArray("values");
         values2.add("valueSchema2");
         membershipPlainAttrs.add(plainAttrNode2);
-        
+
         memberships.add(membershipsInfo);
-        
+
         val plainAttrs = MAPPER.createObjectNode();
         plainAttrs.put("schema", "S1");
         plainAttrs.putArray("values").add("V1");
@@ -152,24 +155,27 @@ public abstract class BaseSyncopeTests {
 
         return user;
     }
-    
+
     @ImportAutoConfiguration({
-        CasSyncopeAutoConfiguration.class,
-        CasCoreAutoConfiguration.class,
-        CasCoreLogoutAutoConfiguration.class,
-        CasCoreCookieAutoConfiguration.class,
-        CasCoreServicesAutoConfiguration.class,
-        CasCoreTicketsAutoConfiguration.class,
-        CasCoreAuthenticationAutoConfiguration.class,
-        CasCoreMultifactorAuthenticationAutoConfiguration.class,
-        CasCoreMultifactorAuthenticationWebflowAutoConfiguration.class,
-        CasCoreAuditAutoConfiguration.class,
-        CasCoreWebAutoConfiguration.class,
-        CasCoreUtilAutoConfiguration.class,
-        CasPersonDirectoryAutoConfiguration.class,
-        CasCoreWebflowAutoConfiguration.class,
-        CasCoreNotificationsAutoConfiguration.class,
-        CasCoreScriptingAutoConfiguration.class
+            CasSyncopeAutoConfiguration.class,
+            CasCoreAutoConfiguration.class,
+            CasCoreLogoutAutoConfiguration.class,
+            CasCoreCookieAutoConfiguration.class,
+            CasCoreServicesAutoConfiguration.class,
+            CasCoreTicketsAutoConfiguration.class,
+            CasCoreAuthenticationAutoConfiguration.class,
+            CasCoreMultifactorAuthenticationAutoConfiguration.class,
+            CasCoreMultifactorAuthenticationWebflowAutoConfiguration.class,
+            CasCoreAuditAutoConfiguration.class,
+            CasCoreWebAutoConfiguration.class,
+            CasCoreUtilAutoConfiguration.class,
+            CasPersonDirectoryAutoConfiguration.class,
+            CasCoreWebflowAutoConfiguration.class,
+            CasCoreNotificationsAutoConfiguration.class,
+            CasCoreScriptingAutoConfiguration.class,
+            CasPasswordlessAuthenticationAutoConfiguration.class,
+            CasPasswordManagementAutoConfiguration.class,
+            CasAccountManagementWebflowAutoConfiguration.class
     })
     @SpringBootConfiguration(proxyBeanMethods = false)
     @SpringBootTestAutoConfigurations

--- a/support/cas-server-support-syncope-authentication/src/test/java/org/apereo/cas/syncope/pm/SyncopePasswordManagementServiceTests.java
+++ b/support/cas-server-support-syncope-authentication/src/test/java/org/apereo/cas/syncope/pm/SyncopePasswordManagementServiceTests.java
@@ -1,0 +1,121 @@
+package org.apereo.cas.syncope.pm;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import javax.security.auth.login.FailedLoginException;
+import lombok.val;
+import org.apereo.cas.authentication.AuthenticationHandler;
+import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
+import org.apereo.cas.authentication.credential.BasicIdentifiableCredential;
+import org.apereo.cas.authentication.exceptions.AccountPasswordMustChangeException;
+import org.apereo.cas.authentication.principal.Service;
+import org.apereo.cas.pm.PasswordChangeRequest;
+import org.apereo.cas.pm.PasswordManagementQuery;
+import org.apereo.cas.pm.PasswordManagementService;
+import org.apereo.cas.syncope.BaseSyncopeTests;
+import org.apereo.cas.test.CasTestExtension;
+import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
+import org.apereo.cas.util.spring.beans.BeanContainer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * This is {@link SyncopePasswordManagementServiceTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 7.3.0
+ */
+@Tag("Syncope")
+@ExtendWith(CasTestExtension.class)
+@EnabledIfListeningOnPort(port = 18080)
+@SpringBootTest(classes = BaseSyncopeTests.SharedTestConfiguration.class, properties = {
+        "cas.authn.syncope.url=http://localhost:18080/syncope",
+
+        "cas.authn.pm.core.enabled=true",
+        "cas.authn.pm.history.core.enabled=true",
+        "cas.authn.pm.syncope.basic-auth-username=admin",
+        "cas.authn.pm.syncope.basic-auth-password=password",
+        "cas.authn.pm.syncope.url=http://localhost:18080/syncope",
+        "cas.authn.pm.syncope.attribute-mappings.syncopeUserAttr_givenName=name",
+        "cas.authn.pm.syncope.attribute-mappings.syncopeUserAttr_email=email",
+        "cas.authn.pm.syncope.attribute-mappings.syncopeUserAttr_phoneNumber=phoneNumber",
+        "cas.authn.pm.syncope.attribute-mappings.username=username"
+})
+class SyncopePasswordManagementServiceTests {
+
+    @Autowired
+    @Qualifier(PasswordManagementService.DEFAULT_BEAN_NAME)
+    private PasswordManagementService passwordChangeService;
+
+    @Autowired
+    @Qualifier("syncopeAuthenticationHandlers")
+    private BeanContainer<AuthenticationHandler> syncopeAuthenticationHandlers;
+
+    @Test
+    void verifyFindEmail() throws Throwable {
+        val email =
+                passwordChangeService.findEmail(PasswordManagementQuery.builder().username("mustChangePasswordUser").build());
+        assertEquals("mustChangePasswordUser@syncope.org", email);
+    }
+
+    @Test
+    void verifyFindPhone() throws Throwable {
+        val ph =
+                passwordChangeService.findPhone(PasswordManagementQuery.builder().username("mustChangePasswordUser").build());
+        assertEquals("2345678901", ph);
+    }
+
+    @Test
+    void verifyFindSecurityQuestions() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> passwordChangeService.getSecurityQuestions(
+                        PasswordManagementQuery.builder().username("mustChangePasswordUser").build()));
+    }
+
+    @Test
+    void verifyUpdateSecurityQuestions() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> passwordChangeService.updateSecurityQuestions(
+                        PasswordManagementQuery.builder().username("mustChangePasswordUser").build()));
+    }
+
+    @Test
+    void verifyUnlockSecurityQuestions() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> passwordChangeService.unlockAccount(new BasicIdentifiableCredential("mustChangePasswordUser")));
+    }
+
+    @Test
+    void verifyMustChangePasswordPasses() throws Throwable {
+        assertNotNull(syncopeAuthenticationHandlers);
+        val syncopeAuthenticationHandler = syncopeAuthenticationHandlers.first();
+        val credential = CoreAuthenticationTestUtils.getCredentialsWithDifferentUsernameAndPassword(
+                "mustChangePasswordUser",
+                "ChangePassword");
+        assertThrows(AccountPasswordMustChangeException.class,
+                () -> syncopeAuthenticationHandler.authenticate(credential, mock(Service.class)));
+
+        val passwordChangeRequest = new PasswordChangeRequest(
+                "mustChangePasswordUser",
+                "ChangePassword".toCharArray(),
+                "Password123!".toCharArray(),
+                "Password123!".toCharArray());
+
+        assertTrue(((SyncopePasswordManagementService)passwordChangeService).changeInternal(passwordChangeRequest));
+        assertThrows(FailedLoginException.class,
+                () -> syncopeAuthenticationHandler.authenticate(credential, mock(Service.class)));
+
+        credential.setPassword("Password123!".toCharArray());
+        assertDoesNotThrow(() -> syncopeAuthenticationHandler.authenticate(credential, mock(Service.class)));
+    }
+
+}


### PR DESCRIPTION
**Brief description of changes applied**

Configuration for syncope password management. In this way, if a user on syncope has `mustChangePassword` enabled, it'll be possible to reset his password with CAS. In more details, if a user try to authenticate with CAS with `mustChangePassword` set on `true`, he will be redirected on reset password CAS form

**Test cases for all modified changes**

`SyncopePasswordManagementServiceTasks`

*This PR is based on https://github.com/apereo/cas/commit/abc9efaf370cb0180aa139aaae21abfe5a4716e7*



