### PR TITLE
Fix broken authentication through LDAP

### DIFF
--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapUtils.java
@@ -813,15 +813,15 @@ public class LdapUtils {
         if (StringUtils.isBlank(properties.getSearchFilter())) {
             throw new IllegalArgumentException("User filter cannot be empty/blank for authenticated/anonymous authentication");
         }
-        val connectionFactory = newLdaptiveConnectionFactory(properties);
-        val resolver = buildAggregateDnResolver(properties, connectionFactory);
+        val connectionFactoryForSearch = newLdaptiveConnectionFactory(properties);
+        val resolver = buildAggregateDnResolver(properties, connectionFactoryForSearch);
 
         val auth = StringUtils.isBlank(properties.getPrincipalAttributePassword())
-            ? new Authenticator(resolver, getBindAuthenticationHandler(connectionFactory))
-            : new Authenticator(resolver, getCompareAuthenticationHandler(properties, connectionFactory));
+            ? new Authenticator(resolver, getBindAuthenticationHandler(newLdaptiveConnectionFactory(properties)))
+            : new Authenticator(resolver, getCompareAuthenticationHandler(properties, newLdaptiveConnectionFactory(properties)));
 
         if (properties.isEnhanceWithEntryResolver()) {
-            auth.setEntryResolver(newLdaptiveSearchEntryResolver(properties, connectionFactory));
+            auth.setEntryResolver(newLdaptiveSearchEntryResolver(properties, newLdaptiveConnectionFactory(properties)));
         }
         return auth;
     }

--- a/support/cas-server-support-ldap-core/src/test/java/org/apereo/cas/LdapUtilsTests.java
+++ b/support/cas-server-support-ldap-core/src/test/java/org/apereo/cas/LdapUtilsTests.java
@@ -28,6 +28,7 @@ import org.ldaptive.handler.CaseChangeEntryHandler;
 import org.ldaptive.sasl.Mechanism;
 import org.ldaptive.sasl.QualityOfProtection;
 import org.ldaptive.sasl.SecurityStrength;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -326,6 +327,25 @@ class LdapUtilsTests {
             val config1 = LdapUtils.newLdaptiveConnectionConfig(ldap);
             assertNotNull(config1);
         });
+    }
+
+    @Test
+    public void verifyLdapConnIsNotReused() {
+        val ldap = new Ldap();
+        ldap.setBaseDn("ou=people,dc=example,dc=org");
+        ldap.setLdapUrl("ldap://localhost:10389");
+        ldap.setBindDn("cn=Directory Manager");
+        ldap.setBindCredential("password");
+        ldap.setSearchFilter("cn=foo");
+
+        try (MockedStatic<LdapUtils> mocked = mockStatic(LdapUtils.class)) { 
+            mocked.when(() -> LdapUtils.getAuthenticatedOrAnonSearchAuthenticator(ldap)).thenCallRealMethod();
+
+            val auth = LdapUtils.getAuthenticatedOrAnonSearchAuthenticator(ldap);
+            assertNotNull(auth);
+
+            mocked.verify(() -> LdapUtils.newLdaptiveConnectionFactory(ldap), atLeast(2));
+        }
     }
 
     private static final class Ldap extends AbstractLdapAuthenticationProperties {


### PR DESCRIPTION
Hello,

This pull request reverts commit https://github.com/apereo/cas/commit/e79712cfac805ca25996510a9ecec9fd95537907 as it introduces a regression between 7.3.5 and 7.3.6.

By trying to reuse the LDAP connection, the first user trying to authenticate through the CAS will succeed, but the next ones won't.

I'm bringing this patch directly to the `7.3.x` branch because I haven't had the chance to test the current behavior on 8.0. Also, I guess this is the easier way to fix the regression on 7.3 but maybe you want to handle it differently on 8.0, as you've already applied [a similar patch there](https://github.com/apereo/cas/commit/0e904cb7cc6782217635c2d9acd5abd07e056824).

Have a nice day.