### PR TITLE
Fix SPNEGO support

### DIFF
--- a/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/handler/support/JcifsSpnegoAuthenticationHandler.java
+++ b/support/cas-server-support-spnego/src/main/java/org/apereo/cas/support/spnego/authentication/handler/support/JcifsSpnegoAuthenticationHandler.java
@@ -97,7 +97,9 @@ public class JcifsSpnegoAuthenticationHandler extends AbstractPreAndPostProcessi
                 nextToken = authentication.getNextToken();
             } catch (final AuthenticationException e) {
                 LOGGER.debug("Processing SPNEGO authentication failed with exception", e);
-                throw new FailedLoginException(e.getMessage());
+                if (!it.hasNext()) {
+                    throw new FailedLoginException(e.getMessage());
+                }
             }
         }
 


### PR DESCRIPTION
When multiple configurations (aka `Authentication` objects) are defined, the exception should be thrown only for the last configuration otherwise it fails for the first one and other configurations cannot be attempted.
