### PR TITLE
Fix Palantir support

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir.js
+++ b/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir.js
@@ -1973,6 +1973,7 @@ function initializeServiceButtons() {
                         $.ajax({
                             url: `${actuatorEndpoints.registeredservices}/${serviceId}`,
                             type: "DELETE",
+                            contentType: "application/json",
                             success: response => {
 
                                 let nearestTr = $(this).closest("tr");


### PR DESCRIPTION
In the Palantir UI, the "delete service" action does not work and returns a "415 Unsupported Media Type".

It's because the `content-type` is missing, but it's fixed in v8: https://github.com/apereo/cas/blob/master/support/cas-server-support-thymeleaf/src/main/resources/static/js/palantir-services.js#L179

So this PR backports this fix.

master: https://github.com/apereo/cas/commit/7ddca86529aa79656f9b432ac824eb994a72b101
