### PR TITLE
Refactor: Move client secret check to own function for easier overriding.

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/DefaultOAuth20ClientSecretValidator.java
@@ -32,7 +32,7 @@ public class DefaultOAuth20ClientSecretValidator implements OAuth20ClientSecretV
 
         val clientSecretAssigned = SpringExpressionLanguageValueResolver.getInstance().resolve(registeredService.getClientSecret());
         val definedSecret = cipherExecutor.decode(clientSecretAssigned, new Object[]{registeredService});
-        if (!Strings.CI.equals(definedSecret, clientSecret)) {
+        if (!isClientSecretCorrect(definedSecret, clientSecret)) {
             LOGGER.error("Wrong client secret for service: [{}]. If you intend to use PKCE, note that it does not require a client secret and "
                        + "requests generally must not specify a client secret to CAS.\nFurthermore, you must make sure "
                        + "no client secret is assigned to this registered service in the CAS service registry.",
@@ -49,5 +49,9 @@ public class DefaultOAuth20ClientSecretValidator implements OAuth20ClientSecretV
     
     protected boolean isClientSecretUndefined(final OAuthRegisteredService registeredService) {
         return registeredService != null && StringUtils.isBlank(registeredService.getClientSecret());
+    }
+
+    protected boolean isClientSecretCorrect(String definedSecret, String clientSecret) {
+        return Strings.CI.equals(definedSecret, clientSecret);
     }
 }


### PR DESCRIPTION
This PR moves the client secret check to it's own function. As a result, extensions can easily override the check without having to copy all the other checks and transformations performed in `validate`.