### PR TITLE
Ensure failed LDAP operations are logged at WARN or higher level

### DIFF
--- a/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapConnectionFactory.java
+++ b/support/cas-server-support-ldap-core/src/main/java/org/apereo/cas/util/LdapConnectionFactory.java
@@ -21,7 +21,7 @@ import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
 import org.ldaptive.ModifyOperation;
 import org.ldaptive.ModifyRequest;
-import org.ldaptive.ResultCode;
+import org.ldaptive.Result;
 import org.ldaptive.ReturnAttributes;
 import org.ldaptive.SearchOperation;
 import org.ldaptive.SearchResponse;
@@ -52,8 +52,7 @@ public class LdapConnectionFactory implements Closeable {
         return FunctionUtils.doAndHandle(() -> {
             val operation = new AddOperation(connectionFactory);
             val response = operation.execute(new AddRequest(entry.getDn(), entry.getAttributes()));
-            LOGGER.debug("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
-            return response.getResultCode() == ResultCode.SUCCESS;
+            return logAndReturnSuccessFlag("LDAP add operation", response);
         }, e -> false).get();
     }
 
@@ -69,8 +68,7 @@ public class LdapConnectionFactory implements Closeable {
             val delete = new DeleteOperation(connectionFactory);
             val request = new DeleteRequest(entry.getDn());
             val response = delete.execute(request);
-            LOGGER.debug("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
-            return response.getResultCode() == ResultCode.SUCCESS;
+            return logAndReturnSuccessFlag("LDAP delete operation", response);
         }, e -> false).get();
     }
 
@@ -97,8 +95,7 @@ public class LdapConnectionFactory implements Closeable {
                 .toArray(AttributeModification[]::new);
             val request = new ModifyRequest(currentDn, mods);
             val response = operation.execute(request);
-            LOGGER.debug("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
-            return response.getResultCode() == ResultCode.SUCCESS;
+            return logAndReturnSuccessFlag("LDAP modify operation", response);
         }, e -> false).get();
     }
 
@@ -153,14 +150,21 @@ public class LdapConnectionFactory implements Closeable {
         @Nullable
         final String[] binaryAttributes,
         final String[] returnAttributes) throws LdapException {
-        val request = LdapUtils.newLdaptiveSearchRequest(baseDn, filter, binaryAttributes, returnAttributes);
-        if (pageSize <= 0) {
-            val searchOperation = new SearchOperation(connectionFactory);
-            searchOperation.setSearchResultHandlers(new FollowSearchReferralHandler());
-            return searchOperation.execute(request);
+        try {
+            val request = LdapUtils.newLdaptiveSearchRequest(baseDn, filter, binaryAttributes, returnAttributes);
+            if (pageSize <= 0) {
+                val searchOperation = new SearchOperation(connectionFactory);
+                searchOperation.setSearchResultHandlers(new FollowSearchReferralHandler());
+                return searchOperation.execute(request);
+            }
+            val client = new PagedResultsClient(connectionFactory, pageSize);
+            return client.executeToCompletion(request);
+        } catch (final LdapException e) {
+            LOGGER.error("LDAP search operation failed for URL [{}], baseDn [{}], filter [{}]: [{}]",
+                connectionFactory.getConnectionConfig().getLdapUrl(), baseDn, filter, e.getMessage());
+            LOGGER.debug("LDAP search operation failure details", e);
+            throw e;
         }
-        val client = new PagedResultsClient(connectionFactory, pageSize);
-        return client.executeToCompletion(request);
     }
 
     /**
@@ -197,7 +201,7 @@ public class LdapConnectionFactory implements Closeable {
      * letting user change their own (e.g. expiring) password.
      */
     public boolean executePasswordModifyOperation(final String currentDn,
-                                                  final char[] oldPassword,
+                                                  final char @Nullable [] oldPassword,
                                                   final char[] newPassword,
                                                   final AbstractLdapProperties.LdapType type) {
         try {
@@ -223,22 +227,26 @@ public class LdapConnectionFactory implements Closeable {
                     operation.execute(new ModifyRequest(currentDn,
                         new AttributeModification(AttributeModification.Type.REPLACE, new UnicodePwdAttribute(new String(newPassword)))));
 
-                val success = response.getResultCode() == ResultCode.SUCCESS;
-                val logLevel = success ? LOGGER.atDebug() : LOGGER.atError();
-                logLevel.log("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
-                return success;
+                return logAndReturnSuccessFlag("Active Directory password modification", response);
             }
 
             LOGGER.debug("Executing password modification op for generic LDAP");
             val operation = new ExtendedOperation(connectionFactory);
             val response = operation.execute(new PasswordModifyRequest(currentDn,
                 oldPasswordAvailable ? new String(oldPassword) : null, new String(newPassword)));
-            LOGGER.debug("Result code [{}], message: [{}]", response.getResultCode(), response.getDiagnosticMessage());
-            return response.getResultCode() == ResultCode.SUCCESS;
+            return logAndReturnSuccessFlag("Generic LDAP password modification", response);
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
         }
         return false;
+    }
+
+    private boolean logAndReturnSuccessFlag(final String operation, final Result response) {
+        val success = response.isSuccess();
+        val logLevel = success ? LOGGER.atDebug() : LOGGER.atError();
+        logLevel.log("{} result code [{}], message: [{}]",
+            operation, response.getResultCode(), response.getDiagnosticMessage());
+        return success;
     }
 
     @Override

--- a/support/cas-server-support-ldap-core/src/test/java/org/apereo/cas/util/LdapConnectionFactoryTests.java
+++ b/support/cas-server-support-ldap-core/src/test/java/org/apereo/cas/util/LdapConnectionFactoryTests.java
@@ -1,0 +1,122 @@
+package org.apereo.cas.util;
+
+import module java.base;
+import lombok.Getter;
+import lombok.val;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.ConnectionFactory;
+import org.ldaptive.DeleteOperation;
+import org.ldaptive.DeleteRequest;
+import org.ldaptive.DeleteResponse;
+import org.ldaptive.FilterTemplate;
+import org.ldaptive.LdapEntry;
+import org.ldaptive.LdapException;
+import org.ldaptive.ResultCode;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * This is {@link LdapConnectionFactoryTests}.
+ *
+ * @author Hal Deadman
+ * @since 8.0.0
+ */
+@Tag("Ldap")
+class LdapConnectionFactoryTests {
+
+    @Test
+    void verifySearchFailureIsLoggedAtWarnOrHigher() throws Exception {
+        val context = LoggerContext.getContext(false);
+        val config = context.getConfiguration();
+        val loggerConfig = config.getLoggerConfig(LdapConnectionFactory.class.getName());
+        val appender = new InMemoryLogAppender("LdapConnectionFactoryTestsAppender");
+        appender.start();
+        loggerConfig.addAppender(appender, Level.WARN, null);
+        context.updateLoggers();
+
+        try {
+            val connectionFactory = mock(ConnectionFactory.class);
+            val connectionConfig = mock(ConnectionConfig.class);
+            when(connectionFactory.getConnectionConfig()).thenReturn(connectionConfig);
+            when(connectionConfig.getLdapUrl()).thenReturn("ldaps://localhost:10636");
+            when(connectionFactory.getConnection()).thenThrow(new LdapException("INVALID_CREDENTIALS data 52e"));
+
+            val filter = new FilterTemplate("(cn={user})");
+            filter.setParameter("user", "casuser");
+
+            try (val wrapper = new LdapConnectionFactory(connectionFactory)) {
+                assertThrows(LdapException.class, () -> wrapper.executeSearchOperation("dc=example,dc=org", filter, 0, "cn"));
+            }
+            assertTrue(appender.getEvents().stream().anyMatch(event ->
+                event.getLevel().isMoreSpecificThan(Level.WARN)
+                    && event.getMessage().getFormattedMessage().contains("LDAP search operation failed")
+                    && event.getMessage().getFormattedMessage().contains("dc=example,dc=org")
+                    && event.getMessage().getFormattedMessage().contains("INVALID_CREDENTIALS")));
+        } finally {
+            loggerConfig.removeAppender(appender.getName());
+            appender.stop();
+            context.updateLoggers();
+        }
+    }
+
+    @Test
+    void verifyFailedOperationIsLoggedAtWarnOrHigher() {
+        val context = LoggerContext.getContext(false);
+        val config = context.getConfiguration();
+        val loggerConfig = config.getLoggerConfig(LdapConnectionFactory.class.getName());
+        val appender = new InMemoryLogAppender("LdapConnectionFactoryFailedOperationAppender");
+        appender.start();
+        loggerConfig.addAppender(appender, Level.WARN, null);
+        context.updateLoggers();
+
+        try {
+            val connectionFactory = mock(ConnectionFactory.class);
+            val result = mock(DeleteResponse.class);
+            when(result.isSuccess()).thenReturn(false);
+            when(result.getResultCode()).thenReturn(ResultCode.OTHER);
+            when(result.getDiagnosticMessage()).thenReturn("operation failed");
+
+            try (val ignored = mockConstruction(DeleteOperation.class,
+                (operation, __) -> when(operation.execute(any(DeleteRequest.class))).thenReturn(result));
+                 val wrapper = new LdapConnectionFactory(connectionFactory)) {
+                val entry = new LdapEntry();
+                entry.setDn("cn=casuser,dc=example,dc=org");
+                assertFalse(wrapper.executeDeleteOperation(entry));
+            }
+
+            assertTrue(appender.getEvents().stream()
+                .anyMatch(event -> event.getLevel().isMoreSpecificThan(Level.WARN)));
+        } finally {
+            loggerConfig.removeAppender(appender.getName());
+            appender.stop();
+            context.updateLoggers();
+        }
+    }
+
+    @Getter
+    private static class InMemoryLogAppender extends AbstractAppender {
+        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+        protected InMemoryLogAppender(final String name) {
+            super(name, null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            events.add(event.toImmutable());
+        }
+    }
+}
+
+


### PR DESCRIPTION
When LDAP operations are attempted and fail (e.g. bind user can't connect), netty and ldaptive don't log any warning level logging and often CAS doesn't either. When LDAP errors are happening, I believe a one line warning or error level log message is reasonable and one shouldn't have to adjust log levels to see the result code and ldap error message. 
