### PR TITLE
Fix the OIDC JWKS MongoDB support

### DIFF
--- a/support/cas-server-support-oidc-mongo/src/main/java/org/apereo/cas/oidc/jwks/generator/mongo/OidcMongoDbJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc-mongo/src/main/java/org/apereo/cas/oidc/jwks/generator/mongo/OidcMongoDbJsonWebKeystoreGeneratorService.java
@@ -48,7 +48,7 @@ public class OidcMongoDbJsonWebKeystoreGeneratorService implements OidcJsonWebKe
         Optional.ofNullable(result)
             .ifPresentOrElse(entity -> {
                 val update = Update.update("data", json);
-                val query = new Query(Criteria.where("issuer").is(entity.getIssuer()));
+                val query = new Query(Criteria.where("_id").is(entity.getIssuer()));
                 mongoTemplate.updateFirst(query, update, collectionName);
             }, () -> {
                 val entity = new OidcJsonWebKeystoreEntity(issuer, json);

--- a/support/cas-server-support-oidc-mongo/src/main/java/org/apereo/cas/oidc/jwks/generator/mongo/OidcMongoDbJsonWebKeystoreGeneratorService.java
+++ b/support/cas-server-support-oidc-mongo/src/main/java/org/apereo/cas/oidc/jwks/generator/mongo/OidcMongoDbJsonWebKeystoreGeneratorService.java
@@ -13,9 +13,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
 import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 
 /**
  * This is {@link OidcMongoDbJsonWebKeystoreGeneratorService}.
@@ -43,17 +40,9 @@ public class OidcMongoDbJsonWebKeystoreGeneratorService implements OidcJsonWebKe
     public JsonWebKeySet store(final JsonWebKeySet jsonWebKeySet) {
         val issuer = oidcProperties.getCore().getIssuer();
         val collectionName = oidcProperties.getJwks().getMongo().getCollection();
-        val result = mongoTemplate.findById(issuer, OidcJsonWebKeystoreEntity.class, collectionName);
         val json = jsonWebKeySet.toJson(JsonWebKey.OutputControlLevel.INCLUDE_PRIVATE);
-        Optional.ofNullable(result)
-            .ifPresentOrElse(entity -> {
-                val update = Update.update("data", json);
-                val query = new Query(Criteria.where("_id").is(entity.getIssuer()));
-                mongoTemplate.updateFirst(query, update, collectionName);
-            }, () -> {
-                val entity = new OidcJsonWebKeystoreEntity(issuer, json);
-                mongoTemplate.insert(entity, collectionName);
-            });
+        val entity = new OidcJsonWebKeystoreEntity(issuer, json);
+        mongoTemplate.save(entity, collectionName);
         return jsonWebKeySet;
     }
 

--- a/support/cas-server-support-oidc-mongo/src/test/java/org/apereo/cas/oidc/jwks/generator/OidcMongoDbJsonWebKeystoreGeneratorServiceTests.java
+++ b/support/cas-server-support-oidc-mongo/src/test/java/org/apereo/cas/oidc/jwks/generator/OidcMongoDbJsonWebKeystoreGeneratorServiceTests.java
@@ -3,7 +3,10 @@ package org.apereo.cas.oidc.jwks.generator;
 import module java.base;
 import org.apereo.cas.config.CasOidcJwksMongoDbAutoConfiguration;
 import org.apereo.cas.oidc.AbstractOidcTests;
+import org.apereo.cas.oidc.jwks.OidcJsonWebKeyUsage;
+import org.apereo.cas.oidc.jwks.rotation.OidcJsonWebKeystoreRotationService;
 import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Tag;
@@ -46,5 +49,17 @@ class OidcMongoDbJsonWebKeystoreGeneratorServiceTests extends AbstractOidcTests 
         assertNotNull(set1);
 
         assertTrue(oidcJsonWebKeystoreGeneratorService.find().isPresent());
+
+        val futureKeySigning = OidcJsonWebKeystoreGeneratorService.generateJsonWebKey(casProperties.getAuthn().getOidc(),
+                OidcJsonWebKeyUsage.SIGNING);
+        OidcJsonWebKeystoreRotationService.JsonWebKeyLifecycleStates.setJsonWebKeyState(futureKeySigning,
+                OidcJsonWebKeystoreRotationService.JsonWebKeyLifecycleStates.FUTURE);
+        set1.addJsonWebKey(futureKeySigning);
+
+        oidcJsonWebKeystoreGeneratorService.store(set1);
+        val resource3 = oidcJsonWebKeystoreGeneratorService.find();
+        val json3 = IOUtils.toString(resource3.get().getInputStream(), StandardCharsets.UTF_8);
+        val keys3 = new ObjectMapper().readTree(json3).get("keys");
+        assertEquals(set1.getJsonWebKeys().size(), keys3.size());
     }
 }

--- a/support/cas-server-support-oidc-mongo/src/test/java/org/apereo/cas/oidc/jwks/generator/OidcMongoDbJsonWebKeystoreGeneratorServiceTests.java
+++ b/support/cas-server-support-oidc-mongo/src/test/java/org/apereo/cas/oidc/jwks/generator/OidcMongoDbJsonWebKeystoreGeneratorServiceTests.java
@@ -6,13 +6,13 @@ import org.apereo.cas.oidc.AbstractOidcTests;
 import org.apereo.cas.oidc.jwks.OidcJsonWebKeyUsage;
 import org.apereo.cas.oidc.jwks.rotation.OidcJsonWebKeystoreRotationService;
 import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.val;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
+import tools.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**


### PR DESCRIPTION
I encountered an issue when trying to enable OIDC keys rotation stored in MongoDB. It works the first time (creation), but not after (update).

This PR fixes the problem and the unit test has been updated to confirm the fix.
