### PR TITLE
[AccountManagement] Handle SLO

### DIFF
--- a/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/account/AccountProfileRemoveSingleSignOnSessionAction.java
+++ b/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/account/AccountProfileRemoveSingleSignOnSessionAction.java
@@ -1,6 +1,6 @@
 package org.apereo.cas.web.flow.account;
 
-import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.logout.slo.SingleLogoutRequestExecutor;
 import org.apereo.cas.web.flow.CasWebflowConstants;
 import org.apereo.cas.web.flow.actions.BaseCasWebflowAction;
 import org.apereo.cas.web.support.WebUtils;
@@ -18,13 +18,13 @@ import org.springframework.webflow.execution.RequestContext;
  */
 @RequiredArgsConstructor
 public class AccountProfileRemoveSingleSignOnSessionAction extends BaseCasWebflowAction {
-    private final TicketRegistry ticketRegistry;
+    private final SingleLogoutRequestExecutor singleLogoutRequestExecutor;
 
     @Override
     protected Event doExecuteInternal(final RequestContext requestContext) throws Exception {
         val tgt = WebUtils.getTicketGrantingTicketId(requestContext);
         val id = requestContext.getRequestParameters().get("id", String.class);
-        ticketRegistry.deleteTicket(id);
+        singleLogoutRequestExecutor.execute(id, WebUtils.getHttpServletRequestFromExternalWebflowContext(requestContext), WebUtils.getHttpServletResponseFromExternalWebflowContext(requestContext));
         return tgt.equals(id) ? new Event(this, CasWebflowConstants.TRANSITION_ID_VALIDATE) : success();
     }
 }

--- a/support/cas-server-support-actions/src/main/java/org/apereo/cas/config/CasSupportActionsAutoConfiguration.java
+++ b/support/cas-server-support-actions/src/main/java/org/apereo/cas/config/CasSupportActionsAutoConfiguration.java
@@ -702,13 +702,13 @@ public class CasSupportActionsAutoConfiguration {
         @ConditionalOnMissingBean(name = CasWebflowConstants.ACTION_ID_ACCOUNT_PROFILE_REMOVE_SINGLE_SIGNON_SESSION)
         public Action accountProfileRemoveSingleSignOnSessionAction(
             final ConfigurableApplicationContext applicationContext,
-            @Qualifier(TicketRegistry.BEAN_NAME)
-            final TicketRegistry ticketRegistry,
+            @Qualifier(SingleLogoutRequestExecutor.BEAN_NAME)
+            final SingleLogoutRequestExecutor defaultSingleLogoutRequestExecutor,
             final CasConfigurationProperties casProperties) {
             return WebflowActionBeanSupplier.builder()
                 .withApplicationContext(applicationContext)
                 .withProperties(casProperties)
-                .withAction(() -> new AccountProfileRemoveSingleSignOnSessionAction(ticketRegistry))
+                .withAction(() -> new AccountProfileRemoveSingleSignOnSessionAction(defaultSingleLogoutRequestExecutor))
                 .withId(CasWebflowConstants.ACTION_ID_ACCOUNT_PROFILE_REMOVE_SINGLE_SIGNON_SESSION)
                 .build()
                 .get();

--- a/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/account/AccountProfileRemoveSingleSignOnSessionActionTests.java
+++ b/support/cas-server-support-actions/src/test/java/org/apereo/cas/web/flow/account/AccountProfileRemoveSingleSignOnSessionActionTests.java
@@ -40,12 +40,15 @@ class AccountProfileRemoveSingleSignOnSessionActionTests extends AbstractWebflow
     @Test
     void verifyOperation() throws Throwable {
         val context = MockRequestContext.create(applicationContext);
-        val tgt = new TicketGrantingTicketImpl(RandomUtils.randomAlphabetic(8),
+        val tgtId = RandomUtils.randomAlphabetic(8);
+        val tgt = new TicketGrantingTicketImpl(tgtId,
             CoreAuthenticationTestUtils.getAuthentication(), NeverExpiresExpirationPolicy.INSTANCE);
         WebUtils.putTicketGrantingTicketInScopes(context, tgt);
         getTicketRegistry().addTicket(tgt);
-        context.setParameter("id", tgt.getId());
+        context.setParameter("id", tgtId);
+        assertNotNull(getTicketRegistry().getTicket(tgtId));
         val result = removeSessionAction.execute(context);
+        assertNull(getTicketRegistry().getTicket(tgtId));
         assertEquals(CasWebflowConstants.TRANSITION_ID_VALIDATE, result.getId());
     }
 }


### PR DESCRIPTION
When a session is deleted via account (profile) management, the SLO is now triggered.

notes : 
- `ticketRegistry.deleteTicket(ticketId);` is now implicit
https://github.com/apereo/cas/blob/b54502694771fefda4e6eb1c3996426db322dc5b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/slo/DefaultSingleLogoutRequestExecutor.java#L56

- and of course, the SLO is not triggered if `cas.slo.disabled=true` (in this case, the behavior will be identical to the existing one)
https://github.com/apereo/cas/blob/b54502694771fefda4e6eb1c3996426db322dc5b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/slo/DefaultSingleLogoutRequestExecutor.java#L45
https://github.com/apereo/cas/blob/b54502694771fefda4e6eb1c3996426db322dc5b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultLogoutManager.java#L56-L59
https://github.com/apereo/cas/blob/b54502694771fefda4e6eb1c3996426db322dc5b/core/cas-server-core-logout/src/main/java/org/apereo/cas/config/CasCoreLogoutAutoConfiguration.java#L174
