### PR TITLE
backport: fix: switch dateformatter to use UTC timezone

### DIFF
--- a/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultSingleLogoutMessageCreator.java
+++ b/core/cas-server-core-logout-api/src/main/java/org/apereo/cas/logout/DefaultSingleLogoutMessageCreator.java
@@ -36,7 +36,7 @@ public class DefaultSingleLogoutMessageCreator implements SingleLogoutMessageCre
                                           + "IssueInstant=\"%s\"><saml:NameID xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">%s"
                                           + "</saml:NameID><samlp:SessionIndex>%s</samlp:SessionIndex></samlp:LogoutRequest>",
             GENERATOR.getNewTicketId("LR"),
-            new ISOStandardDateFormat().getCurrentDateAndTime(),
+            new ISOStandardDateFormat(ZoneOffset.UTC).getCurrentDateAndTime(),
             Objects.requireNonNull(authentication).getPrincipal().getId(),
             request.getTicketId());
 

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ISOStandardDateFormat.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/ISOStandardDateFormat.java
@@ -22,9 +22,20 @@ public class ISOStandardDateFormat extends FastDateFormat {
     /**
      * Instantiates a new ISO standard date format
      * based on the format {@link #DATE_FORMAT}.
+     *
+     * @deprecated Use {@link #ISOStandardDateFormat(ZoneId, Locale)} or {@link #ISOStandardDateFormat(ZoneId)}.
      */
+    @Deprecated(since = "8.1.0")
     public ISOStandardDateFormat() {
-        super(DATE_FORMAT, TimeZone.getDefault(), Locale.getDefault());
+        this(ZoneId.systemDefault(), Locale.getDefault());
+    }
+
+    public ISOStandardDateFormat(final ZoneId timezone, final Locale locale) {
+        super(DATE_FORMAT, TimeZone.getTimeZone(timezone), locale);
+    }
+
+    public ISOStandardDateFormat(final ZoneId timezone) {
+        this(timezone, Locale.getDefault());
     }
 
     /**

--- a/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/account/AccountSingleSignOnSession.java
+++ b/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/account/AccountSingleSignOnSession.java
@@ -56,7 +56,7 @@ class AccountSingleSignOnSession implements Serializable {
                 .get(ClientInfoAuthenticationMetaDataPopulator.ATTRIBUTE_CLIENT_IP_ADDRESS))
             .map(Object::toString)
             .orElse(StringUtils.EMPTY);
-        val dateFormat = new ISOStandardDateFormat();
+        val dateFormat = new ISOStandardDateFormat(ZoneOffset.UTC);
         this.authenticationDate = dateFormat.format(DateTimeUtils.dateOf(ticket.getAuthentication().getAuthenticationDate()));
     }
 }

--- a/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
+++ b/support/cas-server-support-reports-core/src/main/java/org/apereo/cas/web/report/SingleSignOnSessionsEndpoint.java
@@ -53,7 +53,7 @@ import jakarta.validation.Valid;
 @Getter
 @Endpoint(id = "ssoSessions", defaultAccess = Access.NONE)
 public class SingleSignOnSessionsEndpoint extends BaseCasRestActuatorEndpoint {
-    private static final ISOStandardDateFormat DATE_FORMAT = new ISOStandardDateFormat();
+    private static final ISOStandardDateFormat DATE_FORMAT = new ISOStandardDateFormat(ZoneOffset.UTC);
 
     private static final String STATUS = "status";
 


### PR DESCRIPTION
backport "[fix: switch dateformatter to use UTC timezone](https://github.com/apereo/cas/commit/947e95c2998d7a04435033a4214f73968a887b45)" commit

- [x] Brief description of changes applied
- [ ] Test cases for all modified changes, where applicable
- [ ] Test cases to demonstrate the problem before the fix, where applicable
- [ ] The same pull request targeted at the master branch, if applicable
- [ ] Any documentation on how to configure, test, etc
- [ ] Any possible limitations, side effects, performance issues, etc
- [ ] Reference any other pull requests that might be related



```
master: https://github.com/apereo/cas/commit/947e95c2998d7a04435033a4214f73968a887b45
```

(NB: for [AccountSingleSignOnSession.java#59](https://github.com/apereo/cas/blob/master/support/cas-server-support-actions-core/src/main/java/org/apereo/cas/web/flow/account/AccountSingleSignOnSession.java#L59), the change does not come from commit https://github.com/apereo/cas/commit/947e95c2998d7a04435033a4214f73968a887b45, but from https://github.com/apereo/cas/commit/1eb6e44854a11732b5bf06e392a99f84d4125922 )