### PR TITLE
docs: add Apache APISIX CAS client reference

### DIFF
--- a/docs/cas-server-documentation/integration/CAS-Clients.md
+++ b/docs/cas-server-documentation/integration/CAS-Clients.md
@@ -24,6 +24,9 @@ supporting a number of software platforms and products have been developed.
 ## Other Clients
 
 Other unofficial or incubating CAS clients may be [found here](https://wiki.jasig.org/display/CASC).
+
+* [Apache APISIX CAS Authentication Plugin](https://apisix.apache.org/docs/apisix/plugins/cas-auth/)
+
 Given the above projects are unofficial and not under direct maintenance of CAS,
 their availability and accuracy may vary.
 


### PR DESCRIPTION
This updates the CAS Clients page to include the existing Apache APISIX CAS authentication plugin under `Other Clients`. The entry links directly to the official Apache APISIX plugin documentation and remains covered by the page's existing disclaimer for clients that are not maintained by the CAS project.

The change is documentation-only and does not modify CAS behavior, configuration, or dependencies.

### Placement

APISIX `cas-auth` handles the service-provider side of the CAS 2.0 login and ticket-validation flow, so it is treated here as a CAS client rather than a CAS server integration. I placed it under `Other Clients` because it is maintained outside the CAS project. This section currently points to the legacy client index instead of listing individual clients directly, so I am happy to adjust the location if the project prefers a different approach.

### Validation

- Applied the one-file change to the current `master` branch.
- Confirmed the Apache APISIX plugin documentation link returns HTTP 200.
- Ran `git diff --check` successfully.
- Did not run the full Jekyll site build locally; the upstream documentation workflow can perform that check if maintainers add the `CI` label.

### Checklist

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable — not applicable to this one-link documentation update
- [x] Test cases to demonstrate the problem before the fix, where applicable — not applicable; the missing reference is visible in the current page
- [x] The same pull request targeted at the `master` branch, if applicable
- [x] Documentation on how to configure or test, where applicable — the entry links to the official plugin documentation
- [x] Possible limitations, side effects, or performance issues — documentation-only; APISIX is not maintained by the CAS project and remains covered by the existing disclaimer
- [x] Related pull requests — none found