### PR TITLE
Honor cas.audit.jdbc.schedule.enabled-on-host

### DIFF
--- a/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/config/CasJdbcAuditAutoConfiguration.java
+++ b/support/cas-server-support-audit-jdbc/src/main/java/org/apereo/cas/config/CasJdbcAuditAutoConfiguration.java
@@ -17,6 +17,7 @@ import org.apereo.cas.util.function.FunctionUtils;
 import org.apereo.cas.util.spring.beans.BeanCondition;
 import org.apereo.cas.util.spring.beans.BeanSupplier;
 import org.apereo.cas.util.spring.boot.ConditionalOnFeatureEnabled;
+import org.apereo.cas.util.spring.boot.ConditionalOnMatchingHostname;
 import org.apereo.cas.util.thread.Cleanable;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -225,6 +226,7 @@ public class CasJdbcAuditAutoConfiguration {
     static class CasSupportJdbcAuditScheduleConfiguration {
 
         @ConditionalOnMissingBean(name = "inspektrAuditTrailCleaner")
+        @ConditionalOnMatchingHostname(name = "cas.audit.jdbc.schedule.enabled-on-host")
         @Bean
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         @Lazy(false)

--- a/support/cas-server-support-audit-jdbc/src/test/java/org/apereo/cas/audit/CasJdbcAuditScheduleEnabledOnHostConfigurationTests.java
+++ b/support/cas-server-support-audit-jdbc/src/test/java/org/apereo/cas/audit/CasJdbcAuditScheduleEnabledOnHostConfigurationTests.java
@@ -1,0 +1,53 @@
+package org.apereo.cas.audit;
+
+import module java.base;
+import org.apereo.cas.audit.spi.BaseAuditConfigurationTests;
+import org.apereo.cas.config.CasHibernateJpaAutoConfiguration;
+import org.apereo.cas.config.CasJdbcAuditAutoConfiguration;
+import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.test.CasTestExtension;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This is {@link CasJdbcAuditScheduleEnabledOnHostConfigurationTests}.
+ *
+ * @since 8.0.0
+ */
+@SpringBootTest(
+    classes = {
+        BaseAuditConfigurationTests.SharedTestConfiguration.class,
+        CasJdbcAuditAutoConfiguration.class,
+        CasHibernateJpaAutoConfiguration.class
+    },
+    properties = {
+        "cas.jdbc.show-sql=true",
+        "cas.audit.jdbc.column-length=-1",
+        "cas.audit.jdbc.asynchronous=false",
+        "cas.audit.jdbc.schedule.enabled=true",
+        "cas.audit.jdbc.schedule.enabled-on-host=some-host-that-does-not-exist-anywhere"
+    })
+@EnableConfigurationProperties(CasConfigurationProperties.class)
+@Tag("JDBC")
+@ExtendWith(CasTestExtension.class)
+class CasJdbcAuditScheduleEnabledOnHostConfigurationTests {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    /**
+     * The {@code enabled-on-host} property is set to a hostname that can never match
+     * the local machine, so the {@code inspektrAuditTrailCleaner} bean must be skipped
+     * entirely rather than registered and simply left un-scheduled.
+     */
+    @Test
+    void verifyCleanerIsNotRegisteredOnNonMatchingHost() {
+        assertThat(applicationContext.containsBean("inspektrAuditTrailCleaner")).isFalse();
+    }
+}


### PR DESCRIPTION
## Description

`cas.audit.jdbc.schedule.enabled-on-host` is documented (inherited generically from `SchedulingProperties`, nested inside `AuditJdbcProperties`) but was never consulted anywhere in the JDBC audit trail scheduling path. The `inspektrAuditTrailCleaner` bean in `CasJdbcAuditAutoConfiguration` only checked `cas.audit.jdbc.schedule.enabled`, so the cleaner ran on every CAS node regardless of hostname — the property had no effect at all.

Other scheduled cleaners in CAS already implement this correctly, e.g. `ticketRegistryCleanerScheduler` in `CasCoreTicketsSchedulingConfiguration` is annotated with `@ConditionalOnMatchingHostname(name = "cas.ticket.registry.cleaner.schedule.enabled-on-host")`. The JDBC audit cleaner was missing the equivalent wiring.

**Fix:** add `@ConditionalOnMatchingHostname(name = "cas.audit.jdbc.schedule.enabled-on-host")` to the `inspektrAuditTrailCleaner` bean definition, matching the existing convention used elsewhere in the codebase (ticket registry cleaner, MFA trusted-device cleaner).

## Limitations / side effects

- Any deployment currently relying — unknowingly — on the cleaner running on *all* nodes will see a behavior change if it has `enabled-on-host` set: the cleaner will now actually be restricted to the matching host. This is the intended fix but is a real behavior change for anyone who set the property expecting it to already work.
- No effect if the property is left unset (default `.*` matches every host — same as current behavior).
