### PR TITLE
feat: fail oauth authorization request when unsupported scope is requested

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/authorization/BaseOAuth20AuthorizationRequestValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/authorization/BaseOAuth20AuthorizationRequestValidator.java
@@ -1,6 +1,8 @@
 package org.apereo.cas.support.oauth.validator.authorization;
 
 import module java.base;
+import java.util.HashSet;
+import java.util.Set;
 import org.apereo.cas.audit.AuditableContext;
 import org.apereo.cas.audit.AuditableExecution;
 import org.apereo.cas.authentication.principal.ServiceFactory;
@@ -19,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apereo.cas.util.CollectionUtils;
 import org.pac4j.core.context.WebContext;
 
 /**
@@ -65,7 +68,12 @@ public abstract class BaseOAuth20AuthorizationRequestValidator implements OAuth2
         }
 
         val responseType = getResponseTypeFromRequest(context);
-        return verifyResponseType(context, responseType);
+        if (!verifyResponseType(context, responseType)) {
+            return false;
+        }
+
+        val requestedScopes = getRequestedScopesFromRequest(context);
+        return verifyRequestedScopes(context, registeredService, requestedScopes, clientId);
     }
 
     protected String getResponseTypeFromRequest(final WebContext context) {
@@ -78,6 +86,11 @@ public abstract class BaseOAuth20AuthorizationRequestValidator implements OAuth2
 
     protected String getClientIdFromRequest(final WebContext context) {
         return requestParameterResolver.resolveRequestParameter(context, OAuth20Constants.CLIENT_ID).orElse(StringUtils.EMPTY);
+    }
+
+    protected Set<String> getRequestedScopesFromRequest(final WebContext context) {
+        val parameterValues = requestParameterResolver.resolveRequestParameter(context, OAuth20Constants.SCOPE);
+        return parameterValues.map(s -> CollectionUtils.wrapSet(s.split(" "))).orElseGet(HashSet::new);
     }
 
     protected OAuthRegisteredService verifyRegisteredServiceByClientId(final WebContext context, final String clientId) throws Throwable {
@@ -168,6 +181,23 @@ public abstract class BaseOAuth20AuthorizationRequestValidator implements OAuth2
             setErrorDetails(context, OAuth20Constants.UNSUPPORTED_RESPONSE_TYPE,
                 String.format("Unsupported response_type: [%s]", responseType), true);
 
+            return false;
+        }
+        return true;
+    }
+
+    private boolean verifyRequestedScopes(final WebContext context, final OAuthRegisteredService registeredService,
+                                          final Set<String> requestedScopes, final String clientId) {
+        Set<String> supportedScopes = registeredService.getScopes();
+        requestedScopes.removeAll(supportedScopes);
+
+        if (!requestedScopes.isEmpty()) {
+            LOGGER.warn("Client [{}] has requested scopes {}, which are not supported by the service.",
+                clientId, requestedScopes);
+            setErrorDetails(context, OAuth20Constants.INVALID_SCOPE,
+                String.format("Client [%s] has requested scopes %s, which are not supported by the service",
+                    clientId, requestedScopes),
+                true);
             return false;
         }
         return true;

--- a/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/validator/authorization/OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidatorTests.java
+++ b/support/cas-server-support-oauth/src/test/java/org/apereo/cas/support/oauth/validator/authorization/OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidatorTests.java
@@ -36,7 +36,8 @@ class OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidatorTests ext
 
     @Test
     void verifyUnsignedRequestParameter() throws Throwable {
-        addRegisteredService(Set.of(), "client", UUID.randomUUID().toString(), "https://.+");
+        val service = addRegisteredService(Set.of(), "client", UUID.randomUUID().toString(), "https://.+");
+        service.setScopes(Set.of("openid"));
         val validator = getValidator(servicesManager);
 
         val request = new MockHttpServletRequest();
@@ -113,6 +114,17 @@ class OAuth20AuthorizationCodeResponseTypeAuthorizationRequestValidatorTests ext
         assertTrue(validator.supports(context));
         assertFalse(validator.validate(context));
         assertTrue(context.getRequestAttribute(OAuth20Constants.ERROR).isPresent());
+
+        request.removeAttribute(OAuth20Constants.ERROR);
+        request.setParameter(OAuth20Constants.SCOPE, "unknown-scope");
+        service.setScopes(Set.of("supported-scope"));
+        assertFalse(validator.supports(context));
+        assertTrue(context.getRequestAttribute(OAuth20Constants.ERROR).isPresent());
+        assertEquals(OAuth20Constants.INVALID_SCOPE, context.getRequestAttribute(OAuth20Constants.ERROR).get().toString());
+
+        request.removeAttribute(OAuth20Constants.ERROR);
+        request.setParameter(OAuth20Constants.SCOPE, "supported-scope");
+        assertTrue(validator.supports(context));
 
         request.removeAttribute(OAuth20Constants.ERROR);
         request.setParameter(OAuth20Constants.REDIRECT_URI, "unknown-uri");


### PR DESCRIPTION
If an authorization request includes a scope not supported by the registered service, CAS would silently ignore it. This PR changes that behaviour to return an error response whenever a scope not defined by the service is requested.

This behaviour should possibly be configurable, but opening this PR in a base variant to start a discussion.

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] Test cases to demonstrate the problem before the fix, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test, etc
- [x] Any possible limitations, side effects, performance issues, etc
- [x] Reference any other pull requests that might be related