### PR TITLE
Make logout propagation configurable in authn delegation

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jBaseClientProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/pac4j/Pac4jBaseClientProperties.java
@@ -98,4 +98,9 @@ public class Pac4jBaseClientProperties implements CasFeatureModule, Serializable
          */
         NONE
     }
+
+    /**
+     * Indicate whether the logout should be propagated from the CAS server to the delegated identity server.
+     */
+    private boolean propagateLogout = true;
 }

--- a/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/pac4j/client/DelegatedIdentityProviderFactory.java
+++ b/support/cas-server-support-pac4j-api/src/main/java/org/apereo/cas/pac4j/client/DelegatedIdentityProviderFactory.java
@@ -132,4 +132,16 @@ public interface DelegatedIdentityProviderFactory extends DisposableBean {
             indirectClient.setCallbackUrlResolver(resolver);
         }
     }
+
+    /**
+     * Configure the logout propagation.
+     *
+     * @param client           the client
+     * @param clientProperties the client properties
+     */
+    static void configureLogoutPropagation(final BaseClient client, final Pac4jBaseClientProperties clientProperties) {
+        if (!clientProperties.isPropagateLogout() && client instanceof final IndirectClient indirectClient) {
+            indirectClient.setLogoutActionBuilder((ctx, profile, url) -> Optional.empty());
+        }
+    }
 }

--- a/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/BaseDelegatedIdentityProviderFactory.java
+++ b/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/clients/BaseDelegatedIdentityProviderFactory.java
@@ -87,6 +87,7 @@ public abstract class BaseDelegatedIdentityProviderFactory implements DelegatedI
             DelegatedIdentityProviderFactory.configureClientName(client, clientProperties.getClientName());
             DelegatedIdentityProviderFactory.configureClientCustomProperties(client, clientProperties);
             DelegatedIdentityProviderFactory.configureClientCallbackUrl(client, clientProperties, casProperties.getServer().getLoginUrl());
+            DelegatedIdentityProviderFactory.configureLogoutPropagation(client, clientProperties);
         }
 
         invokeClientCustomizers(client);

--- a/support/cas-server-support-pac4j-oidc/src/test/java/org/apereo/cas/support/pac4j/clients/DefaultDelegatedIdentityProviderFactoryOidcTests.java
+++ b/support/cas-server-support-pac4j-oidc/src/test/java/org/apereo/cas/support/pac4j/clients/DefaultDelegatedIdentityProviderFactoryOidcTests.java
@@ -7,9 +7,12 @@ import lombok.val;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.pac4j.core.context.CallContext;
+import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.oauth.client.GitHubClient;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.method.PrivateKeyJwtClientAuthnMethodConfig;
+import org.pac4j.test.context.MockWebContext;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import static org.junit.jupiter.api.Assertions.*;
@@ -42,6 +45,45 @@ class DefaultDelegatedIdentityProviderFactoryOidcTests {
             assertEquals(1, clients.size());
             val client = (GitHubClient) clients.getFirst();
             assertEquals("user", client.getScope());
+            assertTrue(client.getLogoutAction(new CallContext(MockWebContext.create(), null), new CommonProfile(), "url").isPresent());
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = {
+            "cas.authn.pac4j.github.scope=user",
+            "cas.authn.pac4j.github.id=12345",
+            "cas.authn.pac4j.github.secret=s3cr3t",
+            "cas.authn.pac4j.github.propagate-logout=true",
+            "cas.authn.pac4j.core.lazy-init=true"
+    })
+    class GitHubClientsPropagateLogout extends BaseTests {
+        @Test
+        void verifyGitHubClient() {
+            val clients = delegatedIdentityProviderFactory.build();
+            assertEquals(1, clients.size());
+            val client = (GitHubClient) clients.getFirst();
+            assertEquals("user", client.getScope());
+            assertTrue(client.getLogoutAction(new CallContext(MockWebContext.create(), null), new CommonProfile(), "url").isPresent());
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = {
+            "cas.authn.pac4j.github.scope=user",
+            "cas.authn.pac4j.github.id=12345",
+            "cas.authn.pac4j.github.secret=s3cr3t",
+            "cas.authn.pac4j.github.propagate-logout=false",
+            "cas.authn.pac4j.core.lazy-init=true"
+    })
+    class GitHubClientsDontPropagateLogout extends BaseTests {
+        @Test
+        void verifyGitHubClient() {
+            val clients = delegatedIdentityProviderFactory.build();
+            assertEquals(1, clients.size());
+            val client = (GitHubClient) clients.getFirst();
+            assertEquals("user", client.getScope());
+            assertFalse(client.getLogoutAction(new CallContext(MockWebContext.create(), null), new CommonProfile(), "url").isPresent());
         }
     }
 

--- a/support/cas-server-support-pac4j-saml/src/main/java/org/apereo/cas/web/saml2/DelegatedClientSaml2Builder.java
+++ b/support/cas-server-support-pac4j-saml/src/main/java/org/apereo/cas/web/saml2/DelegatedClientSaml2Builder.java
@@ -267,6 +267,7 @@ public class DelegatedClientSaml2Builder implements ConfigurableDelegatedClientB
         DelegatedIdentityProviderFactory.configureClientName(singleClient, clientName);
         DelegatedIdentityProviderFactory.configureClientCustomProperties(singleClient, saml2Properties);
         DelegatedIdentityProviderFactory.configureClientCallbackUrl(singleClient, saml2Properties, properties.getServer().getLoginUrl());
+        DelegatedIdentityProviderFactory.configureLogoutPropagation(singleClient, saml2Properties);
         singleClient.getCustomProperties().put(ClientCustomPropertyConstants.CLIENT_CUSTOM_PROPERTY_IDENTITY_PROVIDER_METADATA_AGGREGATE, true);
 
         val idpSSODescriptor = entityDescriptor.getIDPSSODescriptor(SAMLConstants.SAML20P_NS);


### PR DESCRIPTION
The idea here is to add a new property when configuring a pac4j client to allow blocking the logout propagation from the CAS server to the delegated identity server in the case of authn delegation.