### PR TITLE
Only add claims to id token if no access token is issued

### DIFF
--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorService.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorService.java
@@ -159,7 +159,7 @@ public class OidcIdTokenGeneratorService extends BaseIdTokenGeneratorService<Oid
         }
         generateAccessTokenHash(accessToken, oidcRegisteredService, claims);
 
-        if (includeClaimsInIdToken(context) || includeClaimsInIdTokenForcefully(context)) {
+        if (context.getResponseType() == OAuth20ResponseTypes.ID_TOKEN || includeClaimsInIdTokenForcefully(context)) {
             FunctionUtils.doIf(includeClaimsInIdTokenForcefully(context),
                     _ -> LOGGER.warn("Individual claims requested by OpenID scopes are forced to be included in the ID token. "
                         + "This is a violation of the OpenID Connect specification and a workaround via dedicated CAS configuration. "
@@ -180,12 +180,6 @@ public class OidcIdTokenGeneratorService extends BaseIdTokenGeneratorService<Oid
         Optional.ofNullable(accessToken.getAuthentication().getSingleValuedAttribute(OAuth20Constants.CLAIM_ACT, Map.class))
             .ifPresent(value -> claims.setClaim(OAuth20Constants.CLAIM_ACT, value));
         return claims;
-    }
-
-    protected boolean includeClaimsInIdToken(final IdTokenGenerationContext context) {
-        return context.getResponseType() != OAuth20ResponseTypes.CODE
-            && context.getGrantType() != OAuth20GrantTypes.AUTHORIZATION_CODE
-            && context.getGrantType() != OAuth20GrantTypes.REFRESH_TOKEN;
     }
 
     private boolean includeClaimsInIdTokenForcefully(final IdTokenGenerationContext context) {

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorServiceTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/token/OidcIdTokenGeneratorServiceTests.java
@@ -487,7 +487,7 @@ class OidcIdTokenGeneratorServiceTests {
             val idTokenContext = IdTokenGenerationContext.builder()
                 .accessToken(accessToken)
                 .userProfile(profile)
-                .responseType(OAuth20ResponseTypes.ID_TOKEN)
+                .responseType(OAuth20ResponseTypes.CODE)
                 .grantType(OAuth20GrantTypes.AUTHORIZATION_CODE)
                 .registeredService(registeredService)
                 .build();
@@ -538,7 +538,7 @@ class OidcIdTokenGeneratorServiceTests {
             val idTokenContext = IdTokenGenerationContext.builder()
                 .accessToken(accessToken)
                 .userProfile(profile)
-                .responseType(OAuth20ResponseTypes.ID_TOKEN)
+                .responseType(OAuth20ResponseTypes.NONE)
                 .grantType(OAuth20GrantTypes.REFRESH_TOKEN)
                 .registeredService(registeredService)
                 .build();


### PR DESCRIPTION
> The Claims requested by the profile, email, address, and phone scope values are returned from the UserInfo Endpoint, as described in [Section 5.3.2](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse), when a response_type value is used that results in an Access Token being issued. However, when no Access Token is issued (which is the case for the response_type value id_token), the resulting Claims are returned in the ID Token.

OpenID Connect spec, Section 5.4, https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims

Currently, CAS checks for some grant types. This misses some scenarios, like `grant_type=password` or `grant_type=client_credentials`.

This PR changes the checks to check for `response_type=id_token`, as intended by the spec.

As a consequence, I corrected two test cases:
- the refresh token grant has no `response_type` parameter, cf. RFC 6749, Section 6
- the authorization code grant has `response_type=code`, cf. RFC 6749, Section 4.1.1 and OpenID Connect, Section 3.1.2.1