### PR TITLE
Remember approved scopes for each service

### DIFF
--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/script.js
@@ -1,0 +1,74 @@
+const cas = require("../../cas.js");
+const assert = require("assert");
+
+async function verifyAccessTokenAndProfile(context, client, scopes, consent, defined, login) {
+    const page = await cas.newPage(context);
+    const redirectUri = `http://localhost:9889/anything/app${client}`;
+    const url = "https://localhost:8443/cas/oidc/oidcAuthorize?response_type=code"
+        + `&client_id=client${client}&scope=${encodeURIComponent(scopes.join(" "))}`
+        + `&redirect_uri=${redirectUri}&nonce=3d3a7457f9ad3&state=1735fd6c43c14`;
+
+    await cas.goto(page, url);
+    if (login) {
+        await cas.sleep(1000);
+        await cas.loginWith(page);
+    }
+    await cas.sleep(2000);
+    await cas.assertVisibility(page, "#scopes");
+    await cas.assertVisibility(page, "#informationUrl");
+    await cas.assertVisibility(page, "#privacyUrl");
+    for (const id of consent) {
+        await cas.assertVisibility(page, id);
+    }
+
+    if (await cas.isVisible(page, "#allow")) {
+        await cas.click(page, "#allow");
+        await cas.waitForNavigation(page);
+    }
+    await cas.sleep(2000);
+    await cas.screenshot(page);
+    await cas.logPage(page);
+    const code = await cas.assertParameter(page, "code");
+    await cas.log(`Current code is ${code}`);
+    const accessTokenUrl = "https://localhost:8443/cas/oidc/token?grant_type=authorization_code"
+        + `&client_id=client${client}&client_secret=secret&redirect_uri=${redirectUri}&code=${code}`;
+    const payload = await cas.doPost(accessTokenUrl, "", {
+        "Content-Type": "application/json"
+    }, (res) => res.data, (error) => {
+        throw `Operation failed to obtain access token: ${error}`;
+    });
+    assert(payload.access_token !== undefined);
+    assert(payload.token_type !== undefined);
+    assert(payload.expires_in !== undefined);
+    assert(payload.scope !== undefined);
+
+    const decoded = await cas.decodeJwt(payload.id_token);
+    assert(decoded.sub !== undefined);
+    assert(decoded.client_id !== undefined);
+
+    const profileUrl = `https://localhost:8443/cas/oidc/profile?access_token=${payload.access_token}`;
+    await cas.log(`Calling user profile ${profileUrl}`);
+
+    await cas.doPost(profileUrl, "", {
+        "Content-Type": "application/json"
+    }, (res) => {
+        for (const attr of defined) {
+            assert(res.data[attr] !== undefined);
+        }
+    }, (error) => {
+        throw `Operation failed: ${error}`;
+    });
+    return {redirectUri, url, code, accessTokenUrl, payload};
+}
+
+(async () => {
+    const browser = await cas.newBrowser(cas.browserOptions());
+
+    const context = await browser.createBrowserContext();
+    await verifyAccessTokenAndProfile(context, 1, ["openid"], ["#openid"], ["sub"], true);
+    await verifyAccessTokenAndProfile(context, 1, ["openid", "profile", "MyCustomScope"], ["#profile", "#MyCustomScope"], ["sub", "name", "family_name", "cn"], false);
+    await verifyAccessTokenAndProfile(context, 2, ["openid", "profile", "MyCustomScope"], ["#openid", "#profile", "#MyCustomScope"], ["sub", "name", "family_name", "cn"], false);
+    await context.close();
+
+    await cas.closeBrowser(browser);
+})();

--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/script.js
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/script.js
@@ -13,17 +13,19 @@ async function verifyAccessTokenAndProfile(context, client, scopes, consent, def
         await cas.sleep(1000);
         await cas.loginWith(page);
     }
-    await cas.sleep(2000);
-    await cas.assertVisibility(page, "#scopes");
-    await cas.assertVisibility(page, "#informationUrl");
-    await cas.assertVisibility(page, "#privacyUrl");
-    for (const id of consent) {
-        await cas.assertVisibility(page, id);
-    }
+    if (consent.length) {
+        await cas.sleep(2000);
+        await cas.assertVisibility(page, "#scopes");
+        await cas.assertVisibility(page, "#informationUrl");
+        await cas.assertVisibility(page, "#privacyUrl");
+        for (const id of consent) {
+            await cas.assertVisibility(page, id);
+        }
 
-    if (await cas.isVisible(page, "#allow")) {
-        await cas.click(page, "#allow");
-        await cas.waitForNavigation(page);
+        if (await cas.isVisible(page, "#allow")) {
+            await cas.click(page, "#allow");
+            await cas.waitForNavigation(page);
+        }
     }
     await cas.sleep(2000);
     await cas.screenshot(page);
@@ -68,6 +70,7 @@ async function verifyAccessTokenAndProfile(context, client, scopes, consent, def
     await verifyAccessTokenAndProfile(context, 1, ["openid"], ["#openid"], ["sub"], true);
     await verifyAccessTokenAndProfile(context, 1, ["openid", "profile", "MyCustomScope"], ["#profile", "#MyCustomScope"], ["sub", "name", "family_name", "cn"], false);
     await verifyAccessTokenAndProfile(context, 2, ["openid", "profile", "MyCustomScope"], ["#openid", "#profile", "#MyCustomScope"], ["sub", "name", "family_name", "cn"], false);
+    await verifyAccessTokenAndProfile(context, 2, ["openid", "profile"], [], ["sub"], false);
     await context.close();
 
     await cas.closeBrowser(browser);

--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/script.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/script.json
@@ -1,0 +1,35 @@
+{
+  "dependencies": "oidc",
+  "conditions": {
+    "docker": "true"
+  },
+  "properties": [
+    "--cas.server.name=https://localhost:8443",
+    "--cas.server.prefix=${cas.server.name}/cas",
+
+    "--cas.authn.attribute-repository.stub.attributes.common-name=casuser",
+    "--cas.authn.attribute-repository.stub.attributes.name=CAS",
+    "--cas.authn.attribute-repository.stub.attributes.lastname=Apereo",
+    "--cas.authn.attribute-repository.stub.attributes.identity-name=apereo-cas",
+
+    "--cas.authn.oidc.core.issuer=https://localhost:8443/cas/oidc",
+    "--cas.authn.oidc.discovery.scopes=openid,profile,email,address,phone,MyCustomScope",
+    "--cas.authn.oidc.discovery.claims=sub,name,cn,given-name,given:name,family_name",
+
+    "--cas.authn.oidc.core.user-defined-scopes.MyCustomScope=cn,given:name,name",
+    "--cas.authn.oidc.jwks.file-system.jwks-file=file:${#systemProperties['java.io.tmpdir']}/keystore.jwks",
+
+    "--cas.authn.oidc.core.claims-map.cn=common-name",
+    "--cas.authn.oidc.core.claims-map.name=identity-name",
+    "--cas.authn.oidc.core.claims-map.family_name=lastname",
+
+    "--cas.authn.oauth.core.user-profile-view-type=FLAT",
+
+    "--cas.ticket.track-descendant-tickets=true",
+
+    "--cas.service-registry.core.init-from-json=true",
+    "--cas.service-registry.json.location=file:${PWD}/ci/tests/puppeteer/scenarios/${SCENARIO}/services"
+  ],
+  "initScript": "${PWD}/ci/tests/httpbin/run-httpbin-server.sh"
+}
+

--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/services/Sample-1.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/services/Sample-1.json
@@ -1,0 +1,15 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client1",
+  "clientSecret": "secret",
+  "serviceId": "^http://localhost:9889/anything/app1.*",
+  "name": "Sample",
+  "id": 1,
+  "description": "Sample Service",
+  "evaluationOrder": 10000,
+  "informationUrl": "https://github.com/apereo/cas",
+  "privacyUrl": "https://github.com/apereo/cas",
+  "scopes" : [ "java.util.HashSet", [ "MyCustomScope", "openid", "profile" ] ],
+  "supportedGrantTypes": [ "java.util.HashSet", [ "authorization_code" ] ],
+  "supportedResponseTypes": [ "java.util.HashSet", [ "code" ] ]
+}

--- a/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/services/Sample-2.json
+++ b/ci/tests/puppeteer/scenarios/oidc-authzcode-login-consent/services/Sample-2.json
@@ -1,0 +1,15 @@
+{
+  "@class": "org.apereo.cas.services.OidcRegisteredService",
+  "clientId": "client2",
+  "clientSecret": "secret",
+  "serviceId": "^http://localhost:9889/anything/app2.*",
+  "name": "Sample",
+  "id": 2,
+  "description": "Sample Service",
+  "evaluationOrder": 10000,
+  "informationUrl": "https://github.com/apereo/cas",
+  "privacyUrl": "https://github.com/apereo/cas",
+  "scopes" : [ "java.util.HashSet", [ "MyCustomScope", "openid", "profile" ] ],
+  "supportedGrantTypes": [ "java.util.HashSet", [ "authorization_code" ] ],
+  "supportedResponseTypes": [ "java.util.HashSet", [ "code" ] ]
+}

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/views/OAuth20ConsentApprovalViewResolver.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/web/views/OAuth20ConsentApprovalViewResolver.java
@@ -9,6 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apereo.cas.support.oauth.web.OAuth20RequestParameterResolver;
+import org.apereo.cas.ticket.TicketFactory;
+import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.springframework.web.servlet.ModelAndView;
@@ -33,18 +36,32 @@ public class OAuth20ConsentApprovalViewResolver implements ConsentApprovalViewRe
      */
     protected final SessionStore sessionStore;
 
+    protected final OAuth20RequestParameterResolver oauthRequestParameterResolver;
+
     @Override
     public ModelAndView resolve(final WebContext context, final OAuthRegisteredService service) throws Exception {
+        // do not store approval, if it is always bypassed
+        if (isConsentApprovalBypassed(context, service)) {
+            return new ModelAndView();
+        }
+
         var bypassApprovalParameter = context.getRequestParameter(OAuth20Constants.BYPASS_APPROVAL_PROMPT)
-            .map(String::valueOf).orElse(StringUtils.EMPTY);
-        if (StringUtils.isBlank(bypassApprovalParameter)) {
-            bypassApprovalParameter = sessionStore
-                .get(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT)
-                .map(String::valueOf).orElse(StringUtils.EMPTY);
+            .map(String::valueOf).orElse(StringUtils.EMPTY).equalsIgnoreCase(Boolean.TRUE.toString());
+        val approvalKey = OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId();
+        var approvedScopes = new HashSet<>(sessionStore
+                .get(context, approvalKey)
+                .map(o -> o instanceof Collection ? ((Collection<?>) o).stream()
+                                                    .map(String::valueOf)
+                                                    .collect(Collectors.toSet()) : null)
+                .orElse(Set.of()));
+        val requestedScopes = resolveRequestedScopes(context, service);
+        if (!bypassApprovalParameter && approvedScopes.containsAll(requestedScopes)) {
+            bypassApprovalParameter = true;
         }
         LOGGER.trace("Bypassing approval prompt for service [{}]: [{}]", service, bypassApprovalParameter);
-        if (Boolean.TRUE.toString().equalsIgnoreCase(bypassApprovalParameter) || isConsentApprovalBypassed(context, service)) {
-            sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT, Boolean.TRUE.toString());
+        if (bypassApprovalParameter) {
+            approvedScopes.addAll(requestedScopes);
+            sessionStore.set(context, approvalKey, approvedScopes);
             return new ModelAndView();
         }
         return redirectToApproveView(context, service);
@@ -60,6 +77,18 @@ public class OAuth20ConsentApprovalViewResolver implements ConsentApprovalViewRe
     protected boolean isConsentApprovalBypassed(final WebContext context, final OAuthRegisteredService service) {
         return service.isBypassApprovalPrompt()
                || casProperties.getAuthn().getOauth().getCore().isBypassApprovalPrompt();
+    }
+
+    /**
+     * Get a collection of requested scopes
+     * @param context the context
+     * @return a collection of requested scopes
+     */
+    protected Collection<String> resolveRequestedScopes(final WebContext context, final OAuthRegisteredService service) {
+        val supportedScopes = new HashSet<>(casProperties.getAuthn().getOidc().getDiscovery().getScopes());
+        supportedScopes.retainAll(service.getScopes());
+        supportedScopes.retainAll(oauthRequestParameterResolver.resolveRequestedScopes(context));
+        return supportedScopes;
     }
 
     /**

--- a/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
+++ b/support/cas-server-support-oauth/src/main/java/org/apereo/cas/config/CasOAuth20Configuration.java
@@ -412,8 +412,10 @@ class CasOAuth20Configuration {
         public ConsentApprovalViewResolver consentApprovalViewResolver(
             @Qualifier("oauthDistributedSessionStore")
             final SessionStore oauthDistributedSessionStore,
+            @Qualifier(OAuth20RequestParameterResolver.BEAN_NAME)
+            final OAuth20RequestParameterResolver oauthRequestParameterResolver,
             final CasConfigurationProperties casProperties) {
-            return new OAuth20ConsentApprovalViewResolver(casProperties, oauthDistributedSessionStore);
+            return new OAuth20ConsentApprovalViewResolver(casProperties, oauthDistributedSessionStore, oauthRequestParameterResolver);
         }
 
         @ConditionalOnMissingBean(name = OAuth20UserProfileDataCreator.BEAN_NAME)

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/web/endpoints/OAuth20AuthorizeEndpointControllerTests.java
@@ -90,11 +90,14 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     @Test
     void verifyBadResponseType() throws Throwable {
         val registeredService = addRegisteredService();
+        registeredService.setScopes(Set.of("openid", "email", "profile"));
+        servicesManager.save(registeredService);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, registeredService.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, "badvalue");
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setAttribute(OAuth20Constants.ERROR, OAuth20Constants.INVALID_REQUEST);
         mockRequest.setAttribute(OAuth20Constants.ERROR_WITH_CALLBACK, true);
         val mockResponse = new MockHttpServletResponse();
@@ -120,11 +123,13 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     @Test
     void verifyCasClientCanValidate() throws Throwable {
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.addHeader(HttpHeaders.USER_AGENT, "MSIE");
         val mockResponse = new MockHttpServletResponse();
         val callContext = new CallContext(new JEEContext(mockRequest, mockResponse),
@@ -176,12 +181,14 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     void verifyCodeNoProfile() {
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -197,6 +204,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     void verifyMissingTicketGrantingTicket() throws Throwable {
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         authorizeController.getConfigurationContext().getServicesManager().save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -204,6 +212,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -227,6 +236,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     void verifyServiceAccessDenied() throws Throwable {
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         service.setAccessStrategy(new DefaultRegisteredServiceAccessStrategy(Map.of("required", Set.of("value1"))));
         authorizeController.getConfigurationContext().getServicesManager().save(service);
 
@@ -235,6 +245,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -260,6 +271,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     void verifyCodeRedirectToClient() throws Throwable {
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         authorizeController.getConfigurationContext().getServicesManager().save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -267,6 +279,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -311,6 +324,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     void verifyTokenRedirectToClient() throws Throwable {
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -318,6 +332,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.TOKEN.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -358,6 +373,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     void verifyPerServiceExpiration() throws Throwable {
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         val expirationPolicy = new DefaultRegisteredServiceOAuthAccessTokenExpirationPolicy();
         expirationPolicy.setMaxTimeToLive("5005");
         expirationPolicy.setTimeToKill("1001");
@@ -370,6 +386,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.TOKEN.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -412,6 +429,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
 
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -419,6 +437,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -458,6 +477,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
 
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -465,6 +485,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.TOKEN.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -506,6 +527,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
 
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(false);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -513,6 +535,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.addHeader(HttpHeaders.USER_AGENT, "MSIE");
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -524,7 +547,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         val sessionStore = authorizeController.getConfigurationContext().getSessionStore();
         val context = new JEEContext(mockRequest, mockResponse);
         sessionStore.set(context, Pac4jConstants.USER_PROFILES, CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
-        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT, "true");
+        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId(), Set.of("openid"));
 
         val modelAndView = authorizeController.handleRequest(mockRequest, mockResponse);
         val view = modelAndView.getView();
@@ -545,11 +568,62 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     }
 
     @Test
+    void verifyCodeRedirectToClientConsented() throws Throwable {
+
+
+        val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
+        service.setBypassApprovalPrompt(false);
+        service.setScopes(Set.of("openid", "email", "profile", "phone"));
+        servicesManager.save(service);
+
+        val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
+        mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
+        mockRequest.addHeader(HttpHeaders.USER_AGENT, "MSIE");
+        mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
+        mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid email address");
+        mockRequest.setParameter(OAuth20Constants.BYPASS_APPROVAL_PROMPT, Boolean.TRUE.toString());
+        mockRequest.setServerName(CAS_SERVER);
+        mockRequest.setServerPort(CAS_PORT);
+        mockRequest.setScheme(CAS_SCHEME);
+        val mockResponse = new MockHttpServletResponse();
+
+        val profile = buildCasProfile();
+        val session = new MockHttpSession();
+        mockRequest.setSession(session);
+        val sessionStore = authorizeController.getConfigurationContext().getSessionStore();
+        val context = new JEEContext(mockRequest, mockResponse);
+        sessionStore.set(context, Pac4jConstants.USER_PROFILES, CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
+        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId(), Set.of("openid", "profile"));
+
+        val modelAndView = authorizeController.handleRequest(mockRequest, mockResponse);
+        val view = modelAndView.getView();
+        assertInstanceOf(RedirectView.class, view);
+        val redirectView = (RedirectView) view;
+        val redirectUrl = redirectView.getUrl();
+        assertNotNull(redirectUrl);
+        assertEquals(REDIRECT_URI, redirectUrl);
+
+        val code = modelAndView.getModelMap().get("code");
+        val oAuthCode = (OAuth20Code) this.ticketRegistry.getTicket(String.valueOf(code));
+        assertNotNull(oAuthCode);
+        val principal = oAuthCode.getAuthentication().getPrincipal();
+        assertEquals(ID, principal.getId());
+        val principalAttributes = principal.getAttributes();
+        assertEquals(profile.getAttributes().size(), principalAttributes.size());
+        assertEquals(FIRST_NAME, principalAttributes.get(FIRST_NAME_ATTRIBUTE).getFirst());
+
+        val approvedScopes = sessionStore.get(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId());
+        assertEquals(Set.of("openid", "email", "profile"), approvedScopes.orElse(Set.of()));
+    }
+
+    @Test
     void verifyTokenRedirectToClientApproved() throws Throwable {
 
 
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(false);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -557,6 +631,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.TOKEN.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid", "unknown_scope");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -570,7 +645,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         val context = new JEEContext(mockRequest, mockResponse);
 
         sessionStore.set(context, Pac4jConstants.USER_PROFILES, CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
-        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT, "true");
+        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId(), Set.of("openid", "email"));
 
         val modelAndView = authorizeController.handleRequest(mockRequest, mockResponse);
         val view = modelAndView.getView();
@@ -596,6 +671,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
 
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(false);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -603,6 +679,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -626,12 +703,87 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
     }
 
     @Test
+    void verifyRedirectToApprovalOtherScope() throws Throwable {
+
+        val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
+        service.setBypassApprovalPrompt(false);
+        service.setScopes(Set.of("openid", "email", "profile"));
+        servicesManager.save(service);
+
+        val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
+        mockRequest.addHeader(HttpHeaders.USER_AGENT, "MSIE");
+        mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
+        mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
+        mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid email");
+        mockRequest.setServerName(CAS_SERVER);
+        mockRequest.setServerPort(CAS_PORT);
+        mockRequest.setScheme(CAS_SCHEME);
+        val mockResponse = new MockHttpServletResponse();
+
+        val profile = buildCasProfile();
+
+        val session = new MockHttpSession();
+        mockRequest.setSession(session);
+        val sessionStore = authorizeController.getConfigurationContext().getSessionStore();
+        val context = new JEEContext(mockRequest, mockResponse);
+
+        sessionStore.set(context, Pac4jConstants.USER_PROFILES, CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
+        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId(), Set.of("openid", "profile"));
+
+        val modelAndView = authorizeController.handleRequest(mockRequest, mockResponse);
+        assertEquals(OAuth20Constants.CONFIRM_VIEW, modelAndView.getViewName());
+        val model = modelAndView.getModel();
+        assertEquals(AUTHORIZE_URL + '?' + OAuth20Constants.BYPASS_APPROVAL_PROMPT + "=true", model.get("callbackUrl"));
+        assertEquals(SERVICE_NAME, model.get("serviceName"));
+    }
+
+    @Test
+    void verifyRedirectToApprovalOtherService() throws Throwable {
+
+        val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
+        service.setBypassApprovalPrompt(false);
+        service.setScopes(Set.of("openid", "email", "profile"));
+        servicesManager.save(service);
+
+        val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
+        mockRequest.addHeader(HttpHeaders.USER_AGENT, "MSIE");
+        mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
+        mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
+        mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.CODE.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
+        mockRequest.setServerName(CAS_SERVER);
+        mockRequest.setServerPort(CAS_PORT);
+        mockRequest.setScheme(CAS_SCHEME);
+        val mockResponse = new MockHttpServletResponse();
+
+        val profile = buildCasProfile();
+
+        val session = new MockHttpSession();
+        mockRequest.setSession(session);
+        val sessionStore = authorizeController.getConfigurationContext().getSessionStore();
+        val context = new JEEContext(mockRequest, mockResponse);
+
+        sessionStore.set(context, Pac4jConstants.USER_PROFILES, CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
+        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_other_service", Set.of("openid"));
+
+        sessionStore.set(context, Pac4jConstants.USER_PROFILES, CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
+
+        val modelAndView = authorizeController.handleRequest(mockRequest, mockResponse);
+        assertEquals(OAuth20Constants.CONFIRM_VIEW, modelAndView.getViewName());
+        val model = modelAndView.getModel();
+        assertEquals(AUTHORIZE_URL + '?' + OAuth20Constants.BYPASS_APPROVAL_PROMPT + "=true", model.get("callbackUrl"));
+        assertEquals(SERVICE_NAME, model.get("serviceName"));
+    }
+
+    @Test
     void verifyTokenRedirectToClientApprovedWithJwtToken() throws Throwable {
 
 
         val service = getOAuthRegisteredService(REDIRECT_URI, SERVICE_NAME);
         service.setBypassApprovalPrompt(true);
         service.setJwtAccessToken(true);
+        service.setScopes(Set.of("openid", "email", "profile"));
         servicesManager.save(service);
 
         val mockRequest = new MockHttpServletRequest(HttpMethod.GET.name(), CONTEXT + OAuth20Constants.AUTHORIZE_URL);
@@ -639,6 +791,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         mockRequest.setParameter(OAuth20Constants.CLIENT_ID, service.getClientId());
         mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, REDIRECT_URI);
         mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.TOKEN.name().toLowerCase(Locale.ENGLISH));
+        mockRequest.setParameter(OAuth20Constants.SCOPE, "openid");
         mockRequest.setServerName(CAS_SERVER);
         mockRequest.setServerPort(CAS_PORT);
         mockRequest.setScheme(CAS_SCHEME);
@@ -653,7 +806,7 @@ class OAuth20AuthorizeEndpointControllerTests extends AbstractOAuth20Tests {
         val ticket = new MockTicketGrantingTicket("casuser");
         authorizeController.getConfigurationContext().getTicketRegistry().addTicket(ticket);
         sessionStore.set(context, Pac4jConstants.USER_PROFILES, CollectionUtils.wrapLinkedHashMap(profile.getClientName(), profile));
-        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT, "true");
+        sessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId(), Set.of("openid"));
 
         val modelAndView = authorizeController.handleRequest(mockRequest, mockResponse);
         val view = modelAndView.getView();

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcConsentApprovalViewResolver.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/OidcConsentApprovalViewResolver.java
@@ -30,17 +30,14 @@ public class OidcConsentApprovalViewResolver extends OAuth20ConsentApprovalViewR
 
     private final TicketFactory ticketFactory;
 
-    private final OAuth20RequestParameterResolver oauthRequestParameterResolver;
-
     public OidcConsentApprovalViewResolver(final CasConfigurationProperties casProperties,
                                            final SessionStore sessionStore,
                                            final TicketRegistry ticketRegistry,
                                            final TicketFactory ticketFactory,
                                            final OAuth20RequestParameterResolver oauthRequestParameterResolver) {
-        super(casProperties, sessionStore);
+        super(casProperties, sessionStore, oauthRequestParameterResolver);
         this.ticketRegistry = ticketRegistry;
         this.ticketFactory = ticketFactory;
-        this.oauthRequestParameterResolver = oauthRequestParameterResolver;
     }
 
     @Override
@@ -56,6 +53,23 @@ public class OidcConsentApprovalViewResolver extends OAuth20ConsentApprovalViewR
             }
         }
         return super.isConsentApprovalBypassed(context, service);
+    }
+
+    @Override
+    protected Collection<String> resolveRequestedScopes(final WebContext context, final OAuthRegisteredService service) {
+        val supportedScopes = new HashSet<>(casProperties.getAuthn().getOidc().getDiscovery().getScopes());
+        supportedScopes.retainAll(service.getScopes());
+
+        var requestedScopes = new HashSet<>(super.resolveRequestedScopes(context, service));
+        context.getRequestParameter(OidcConstants.REQUEST_URI).ifPresent(Unchecked.consumer(uri -> {
+            val authzRequest = ticketRegistry.getTicket(uri, OidcPushedAuthorizationRequest.class);
+            val uriFactory = (OidcPushedAuthorizationRequestFactory) ticketFactory.get(OidcPushedAuthorizationRequest.class);
+            val holder = uriFactory.toAccessTokenRequest(authzRequest);
+            requestedScopes.addAll(holder.getScopes());
+        }));
+        supportedScopes.retainAll(requestedScopes);
+        supportedScopes.add(OidcConstants.StandardScopes.OPENID.getScope());
+        return supportedScopes;
     }
 
     @Override
@@ -77,21 +91,15 @@ public class OidcConsentApprovalViewResolver extends OAuth20ConsentApprovalViewR
                 model.put("dynamicTime", oidcRegisteredService.getProperties()
                     .get(RegisteredServiceProperties.OIDC_DYNAMIC_CLIENT_REGISTRATION_DATE.getPropertyName()).getValue(String.class));
             }
-            val supportedScopes = new HashSet<>(casProperties.getAuthn().getOidc().getDiscovery().getScopes());
-            supportedScopes.retainAll(oidcRegisteredService.getScopes());
 
-            val requestedScopes = oauthRequestParameterResolver.resolveRequestedScopes(webContext);
             val userInfoClaims = oauthRequestParameterResolver.resolveUserInfoRequestClaims(webContext);
             webContext.getRequestParameter(OidcConstants.REQUEST_URI).ifPresent(Unchecked.consumer(uri -> {
                 val authzRequest = ticketRegistry.getTicket(uri, OidcPushedAuthorizationRequest.class);
                 val uriFactory = (OidcPushedAuthorizationRequestFactory) ticketFactory.get(OidcPushedAuthorizationRequest.class);
                 val holder = uriFactory.toAccessTokenRequest(authzRequest);
                 userInfoClaims.addAll(holder.getClaims().keySet());
-                requestedScopes.addAll(holder.getScopes());
             }));
-            supportedScopes.retainAll(requestedScopes);
-            supportedScopes.add(OidcConstants.StandardScopes.OPENID.getScope());
-            model.put("scopes", supportedScopes);
+            model.put("scopes", resolveRequestedScopes(webContext, oidcRegisteredService));
             model.put("userInfoClaims", userInfoClaims);
         }
     }

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/OidcConsentApprovalViewResolverTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/OidcConsentApprovalViewResolverTests.java
@@ -32,13 +32,14 @@ class OidcConsentApprovalViewResolverTests extends AbstractOidcTests {
 
     @Test
     void verifyBypassedBySession() throws Throwable {
-        val request = new MockHttpServletRequest();
-        request.addHeader(HttpHeaders.USER_AGENT, "MSIE");
-        val response = new MockHttpServletResponse();
-        val context = new JEEContext(request, response);
-        oauthDistributedSessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT, "true");
         val service = getOidcRegisteredService(UUID.randomUUID().toString(), randomServiceUrl());
         servicesManager.save(service);
+        val request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.USER_AGENT, "MSIE");
+        request.setParameter(OAuth20Constants.SCOPE, OidcConstants.StandardScopes.OPENID.getScope());
+        val response = new MockHttpServletResponse();
+        val context = new JEEContext(request, response);
+        oauthDistributedSessionStore.set(context, OAuth20Constants.BYPASS_APPROVAL_PROMPT + "_" + service.getClientId(), Set.of(OidcConstants.StandardScopes.OPENID.getScope()));
         assertFalse(consentApprovalViewResolver.resolve(context, service).hasView());
     }
 
@@ -47,7 +48,8 @@ class OidcConsentApprovalViewResolverTests extends AbstractOidcTests {
         val request = new MockHttpServletRequest();
         request.setRequestURI("https://cas.org/something");
         request.addHeader(HttpHeaders.USER_AGENT, "MSIE");
-        request.setQueryString(OAuth20Constants.PROMPT + '=' + OidcConstants.PROMPT_CONSENT);
+        request.setParameter(OAuth20Constants.SCOPE, OidcConstants.StandardScopes.OPENID.getScope());
+        request.setParameter(OAuth20Constants.PROMPT, OidcConstants.PROMPT_CONSENT);
 
         val response = new MockHttpServletResponse();
         val context = new JEEContext(request, response);
@@ -112,6 +114,7 @@ class OidcConsentApprovalViewResolverTests extends AbstractOidcTests {
         val request = new MockHttpServletRequest();
         request.addHeader(HttpHeaders.USER_AGENT, "MSIE");
         request.setRequestURI("https://cas.org/something");
+        request.setParameter(OAuth20Constants.SCOPE, OidcConstants.StandardScopes.OPENID.getScope());
 
         val response = new MockHttpServletResponse();
         val context = new JEEContext(request, response);

--- a/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/controllers/authorize/OidcAuthorizeEndpointControllerTests.java
+++ b/support/cas-server-support-oidc/src/test/java/org/apereo/cas/oidc/web/controllers/authorize/OidcAuthorizeEndpointControllerTests.java
@@ -97,6 +97,7 @@ class OidcAuthorizeEndpointControllerTests {
             mockRequest.setParameter(OAuth20Constants.CLIENT_ID, id);
             mockRequest.setParameter(OAuth20Constants.REDIRECT_URI, "https://oauth.example.org/");
             mockRequest.setParameter(OAuth20Constants.RESPONSE_TYPE, OAuth20ResponseTypes.TOKEN.name().toLowerCase(Locale.ENGLISH));
+            mockRequest.setParameter(OAuth20Constants.SCOPE, OidcConstants.StandardScopes.OPENID.getScope());
             mockRequest.setContextPath(StringUtils.EMPTY);
             val mockResponse = new MockHttpServletResponse();
 


### PR DESCRIPTION
Currently, the CAS consent page for OAuth2.0/OIDC is only shown for the first authorization request. All subsequent authorization requests during the validity period of the SessionStore are automatically approved, independently of the requesting service or the requested scopes.

As a result, the following actions are currently possible:
1. Service A asks for the `openid` scope
2. CAS shows the consent page, the user approves
3. Service A asks for all remaining scopes
4. CAS uses the approval for the `openid` scope to also approve all other scopes
5. Service B asks for all scopes
6. CAS uses the approval from Service A to also approve all scopes for Service B

This PR changes the behavior to track the scopes approved by the user for each service. If one of the requested scopes is not approved, the consent page will be shown.