### PR TITLE
publish CasAuthenticationPolicyFailureEvent after errors are added

### DIFF
--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationManager.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/DefaultAuthenticationManager.java
@@ -286,8 +286,8 @@ public class DefaultAuthenticationManager implements AuthenticationManager {
         val authentication = builder.build();
         val executionResult = evaluateAuthenticationPolicies(authentication, transaction, authenticationHandlers);
         if (!executionResult.isSuccess()) {
-            publishEvent(new CasAuthenticationPolicyFailureEvent(this, builder.getFailures(), transaction, authentication, clientInfo));
             executionResult.getFailures().forEach(e -> handleAuthenticationException(e, e.getClass().getSimpleName(), builder));
+            publishEvent(new CasAuthenticationPolicyFailureEvent(this, builder.getFailures(), transaction, authentication, clientInfo));
             throw createAuthenticationException(builder);
         }
     }

--- a/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/DefaultAuthenticationManagerTests.java
+++ b/core/cas-server-core-authentication/src/test/java/org/apereo/cas/authentication/DefaultAuthenticationManagerTests.java
@@ -22,6 +22,7 @@ import org.apereo.cas.config.CasCoreWebAutoConfiguration;
 import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.multitenancy.TenantExtractor;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.support.events.authentication.CasAuthenticationPolicyFailureEvent;
 import org.apereo.cas.test.CasTestExtension;
 import org.apereo.cas.util.CollectionUtils;
 import org.apereo.cas.util.MockRequestContext;
@@ -39,6 +40,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.StaticApplicationContext;
@@ -366,6 +368,34 @@ class DefaultAuthenticationManagerTests {
     }
 
     @Test
+    void verifyAuthenticatePolicyFailsGenericAndPublishesEvent() throws Throwable {
+        val map = new LinkedHashMap<AuthenticationHandler, PrincipalResolver>();
+        map.put(newMockHandler(true), null);
+
+        val authenticationExecutionPlan = getAuthenticationExecutionPlan(map);
+        val policy = mock(AuthenticationPolicy.class);
+        val failure = new FailedLoginException();
+        when(policy.isSatisfiedBy(any(Authentication.class), any(), any(ConfigurableApplicationContext.class)))
+            .thenThrow(new GeneralSecurityException(failure));
+        authenticationExecutionPlan.registerAuthenticationPolicy(policy);
+        val manager = getAuthenticationManager(authenticationExecutionPlan);
+        val listener =
+            new ApplicationListener<CasAuthenticationPolicyFailureEvent>() {
+                private boolean failureFound;
+
+                @Override
+                public void onApplicationEvent(final CasAuthenticationPolicyFailureEvent event) {
+                    failureFound = event.getAuthentication().getFailures().values().stream()
+                        .anyMatch(t -> t.equals(failure));
+                }
+            };
+        applicationContext.addApplicationListener(listener);
+
+        assertThrows(AuthenticationException.class, () -> manager.authenticate(transaction));
+        assertTrue(listener.failureFound, "Failure events captured");
+    }
+
+    @Test
     void verifyAuthenticatePolicyFails() throws Throwable {
         val map = new LinkedHashMap<AuthenticationHandler, PrincipalResolver>();
         map.put(newMockHandler(true), null);
@@ -450,7 +480,7 @@ class DefaultAuthenticationManagerTests {
             new DirectObjectProvider<>(CoreAuthenticationTestUtils.getAuthenticationSystemSupport(attributeMerger)),
             false, applicationContext);
     }
-    
+
 
     @TestConfiguration(value = "AuthenticationPlanTestConfiguration", proxyBeanMethods = false)
     @EnableConfigurationProperties(CasConfigurationProperties.class)


### PR DESCRIPTION
CasAuthenticationPolicyFailureEvent was being published before authentication policy failures were added to it. This pr switches the order so that `handleAuthenticationException()` is called before `publishEvent()` is called.

Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [ ] Test cases to demonstrate the problem before the fix, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [x] Any documentation on how to configure, test, etc
- [ ] Any possible limitations, side effects, performance issues, etc
- [ ] Reference any other pull requests that might be related


