### PR TITLE
refactor: add custom database password encoder config for query and encode auth handler

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jdbc/authn/QueryEncodeJdbcAuthenticationProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/jdbc/authn/QueryEncodeJdbcAuthenticationProperties.java
@@ -72,4 +72,13 @@ public class QueryEncodeJdbcAuthenticationProperties extends BaseJdbcAuthenticat
      */
     private String staticSalt;
 
+    /**
+     * Custom database password encoder class (that implements
+     * {@link org.apereo.cas.authentication.support.password.DatabasePasswordEncoder})
+     * to use. If left blank, a default
+     * {@link org.apereo.cas.jdbc.QueryAndEncodeDatabasePasswordEncoder}
+     * will be used instead.
+     */
+    private String databasePasswordEncoder;
+
 }

--- a/core/cas-server-core-authentication/build.gradle
+++ b/core/cas-server-core-authentication/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation project(":core:cas-server-core-notifications")
     testImplementation project(":core:cas-server-core-monitor")
     testImplementation project(":core:cas-server-core-scripting")
+    testImplementation project(":support:cas-server-support-jdbc-authentication")
 
     testImplementation project(path: ":core:cas-server-core-util-api", configuration: "tests")
     testImplementation project(path: ":core:cas-server-core-authentication-api", configuration: "tests")

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/support/password/DatabasePasswordEncoderUtilsTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/support/password/DatabasePasswordEncoderUtilsTests.java
@@ -1,0 +1,47 @@
+package org.apereo.cas.authentication.support.password;
+
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.configuration.model.support.jdbc.authn.QueryEncodeJdbcAuthenticationProperties;
+import org.apereo.cas.jdbc.DatabasePasswordEncoder;
+import org.apereo.cas.jdbc.DatabasePasswordEncoderUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link DatabasePasswordEncoderUtilsTests}.
+ *
+ * @author Yusuf Gunduz
+ *
+ * @since 7.3.0
+ */
+
+@Tag("Utility")
+class DatabasePasswordEncoderUtilsTests {
+
+    private static void verifyEncoder(final DatabasePasswordEncoder encoder) {
+        assertNotNull(encoder);
+        assertInstanceOf(DatabasePasswordEncoder.class, encoder);
+    }
+
+    @Test
+    void verifyNoType() {
+        val properties = new QueryEncodeJdbcAuthenticationProperties();
+        properties.setDatabasePasswordEncoder(null);
+        var encoder = DatabasePasswordEncoderUtils.newDatabasePasswordEncoder(properties);
+        assertNotNull(encoder);
+        properties.setDatabasePasswordEncoder(StringUtils.EMPTY);
+        encoder = DatabasePasswordEncoderUtils.newDatabasePasswordEncoder(properties);
+        verifyEncoder(encoder);
+    }
+
+    @Test
+    void verifyClassType() {
+        val properties = new QueryEncodeJdbcAuthenticationProperties();
+        properties.setDatabasePasswordEncoder("org.example.cas.SampleDatabasePasswordEncoder");
+        val encoder = DatabasePasswordEncoderUtils.newDatabasePasswordEncoder(properties);
+        verifyEncoder(encoder);
+    }
+}

--- a/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/AbstractDatabasePasswordEncoder.java
+++ b/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/AbstractDatabasePasswordEncoder.java
@@ -1,0 +1,46 @@
+package org.apereo.cas.jdbc;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apereo.cas.configuration.model.support.jdbc.authn.QueryEncodeJdbcAuthenticationProperties;
+import org.apereo.cas.util.DigestUtils;
+import org.apereo.cas.util.function.FunctionUtils;
+
+@RequiredArgsConstructor
+@Getter
+public abstract class AbstractDatabasePasswordEncoder implements DatabasePasswordEncoder{
+  protected final QueryEncodeJdbcAuthenticationProperties properties;
+
+  @Override
+  public String encode(final String password, final Map<String, Object> queryValues) {
+    val iterations = getIterations(queryValues);
+    val dynaSalt = getDynamicSalt(queryValues);
+    val staticSalt = getStaticSalt(queryValues);
+    return DigestUtils.rawDigest(properties.getAlgorithmName(), staticSalt, dynaSalt, password, iterations);
+  }
+
+  protected int getIterations(final Map<String, Object> queryValues) {
+    var iterations = properties.getNumberOfIterations();
+    if (queryValues.containsKey(properties.getNumberOfIterationsFieldName())) {
+      val longAsStr = queryValues.get(properties.getNumberOfIterationsFieldName()).toString();
+      iterations = Integer.parseInt(longAsStr);
+    }
+    return iterations;
+  }
+
+  protected byte[] getStaticSalt(final Map<String, Object> queryValues) {
+    return FunctionUtils.doIfNotBlank(properties.getStaticSalt(),
+        () -> properties.getStaticSalt().getBytes(StandardCharsets.UTF_8),
+        () -> ArrayUtils.EMPTY_BYTE_ARRAY);
+  }
+
+  protected byte[] getDynamicSalt(final Map<String, Object> queryValues) {
+    return queryValues.containsKey(properties.getSaltFieldName())
+        ? queryValues.get(properties.getSaltFieldName()).toString().getBytes(StandardCharsets.UTF_8)
+        : ArrayUtils.EMPTY_BYTE_ARRAY;
+  }
+}

--- a/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/DatabasePasswordEncoderUtils.java
+++ b/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/DatabasePasswordEncoderUtils.java
@@ -1,0 +1,62 @@
+package org.apereo.cas.jdbc;
+
+import org.apereo.cas.configuration.model.support.jdbc.authn.QueryEncodeJdbcAuthenticationProperties;
+import org.apereo.cas.util.LoggingUtils;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * This is {@link DatabasePasswordEncoderUtils}.
+ *
+ * @author Yusuf Gunduz
+ *
+ * @since 7.3.0
+ *
+ */
+@Slf4j
+@UtilityClass
+public class DatabasePasswordEncoderUtils {
+
+    /**
+     * New database password encoder.
+     *
+     * @param properties         the properties
+     * @return the database password encoder
+     */
+    public static DatabasePasswordEncoder newDatabasePasswordEncoder(
+        final QueryEncodeJdbcAuthenticationProperties properties) {
+        val type = properties.getDatabasePasswordEncoder();
+
+        if (StringUtils.isBlank(type)) {
+            LOGGER.trace("No database password encoder type is defined, and so a QueryAndEncodeDatabasePasswordEncoder shall be created");
+            return getDefaultPasswordEncoder(properties);
+        }
+
+        if (type.contains(".")) {
+            try {
+                LOGGER.debug("Configuration indicates use of a custom database password encoder [{}]", type);
+                val clazz = (Class<DatabasePasswordEncoder>) Class.forName(type);
+                return clazz.getDeclaredConstructor().newInstance();
+            } catch (final Exception e) {
+                val msg = "Falling back to a QueryAndEncodeDatabasePasswordEncoder database password encoder as CAS has failed to create "
+                          + "an instance of the custom database password encoder class " + type;
+                LoggingUtils.error(LOGGER, msg, e);
+                return getDefaultPasswordEncoder(properties);
+            }
+        }
+        LOGGER.trace("No database password encoder shall be created given the requested encoder type [{}]", type);
+        return getDefaultPasswordEncoder(properties);
+    }
+
+    /**
+     * Get default password encoder database password encoder.
+     * @param properties         the properties
+     * @return the default database password encoder
+     */
+    private static DatabasePasswordEncoder getDefaultPasswordEncoder(final QueryEncodeJdbcAuthenticationProperties properties) {
+        return new QueryAndEncodeDatabasePasswordEncoder(properties);
+    }
+}

--- a/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/JdbcAuthenticationUtils.java
+++ b/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/JdbcAuthenticationUtils.java
@@ -103,7 +103,7 @@ public class JdbcAuthenticationUtils {
                                                                  final PrincipalFactory jdbcPrincipalFactory,
                                                                  final PasswordPolicyContext queryAndEncodePasswordPolicyConfiguration,
                                                                  final DataSource dataSource) {
-        val databasePasswordEncoder = new QueryAndEncodeDatabasePasswordEncoder(properties);
+        val databasePasswordEncoder = DatabasePasswordEncoderUtils.newDatabasePasswordEncoder(properties);
         val handler = new QueryAndEncodeDatabaseAuthenticationHandler(properties,
             jdbcPrincipalFactory, dataSource, databasePasswordEncoder);
         configureJdbcAuthenticationHandler(handler, queryAndEncodePasswordPolicyConfiguration, properties, applicationContext);

--- a/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/QueryAndEncodeDatabasePasswordEncoder.java
+++ b/support/cas-server-support-jdbc-authentication/src/main/java/org/apereo/cas/jdbc/QueryAndEncodeDatabasePasswordEncoder.java
@@ -15,36 +15,10 @@ import java.util.Map;
  * @author Misagh Moayyed
  * @since 7.0.0
  */
-@RequiredArgsConstructor
-public class QueryAndEncodeDatabasePasswordEncoder implements DatabasePasswordEncoder {
-    protected final QueryEncodeJdbcAuthenticationProperties properties;
+public class QueryAndEncodeDatabasePasswordEncoder extends AbstractDatabasePasswordEncoder {
 
-    @Override
-    public String encode(final String password, final Map<String, Object> queryValues) {
-        val iterations = getIterations(queryValues);
-        val dynaSalt = getDynamicSalt(queryValues);
-        val staticSalt = getStaticSalt(queryValues);
-        return DigestUtils.rawDigest(properties.getAlgorithmName(), staticSalt, dynaSalt, password, iterations);
-    }
-
-    protected int getIterations(final Map<String, Object> queryValues) {
-        var iterations = properties.getNumberOfIterations();
-        if (queryValues.containsKey(properties.getNumberOfIterationsFieldName())) {
-            val longAsStr = queryValues.get(properties.getNumberOfIterationsFieldName()).toString();
-            iterations = Integer.parseInt(longAsStr);
-        }
-        return iterations;
-    }
-
-    protected byte[] getStaticSalt(final Map<String, Object> queryValues) {
-        return FunctionUtils.doIfNotBlank(properties.getStaticSalt(),
-            () -> properties.getStaticSalt().getBytes(StandardCharsets.UTF_8),
-            () -> ArrayUtils.EMPTY_BYTE_ARRAY);
-    }
-
-    protected byte[] getDynamicSalt(final Map<String, Object> queryValues) {
-        return queryValues.containsKey(properties.getSaltFieldName())
-            ? queryValues.get(properties.getSaltFieldName()).toString().getBytes(StandardCharsets.UTF_8)
-            : ArrayUtils.EMPTY_BYTE_ARRAY;
+    public QueryAndEncodeDatabasePasswordEncoder(
+        QueryEncodeJdbcAuthenticationProperties properties) {
+        super(properties);
     }
 }


### PR DESCRIPTION
About query-and-encode authentication handler, default (single type of hashing but iterable) kind of database password encoding was not enough for the use case i was given. So instead of reconfiguring the CAS like this: 

```

  /**
   * *****-style password encryption configuration for CAS JDBC Query-And-Encode database
   * authentication. This bean overrides default execution of
   * {@link
   * CasJdbcQueryEncodeAuthenticationConfiguration#queryAndEncodeDatabaseAuthenticationHandlers}.
   * Instead of defining a custom auth handler (writing extra custom prop class, re-define the same
   * properties for the custom one, etc...) and register it via plan configurer, i can simply
   * override the default `queryAndEncodeDatabaseAuthenticationHandlers` bean, registering
   * {@link QueryAndEncodeDatabaseAuthenticationHandler} with my custom encoder
   * ({@link CustomDatabasePasswordEncoder}), instead of the default. This configuration needs these
   * modules in the `build.gradle` file:
   * <ul>
   *   <li>cas-server-support-jdbc</li>
   *   <li>cas-server-core-authentication-api</li>
   *   <li>cas-server-support-jdbc-authentication</li>
   * </ul>
   */
  @Bean(name = "queryAndEncodeDatabaseAuthenticationHandlers")
  @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
  public Collection<AuthenticationHandler> queryAndEncodeDatabaseAuthenticationHandlers(
      @Qualifier("queryAndEncodePasswordPolicyConfiguration")
      PasswordPolicyContext passwordPolicyContext,
      ConfigurableApplicationContext applicationContext,
      @Qualifier(ServicesManager.BEAN_NAME)
      ServicesManager servicesManager,
      @Qualifier("queryAndEncodePrincipalFactory")
      PrincipalFactory jdbcPrincipalFactory,
      CasConfigurationProperties casProperties) {

    val handlers = new HashSet<AuthenticationHandler>();
    val jdbcProps = casProperties.getAuthn().getJdbc().getEncode();

    jdbcProps.forEach(props -> {
      AuthenticationHandler handler = new QueryAndEncodeDatabaseAuthenticationHandler(
          props,
          jdbcPrincipalFactory,
          JpaBeans.newDataSource(props),
          new CustomDatabasePasswordEncoder(props) // <-- Custom database password encoder
      );
      JdbcAuthenticationUtils.configureJdbcAuthenticationHandler(
          (QueryAndEncodeDatabaseAuthenticationHandler) handler,
          passwordPolicyContext,
          props,
          applicationContext
      );
      handlers.add(handler);
    });

    return handlers;
  }

```
i've decided to add a new configuration named `databasePasswordEncoder` in `QueryEncodeJdbcAuthenticationProperties`. Then i can enter my CustomDatabasePasswordEncoder fqdn in there, CAS can pick it up and use it in my defined QueryEncodeJdbcAuthentication definitions.

For ease of customization, i've moved the DatabasePasswordEncoder contents to a `AbstractDatabasePasswordEncoder`, and made DatabasePasswordEncoder extend this abstract class making any modifications easier.

I've prepared `DatabasePasswordEncoderUtils` inspired from `PasswordEncoderUtils`. If user leaves _databasePasswordEncoder_ blank, or no `.` is present or could not find the necessary class fqdn from given value, it will default to a new `QueryAndEncodeDatabasePasswordEncoder` instance. Otherwise it will return a new instance of the given class fqdn. 

For tests, i've prepared `DatabasePasswordEncoderUtilsTests` inspired from the `PasswordEncoderUtilsTests` testing against the property values.
