### PR TITLE
Return 403 instead of 500 for unauthorized service in REST API

### DIFF
--- a/support/cas-server-support-rest-core/src/main/java/org/apereo/cas/support/rest/resources/ServiceTicketResource.java
+++ b/support/cas-server-support-rest-core/src/main/java/org/apereo/cas/support/rest/resources/ServiceTicketResource.java
@@ -7,6 +7,7 @@ import org.apereo.cas.authentication.AuthenticationSystemSupport;
 import org.apereo.cas.rest.BadRestRequestException;
 import org.apereo.cas.rest.factory.RestHttpRequestCredentialFactory;
 import org.apereo.cas.rest.factory.ServiceTicketResourceEntityResponseFactory;
+import org.apereo.cas.services.UnauthorizedServiceException;
 import org.apereo.cas.ticket.InvalidTicketException;
 import org.apereo.cas.ticket.registry.TicketRegistrySupport;
 import org.apereo.cas.util.LoggingUtils;
@@ -114,6 +115,9 @@ public class ServiceTicketResource {
         } catch (final BadRestRequestException e) {
             LoggingUtils.error(LOGGER, e);
             return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.BAD_REQUEST);
+        } catch (final UnauthorizedServiceException e) {
+            LoggingUtils.error(LOGGER, e);
+            return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.FORBIDDEN);
         } catch (final Throwable e) {
             LoggingUtils.error(LOGGER, e);
             return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/support/cas-server-support-rest-core/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
+++ b/support/cas-server-support-rest-core/src/main/java/org/apereo/cas/support/rest/resources/TicketGrantingTicketResource.java
@@ -8,6 +8,7 @@ import org.apereo.cas.logout.slo.SingleLogoutRequestExecutor;
 import org.apereo.cas.rest.BadRestRequestException;
 import org.apereo.cas.rest.authentication.RestAuthenticationService;
 import org.apereo.cas.rest.factory.TicketGrantingTicketResourceEntityResponseFactory;
+import org.apereo.cas.services.UnauthorizedServiceException;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.util.LoggingUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -101,6 +102,9 @@ public class TicketGrantingTicketResource {
         } catch (final BadRestRequestException e) {
             LoggingUtils.error(LOGGER, e);
             return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.BAD_REQUEST);
+        } catch (final UnauthorizedServiceException e) {
+            LoggingUtils.error(LOGGER, e);
+            return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.FORBIDDEN);
         } catch (final Throwable e) {
             LoggingUtils.error(LOGGER, e);
             return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/support/cas-server-support-rest-core/src/main/java/org/apereo/cas/support/rest/resources/UserAuthenticationResource.java
+++ b/support/cas-server-support-rest-core/src/main/java/org/apereo/cas/support/rest/resources/UserAuthenticationResource.java
@@ -5,6 +5,7 @@ import org.apereo.cas.authentication.AuthenticationException;
 import org.apereo.cas.rest.BadRestRequestException;
 import org.apereo.cas.rest.authentication.RestAuthenticationService;
 import org.apereo.cas.rest.factory.UserAuthenticationResourceEntityResponseFactory;
+import org.apereo.cas.services.UnauthorizedServiceException;
 import org.apereo.cas.util.LoggingUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -75,6 +76,9 @@ public class UserAuthenticationResource {
         } catch (final BadRestRequestException e) {
             LoggingUtils.error(LOGGER, e);
             return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.BAD_REQUEST);
+        } catch (final UnauthorizedServiceException e) {
+            LoggingUtils.error(LOGGER, e);
+            return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.FORBIDDEN);
         } catch (final Exception e) {
             LoggingUtils.error(LOGGER, e);
             return new ResponseEntity<>(StringEscapeUtils.escapeHtml4(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/ServiceTicketResourceTests.java
+++ b/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/ServiceTicketResourceTests.java
@@ -12,6 +12,7 @@ import org.apereo.cas.rest.factory.CasProtocolServiceTicketResourceEntityRespons
 import org.apereo.cas.rest.factory.UsernamePasswordRestHttpRequestCredentialFactory;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.UnauthorizedSsoServiceException;
 import org.apereo.cas.support.rest.resources.ServiceTicketResource;
 import org.apereo.cas.support.rest.resources.TicketGrantingTicketResource;
 import org.apereo.cas.ticket.InvalidTicketException;
@@ -129,6 +130,16 @@ class ServiceTicketResourceTests {
             .param(SERVICE, CoreAuthenticationTestUtils.getService().getId()))
             .andExpect(status().is5xxServerError())
             .andExpect(content().string(OTHER_EXCEPTION));
+    }
+
+    @Test
+    void creationOfSTWithUnauthorizedServiceException() throws Throwable {
+        configureCasMockSTCreationToThrow(new UnauthorizedSsoServiceException());
+
+        this.mockMvc.perform(post(TICKETS_RESOURCE_URL + "/TGT-1")
+            .param(SERVICE, CoreAuthenticationTestUtils.getService().getId()))
+            .andExpect(status().isForbidden())
+            .andExpect(content().string(UnauthorizedSsoServiceException.CODE));
     }
 
     @Test

--- a/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/TicketGrantingTicketResourceTests.java
+++ b/support/cas-server-support-rest/src/test/java/org/apereo/cas/support/rest/TicketGrantingTicketResourceTests.java
@@ -23,6 +23,7 @@ import org.apereo.cas.rest.factory.DefaultTicketGrantingTicketResourceEntityResp
 import org.apereo.cas.rest.factory.UsernamePasswordRestHttpRequestCredentialFactory;
 import org.apereo.cas.services.RegisteredServiceTestUtils;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.services.UnauthorizedSsoServiceException;
 import org.apereo.cas.support.rest.resources.TicketGrantingTicketResource;
 import org.apereo.cas.ticket.Ticket;
 import org.apereo.cas.ticket.TicketGrantingTicket;
@@ -255,6 +256,17 @@ class TicketGrantingTicketResourceTests {
                 .param(PASSWORD, TEST_VALUE))
             .andExpect(status().is5xxServerError())
             .andExpect(content().string(OTHER_EXCEPTION));
+    }
+
+    @Test
+    void creationOfTGTWithUnauthorizedServiceException() throws Throwable {
+        configureCasMockTGTCreationToThrow(new UnauthorizedSsoServiceException());
+
+        this.mockMvc.perform(post(TICKETS_RESOURCE_URL)
+                .param(USERNAME, TEST_VALUE)
+                .param(PASSWORD, TEST_VALUE))
+            .andExpect(status().isForbidden())
+            .andExpect(content().string(UnauthorizedSsoServiceException.CODE));
     }
 
     @Test


### PR DESCRIPTION
UnauthorizedServiceException is annotated with @ResponseStatus(FORBIDDEN), but the REST resources catch it in their generic catch-all and answer 500 Internal Server Error, e.g. when a service ticket is requested for a service that is not authorized in the service registry. An unauthorized service is a client-side error, so map it to 403 Forbidden.

Practically this fixes a real nuisance we had: A service that uses our CAS instance for authentication and due to a configuration error at their end they use an invalid service URL when attempting to authenticate. This unexpectedly results in CAS responding with HTTP 500 status code which usually indicates some sort of unrecoverable internal error. However in this case it's clear the issue is unauthorized service which is could be and is handled gracefully. We monitor our CAS instances 5XX responses as a metric of actual errors that deserve investigation and this has been a false positive for us.


- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] Test cases to demonstrate the problem before the fix, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [ ] Any documentation on how to configure, test, etc
- [ ] Any possible limitations, side effects, performance issues, etc
- [ ] Reference any other pull requests that might be related