### PR TITLE
Don't use Pattern.COMMENTS for PasswordValidationService -- Backport #9461

### DIFF
--- a/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/DefaultPasswordValidationService.java
+++ b/support/cas-server-support-pm-core/src/main/java/org/apereo/cas/pm/impl/DefaultPasswordValidationService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.util.StringUtils;
-import java.util.regex.Pattern;
 
 /**
  * This is {@link DefaultPasswordValidationService}.
@@ -55,7 +54,7 @@ public class DefaultPasswordValidationService implements PasswordValidationServi
     public boolean isAcceptedByPasswordPolicy(final String password) {
         val policyPattern = casProperties.getAuthn().getPm().getCore().getPasswordPolicyPattern();
         LOGGER.debug("Checking provided password against pattern required for password policy: [{}]", policyPattern);
-        return RegexUtils.find(policyPattern, password, Pattern.COMMENTS);
+        return RegexUtils.find(policyPattern, password, 0);
     }
 
     protected boolean validatePassword(final PasswordChangeRequest bean) {

--- a/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/DefaultPasswordValidationServiceTests.java
+++ b/support/cas-server-support-pm/src/test/java/org/apereo/cas/pm/DefaultPasswordValidationServiceTests.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.*;
 }, properties = {
     "cas.authn.pm.core.enabled=true",
     "cas.authn.pm.history.core.enabled=true",
-    "cas.authn.pm.core.password-policy-pattern=^Th!.+{8,10}"
+    "cas.authn.pm.core.password-policy-pattern=^Th ?!.+{8,10}"
 })
 @Tag("PasswordOps")
 @ExtendWith(CasTestExtension.class)
@@ -96,6 +96,12 @@ class DefaultPasswordValidationServiceTests {
         val request = new PasswordChangeRequest("casuser", "current-psw".toCharArray(), "th!sIsT3st".toCharArray(), "th!sIsT3st".toCharArray());
         assertFalse(passwordValidationService.isValid(request));
     }
+
+	@Test
+	void verifyNoCommentSpecialHandling() throws Throwable {
+		val request = new PasswordChangeRequest("casuser", "current-psw".toCharArray(), "Th !sIsT3st".toCharArray(), "Th !sIsT3st".toCharArray());
+		assertTrue(passwordValidationService.isValid(request));
+	}
 }
 
 


### PR DESCRIPTION
This backports 3f036c63837abaf3665dcdee40d97d5117e9501e into the 8.0.x series which originally came from PR #9461 

master:https://github.com/apereo/cas/pull/9461


- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [ ] Test cases to demonstrate the problem before the fix, where applicable
- [ ] The same pull request targeted at the master branch, if applicable
- [ ] Any documentation on how to configure, test, etc
- [ ] Any possible limitations, side effects, performance issues, etc
- [x] Reference any other pull requests that might be related