### PR TITLE
Fix password reset content type

### DIFF
--- a/support/cas-server-support-pm-rest/src/main/java/org/apereo/cas/config/CasRestPasswordManagementAutoConfiguration.java
+++ b/support/cas-server-support-pm-rest/src/main/java/org/apereo/cas/config/CasRestPasswordManagementAutoConfiguration.java
@@ -65,7 +65,6 @@ public class CasRestPasswordManagementAutoConfiguration {
             builder = builder.basicAuthentication(username, password, StandardCharsets.UTF_8);
         }
         builder = builder.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .defaultHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
         for (val entry : pmRest.getHeaders().entrySet()) {
             LOGGER.debug("Configuring header [{}] with value [{}]", entry.getKey(), entry.getValue());

--- a/support/cas-server-support-pm-rest/src/main/java/org/apereo/cas/pm/rest/RestPasswordManagementService.java
+++ b/support/cas-server-support-pm-rest/src/main/java/org/apereo/cas/pm/rest/RestPasswordManagementService.java
@@ -10,8 +10,10 @@ import org.apereo.cas.util.crypto.CipherExecutor;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -52,7 +54,9 @@ public class RestPasswordManagementService extends BasePasswordManagementService
         if (bean.getCurrentPassword() != null) {
             body.put(rest.getFieldNamePasswordOld(), bean.toCurrentPassword());
         }
-        val entity = new HttpEntity<>(body);
+        val headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        val entity = new HttpEntity<>(body, headers);
         val result = restTemplate.exchange(rest.getEndpointUrlChange(), HttpMethod.POST, entity, Boolean.class);
         return result.getStatusCode().value() == HttpStatus.OK.value() && result.hasBody()
             && Objects.requireNonNull(result.getBody());


### PR DESCRIPTION
Set the Content-Type header at request Level to avoid sending XML.

Before this fix, RestTemplate has Choosen an XML Message Converter, while still sending Content-Type: application/json.