### PR TITLE
ci: let a broken CodeQL analysis job show as a failure

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -90,7 +90,6 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     needs: [ initialize ]
-    continue-on-error: true
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Hi, and thanks for CAS.

In `.github/workflows/analysis.yml`, the `codeql-analysis` job carries `continue-on-error: true` at job level:

```yaml
  codeql-analysis:
    name: CodeQL Analysis
    runs-on: ubuntu-latest
    needs: [ initialize ]
    continue-on-error: true
```

I want to be precise about what this does and does not mean, because it is easy to overstate. It does **not** suppress CodeQL findings — those go to the Security tab and would not fail the build in any case. What it suppresses is the job *breaking*: if `./gradlew build` fails, or the CodeQL setup drifts, or the toolchain changes underneath it, the job goes amber and the workflow still reports success. Nothing downstream inspects the result — I looked for a `needs.codeql-analysis.result` or `outcome ==` check elsewhere in the file and there is none.

The practical effect is that CodeQL could stop producing analyses for a while without anything drawing attention to it. For an SSO server that seemed worth raising.

This PR removes the one line, so a broken analysis job shows up as a failure.

I appreciate that may be the wrong trade-off, and I would rather offer the alternative than assume: this job runs a full `./gradlew build`, which is a large surface, and if it has been intermittently flaky then making it blocking is a real cost. If that is the case, keeping `continue-on-error` and adding a small job that checks `needs.codeql-analysis.result` and emits `::warning::` would keep the visibility without the blocking — happy to send that version instead. Or if this is simply deliberate, please close it; no hard feelings.

Single deleted line; nothing else touched.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the job and the rest of the workflow myself.
