### PR TITLE
Supplement WebAuthn support

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mfa/webauthn/WebAuthnMultifactorAuthenticationCoreProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/mfa/webauthn/WebAuthnMultifactorAuthenticationCoreProperties.java
@@ -140,7 +140,17 @@ public class WebAuthnMultifactorAuthenticationCoreProperties implements Serializ
      * to use the primary device to authenticate for security or other practical reasons.
      */
     private boolean qrCodeAuthenticationEnabled;
-    
+
+    /**
+     * Defines the authenticator attachment: CROSS_PLATFORM or PLATFORM.
+     */
+    private String authenticatorAttachment;
+
+    /**
+     * Defines the user verification requirement: DISCOURAGED, PREFERRED or REQUIRED.
+     */
+    private String userVerificationRequirement;
+
     public WebAuthnMultifactorAuthenticationCoreProperties() {
         trustSource.getTrustedDeviceMetadata().setLocation(new ClassPathResource("webauthn-metadata.json"));
     }

--- a/support/cas-server-support-webauthn-core/src/main/java/com/yubico/core/WebAuthnServer.java
+++ b/support/cas-server-support-webauthn-core/src/main/java/com/yubico/core/WebAuthnServer.java
@@ -1,5 +1,6 @@
 package com.yubico.core;
 import module java.base;
+import com.yubico.webauthn.data.*;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -25,12 +26,6 @@ import com.yubico.webauthn.StartAssertionOptions;
 import com.yubico.webauthn.StartRegistrationOptions;
 import com.yubico.webauthn.attestation.Attestation;
 import com.yubico.webauthn.attestation.AttestationMetadataSource;
-import com.yubico.webauthn.data.AuthenticatorData;
-import com.yubico.webauthn.data.AuthenticatorSelectionCriteria;
-import com.yubico.webauthn.data.AuthenticatorTransport;
-import com.yubico.webauthn.data.ByteArray;
-import com.yubico.webauthn.data.ResidentKeyRequirement;
-import com.yubico.webauthn.data.UserIdentity;
 import com.yubico.webauthn.exception.AssertionFailedException;
 import com.yubico.webauthn.exception.RegistrationFailedException;
 import lombok.AllArgsConstructor;
@@ -84,6 +79,12 @@ public class WebAuthnServer {
                     .build()
             );
 
+            val authenticatorAttachementProperty = casProperties.getAuthn().getMfa().getWebAuthn().getCore().getAuthenticatorAttachment();
+            val authenticatorAttachement = authenticatorAttachementProperty != null
+                    ? AuthenticatorAttachment.valueOf(authenticatorAttachementProperty) : null;
+            val userVerificationRequirementProperty = casProperties.getAuthn().getMfa().getWebAuthn().getCore().getUserVerificationRequirement();
+            val userVerificationRequirement = userVerificationRequirementProperty != null
+                    ? UserVerificationRequirement.valueOf(userVerificationRequirementProperty) : null;
             val registrationRequest = new RegistrationRequest(
                 username,
                 credentialNickname,
@@ -92,6 +93,8 @@ public class WebAuthnServer {
                     StartRegistrationOptions.builder()
                         .user(registrationUserId)
                         .authenticatorSelection(AuthenticatorSelectionCriteria.builder()
+                            .authenticatorAttachment(authenticatorAttachement)
+                            .userVerification(userVerificationRequirement)
                             .residentKey(residentKeyRequirement)
                             .build()
                         )

--- a/support/cas-server-support-webauthn-core/src/main/java/com/yubico/core/WebAuthnServer.java
+++ b/support/cas-server-support-webauthn-core/src/main/java/com/yubico/core/WebAuthnServer.java
@@ -1,6 +1,6 @@
 package com.yubico.core;
+
 import module java.base;
-import com.yubico.webauthn.data.*;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -26,6 +26,14 @@ import com.yubico.webauthn.StartAssertionOptions;
 import com.yubico.webauthn.StartRegistrationOptions;
 import com.yubico.webauthn.attestation.Attestation;
 import com.yubico.webauthn.attestation.AttestationMetadataSource;
+import com.yubico.webauthn.data.AuthenticatorAttachment;
+import com.yubico.webauthn.data.AuthenticatorData;
+import com.yubico.webauthn.data.AuthenticatorSelectionCriteria;
+import com.yubico.webauthn.data.AuthenticatorTransport;
+import com.yubico.webauthn.data.ByteArray;
+import com.yubico.webauthn.data.ResidentKeyRequirement;
+import com.yubico.webauthn.data.UserIdentity;
+import com.yubico.webauthn.data.UserVerificationRequirement;
 import com.yubico.webauthn.exception.AssertionFailedException;
 import com.yubico.webauthn.exception.RegistrationFailedException;
 import lombok.AllArgsConstructor;

--- a/support/cas-server-support-webauthn/src/test/java/org/apereo/cas/webauthn/WebAuthnServerTests.java
+++ b/support/cas-server-support-webauthn/src/test/java/org/apereo/cas/webauthn/WebAuthnServerTests.java
@@ -1,0 +1,155 @@
+package org.apereo.cas.webauthn;
+
+import module java.base;
+import org.apereo.cas.test.CasTestExtension;
+import org.apereo.cas.webauthn.web.flow.BaseWebAuthnWebflowTests;
+import com.yubico.core.WebAuthnServer;
+import com.yubico.webauthn.data.AuthenticatorAttachment;
+import com.yubico.webauthn.data.ResidentKeyRequirement;
+import com.yubico.webauthn.data.UserVerificationRequirement;
+import lombok.val;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is {@link WebAuthnServerTests}.
+ *
+ * @author Jerome LELEU
+ * @since 8.0.0
+ */
+@Tag("MFAProvider")
+@ExtendWith(CasTestExtension.class)
+class WebAuthnServerTests {
+
+    abstract class BaseWebAuthnServerStartRegistrationIntegrationTests {
+        @Autowired
+        @Qualifier("webAuthnServer")
+        private WebAuthnServer webAuthnServer;
+
+        protected abstract AuthenticatorAttachment expectedAuthenticatorAttachment();
+
+        protected abstract UserVerificationRequirement expectedUserVerificationRequirement();
+
+        protected abstract ResidentKeyRequirement requestedResidentKeyRequirement();
+
+        @Test
+        void verifyOperation() {
+            val request = new MockHttpServletRequest();
+            val username = UUID.randomUUID().toString();
+            val registration = webAuthnServer.startRegistration(
+                    request,
+                    username,
+                    Optional.of("CAS User"),
+                    Optional.of("key"),
+                    requestedResidentKeyRequirement(),
+                    Optional.empty()
+            );
+
+            assertTrue(registration.isRight());
+            val options = registration.right().orElseThrow().publicKeyCredentialCreationOptions();
+            val authenticatorSelection = options.getAuthenticatorSelection().orElseThrow();
+            assertEquals(expectedAuthenticatorAttachment(), authenticatorSelection.getAuthenticatorAttachment().orElse(null));
+            assertEquals(expectedUserVerificationRequirement(), authenticatorSelection.getUserVerification().orElse(null));
+            assertEquals(requestedResidentKeyRequirement(), authenticatorSelection.getResidentKey().orElseThrow());
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = BaseWebAuthnWebflowTests.SharedTestConfiguration.class,
+            properties = "cas.server.name=https://localhost:8443")
+    class WebAuthnServerStartRegistrationNullIntegrationTests extends BaseWebAuthnServerStartRegistrationIntegrationTests {
+        @Override
+        protected AuthenticatorAttachment expectedAuthenticatorAttachment() {
+            return null;
+        }
+
+        @Override
+        protected UserVerificationRequirement expectedUserVerificationRequirement() {
+            return null;
+        }
+
+        @Override
+        protected ResidentKeyRequirement requestedResidentKeyRequirement() {
+            return ResidentKeyRequirement.REQUIRED;
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = BaseWebAuthnWebflowTests.SharedTestConfiguration.class,
+            properties = {
+                    "cas.server.name=https://localhost:8443",
+                    "cas.authn.mfa.web-authn.core.authenticator-attachment=PLATFORM",
+                    "cas.authn.mfa.web-authn.core.user-verification-requirement=REQUIRED"
+            })
+    class WebAuthnServerStartRegistrationPlatformRequiredIntegrationTests extends BaseWebAuthnServerStartRegistrationIntegrationTests {
+        @Override
+        protected AuthenticatorAttachment expectedAuthenticatorAttachment() {
+            return AuthenticatorAttachment.PLATFORM;
+        }
+
+        @Override
+        protected UserVerificationRequirement expectedUserVerificationRequirement() {
+            return UserVerificationRequirement.REQUIRED;
+        }
+
+        @Override
+        protected ResidentKeyRequirement requestedResidentKeyRequirement() {
+            return ResidentKeyRequirement.REQUIRED;
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = BaseWebAuthnWebflowTests.SharedTestConfiguration.class,
+            properties = {
+                    "cas.server.name=https://localhost:8443",
+                    "cas.authn.mfa.web-authn.core.authenticator-attachment=CROSS_PLATFORM",
+                    "cas.authn.mfa.web-authn.core.user-verification-requirement=DISCOURAGED"
+            })
+    class WebAuthnServerStartRegistrationCrossPlatformDiscouragedIntegrationTests extends BaseWebAuthnServerStartRegistrationIntegrationTests {
+        @Override
+        protected AuthenticatorAttachment expectedAuthenticatorAttachment() {
+            return AuthenticatorAttachment.CROSS_PLATFORM;
+        }
+
+        @Override
+        protected UserVerificationRequirement expectedUserVerificationRequirement() {
+            return UserVerificationRequirement.DISCOURAGED;
+        }
+
+        @Override
+        protected ResidentKeyRequirement requestedResidentKeyRequirement() {
+            return ResidentKeyRequirement.DISCOURAGED;
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = BaseWebAuthnWebflowTests.SharedTestConfiguration.class,
+            properties = {
+                    "cas.server.name=https://localhost:8443",
+                    "cas.authn.mfa.web-authn.core.authenticator-attachment=PLATFORM",
+                    "cas.authn.mfa.web-authn.core.user-verification-requirement=PREFERRED"
+            })
+    class WebAuthnServerStartRegistrationPlatformPreferredIntegrationTests extends BaseWebAuthnServerStartRegistrationIntegrationTests {
+        @Override
+        protected AuthenticatorAttachment expectedAuthenticatorAttachment() {
+            return AuthenticatorAttachment.PLATFORM;
+        }
+
+        @Override
+        protected UserVerificationRequirement expectedUserVerificationRequirement() {
+            return UserVerificationRequirement.PREFERRED;
+        }
+
+        @Override
+        protected ResidentKeyRequirement requestedResidentKeyRequirement() {
+            return ResidentKeyRequirement.DISCOURAGED;
+        }
+    }
+}


### PR DESCRIPTION
The `authenticatorAttachement` and `userVerificationRequirement` are interesting options for the WebAuthn protocol.

This PR allows to set them in the CAS configuration. Tests confirm the behavior.
