### PR TITLE
feat: [SessionsEndpoint] add unformatted datetimes

### DIFF
--- a/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
+++ b/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
@@ -249,6 +249,14 @@ public class SingleSignOnSessionsEndpoint extends BaseCasRestActuatorEndpoint {
          */
         AUTHENTICATED_PRINCIPAL("authenticated_principal"),
         /**
+         * Creation date sso session attribute keys.
+         */
+        CREATION_DATE("creation_date"),
+        /**
+         * Last used date sso session attribute keys.
+         */
+        LAST_USED_DATE("last_used_date"),
+        /**
          * Authentication date sso session attribute keys.
          */
         AUTHENTICATION_DATE("authentication_date"),
@@ -362,8 +370,12 @@ public class SingleSignOnSessionsEndpoint extends BaseCasRestActuatorEndpoint {
         sso.put(SsoSessionAttributeKeys.AUTHENTICATION_DATE_FORMATTED.getAttributeKey(),
             DATE_FORMAT.format(DateTimeUtils.dateOf(authentication.getAuthenticationDate())));
 
+        sso.put(SsoSessionAttributeKeys.CREATION_DATE.getAttributeKey(), tgt.getCreationTime());
+
         sso.put(SsoSessionAttributeKeys.CREATION_DATE_FORMATTED.getAttributeKey(),
             DATE_FORMAT.format(DateTimeUtils.dateOf(tgt.getCreationTime())));
+
+        sso.put(SsoSessionAttributeKeys.LAST_USED_DATE.getAttributeKey(), tgt.getLastTimeUsed());
 
         sso.put(SsoSessionAttributeKeys.LAST_USED_DATE_FORMATTED.getAttributeKey(),
             DATE_FORMAT.format(DateTimeUtils.dateOf(tgt.getLastTimeUsed())));

--- a/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpointTests.java
+++ b/support/cas-server-support-reports/src/test/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpointTests.java
@@ -6,6 +6,7 @@ import org.apereo.cas.authentication.CoreAuthenticationTestUtils;
 import org.apereo.cas.mock.MockTicketGrantingTicket;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.ticket.TicketGrantingTicket;
 import org.apereo.cas.util.serialization.JacksonObjectMapperFactory;
 import lombok.val;
 import org.junit.jupiter.api.AfterEach;
@@ -63,6 +64,32 @@ class SingleSignOnSessionsEndpointTests extends AbstractCasEndpointTests {
                 .queryParam("type", SingleSignOnSessionsEndpoint.SsoSessionReportOptions.ALL.getType())
             )
             .andExpect(status().isOk());
+    }
+
+    @Test
+    void verifyGetSsoSessions() throws Exception {
+        val sessions = (List) MAPPER.readValue(mockMvc.perform(get("/actuator/ssoSessions")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .queryParam("username", CoreAuthenticationTestUtils.CONST_USERNAME)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", greaterThan(0)))
+                .andExpect(jsonPath("$.activeSsoSessions").exists())
+                .andExpect(jsonPath("$.activeSsoSessions.length()", equalTo(1)))
+                .andReturn()
+                .getResponse()
+                .getContentAsString(), Map.class)
+            .get("activeSsoSessions");
+
+        val session = (Map) sessions.getFirst();
+        val tgt = session.get(SingleSignOnSessionsEndpoint.SsoSessionAttributeKeys.TICKET_GRANTING_TICKET_ID.getAttributeKey()).toString();
+        val ticket = ticketRegistry.getTicket(tgt, TicketGrantingTicket.class);
+        val authentication = ticket.getAuthentication();
+
+        assertEquals(authentication.getAuthenticationDate().toInstant(), Instant.parse(session.get(SingleSignOnSessionsEndpoint.SsoSessionAttributeKeys.AUTHENTICATION_DATE.getAttributeKey()).toString()));
+        assertEquals(ticket.getCreationTime().toInstant(), Instant.parse(session.get(SingleSignOnSessionsEndpoint.SsoSessionAttributeKeys.CREATION_DATE.getAttributeKey()).toString()));
+        assertEquals(ticket.getLastTimeUsed().toInstant(), Instant.parse(session.get(SingleSignOnSessionsEndpoint.SsoSessionAttributeKeys.LAST_USED_DATE.getAttributeKey()).toString()));
     }
 
     @Test


### PR DESCRIPTION
The SingleSignOnSessionsEndpoint currently provides "authentication_date", "creation_date_formatted", "last_used_date_formatted", and "authentication_date_formatted".

This PR aims to add "creation_date" and "last_used_date". Dates that do not depend on the server’s time zone.


- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [ ] Test cases to demonstrate the problem before the fix, where applicable
- [ ] The same pull request targeted at the master branch, if applicable
- [ ] Any documentation on how to configure, test, etc
- [ ] Any possible limitations, side effects, performance issues, etc
- [ ] Reference any other pull requests that might be related