### PR TITLE
Fix OIDC throttling configuration

### DIFF
--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcThrottleConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcThrottleConfiguration.java
@@ -3,7 +3,6 @@ package org.apereo.cas.config;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.features.CasFeatureModule;
 import org.apereo.cas.oidc.OidcConstants;
-import org.apereo.cas.oidc.issuer.OidcIssuerService;
 import org.apereo.cas.throttle.AuthenticationThrottlingExecutionPlan;
 import org.apereo.cas.throttle.AuthenticationThrottlingExecutionPlanConfigurer;
 import org.apereo.cas.throttle.ThrottledRequestFilter;
@@ -89,12 +88,11 @@ class OidcThrottleConfiguration {
         @Bean
         @ConditionalOnMissingBean(name = "oidcThrottledRequestFilter")
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
-        public ThrottledRequestFilter oidcThrottledRequestFilter(
-            @Qualifier(OidcIssuerService.BEAN_NAME)
-            final OidcIssuerService oidcIssuerService) {
+        public ThrottledRequestFilter oidcThrottledRequestFilter() {
             return (request, response) -> {
                 val webContext = new JEEContext(request, response);
-                return oidcIssuerService.validateIssuer(webContext, THROTTLED_ENDPOINTS);
+                val url = webContext.getRequestURL();
+                return THROTTLED_ENDPOINTS.stream().anyMatch(endpoint -> url.endsWith(endpoint));
             };
         }
     }


### PR DESCRIPTION
We should not check the OIDC issuer for the throttling (this is already done in the protocol implementation), we should only check URLs.