### PR TITLE
Allow providing OAuth client secret as hash

### DIFF
--- a/docs/cas-server-documentation/authentication/OAuth-Authentication-Clients.md
+++ b/docs/cas-server-documentation/authentication/OAuth-Authentication-Clients.md
@@ -75,6 +75,21 @@ either manually or via the [CAS Command-line shell](../installation/Configuring-
 
 {% include_cached casproperties.html properties="cas.authn.oauth" %}
 
+## Hashed Client Secrets
+
+Client secrets for OAuth relying parties may be defined as hashed values prefixed with `{cas-hash}` using [Spring's DelegatingPasswordEncoder Storage Format](https://docs.spring.io/spring-security/reference/features/authentication/password-storage.html#authentication-password-storage-dpe-format):
+
+```json
+{
+  "@class": "org.apereo.cas.support.oauth.services.OAuthRegisteredService",
+  "clientId": "clientid",
+  "clientSecret": "{cas-hash}{argon2}$argon2id$v=19$m=16384,t=2,p=1$677d2HGv...",
+  "serviceId" : "^(https|imaps)://<redirect-uri>.*",
+  "name": "Sample",
+  "id": 100
+}
+```
+
 ## Attribute Release
 
 Attribute/claim filtering and release policies are defined per OAuth service.

--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
@@ -10,6 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
  * This is {@link DefaultOAuth20ClientSecretValidator}.
@@ -22,6 +25,9 @@ import org.apache.commons.lang3.Strings;
 @Getter
 public class DefaultOAuth20ClientSecretValidator implements OAuth20ClientSecretValidator {
     private final CipherExecutor<Serializable, String> cipherExecutor;
+    private final PasswordEncoder delegatingPasswordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+    public static final String ENCODED_VALUE_PREFIX = "{cas-hash}";
 
     @Override
     public boolean validate(final OAuthRegisteredService registeredService, final String clientSecret) {
@@ -32,7 +38,13 @@ public class DefaultOAuth20ClientSecretValidator implements OAuth20ClientSecretV
 
         val clientSecretAssigned = SpringExpressionLanguageValueResolver.getInstance().resolve(registeredService.getClientSecret());
         val definedSecret = cipherExecutor.decode(clientSecretAssigned, new Object[]{registeredService});
-        if (!Strings.CI.equals(definedSecret, clientSecret)) {
+        boolean isCorrectPassword = false;
+        if (definedSecret.startsWith(ENCODED_VALUE_PREFIX)) {
+            isCorrectPassword = delegatingPasswordEncoder.matches(clientSecret, definedSecret.substring(ENCODED_VALUE_PREFIX.length()));
+        } else {
+            isCorrectPassword = Strings.CI.equals(definedSecret, clientSecret);
+        }
+        if (!isCorrectPassword) {
             LOGGER.error("Wrong client secret for service: [{}]. If you intend to use PKCE, note that it does not require a client secret and "
                        + "requests generally must not specify a client secret to CAS.\nFurthermore, you must make sure "
                        + "no client secret is assigned to this registered service in the CAS service registry.",

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidatorTests.java
@@ -9,6 +9,7 @@ import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.test.context.TestPropertySource;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -43,6 +44,31 @@ class DefaultOAuth20ClientSecretValidatorTests extends AbstractOAuth20Tests {
     void verifyClientSecretIsWrong() {
         val secret = RandomUtils.randomAlphanumeric(12);
         val encodedSecret = oauth20ClientSecretValidator.getCipherExecutor().encode(secret);
+        val registeredService = new OAuthRegisteredService();
+        registeredService.setClientId("clientid");
+        registeredService.setClientSecret(encodedSecret);
+        val result = oauth20ClientSecretValidator.validate(registeredService, "badSecret");
+        assertFalse(result);
+    }
+
+    @Test
+    void verifyClientSecretCheckHash() {
+        val secret = RandomUtils.randomAlphanumeric(12);
+        val passwordEncoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+        val encodedSecret = "{cas-hash}{argon2}" + passwordEncoder.encode(secret);
+        val registeredService = new OAuthRegisteredService();
+        registeredService.setClientId("clientid");
+        registeredService.setClientSecret(encodedSecret);
+        val result = oauth20ClientSecretValidator.validate(registeredService, secret);
+        assertTrue(result);
+        assertFalse(oauth20ClientSecretValidator.isClientSecretExpired(registeredService));
+    }
+
+    @Test
+    void verifyClientSecretIsWrongHash() {
+        val secret = RandomUtils.randomAlphanumeric(12);
+        val passwordEncoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+        val encodedSecret = "{cas-hash}{argon2}" + passwordEncoder.encode(secret);
         val registeredService = new OAuthRegisteredService();
         registeredService.setClientId("clientid");
         registeredService.setClientSecret(encodedSecret);


### PR DESCRIPTION
If credentials are only checked, saving them as hashes is considered best practice.

This PR leverages Spring's DelegatingPasswordEncoder for validating passwords stored in a variety of formats.