### PR TITLE
fix(tickets): ensure ticket registry stream is auto-closed in cleaner

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleaner.java
@@ -68,8 +68,9 @@ public class DefaultTicketRegistryCleaner implements TicketRegistryCleaner {
     }
 
     protected int cleanInternal() {
-        try (val executor = Executors.newVirtualThreadPerTaskExecutor()) {
-            val ticketsDeleted = ticketRegistry.stream()
+        try (val executor = Executors.newVirtualThreadPerTaskExecutor();
+             val ticketStream = ticketRegistry.stream()) {
+            val ticketsDeleted = ticketStream
                 .unordered()
                 .filter(Objects::nonNull)
                 .filter(Ticket::isExpired)

--- a/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleanerTests.java
+++ b/core/cas-server-core-tickets/src/test/java/org/apereo/cas/ticket/registry/DefaultTicketRegistryCleanerTests.java
@@ -71,6 +71,18 @@ class DefaultTicketRegistryCleanerTests {
     }
 
     @Test
+    void verifyStreamClosedOnClean() {
+        val applicationContext = mock(ConfigurableApplicationContext.class);
+        val ticketRegistry = mock(TicketRegistry.class);
+        val closed = new AtomicBoolean(false);
+        val stream = Stream.<Ticket>empty().onClose(() -> closed.set(true));
+        when(ticketRegistry.stream()).thenReturn(stream);
+        val cleaner = new DefaultTicketRegistryCleaner(LockRepository.noOp(), applicationContext, ticketRegistry);
+        cleaner.clean();
+        assertTrue(closed.get());
+    }
+
+    @Test
     void verifyNoCleaner() {
         val applicationContext = mock(ConfigurableApplicationContext.class);
         val ticketRegistry = newTicketRegistry();


### PR DESCRIPTION
# Description
Ensure the `Stream<Ticket>` returned by `TicketRegistry.stream()` is auto-closed in `DefaultTicketRegistryCleaner.cleanInternal()`.

### Problem
In `DefaultCasRedisTemplate.scan(String, Long)`, a dedicated Redis connection is acquired and closed via a `Stream.onClose` handler:
```java
return StreamSupport.stream(Spliterators.spliteratorUnknownSize(cursor, 16), false)
    .onClose(() -> {
        IOUtils.closeQuietly(cursor);
        connection.close();
    });
```
However, `DefaultTicketRegistryCleaner.cleanInternal()` does not close the stream returned by `ticketRegistry.stream()`:
```java
try (val executor = Executors.newVirtualThreadPerTaskExecutor()) {
    val ticketsDeleted = ticketRegistry.stream()
        .unordered()
        ...
        .sum();
    ...
}
```
In Java, terminal stream operations (such as `.sum()`, `.collect()`) do not auto-close streams. Consequently, the `.onClose(...)` hook on the stream is never invoked, and the underlying `RedisConnection` is permanently leaked on every cleaner execution. Over time, this exhausts the Lettuce connection pool (e.g. `cas.ticket.registry.redis.pool.max-active`), causing subsequent authentication and ticket creation requests to fail with `Unable to connect to Redis`.

### Solution
Include `ticketRegistry.stream()` in the `try-with-resources` block alongside `executor` in `DefaultTicketRegistryCleaner.cleanInternal()`:
```java
try (val executor = Executors.newVirtualThreadPerTaskExecutor();
     val ticketStream = ticketRegistry.stream()) {
```
This guarantees that `stream.close()` is invoked upon completion or error, properly executing any registered `onClose` callbacks and returning connections to the pool.

Added unit test `verifyStreamClosedOnClean` in `DefaultTicketRegistryCleanerTests` to verify that `onClose` is invoked when `clean()` runs.

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable
- [x] Test cases to demonstrate the problem before the fix, where applicable
- [x] The same pull request targeted at the master branch, if applicable
- [ ] Any documentation on how to configure, test, etc
- [x] Any possible limitations, side effects, performance issues, etc
- [ ] Reference any other pull requests that might be related
