### PR TITLE
feat: always add error message to context when validating an oauth re…

### DIFF
--- a/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/authorization/BaseOAuth20AuthorizationRequestValidator.java
+++ b/support/cas-server-support-oauth-core-api/src/main/java/org/apereo/cas/support/oauth/validator/authorization/BaseOAuth20AuthorizationRequestValidator.java
@@ -97,7 +97,8 @@ public abstract class BaseOAuth20AuthorizationRequestValidator implements OAuth2
         if (accessResult.isExecutionFailure()) {
             LOGGER.warn("Registered service [{}] is not found or is not authorized for access.",
                 ObjectUtils.getIfNull(registeredService, clientId));
-            setErrorDetails(context, OAuth20Constants.INVALID_REQUEST, StringUtils.EMPTY, false);
+            setErrorDetails(context, OAuth20Constants.INVALID_REQUEST,
+                String.format("Service [%s] is not found or is not authorized for access", clientId), false);
             return null;
         }
         return registeredService;
@@ -149,7 +150,8 @@ public abstract class BaseOAuth20AuthorizationRequestValidator implements OAuth2
         if (!OAuth20Utils.checkCallbackValid(registeredService, redirectUri)) {
             LOGGER.warn("Redirect URI [{}] found in the request is not authorized for registered service [{}].",
                 redirectUri, registeredService.getServiceId());
-            setErrorDetails(context, OAuth20Constants.INVALID_REQUEST, StringUtils.EMPTY, false);
+            setErrorDetails(context, OAuth20Constants.INVALID_REQUEST,
+                String.format("Redirect URI [%s] found in the request, or is not authorized for this service", redirectUri), false);
             return false;
         }
         return true;


### PR DESCRIPTION
When the validation of an oauth authorization request fails, an error is put into the context along with a description. On some cases the description was missing and was not put into the context. This PR adds the error description in the two cases, where it was missing.

In the upstream CAS the error description is not displayed on authorize error page, it is only used on error callback to the service. That is probably the reason why the error description was not present in these cases. However, the views can be customized downstream and the error descriptions should be available there.

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] Test cases to demonstrate the problem before the fix, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test, etc
- [x] Any possible limitations, side effects, performance issues, etc
- [x] Reference any other pull requests that might be related
