### PR TITLE
Don't use Pattern.COMMENTS for PasswordValidationService

### DIFF
--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/DefaultPasswordValidationService.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/DefaultPasswordValidationService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.util.StringUtils;
-import java.util.regex.Pattern;
 
 /**
  * This is {@link DefaultPasswordValidationService}.
@@ -55,7 +54,7 @@ public class DefaultPasswordValidationService implements PasswordValidationServi
     public boolean isAcceptedByPasswordPolicy(final String password) {
         val policyPattern = casProperties.getAuthn().getPm().getCore().getPasswordPolicyPattern();
         LOGGER.debug("Checking provided password against pattern required for password policy: [{}]", policyPattern);
-        return RegexUtils.find(policyPattern, password, Pattern.COMMENTS);
+        return RegexUtils.find(policyPattern, password, 0);
     }
 
     protected boolean validatePassword(final PasswordChangeRequest bean) {

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/DefaultPasswordValidationServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/DefaultPasswordValidationServiceTests.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.*;
 }, properties = {
     "cas.authn.pm.core.enabled=true",
     "cas.authn.pm.history.core.enabled=true",
-    "cas.authn.pm.core.password-policy-pattern=^Th!.+{8,10}"
+    "cas.authn.pm.core.password-policy-pattern=^Th ?!.+{8,10}"
 })
 @Tag("PasswordOps")
 @ExtendWith(CasTestExtension.class)
@@ -96,6 +96,12 @@ class DefaultPasswordValidationServiceTests {
         val request = new PasswordChangeRequest("casuser", "current-psw".toCharArray(), "th!sIsT3st".toCharArray(), "th!sIsT3st".toCharArray());
         assertFalse(passwordValidationService.isValid(request));
     }
+
+	@Test
+	void verifyNoCommentSpecialHandling() throws Throwable {
+		val request = new PasswordChangeRequest("casuser", "current-psw".toCharArray(), "Th !sIsT3st".toCharArray(), "Th !sIsT3st".toCharArray());
+		assertTrue(passwordValidationService.isValid(request));
+	}
 }
 
 


### PR DESCRIPTION
@mmoayyed Hello, David from Coop here, as discussed via email here's my PR for this. 

# Problem

The change on line [58 of DefaultPasswordValidationService](https://github.com/apereo/cas/blame/ca02a58b41ddd65d3b43270d01c854b845d5e1dc/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/DefaultPasswordValidationService.java#L58) which got introduced in https://github.com/apereo/cas/commit/56aa62323e8467208611cb57bacd8ddfa57c19e1 regresses Patterns that contain whitespace and/or the # sign.

The commit intended to move the Regex validation logic  away from the "case-insensitive" default used throughout the codebase, but using Pattern.COMMENTS there will additionally start to special case whitespace  characters and more importantly the #-sign which happened to be a relevant token in our validation pattern.

# Solution

This adjusts the corresponding line to not use any flags 


Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [ ] Test cases to demonstrate the problem before the fix, where applicable
- [ ] The same pull request targeted at the master branch, if applicable
- [ ] Any documentation on how to configure, test, etc
- [ ] Any possible limitations, side effects, performance issues, etc
- [ ] Reference any other pull requests that might be related

