### PR TITLE
Do not echo the existing cookie value when removing cookies

### DIFF
--- a/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
+++ b/core/cas-server-core-cookie-api/src/main/java/org/apereo/cas/web/support/gen/CookieRetrievingCookieGenerator.java
@@ -169,7 +169,7 @@ public class CookieRetrievingCookieGenerator implements Serializable, CasCookieB
                     .distinct()
                     .filter(StringUtils::isNotBlank)
                     .forEach(path -> {
-                        val crm = new Cookie(cookie.getName(), cookie.getValue());
+                        val crm = new Cookie(cookie.getName(), StringUtils.EMPTY);
                         crm.setMaxAge(0);
                         crm.setPath(path);
                         crm.setSecure(cookie.getSecure());

--- a/core/cas-server-core-cookie/src/test/java/org/apereo/cas/web/support/CookieRetrievingCookieGeneratorTests.java
+++ b/core/cas-server-core-cookie/src/test/java/org/apereo/cas/web/support/CookieRetrievingCookieGeneratorTests.java
@@ -116,6 +116,25 @@ class CookieRetrievingCookieGeneratorTests {
     }
 
     @Test
+    void verifyRemoveAllDoesNotEchoCookieValue() {
+        val request = new MockHttpServletRequest();
+        val cookieValueManager = new NoOpCookieValueManager(tenantExtractor);
+
+        val gen = CookieUtils.buildCookieRetrievingGenerator(cookieValueManager, getCookieGenerationContext("/cas"));
+        val cookie = gen.addCookie(request, new MockHttpServletResponse(), "tgc-value-".repeat(200));
+        val cookieValue = cookie.getValue();
+        request.setCookies(cookie);
+
+        val response = new MockHttpServletResponse();
+        gen.removeAll(request, response);
+
+        val headers = response.getHeaders("Set-Cookie");
+        assertEquals(3, headers.size());
+        assertTrue(headers.stream().noneMatch(header -> header.contains(cookieValue)));
+        assertTrue(Arrays.stream(response.getCookies()).allMatch(removed -> StringUtils.isEmpty(removed.getValue())));
+    }
+
+    @Test
     void verifyExistingCookieInResponse() {
         val context = getCookieGenerationContext();
         val request = new MockHttpServletRequest();


### PR DESCRIPTION
`CookieRetrievingCookieGenerator#removeAll` builds each expiring `Set-Cookie` header from the value of the                                                                                                                                    
incoming cookie, so the full cookie value is written back into the response once per candidate path. For a                                                                                                                                    
cookie configured under `/cas` that is three headers (`/`, `/cas`, `/cas/`), each carrying the complete value.                                                                                                                                
                                                                                                                                                                                                                                              
That value is not small. With the default cookie value manager the ticket-granting cookie is encrypted and                                                                                                                                    
signed, and the resulting token routinely runs well over a kilobyte, so a single logout response can carry                                                                                                                                    
several kilobytes of `Set-Cookie` payload that serves no purpose — the browser expires the cookie based on                                                                                                                                    
`Max-Age=0` plus the matching name/path/secure/httpOnly combination, and the value in an expiring header is                                                                                                                                   
never used.                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                              
The practical cost shows up in front of CAS. Deployments behind a reverse proxy have to size their response                                                                                                                                   
header buffers for this worst case; on nginx that means raising `proxy_buffer_size` (and `proxy_buffers`) to                                                                                                                                  
avoid `upstream sent too big header while reading response header from upstream` on the logout round-trip.                                                                                                                                    
Tuning proxy buffers to accommodate data that is discarded on arrival is the part worth fixing. The same                                                                                                                                      
payload is also duplicated into every access log and any intermediate proxy that records response headers.                                                                                                                                    
                                                                                                                                                                                                                                              
`removeCookie` already writes an empty value through `CookieUtils.createSetCookieHeader(null, ...)`; this change                                                                                                                              
aligns `removeAll` with that behavior. Client-visible behavior is unchanged — only the redundant payload goes away.                                                                                                                                          
                                                                                                                                                                                                                                              
- [x] Brief description of changes applied                                                                                                                                                                                                    
- [x] Test cases for all modified changes, where applicable                                                                                                                                                                                   
- [x] Test cases to demonstrate the problem before the fix, where applicable — `verifyRemoveAllDoesNotEchoCookieValue`                                                                                                                        
      fails on an unmodified `master` (the header still carries the cookie value) and passes with the change applied                                                                                                                          
- [x] The same pull request targeted at the master branch, if applicable — this pull request targets `master`
- [ ] Any documentation on how to configure, test, etc — not applicable; no user-facing or configuration change 
- [ ] Any possible limitations, side effects, performance issues, etc — none known
- [ ] Reference any other pull requests that might be related — none  