### PR TITLE
Fix the 'Application Events' tab in Palantir

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir-cas-events.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir-cas-events.js
@@ -22,7 +22,7 @@ async function initializeCasEventsOperations() {
                             casEventsTable.clear();
                             const jsonEvents = JSON.parse(response);
                             if (jsonEvents.length > 0) {
-                                for (const entry of Object.values(jsonEvents[1])) {
+                                for (const entry of jsonEvents) {
                                     const geoLocation = `${entry?.properties?.geoLatitude ?? ""} ${entry?.properties?.geoLongitude ?? ""} ${entry?.properties?.geoAccuracy ?? ""}`.trim();
                                     casEventsTable.row.add({
                                         0: `<code>${entry?.creationTime ?? "N/A"}</code>`,


### PR DESCRIPTION
Currently, the `Application Events` tab in Palantir returns a list of "N/A" lines (at best).

We can see that in the `CasEventsReportEndpoint.events`, an array of events is returned .

The original JS code does:

```javascript
for (const entry of Object.values(jsonEvents[1])) {
```

to iterate through the events while the correct code is simply:

```javascript
for (const entry of jsonEvents) {
```

This PR fixes this issue.
