### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you (or your employer) benefit from this project, please consider becoming a 
 Commercial support options may be [found here][cassupport].
 
 [cascodecov]: https://codecov.io/gh/apereo/cas
-[devlocity]: https://develocity.apereo.org
+[devlocity]: https://community.develocity.cloud/scans?search.rootProjectNames=cas-server
 [maintenance]: https://apereo.github.io/cas/developer/Maintenance-Policy.html
 [releaseschedule]: https://github.com/apereo/cas/milestones
 [wiki]: https://apereo.github.io/cas

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,4 +45,4 @@ targetCompatibility=25
 ################
 # Gradle plugins
 ################
-develocityApereoServerUrl=https://develocity.apereo.org/
+develocityApereoServerUrl=https://community.develocity.cloud

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,6 +43,7 @@ buildCache {
 if (applyDevelocityPlugin) {
     develocity {
         server = "${develocityApereoServerUrl}"
+        projectId = "apereo"
         buildScan {
             publishing.onlyIf { it.authenticated }
             uploadInBackground = !isCiServer


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR migrates [Develocity](https://develocity.ai) Build Scan® and Build Cache support for this
project from the `develocity.apereo.org` instance to the **OSS Community Develocity Instance** at
<https://community.develocity.cloud>, under project ID `apereo`.

The OSS Community Develocity Instance is a managed instance provided by Gradle for open-source
projects. Gradle is consolidating sponsored OSS projects onto it, and `develocity.apereo.org` is
being **decommissioned on Thursday, 27 August 2026** — after that date the current instance stops
accepting Build Scans and remote build cache traffic, so this change needs to land before then.

The diff is three lines:

- `gradle.properties` — `develocityApereoServerUrl` now points at `https://community.develocity.cloud`.
  The property keeps its name to hold the diff down; only the value changes.
- `settings.gradle` — adds `projectId = "apereo"`, which routes Build Scans to this project's group
  on the shared instance.
- `README.md` — the Develocity badge now links to this project's scans on the community instance.

`buildCache { remote(develocity.buildCache) }` derives its endpoint from `develocity.server`, so it
needs no change.

## Step 1 — Get an access key for `community.develocity.cloud`

Build Scan publishing **and** remote Build Cache writes from CI need a Develocity access key that is
authorised for the `apereo` project on the community instance. The existing `develocity.apereo.org`
key will **not** work against the new instance.

1. Visit <https://community.develocity.cloud>.
2. Sign in as the CI account that has been provided for CAS.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy the
   generated key. Keep this tab open until you complete Step 2 — the key is only shown once.

## Step 2 — Update the GitHub Actions secret on this repository

All eleven workflows that publish Build Scans (`tests.yml`, `build.yml`, `functional-tests.yml`,
`native-tests.yml`, `analysis.yml`, `validation.yml`, `performance.yml`, `dependencies.yml`,
`publish.yml`, `publish-docs.yml`, `release.yml`) read the secret `GRADLE_ENTERPRISE_ACCESS_KEY` and
expose it to Gradle as the `DEVELOCITY_ACCESS_KEY` environment variable. That secret currently holds
a key for `develocity.apereo.org`, so its **value** must be replaced.

This is a single secret rotation, but it is a broad-impact one: every one of those workflows is
affected the moment this PR merges. Until the secret is updated, builds still succeed — scan
publishing is guarded by `publishing.onlyIf { it.authenticated }`, cache push is guarded on the
access key being present, and Gradle treats remote cache errors as non-fatal — but no scans are
published, nothing is written to the remote cache, and unauthenticated remote cache reads will log
warnings.

1. Open this repository on GitHub.
2. Click **Settings**.
3. In the left sidebar, click **Secrets and variables** → **Actions**.
4. Find the existing `GRADLE_ENTERPRISE_ACCESS_KEY` secret and click **Update**.
5. Set the value to the following, replacing `PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE` with the key you
   copied in Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without the host name, the access key
   is silently ignored. This is the most common point of failure when onboarding, so please
   double-check the format.
6. Click **Update secret**.

Optionally, you may want to rename this secret to `DEVELOCITY_ACCESS_KEY` to match the current
product naming.

## Step 3 — Provision an access key for your local builds

Maintainers building CAS locally should provision an access key for `community.develocity.cloud` so
their Build Scans publish. The Develocity Gradle plugin's `provisionDevelocityAccessKey` task does
this in a single command — it opens the browser, asks you to confirm, and writes the key to
`~/.gradle/develocity/keys.properties` automatically.

**Before running this command**, sign out of `community.develocity.cloud` in your browser (or use a
private/incognito window) so the access key gets associated with **your personal account**, not the
CI service account from Step 1.

```
./gradlew provisionDevelocityAccessKey
```

## Accounts

Accounts on the community instance for the maintainer and for the CI agent are being provided
separately, outside this PR.

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read this repository's secrets, so the workflow runs on
this PR cannot publish to `community.develocity.cloud` even after Step 2 is complete — the same
constraint that applies to CAS's existing fork builds today.

If you want CI verification before merging, push the branch
`dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not the fork)
and re-run a workflow there — it will pick up the secret and publish a Build Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks of this repository will not, and that's
expected.
