### PR TITLE
Fix - Honor  cas.audit.jdbc.schedule.enabled-on-host 

### DIFF
--- a/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/config/CasJdbcAuditAutoConfiguration.java
+++ b/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/config/CasJdbcAuditAutoConfiguration.java
@@ -16,6 +16,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.spring.beans.BeanCondition;
 import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
+import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostname;
 import org.apereo.cas.util.thread.Cleanable;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -224,6 +225,7 @@ public class CasJdbcAuditAutoConfiguration {
     static class CasSupportJdbcAuditScheduleConfiguration {
 
         @ConditionalOnMissingBean(name = "inspektrAuditTrailCleaner")
+        @ConditionalOnMatchingHostname(name = "cas.audit.jdbc.schedule.enabled-on-host")
         @Bean
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         @Lazy(false)


### PR DESCRIPTION
## Description

`cas.audit.jdbc.schedule.enabled-on-host` is documented (inherited generically from `SchedulingProperties`, nested inside `AuditJdbcProperties`) but was never consulted anywhere in the JDBC audit trail scheduling path. The `inspektrAuditTrailCleaner` bean in `CasJdbcAuditAutoConfiguration` only checked `cas.audit.jdbc.schedule.enabled`, so the cleaner ran on every CAS node regardless of hostname — the property had no effect at all.

Other scheduled cleaners in CAS already implement this correctly, e.g. `ticketRegistryCleanerScheduler` in `CasCoreTicketsSchedulingConfiguration` is annotated with `@ConditionalOnMatchingHostname(name = "cas.ticket.registry.cleaner.schedule.enabled-on-host")`. The JDBC audit cleaner was missing the equivalent wiring.

**Fix:** add `@ConditionalOnMatchingHostname(name = "cas.audit.jdbc.schedule.enabled-on-host")` to the `inspektrAuditTrailCleaner` bean definition, matching the existing convention used elsewhere in the codebase (ticket registry cleaner, MFA trusted-device cleaner).

## Limitations / side effects

- Any deployment currently relying — unknowingly — on the cleaner running on *all* nodes will see a behavior change if it has `enabled-on-host` set: the cleaner will now actually be restricted to the matching host. This is the intended fix but is a real behavior change for anyone who set the property expecting it to already work.
- No effect if the property is left unset (default `.*` matches every host — same as current behavior).
