### PR TITLE
allow redis-modules to use sentinel config

### DIFF
--- a/support/cas-server-support-redis-modules/src/main/java/org/apereo/cas/redis/modules/LettuceRedisModulesOperations.java
+++ b/support/cas-server-support-redis-modules/src/main/java/org/apereo/cas/redis/modules/LettuceRedisModulesOperations.java
@@ -16,6 +16,7 @@ import lombok.val;
 import org.springframework.util.StringUtils;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -61,18 +62,28 @@ public class LettuceRedisModulesOperations implements RedisModulesOperations {
      */
     public static RediSearchCommands newRediSearchCommands(
         final BaseRedisProperties redis, final CasSSLContext casSslContext) throws Exception {
-        val uriBuilder = RedisURI.builder()
+        var uriBuilder = RedisURI.builder()
             .withStartTls(redis.isStartTls())
             .withVerifyPeer(redis.isVerifyPeer())
-            .withHost(redis.getHost())
-            .withPort(redis.getPort())
             .withDatabase(redis.getDatabase())
             .withSsl(redis.isUseSsl());
 
         if (StringUtils.hasText(redis.getUsername()) && StringUtils.hasText(redis.getPassword())) {
-            uriBuilder.withAuthentication(redis.getUsername(), redis.getPassword());
+            uriBuilder = uriBuilder.withAuthentication(redis.getUsername(), redis.getPassword());
         } else if (StringUtils.hasText(redis.getPassword())) {
-            uriBuilder.withPassword(redis.getPassword().toCharArray());
+            uriBuilder = uriBuilder.withPassword(redis.getPassword().toCharArray());
+        }
+        if (redis.getSentinel() != null && StringUtils.hasText(redis.getSentinel().getMaster())) {
+            uriBuilder = uriBuilder.withSentinelMasterId(redis.getSentinel().getMaster());
+            val nodes = redis.getSentinel().getNode();
+            for (val node : nodes) {
+                val hostAndPort = Objects.requireNonNull(StringUtils.split(node, ":"));
+                uriBuilder = uriBuilder.withSentinel(hostAndPort[0],
+                    Integer.parseInt(hostAndPort[1]),
+                    redis.getSentinel().getPassword());
+            }
+        } else {
+            uriBuilder = uriBuilder.withHost(redis.getHost()).withPort(redis.getPort());
         }
 
         val redisModulesClient = RedisModulesClient.create(uriBuilder.build());

--- a/support/cas-server-support-redis-modules/src/test/java/org/apereo/cas/redis/modules/RedisModulesOperationsTests.java
+++ b/support/cas-server-support-redis-modules/src/test/java/org/apereo/cas/redis/modules/RedisModulesOperationsTests.java
@@ -1,13 +1,22 @@
 package org.apereo.cas.redis.modules;
 
 import org.apereo.cas.authentication.CasSSLContext;
+import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.configuration.model.support.redis.BaseRedisProperties;
+import org.apereo.cas.test.CasTestExtension;
 import org.apereo.cas.util.junit.EnabledIfListeningOnPort;
 import io.lettuce.core.search.arguments.NumericFieldArgs;
 import io.lettuce.core.search.arguments.TextFieldArgs;
 import lombok.val;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import java.io.File;
 import java.util.List;
 import java.util.UUID;
@@ -22,54 +31,88 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("Redis")
 @EnabledIfListeningOnPort(port = 6379)
 class RedisModulesOperationsTests {
-    @Test
-    void verifyConnectionWithUsernamePassword() throws Throwable {
-        val props = new BaseRedisProperties();
-        props.setHost("localhost");
-        props.setPort(16389);
-        props.setUsername("default");
-        props.setPassword("pAssw0rd123");
-        val connection = LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.disabled());
-        assertNotNull(connection);
+
+    @Nested
+    class DefaultTests {
+        @Test
+        void verifyConnectionWithUsernamePassword() throws Throwable {
+            val props = new BaseRedisProperties();
+            props.setHost("localhost");
+            props.setPort(16389);
+            props.setUsername("default");
+            props.setPassword("pAssw0rd123");
+            val connection = LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.disabled());
+            assertNotNull(connection);
+        }
+
+        @Test
+        void verifyRedisSearchCommandSupported() throws Throwable {
+            val props = new BaseRedisProperties();
+            props.setHost("localhost");
+            props.setPort(6379);
+            val command = LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.disabled());
+            val indexName = UUID.randomUUID().toString();
+            val result = command.ftCreate(indexName,
+                List.of(TextFieldArgs.builder().name("name").build(), NumericFieldArgs.builder().name("id").build()));
+            assertEquals("OK", result);
+            val info = command.ftInfo(indexName);
+            assertNotNull(info);
+        }
+
+        @Test
+        void verifyConnectionWithUsernamePasswordOverTls() throws Throwable {
+            val props = new BaseRedisProperties();
+            props.setHost("localhost");
+            props.setPort(16669);
+            props.setUsername("default");
+            props.setPassword("pAssw0rd123");
+            props.setKeyCertificateChainFile(new File("../../ci/tests/redis/certs/redis.crt"));
+            props.setKeyFile(new File("../../ci/tests/redis/certs/redis.key"));
+            props.setVerifyPeer(false);
+            props.setUseSsl(true);
+            val connection = LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.disabled());
+            assertNotNull(connection);
+            assertDoesNotThrow(connection::ftList);
+        }
+
+        @Test
+        void verifyConnectionWithPassword() {
+            val props = new BaseRedisProperties();
+            props.setHost("localhost");
+            props.setPort(16389);
+            props.setUsername(null);
+            props.setPassword("pAssw0rd123");
+            assertDoesNotThrow(() -> LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.system()));
+        }
     }
 
-    @Test
-    void verifyRedisSearchCommandSupported() throws Throwable {
-        val props = new BaseRedisProperties();
-        props.setHost("localhost");
-        props.setPort(6379);
-        val command = LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.disabled());
-        val indexName = UUID.randomUUID().toString();
-        val result = command.ftCreate(indexName,
-            List.of(TextFieldArgs.builder().name("name").build(), NumericFieldArgs.builder().name("id").build()));
-        assertEquals("OK", result);
-        val info = command.ftInfo(indexName);
-        assertNotNull(info);
-    }
+    @Nested
+    @SpringBootTest(
+        classes = AopAutoConfiguration.class,
+        properties = {
+            "cas.ticket.registry.redis.protocol-version=RESP2",
+            "cas.ticket.registry.redis.host=localhost",
+            "cas.ticket.registry.redis.port=6379",
+            "cas.ticket.registry.redis.read-from=MASTER",
 
-    @Test
-    void verifyConnectionWithUsernamePasswordOverTls() throws Throwable {
-        val props = new BaseRedisProperties();
-        props.setHost("localhost");
-        props.setPort(16669);
-        props.setUsername("default");
-        props.setPassword("pAssw0rd123");
-        props.setKeyCertificateChainFile(new File("../../ci/tests/redis/certs/redis.crt"));
-        props.setKeyFile(new File("../../ci/tests/redis/certs/redis.key"));
-        props.setVerifyPeer(false);
-        props.setUseSsl(true);
-        val connection = LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.disabled());
-        assertNotNull(connection);
-        assertDoesNotThrow(connection::ftList);
-    }
+            "cas.ticket.registry.redis.sentinel.master=mymaster",
+            "cas.ticket.registry.redis.sentinel.password=password456",
+            "cas.ticket.registry.redis.sentinel.node[0]=localhost:26379",
+            "cas.ticket.registry.redis.sentinel.node[1]=localhost:26380",
+            "cas.ticket.registry.redis.sentinel.node[2]=localhost:26381"
+        })
+    @EnableScheduling
+    @EnableConfigurationProperties(CasConfigurationProperties.class)
+    @ExtendWith(CasTestExtension.class)
+    class SentinelTests {
+        @Autowired
+        private CasConfigurationProperties casProperties;
 
-    @Test
-    void verifyConnectionWithPassword() {
-        val props = new BaseRedisProperties();
-        props.setHost("localhost");
-        props.setPort(16389);
-        props.setUsername(null);
-        props.setPassword("pAssw0rd123");
-        assertDoesNotThrow(() -> LettuceRedisModulesOperations.newRediSearchCommands(props, CasSSLContext.system()));
+        @Test
+        void verifySentinelConfig() throws Throwable {
+            val redis = casProperties.getTicket().getRegistry().getRedis();
+            val connection = LettuceRedisModulesOperations.newRediSearchCommands(redis, CasSSLContext.disabled());
+            assertNotNull(connection);
+        }
     }
 }


### PR DESCRIPTION
(cherry picked from commit 0d3343b222c48b289afcbc7839dd38e779d22478)

This backports a change to allow use of redis search with sentinel config and not having to specify a host/port for redis. 

```
master: https://github.com/apereo/cas/commit/0d3343b222c48b289afcbc7839dd38e779d22478
```
