### PR TITLE
Fix Git support

### DIFF
--- a/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
+++ b/support/cas-server-support-git-core/src/main/java/org/apereo/cas/git/GitRepositoryBuilder.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.transport.ChainingCredentialsProvider;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.HttpTransport;
@@ -208,9 +209,13 @@ public class GitRepositoryBuilder {
     private GitRepository getExistingGitRepository(final TransportConfigCallback transportCallback) throws Exception {
         val git = Git.open(repositoryDirectory.getFile());
         LOGGER.debug("Checking out the branch [{}] at [{}]", activeBranch, repositoryDirectory);
-        git.checkout()
-            .setName(activeBranch)
-            .call();
+        try {
+            git.checkout()
+                .setName(activeBranch)
+                .call();
+        } catch (final RefNotFoundException e) {
+            LOGGER.error("Unable to use the [{}] branch. Keeping the current branch. Error: [{}]", activeBranch, e.getMessage());
+        }
         return new DefaultGitRepository(git, credentialsProviders, transportCallback,
             timeoutInSeconds, signCommits, rebase);
     }

--- a/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
+++ b/support/cas-server-support-git-core/src/test/java/org/apereo/cas/git/GitRepositoryBuilderTests.java
@@ -1,6 +1,5 @@
 package org.apereo.cas.git;
 
-
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.git.services.BaseGitProperties;
 import org.apereo.cas.test.CasTestExtension;
@@ -89,5 +88,42 @@ class GitRepositoryBuilderTests {
             "file://" + FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID()));
         val builder = GitRepositoryBuilder.newInstance(props);
         assertDoesNotThrow(builder::build);
+    }
+
+    @Test
+    void verifyBuildWithBadBranchAndWithoutExistingDirectory() throws Throwable {
+        val props = casProperties.getServiceRegistry().getGit();
+        props.setRepositoryUrl("https://github.com/mmoayyed/sample-data.git");
+        props.setUsername("casuser");
+        props.setPassword("password");
+        props.setBranchesToClone("badbranch");
+        props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(
+                FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID()));
+        val builder = GitRepositoryBuilder.newInstance(props);
+        assertThrows(IllegalArgumentException.class, builder::build);
+    }
+
+    @Test
+    void verifyBuildWithBadBranchButWithExistingDirectory() throws Throwable {
+        val directory = FileUtils.getTempDirectoryPath() + File.separator + UUID.randomUUID();
+
+        val props = casProperties.getServiceRegistry().getGit();
+        props.setRepositoryUrl("https://github.com/mmoayyed/sample-data.git");
+        props.setUsername("casuser");
+        props.setPassword("password");
+        props.setBranchesToClone("master");
+        props.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(directory));
+        val builder = GitRepositoryBuilder.newInstance(props);
+        assertDoesNotThrow(builder::build);
+
+
+        val props2 = casProperties.getServiceRegistry().getGit();
+        props2.setRepositoryUrl("https://github.com/mmoayyed/sample-data.git");
+        props2.setUsername("casuser");
+        props2.setPassword("password");
+        props2.setBranchesToClone("badbranch");
+        props2.getCloneDirectory().setLocation(ResourceUtils.getRawResourceFrom(directory));
+        val builder2 = GitRepositoryBuilder.newInstance(props2);
+        assertDoesNotThrow(builder2::build);
     }
 }


### PR DESCRIPTION
For the Git support, there is a general fallback mechanism: if the data is already available on disk, the CAS server can start anyway.
I can define a bad password or switch off my internet connection, I can always start my CAS server based on the existing files and I get warnings in the logs to tell me there is a problem.
Though, if I define a bad branch name, despite files are already available on my disk, the startup of the CAS server fails.

This PR fixes this issue by catching the related exception (`RefNotFoundException`). Two new tests demonstrate the fix. 
