### PR TITLE
feat: dynamic registration of oidc services can be turned off

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oidc/OidcClientRegistrationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/oidc/OidcClientRegistrationProperties.java
@@ -49,6 +49,11 @@ public class OidcClientRegistrationProperties implements Serializable {
     private String initialAccessTokenUser;
 
     /**
+     * Whether dynamic client registration is enabled or not.
+     */
+    private Boolean dynamicClientRegistrationEnabled = true;
+    
+    /**
      * The password used in a basic-auth scheme to request an initial access token
      * that would then be used to dynamically register clients
      * in {@link DynamicClientRegistrationModes#PROTECTED} mode.

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/NoOpOidcClientConfigurationEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/NoOpOidcClientConfigurationEndpointController.java
@@ -1,0 +1,42 @@
+package org.apereo.cas.oidc.web.controllers.dynareg;
+
+import org.apereo.cas.oidc.OidcConfigurationContext;
+import org.apereo.cas.support.oauth.OAuth20Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * This is {@link OidcNoOpClientConfigurationEndpointController}.
+ * Acts as a disabled placeholder when dynamic client registration is turned off.
+ *
+ * @author Jiří Prokop
+ * @since 7.3.0
+ */
+@Slf4j
+public class NoOpOidcClientConfigurationEndpointController extends OidcClientConfigurationEndpointController {
+    public NoOpOidcClientConfigurationEndpointController(final OidcConfigurationContext configurationContext) {
+        super(configurationContext);
+    }
+
+    @Override
+    public ResponseEntity<?> handleRequestInternal(
+        @RequestParam(name = OAuth20Constants.CLIENT_ID, required = false) final String clientId,
+        final HttpServletRequest request, final HttpServletResponse response) {
+        LOGGER.debug("Client configuration endpoint disabled: GET request rejected for clientId=[{}]", clientId);
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public ResponseEntity<?> handleUpdates(
+        @RequestParam(name = OAuth20Constants.CLIENT_ID, required = false) final String clientId,
+        @RequestBody(required = false) final String jsonInput,
+        final HttpServletRequest request, final HttpServletResponse response) {
+        LOGGER.debug("Client configuration endpoint disabled: PATCH request rejected for clientId=[{}]", clientId);
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+}

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/NoOpOidcDynamicClientRegistrationEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/NoOpOidcDynamicClientRegistrationEndpointController.java
@@ -1,0 +1,32 @@
+package org.apereo.cas.oidc.web.controllers.dynareg;
+
+import org.apereo.cas.oidc.OidcConfigurationContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * This is {@link OidcNoOpClientConfigurationEndpointController}.
+ * Acts as a disabled placeholder when dynamic client registration is turned off.
+ *
+ * @author Jiří Prokop
+ * @since 7.3.0
+ */
+@Slf4j
+public class NoOpOidcDynamicClientRegistrationEndpointController extends OidcDynamicClientRegistrationEndpointController {
+    public NoOpOidcDynamicClientRegistrationEndpointController(final OidcConfigurationContext configurationContext) {
+        super(configurationContext);
+    }
+
+    @Override
+    public ResponseEntity handleRequestInternal(
+        final String jsonInput,
+        final HttpServletRequest request,
+        final HttpServletResponse response
+    ) {
+        LOGGER.debug("OIDC Dynamic Client Registration endpoint is disabled.");
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+}

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/NoOpOidcInitialAccessTokenController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/NoOpOidcInitialAccessTokenController.java
@@ -1,0 +1,36 @@
+package org.apereo.cas.oidc.web.controllers.dynareg;
+
+import org.apereo.cas.oidc.OidcConfigurationContext;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+
+/**
+ * This is {@link OidcNoOpClientConfigurationEndpointController}.
+ * Acts as a disabled placeholder when dynamic client registration is turned off.
+ *
+ * @author Jiří Prokop
+ * @since 7.3.0
+ */
+@Slf4j
+public class NoOpOidcInitialAccessTokenController extends OidcInitialAccessTokenController {
+    public NoOpOidcInitialAccessTokenController(final OidcConfigurationContext configurationContext) {
+        super(configurationContext);
+    }
+
+    @Override
+    public ModelAndView handleRequestInternal(
+        final HttpServletRequest request,
+        final HttpServletResponse response
+    ) {
+        LOGGER.debug("OIDC Initial Access Token endpoint is disabled.");
+        val mv = new ModelAndView(new MappingJackson2JsonView());
+        mv.setStatus(HttpStatus.NOT_IMPLEMENTED);
+        return mv;
+    }
+}

--- a/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcEndpointsConfiguration.java
+++ b/support/cas-server-support-oidc/src/main/java/org/apereo/cas/config/OidcEndpointsConfiguration.java
@@ -20,6 +20,9 @@ import org.apereo.cas.oidc.web.controllers.authorize.OidcAuthorizeEndpointContro
 import org.apereo.cas.oidc.web.controllers.authorize.OidcPushedAuthorizeEndpointController;
 import org.apereo.cas.oidc.web.controllers.ciba.OidcCibaController;
 import org.apereo.cas.oidc.web.controllers.discovery.OidcWellKnownEndpointController;
+import org.apereo.cas.oidc.web.controllers.dynareg.NoOpOidcClientConfigurationEndpointController;
+import org.apereo.cas.oidc.web.controllers.dynareg.NoOpOidcDynamicClientRegistrationEndpointController;
+import org.apereo.cas.oidc.web.controllers.dynareg.NoOpOidcInitialAccessTokenController;
 import org.apereo.cas.oidc.web.controllers.dynareg.OidcClientConfigurationEndpointController;
 import org.apereo.cas.oidc.web.controllers.dynareg.OidcDynamicClientRegistrationEndpointController;
 import org.apereo.cas.oidc.web.controllers.dynareg.OidcInitialAccessTokenController;
@@ -39,6 +42,8 @@ import org.apereo.cas.support.oauth.web.OAuth20RequestParameterResolver;
 import org.apereo.cas.support.oauth.web.response.accesstoken.ext.AccessTokenGrantRequestExtractor;
 import org.apereo.cas.util.RandomUtils;
 import org.apereo.cas.util.spring.RefreshableHandlerInterceptor;
+import org.apereo.cas.util.spring.beans.BeanCondition;
+import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
 import org.apereo.cas.validation.CasProtocolViewFactory;
 import org.apereo.cas.web.CasWebSecurityConfigurer;
@@ -388,8 +393,14 @@ class OidcEndpointsConfiguration {
         @ConditionalOnMissingBean(name = "oidcDynamicClientRegistrationEndpointController")
         public OidcDynamicClientRegistrationEndpointController oidcDynamicClientRegistrationEndpointController(
             @Qualifier(OidcConfigurationContext.BEAN_NAME)
-            final OidcConfigurationContext oidcConfigurationContext) {
-            return new OidcDynamicClientRegistrationEndpointController(oidcConfigurationContext);
+            final OidcConfigurationContext oidcConfigurationContext,
+            final ConfigurableApplicationContext applicationContext) {
+            return BeanSupplier.of(OidcDynamicClientRegistrationEndpointController.class)
+            .when(BeanCondition.on("cas.authn.oidc.registration.dynamic-client-registration-enabled")
+                .isTrue().evenIfMissing().given(applicationContext.getEnvironment()))
+            .supply(() -> new OidcDynamicClientRegistrationEndpointController(oidcConfigurationContext))
+            .otherwise(() -> new NoOpOidcDynamicClientRegistrationEndpointController(oidcConfigurationContext))
+            .get();
         }
 
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
@@ -397,8 +408,14 @@ class OidcEndpointsConfiguration {
         @Bean
         public OidcClientConfigurationEndpointController oidcClientConfigurationEndpointController(
             @Qualifier(OidcConfigurationContext.BEAN_NAME)
-            final OidcConfigurationContext oidcConfigurationContext) {
-            return new OidcClientConfigurationEndpointController(oidcConfigurationContext);
+            final OidcConfigurationContext oidcConfigurationContext,
+            final ConfigurableApplicationContext applicationContext) {
+            return BeanSupplier.of(OidcClientConfigurationEndpointController.class)
+            .when(BeanCondition.on("cas.authn.oidc.registration.dynamic-client-registration-enabled")
+                .isTrue().evenIfMissing().given(applicationContext.getEnvironment()))
+            .supply(() -> new OidcClientConfigurationEndpointController(oidcConfigurationContext))
+            .otherwise(() -> new NoOpOidcClientConfigurationEndpointController(oidcConfigurationContext))
+            .get();
         }
 
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
@@ -406,8 +423,14 @@ class OidcEndpointsConfiguration {
         @Bean
         public OidcInitialAccessTokenController oidcInitialAccessTokenController(
             @Qualifier(OidcConfigurationContext.BEAN_NAME)
-            final OidcConfigurationContext oidcConfigurationContext) {
-            return new OidcInitialAccessTokenController(oidcConfigurationContext);
+            final OidcConfigurationContext oidcConfigurationContext,
+            final ConfigurableApplicationContext applicationContext) {
+            return BeanSupplier.of(OidcInitialAccessTokenController.class)
+            .when(BeanCondition.on("cas.authn.oidc.registration.dynamic-client-registration-enabled")
+                .isTrue().evenIfMissing().given(applicationContext.getEnvironment()))
+            .supply(() -> new OidcInitialAccessTokenController(oidcConfigurationContext))
+            .otherwise(() -> new NoOpOidcInitialAccessTokenController(oidcConfigurationContext))
+            .get();
         }
 
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/dynareg/OidcDynamicClientRegistrationToggleTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/dynareg/OidcDynamicClientRegistrationToggleTests.java
@@ -1,0 +1,65 @@
+package org.apereo.cas.oidc.dynareg;
+
+import org.apereo.cas.oidc.AbstractOidcTests;
+import org.apereo.cas.oidc.web.controllers.dynareg.NoOpOidcClientConfigurationEndpointController;
+import org.apereo.cas.oidc.web.controllers.dynareg.NoOpOidcDynamicClientRegistrationEndpointController;
+import org.apereo.cas.oidc.web.controllers.dynareg.NoOpOidcInitialAccessTokenController;
+import org.apereo.cas.oidc.web.controllers.dynareg.OidcClientConfigurationEndpointController;
+import org.apereo.cas.oidc.web.controllers.dynareg.OidcDynamicClientRegistrationEndpointController;
+import org.apereo.cas.oidc.web.controllers.dynareg.OidcInitialAccessTokenController;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link OidcDynamicClientRegistrationToggleTests}.
+ *
+ * @author Jiří Prokop
+ * @since 7.3.0
+ */
+@Tag("OIDC")
+class OidcDynamicClientRegistrationToggleTests {
+    
+    @Nested
+    class DefaultEnabled extends AbstractOidcTests {
+        @Test
+        void verifyRegistrationEnabledByDefault() {
+            assertTrue(applicationContext.getBean("oidcDynamicClientRegistrationEndpointController")
+             instanceof OidcDynamicClientRegistrationEndpointController);
+            assertTrue(applicationContext.getBean("oidcClientConfigurationEndpointController")
+                instanceof OidcClientConfigurationEndpointController);
+            assertTrue(applicationContext.getBean("oidcInitialAccessTokenController")
+                instanceof OidcInitialAccessTokenController);
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = "cas.authn.oidc.registration.dynamic-client-registration-enabled=true")
+    class ExplicitEnabled extends AbstractOidcTests {
+        @Test
+        void verifyRegistrationEnabledExplicitly() {
+            assertTrue(applicationContext.getBean("oidcDynamicClientRegistrationEndpointController")
+             instanceof OidcDynamicClientRegistrationEndpointController);
+            assertTrue(applicationContext.getBean("oidcClientConfigurationEndpointController")
+                instanceof OidcClientConfigurationEndpointController);
+            assertTrue(applicationContext.getBean("oidcInitialAccessTokenController")
+                instanceof OidcInitialAccessTokenController);
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = "cas.authn.oidc.registration.dynamic-client-registration-enabled=false")
+    class Disabled extends AbstractOidcTests {
+        @Test
+        void verifyRegistrationDisabled() {
+            assertTrue(applicationContext.getBean("oidcDynamicClientRegistrationEndpointController")
+             instanceof NoOpOidcDynamicClientRegistrationEndpointController);
+            assertTrue(applicationContext.getBean("oidcClientConfigurationEndpointController")
+                instanceof NoOpOidcClientConfigurationEndpointController);
+            assertTrue(applicationContext.getBean("oidcInitialAccessTokenController")
+                instanceof NoOpOidcInitialAccessTokenController);
+        }
+    }
+}


### PR DESCRIPTION
# Description
This PR introduces a new configuration property:

cas.authn.oidc.registration.dynamic-client-registration-enabled: true
By default, OIDC dynamic client registration (/cas/oidc/register) is still on. Setting this property to false disables all the dynamic registration endpoints.

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test
- [x] Any possible limitations, side effects, etc
- [x] Reference any other pull requests that might be related