### PR TITLE
refactor(ticket-registry): use mapMulti in TicketRegistry#addTicket

### DIFF
--- a/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
+++ b/api/cas-server-core-api-ticket/src/main/java/org/apereo/cas/ticket/registry/TicketRegistry.java
@@ -1,6 +1,7 @@
 package org.apereo.cas.ticket.registry;
 
 import module java.base;
+import lombok.val;
 import org.apereo.cas.authentication.principal.Service;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
@@ -29,7 +30,7 @@ public interface TicketRegistry {
      * Ticket transaction manager bean name.
      */
     String TICKET_TRANSACTION_MANAGER = "ticketTransactionManager";
-    
+
     /**
      * Add a ticket to the registry. Ticket storage is based on the ticket id.
      *
@@ -45,7 +46,12 @@ public interface TicketRegistry {
      * @param toSave the to save
      */
     default @Nullable List<? extends Ticket> addTicket(final Stream<? extends Ticket> toSave) {
-        return toSave.parallel().map(Unchecked.function(this::addTicket)).filter(Objects::nonNull).collect(Collectors.toList());
+        return toSave.parallel().<Ticket>mapMulti((ticket, consumer) -> {
+            val result = Unchecked.supplier(() -> this.addTicket(ticket)).get();
+            if (result != null) {
+                consumer.accept(result);
+            }
+        }).toList();
     }
 
     /**
@@ -189,8 +195,8 @@ public interface TicketRegistry {
      */
     default Stream<? extends Ticket> getSessionsFor(final String principalId) {
         return getTickets(ticket -> ticket instanceof final TicketGrantingTicket ticketGrantingTicket
-            && !ticket.isExpired()
-            && ticketGrantingTicket.getAuthentication().getPrincipal().getId().equals(principalId));
+                && !ticket.isExpired()
+                && ticketGrantingTicket.getAuthentication().getPrincipal().getId().equals(principalId));
     }
 
     /**


### PR DESCRIPTION
## Description

This is a non-functional, internal refactor with no change to public API behavior.

Replaces `map(Unchecked.function(this::addTicket)).filter(Objects::nonNull)` with `mapMulti` in `TicketRegistry#addTicket(Stream<? extends Ticket>)`. This combines the map-and-null-filter logic into a single pass over the stream, avoiding the intermediate filtering stage. Behavior is unchanged — same inputs produce the same outputs.

- [x] Brief description of changes applied
- [ ] Test cases for all modified changes, where applicable
- [ ] Test cases to demonstrate the problem before the fix, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [ ] Any documentation on how to configure, test, etc
- [x] Any possible limitations, side effects, performance issues, etc
- [ ] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

## Test Cases

N/A — this is not a bug fix, so there is no problem to reproduce. Existing tests exercising `addTicket(Stream)` with mixed ticket sets should still pass unchanged; verified locally before submitting.

## Master Branch

This PR already targets `master` directly.

## Limitations / Side Effects

None known. This is purely an internal change to the stream pipeline implementation — no change to the method signature, contract, or behavior.