### PR TITLE
allow timeBetweenEvictionRuns to be set so other eviction related properties can be used

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisPoolProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/redis/RedisPoolProperties.java
@@ -58,6 +58,17 @@ public class RedisPoolProperties implements CasFeatureModule, Serializable {
     private long minEvictableIdleTimeMillis;
 
     /**
+     * Sets the amount of time (in milliseconds) between runs of the idle object
+     * evictor thread. When non-positive, no idle object evictor thread will be run.
+     * If positive, the idle object evictor thread will run at least once every
+     * timeBetweenEvictionRunsMillis milliseconds, and will attempt to evict
+     * objects from the pool that are idle longer than
+     * getMinEvictableIdleTimeMillis() (if positive) or
+     * getSoftMinEvictableIdleTimeMillis() (if positive).
+     */
+    private long timeBetweenEvictionRunsMillis = -1;
+
+    /**
      * Returns whether the pool has LIFO (last in, first out) behaviour with respect
      * to idle objects - always returning the most recently used object from the
      * pool, or as a FIFO (first in, first out) queue, where the pool always returns

--- a/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
+++ b/support/cas-server-support-redis-core/src/main/java/org/apereo/cas/redis/core/RedisObjectFactory.java
@@ -211,6 +211,9 @@ public class RedisObjectFactory {
             config.setTestOnBorrow(pool.isTestOnBorrow());
             config.setTestOnReturn(pool.isTestOnReturn());
             config.setTestOnCreate(pool.isTestOnCreate());
+            if (pool.getTimeBetweenEvictionRunsMillis() > 0) {
+                config.setTimeBetweenEvictionRuns(Duration.ofMillis(pool.getTimeBetweenEvictionRunsMillis()));
+            }
             if (pool.getMinEvictableIdleTimeMillis() > 0) {
                 config.setMinEvictableIdleDuration(Duration.ofMillis(pool.getMinEvictableIdleTimeMillis()));
             }

--- a/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
+++ b/support/cas-server-support-redis-core/src/test/java/org/apereo/cas/redis/core/RedisObjectFactoryTests.java
@@ -30,6 +30,7 @@ class RedisObjectFactoryTests {
         props.setHost("localhost");
         props.setPort(6379);
         props.getPool().setMinEvictableIdleTimeMillis(2000);
+        props.getPool().setTimeBetweenEvictionRunsMillis(30000);
         props.getPool().setNumTestsPerEvictionRun(1);
         props.getPool().setSoftMinEvictableIdleTimeMillis(1);
         props.getPool().setEnabled(true);


### PR DESCRIPTION
My understanding is that the timeBetweenEvictionRuns in commons pool 2 is defaulting to -1 which means there is no eviction thread running. That would seemingly make properties like  minEvictableIdleTimeMillis and numTestsPerEvictionRun not work. This change allows for specifying a positive time for the timeBetweenEvictionRuns. 