### PR TITLE
Avoid reinitializing dispatcher servlet on refresh

### DIFF
--- a/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
+++ b/core/cas-server-core-events-configuration/src/main/java/org/apereo/cas/support/events/listener/DefaultCasConfigurationEventListener.java
@@ -13,7 +13,6 @@ import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
 import org.springframework.context.ApplicationContext;
-import org.springframework.web.servlet.DispatcherServlet;
 
 /**
  * This is {@link DefaultCasConfigurationEventListener}.
@@ -61,11 +60,6 @@ public class DefaultCasConfigurationEventListener implements CasConfigurationEve
         FunctionUtils.doAndHandle(_ -> {
             for (val beanName : applicationContext.getBeanDefinitionNames()) {
                 Objects.requireNonNull(applicationContext.getBean(beanName).getClass());
-            }
-            if (applicationContext.containsBean("dispatcherServlet")) {
-                val servlet = applicationContext.getBean(DispatcherServlet.class);
-                servlet.setApplicationContext(applicationContext);
-                servlet.init();
             }
         });
     }

--- a/core/cas-server-core-events-configuration/src/test/java/org/apereo/cas/support/events/listener/CasConfigurationEventListenerTests.java
+++ b/core/cas-server-core-events-configuration/src/test/java/org/apereo/cas/support/events/listener/CasConfigurationEventListenerTests.java
@@ -9,6 +9,7 @@ import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.support.events.config.CasConfigurationModifiedEvent;
 import org.apereo.cas.test.CasTestExtension;
 import org.apereo.cas.util.spring.boot.SpringBootTestAutoConfigurations;
+import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +20,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * This is {@link CasConfigurationEventListenerTests}.
@@ -59,5 +62,22 @@ class CasConfigurationEventListenerTests {
             new CasConfigurationModifiedEvent(this, true, null)));
         assertDoesNotThrow(() -> applicationContext.publishEvent(
             new RefreshScopeRefreshedEvent()));
+    }
+
+    @Test
+    void verifyDispatcherServletIsNotInitialized() {
+        val context = mock(ConfigurableApplicationContext.class);
+        val dispatcherServlet = new DispatcherServlet();
+        when(context.getBeanDefinitionNames()).thenReturn(new String[] { "dispatcherServlet" });
+        when(context.getBean("dispatcherServlet")).thenReturn(dispatcherServlet);
+        when(context.containsBean("dispatcherServlet")).thenReturn(true);
+        when(context.getBean(DispatcherServlet.class)).thenReturn(dispatcherServlet);
+
+        val listener = new DefaultCasConfigurationEventListener(null, null, null, context);
+        assertDoesNotThrow(() -> listener.onRefreshScopeRefreshed(new RefreshScopeRefreshedEvent()));
+
+        verify(context).getBean("dispatcherServlet");
+        verify(context, never()).containsBean("dispatcherServlet");
+        verify(context, never()).getBean(DispatcherServlet.class);
     }
 }


### PR DESCRIPTION
## Problem

The CAS configuration refresh listener eagerly resolves application context beans after refresh, but it also special-cases the `dispatcherServlet` bean and manually calls `DispatcherServlet.init()`.

That call can run outside the servlet container lifecycle, where no `ServletConfig` is available. This may surface as a `NullPointerException` during refresh.

This was observed downstream in Apache Syncope WA:
https://issues.apache.org/jira/browse/SYNCOPE-1758

## Root Cause

`DefaultCasConfigurationEventListener#initializeBeansEagerly()` currently:
- checks for `dispatcherServlet`
- retrieves `DispatcherServlet.class`
- sets the application context
- calls `servlet.init()`

The refresh listener should eagerly resolve beans as needed, but it should not manually initialize Spring MVC's `DispatcherServlet`. The servlet container/Spring Boot web lifecycle should own that initialization.

## Changes

This removes the special-case reinitialization of Spring's `DispatcherServlet` from the CAS configuration refresh listener.

The listener still eagerly resolves all beans after refresh, but it no longer calls `DispatcherServlet.init()` manually.

## References

- Apache Syncope downstream issue: https://issues.apache.org/jira/browse/SYNCOPE-1758

## Checklist

- [x] Brief description of changes applied
- [x] Test cases for modified changes
- [x] Pull request targets `master`
- [x] Possible limitations or side effects documented
- [x] Related issue referenced

## Tests

- `JAVA_HOME=/tmp/jdk25 ../../gradlew --no-daemon testCasConfiguration --tests org.apereo.cas.support.events.listener.CasConfigurationEventListenerTests`