### PR TITLE
Avoid reinitializing dispatcher servlet on refresh

### DIFF
--- a/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
+++ b/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
@@ -13,7 +13,6 @@ import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
 import org.springframework.context.ApplicationContext;
-import org.springframework.web.servlet.DispatcherServlet;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -65,13 +64,7 @@ public class DefaultCasConfigurationEventListener implements CasConfigurationEve
             for (val beanName : applicationContext.getBeanDefinitionNames()) {
                 Objects.requireNonNull(applicationContext.getBean(beanName).getClass());
             }
-            if (applicationContext.containsBean("dispatcherServlet")) {
-                val servlet = applicationContext.getBean(DispatcherServlet.class);
-                servlet.setApplicationContext(applicationContext);
-                servlet.init();
-            }
         });
-
     }
 
     private void rebind() {

--- a/core/cas-server-core-events-configuration/src/test/java/org/apereo/cas/support/events/listener/CasConfigurationEventListenerTests.java
+++ b/core/cas-server-core-events-configuration/src/test/java/org/apereo/cas/support/events/listener/CasConfigurationEventListenerTests.java
@@ -7,6 +7,7 @@ import org.apereo.cas.configuration.config.CasCoreEnvironmentConfiguration;
 import org.apereo.cas.configuration.config.standalone.CasCoreBootstrapStandaloneConfiguration;
 import org.apereo.cas.support.events.config.CasConfigurationModifiedEvent;
 
+import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,10 +19,12 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
 
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * This is {@link CasConfigurationEventListenerTests}.
@@ -61,5 +64,22 @@ public class CasConfigurationEventListenerTests {
             new CasConfigurationModifiedEvent(this, true)));
         assertDoesNotThrow(() -> applicationContext.publishEvent(
             new RefreshScopeRefreshedEvent()));
+    }
+
+    @Test
+    public void verifyDispatcherServletIsNotInitialized() {
+        val applicationContext = mock(ConfigurableApplicationContext.class);
+        val dispatcherServlet = new DispatcherServlet();
+        when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[] { "dispatcherServlet" });
+        when(applicationContext.getBean("dispatcherServlet")).thenReturn(dispatcherServlet);
+        when(applicationContext.containsBean("dispatcherServlet")).thenReturn(true);
+        when(applicationContext.getBean(DispatcherServlet.class)).thenReturn(dispatcherServlet);
+
+        val listener = new DefaultCasConfigurationEventListener(null, null, null, applicationContext);
+        assertDoesNotThrow(() -> listener.onRefreshScopeRefreshed(new RefreshScopeRefreshedEvent()));
+
+        verify(applicationContext).getBean("dispatcherServlet");
+        verify(applicationContext, never()).containsBean("dispatcherServlet");
+        verify(applicationContext, never()).getBean(DispatcherServlet.class);
     }
 }


### PR DESCRIPTION
This removes the special-case reinitialization of Spring's DispatcherServlet from the CAS configuration refresh listener.

The listener still eagerly resolves all beans after refresh, but it no longer calls DispatcherServlet.init() manually. That call can run outside the servlet container lifecycle, where no ServletConfig is available, and can surface as a NullPointerException during refresh.

Reference:
- Apache Syncope issue: https://issues.apache.org/jira/browse/SYNCOPE-1758
- The failure is visible in Syncope WA because it embeds CAS and triggers the CAS configuration refresh listener.

Tests:
- JAVA_HOME=/tmp/jdk11 ../../gradlew --no-daemon testCasConfiguration --tests org.apereo.cas.support.events.listener.CasConfigurationEventListenerTests
- Locally, CAS 6.6.x also needed a temporary Gradle init script to force org.ajoberstar.grgit:grgit-core from 4.1.0 to 4.1.1 because 4.1.0 was not resolvable from the configured repositories.